### PR TITLE
Add support for Visual Studio 2015 & 2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,13 @@
 *.exe
 *.js
 *.bc
+Win-VS2015/.vs
+Win-VS2015/x64/*
+Win-VS2015/Win-VS2015.VC.db
+Win-VS2015/Win-VS2015.VC.VC.opendb
+Win-VS2015/Win-VS2015.vcxproj.user
+Win-VS2017/.vs
+Win-VS2017/x64/*
+Win-VS2017/Win-VS2017.VC.db
+Win-VS2017/Win-VS2017.VC.VC.opendb
+Win-VS2017/Win-VS2017.vcxproj.user

--- a/Win-VS2015/Win-VS2015.sln
+++ b/Win-VS2015/Win-VS2015.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Win-VS2015", "Win-VS2015.vcxproj", "{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Debug|x64.ActiveCfg = Debug|x64
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Debug|x64.Build.0 = Debug|x64
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Debug|x86.ActiveCfg = Debug|Win32
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Debug|x86.Build.0 = Debug|Win32
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Release|x64.ActiveCfg = Release|x64
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Release|x64.Build.0 = Release|x64
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Release|x86.ActiveCfg = Release|Win32
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Win-VS2015/Win-VS2015.vcxproj
+++ b/Win-VS2015/Win-VS2015.vcxproj
@@ -1,0 +1,204 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>WinVS2015</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>virtualjaguar_libretro</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WINVS2015_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;WINVS2015_EXPORTS;%(PreprocessorDefinitions);INLINE=__inline</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../;../src;/..src/m68000;../libretro-common/include/compat/msvc</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>$(IntDir)asm\</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)obj\</ObjectFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;WINVS2015_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;WINVS2015_EXPORTS;%(PreprocessorDefinitions);INLINE=__inline</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../;../src;/..src/m68000;../libretro-common/include/compat/msvc</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>$(IntDir)asm\</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)obj\</ObjectFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\libretro.h" />
+    <ClInclude Include="..\src\m68000\cpudefs.h" />
+    <ClInclude Include="..\src\m68000\cpuextra.h" />
+    <ClInclude Include="..\src\m68000\m68kinterface.h" />
+    <ClInclude Include="..\src\m68000\readcpu.h" />
+    <ClInclude Include="..\src\vjag_memory.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\libretro.c" />
+    <ClCompile Include="..\src\blitter.c" />
+    <ClCompile Include="..\src\cdintf.c" />
+    <ClCompile Include="..\src\cdrom.c" />
+    <ClCompile Include="..\src\crc32.c" />
+    <ClCompile Include="..\src\dac.c" />
+    <ClCompile Include="..\src\dsp.c" />
+    <ClCompile Include="..\src\eeprom.c" />
+    <ClCompile Include="..\src\event.c" />
+    <ClCompile Include="..\src\file.c" />
+    <ClCompile Include="..\src\filedb.c" />
+    <ClCompile Include="..\src\gpu.c" />
+    <ClCompile Include="..\src\jagbios.c" />
+    <ClCompile Include="..\src\jagbios2.c" />
+    <ClCompile Include="..\src\jagcdbios.c" />
+    <ClCompile Include="..\src\jagdasm.c" />
+    <ClCompile Include="..\src\jagdevcdbios.c" />
+    <ClCompile Include="..\src\jagstub1bios.c" />
+    <ClCompile Include="..\src\jagstub2bios.c" />
+    <ClCompile Include="..\src\jaguar.c" />
+    <ClCompile Include="..\src\jerry.c" />
+    <ClCompile Include="..\src\joystick.c" />
+    <ClCompile Include="..\src\log.c" />
+    <ClCompile Include="..\src\m68000\cpudefs.c" />
+    <ClCompile Include="..\src\m68000\cpuemu.c" />
+    <ClCompile Include="..\src\m68000\cpuextra.c" />
+    <ClCompile Include="..\src\m68000\cpustbl.c" />
+    <ClCompile Include="..\src\m68000\m68kdasm.c" />
+    <ClCompile Include="..\src\m68000\m68kinterface.c" />
+    <ClCompile Include="..\src\m68000\readcpu.c" />
+    <ClCompile Include="..\src\memtrack.c" />
+    <ClCompile Include="..\src\mmu.c" />
+    <ClCompile Include="..\src\op.c" />
+    <ClCompile Include="..\src\settings.c" />
+    <ClCompile Include="..\src\state.c" />
+    <ClCompile Include="..\src\tom.c" />
+    <ClCompile Include="..\src\universalhdr.c" />
+    <ClCompile Include="..\src\vjag_memory.c" />
+    <ClCompile Include="..\src\wavetable.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Win-VS2015/Win-VS2015.vcxproj.filters
+++ b/Win-VS2015/Win-VS2015.vcxproj.filters
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\src">
+      <UniqueIdentifier>{3cc0927f-a6d7-4c15-aed4-d55958d853d4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\src">
+      <UniqueIdentifier>{29864020-081a-4338-a406-0af2d334b2ac}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\m68000">
+      <UniqueIdentifier>{87e70f4b-ccc9-41fc-8edc-0c175bf57730}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\src\m68000">
+      <UniqueIdentifier>{c2025bf1-186a-4595-a4bd-2d37016fd01f}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\libretro.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\vjag_memory.h">
+      <Filter>Header Files\src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\m68000\cpudefs.h">
+      <Filter>Header Files\src\m68000</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\m68000\m68kinterface.h">
+      <Filter>Header Files\src\m68000</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\m68000\readcpu.h">
+      <Filter>Header Files\src\m68000</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\m68000\cpuextra.h">
+      <Filter>Header Files\src\m68000</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\libretro.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\blitter.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dac.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dsp.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\file.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\gpu.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jaguar.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jerry.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagdasm.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cdrom.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\op.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\tom.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cdintf.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\event.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\filedb.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\crc32.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\eeprom.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\m68kinterface.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\readcpu.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\cpudefs.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\cpuemu.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\cpuextra.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\cpustbl.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\m68kdasm.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagstub1bios.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagstub2bios.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagbios.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagbios2.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagcdbios.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagdevcdbios.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\vjag_memory.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\wavetable.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\joystick.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\log.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\memtrack.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\mmu.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\settings.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\state.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\universalhdr.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Win-VS2017/Win-VS2017.sln
+++ b/Win-VS2017/Win-VS2017.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Win-VS2017", "Win-VS2017.vcxproj", "{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Debug|x64.ActiveCfg = Debug|x64
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Debug|x64.Build.0 = Debug|x64
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Debug|x86.ActiveCfg = Debug|Win32
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Debug|x86.Build.0 = Debug|Win32
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Release|x64.ActiveCfg = Release|x64
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Release|x64.Build.0 = Release|x64
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Release|x86.ActiveCfg = Release|Win32
+		{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Win-VS2017/Win-VS2017.vcxproj
+++ b/Win-VS2017/Win-VS2017.vcxproj
@@ -1,0 +1,204 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0CD24617-48B3-4AEA-8223-66FD2CE7CEC2}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>WinVS2015</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <ProjectName>virtualjaguar_libretro</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WINVS2015_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;WINVS2015_EXPORTS;%(PreprocessorDefinitions);INLINE=__inline</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../;../src;/..src/m68000;../libretro-common/include/compat/msvc</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>$(IntDir)asm\</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)obj\</ObjectFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;WINVS2015_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;WINVS2015_EXPORTS;%(PreprocessorDefinitions);INLINE=__inline</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../;../src;/..src/m68000;../libretro-common/include/compat/msvc</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>$(IntDir)asm\</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)obj\</ObjectFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\libretro.h" />
+    <ClInclude Include="..\src\m68000\cpudefs.h" />
+    <ClInclude Include="..\src\m68000\cpuextra.h" />
+    <ClInclude Include="..\src\m68000\m68kinterface.h" />
+    <ClInclude Include="..\src\m68000\readcpu.h" />
+    <ClInclude Include="..\src\vjag_memory.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\libretro.c" />
+    <ClCompile Include="..\src\blitter.c" />
+    <ClCompile Include="..\src\cdintf.c" />
+    <ClCompile Include="..\src\cdrom.c" />
+    <ClCompile Include="..\src\crc32.c" />
+    <ClCompile Include="..\src\dac.c" />
+    <ClCompile Include="..\src\dsp.c" />
+    <ClCompile Include="..\src\eeprom.c" />
+    <ClCompile Include="..\src\event.c" />
+    <ClCompile Include="..\src\file.c" />
+    <ClCompile Include="..\src\filedb.c" />
+    <ClCompile Include="..\src\gpu.c" />
+    <ClCompile Include="..\src\jagbios.c" />
+    <ClCompile Include="..\src\jagbios2.c" />
+    <ClCompile Include="..\src\jagcdbios.c" />
+    <ClCompile Include="..\src\jagdasm.c" />
+    <ClCompile Include="..\src\jagdevcdbios.c" />
+    <ClCompile Include="..\src\jagstub1bios.c" />
+    <ClCompile Include="..\src\jagstub2bios.c" />
+    <ClCompile Include="..\src\jaguar.c" />
+    <ClCompile Include="..\src\jerry.c" />
+    <ClCompile Include="..\src\joystick.c" />
+    <ClCompile Include="..\src\log.c" />
+    <ClCompile Include="..\src\m68000\cpudefs.c" />
+    <ClCompile Include="..\src\m68000\cpuemu.c" />
+    <ClCompile Include="..\src\m68000\cpuextra.c" />
+    <ClCompile Include="..\src\m68000\cpustbl.c" />
+    <ClCompile Include="..\src\m68000\m68kdasm.c" />
+    <ClCompile Include="..\src\m68000\m68kinterface.c" />
+    <ClCompile Include="..\src\m68000\readcpu.c" />
+    <ClCompile Include="..\src\memtrack.c" />
+    <ClCompile Include="..\src\mmu.c" />
+    <ClCompile Include="..\src\op.c" />
+    <ClCompile Include="..\src\settings.c" />
+    <ClCompile Include="..\src\state.c" />
+    <ClCompile Include="..\src\tom.c" />
+    <ClCompile Include="..\src\universalhdr.c" />
+    <ClCompile Include="..\src\vjag_memory.c" />
+    <ClCompile Include="..\src\wavetable.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Win-VS2017/Win-VS2017.vcxproj.filters
+++ b/Win-VS2017/Win-VS2017.vcxproj.filters
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\src">
+      <UniqueIdentifier>{3cc0927f-a6d7-4c15-aed4-d55958d853d4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\src">
+      <UniqueIdentifier>{29864020-081a-4338-a406-0af2d334b2ac}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\m68000">
+      <UniqueIdentifier>{87e70f4b-ccc9-41fc-8edc-0c175bf57730}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\src\m68000">
+      <UniqueIdentifier>{c2025bf1-186a-4595-a4bd-2d37016fd01f}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\libretro.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\vjag_memory.h">
+      <Filter>Header Files\src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\m68000\cpudefs.h">
+      <Filter>Header Files\src\m68000</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\m68000\m68kinterface.h">
+      <Filter>Header Files\src\m68000</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\m68000\readcpu.h">
+      <Filter>Header Files\src\m68000</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\m68000\cpuextra.h">
+      <Filter>Header Files\src\m68000</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\libretro.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\blitter.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dac.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dsp.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\file.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\gpu.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jaguar.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jerry.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagdasm.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cdrom.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\op.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\tom.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cdintf.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\event.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\filedb.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\crc32.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\eeprom.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\m68kinterface.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\readcpu.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\cpudefs.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\cpuemu.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\cpuextra.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\cpustbl.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\m68000\m68kdasm.c">
+      <Filter>Source Files\src\m68000</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagstub1bios.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagstub2bios.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagbios.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagbios2.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagcdbios.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\jagdevcdbios.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\vjag_memory.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\wavetable.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\joystick.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\log.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\memtrack.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\mmu.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\settings.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\state.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\universalhdr.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/libretro-common/include/compat/msvc/stdint.h
+++ b/libretro-common/include/compat/msvc/stdint.h
@@ -31,8 +31,8 @@
 #ifndef __RARCH_STDINT_H
 #define __RARCH_STDINT_H
 
-#if _MSC_VER && (_MSC_VER < 1600)
-/* Pre-MSVC 2010 needs an implementation of stdint.h. */
+#if _MSC_VER && (_MSC_VER <= 1911)
+/* Pre-MSVC 2017 (MSVC++ 14.1) needs an implementation of stdint.h. */
 
 #if _MSC_VER > 1000
 #pragma once


### PR DESCRIPTION
The stdint.h file contains the Visual Studio 2015 & 2017 detection changes.
The Visual Studio 2015 & 2017 projects can probably be put aside but I let you to decide.