### PR TITLE
Proper handling of save files

### DIFF
--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -68,10 +68,21 @@ void EepromInit(void)
       WriteLog("EEPROM: Memory Track device detected...\n");
       return;
    }
+   
+   /* Get EEPROM file names */
+	if (strlen(vjs.romName) > 0)
+	{
+		sprintf(eeprom_filename, "%s%s.srm", vjs.EEPROMPath, vjs.romName);
+		sprintf(cdromEEPROMFilename, "%s%s.cdrom.srm", vjs.EEPROMPath, vjs.romName);
+	}
+	else
+	{
+		// Use old CRC fallback...
+		sprintf(eeprom_filename, "%s%08X.srm", vjs.EEPROMPath, (unsigned int)jaguarMainROMCRC32);
+		sprintf(cdromEEPROMFilename, "%s%08X.cdrom.srm", vjs.EEPROMPath, (unsigned int)jaguarMainROMCRC32);
+	}
 
 	/* Handle regular cartridge EEPROM */
-	sprintf(eeprom_filename, "%s%08X.eeprom", vjs.EEPROMPath, (unsigned int)jaguarMainROMCRC32);
-	sprintf(cdromEEPROMFilename, "%scdrom.eeprom", vjs.EEPROMPath);
 	fp = fopen(eeprom_filename, "rb");
 
 	if (fp)

--- a/src/settings.h
+++ b/src/settings.h
@@ -37,6 +37,8 @@ struct VJSettings
 	char CDBootPath[MAX_PATH];
 	char EEPROMPath[MAX_PATH];
 	char alpineROMPath[MAX_PATH];
+	
+	char romName[MAX_PATH];
 };
 
 // BIOS types


### PR DESCRIPTION
This trivial pull request just modifies the handling of EEPROM saves to match the RetroArch standard. Save files are now located in the user defined save directory, and are named according to the ROM filename.

This should close issue #8.