### PR TITLE
missing include

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <cstring>
 #include "libretro.h"
 #import "jaguar.h"
 #import "file.h"


### PR DESCRIPTION
requires cstring for memcpy()
