### PR TITLE
[WIP] Speedup rebase rebase

### DIFF
--- a/src/blitter.c
+++ b/src/blitter.c
@@ -305,10 +305,10 @@ static int32_t a1_clip_x, a1_clip_y;
 // to optimize the blitter, then we may revisit it in the future...
 
 // Generic blit handler
-void blitter_generic(uint32_t icmd)
+void blitter_generic(uint32_t cmdi)
 {
     Bits32 cmd;
-    cmd.WORD = icmd;
+    cmd.WORD = cmdi;
     
    uint32_t srcdata, srczdata, dstdata, dstzdata, writedata, inhibit;
    uint32_t bppSrc = (DSTA2 ? 1 << ((REG(A1_FLAGS) >> 3) & 0x07) : 1 << ((REG(A2_FLAGS) >> 3) & 0x07));
@@ -3048,7 +3048,7 @@ Sfine		:= DECH38EL (s_fine[0..7], dstart[0..2], sfen\);*/
 /*Maskt[0]	:= BUF1 (maskt[0], s_fine[0]);
 Maskt[1-7]	:= OAN1P (maskt[1-7], maskt[0-6], s_fine[1-7], e_fine\[1-7]);*/
 ////////////////////////////////////// C++ CODE //////////////////////////////////////
-    // TODO: Byte and bit this -jm provenance
+    // TODO: Byte and bit this - @joematt provenance
 
 	maskt = s_fine & 0x0001;
 	maskt |= (((maskt & 0x0001) || (s_fine & 0x02u)) && (e_fine & 0x02u) ? 0x0002 : 0x0000);

--- a/src/blitter.c
+++ b/src/blitter.c
@@ -87,41 +87,41 @@ void BlitterMidsummer2(void);
 
 // Blitter command bits
 
-#define SRCEN			(cmd & 0x00000001)
-#define SRCENZ			(cmd & 0x00000002)
-#define SRCENX			(cmd & 0x00000004)
-#define DSTEN			(cmd & 0x00000008)
-#define DSTENZ			(cmd & 0x00000010)
-#define DSTWRZ			(cmd & 0x00000020)
-#define CLIPA1			(cmd & 0x00000040)
+#define SRCEN			(cmd.bits.b0)
+#define SRCENZ			(cmd.bits.b1)
+#define SRCENX			(cmd.bits.b2)
+#define DSTEN			(cmd.bits.b3)
+#define DSTENZ			(cmd.bits.b4)
+#define DSTWRZ			(cmd.bits.b5)
+#define CLIPA1			(cmd.bits.b6)
 
-#define UPDA1F			(cmd & 0x00000100)
-#define UPDA1			(cmd & 0x00000200)
-#define UPDA2			(cmd & 0x00000400)
+#define UPDA1F			(cmd.bits.b8)
+#define UPDA1			(cmd.bits.b9)
+#define UPDA2			(cmd.bits.b10)
 
-#define DSTA2			(cmd & 0x00000800)
+#define DSTA2			(cmd.bits.b11)
 
-#define Z_OP_INF		(cmd & 0x00040000)
-#define Z_OP_EQU		(cmd & 0x00080000)
-#define Z_OP_SUP		(cmd & 0x00100000)
+#define Z_OP_INF		(cmd.bits.b18)
+#define Z_OP_EQU		(cmd.bits.b19)
+#define Z_OP_SUP		(cmd.bits.b20)
 
-#define LFU_NAN		(cmd & 0x00200000)
-#define LFU_NA			(cmd & 0x00400000)
-#define LFU_AN			(cmd & 0x00800000)
-#define LFU_A			(cmd & 0x01000000)
+#define LFU_NAN		    (cmd.bits.b21)
+#define LFU_NA			(cmd.bits.b22)
+#define LFU_AN			(cmd.bits.b23)
+#define LFU_A			(cmd.bits.b24)
 
-#define CMPDST			(cmd & 0x02000000)
-#define BCOMPEN		(cmd & 0x04000000)
-#define DCOMPEN		(cmd & 0x08000000)
+#define CMPDST			(cmd.bits.b25)
+#define BCOMPEN		    (cmd.bits.b26)
+#define DCOMPEN		    (cmd.bits.b27)
 
-#define PATDSEL		(cmd & 0x00010000)
-#define ADDDSEL		(cmd & 0x00020000)
-#define TOPBEN			(cmd & 0x00004000)
-#define TOPNEN			(cmd & 0x00008000)
-#define BKGWREN		(cmd & 0x10000000)
-#define GOURD			(cmd & 0x00001000)
-#define GOURZ			(cmd & 0x00002000)
-#define SRCSHADE		(cmd & 0x40000000)
+#define PATDSEL		    (cmd.bits.b16)
+#define ADDDSEL		    (cmd.bits.b17)
+#define TOPBEN			(cmd.bits.b14)
+#define TOPNEN			(cmd.bits.b15)
+#define BKGWREN		    (cmd.bits.b28)
+#define GOURD			(cmd.bits.b12)
+#define GOURZ			(cmd.bits.b13)
+#define SRCSHADE		(cmd.bits.b30)
 
 
 #define XADDPHR      0
@@ -305,8 +305,11 @@ static int32_t a1_clip_x, a1_clip_y;
 // to optimize the blitter, then we may revisit it in the future...
 
 // Generic blit handler
-void blitter_generic(uint32_t cmd)
+void blitter_generic(uint32_t icmd)
 {
+    Bits32 cmd;
+    cmd.WORD = icmd;
+    
    uint32_t srcdata, srczdata, dstdata, dstzdata, writedata, inhibit;
    uint32_t bppSrc = (DSTA2 ? 1 << ((REG(A1_FLAGS) >> 3) & 0x07) : 1 << ((REG(A2_FLAGS) >> 3) & 0x07));
 
@@ -338,14 +341,14 @@ void blitter_generic(uint32_t cmd)
 
                if (SRCENZ)
                   srczdata = READ_ZDATA(a2, REG(A2_FLAGS));
-               else if (cmd & 0x0001C020)	// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
+               else if (cmd.WORD & 0x0001C020)	// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
                   srczdata = READ_RDATA(SRCZINT, a2, REG(A2_FLAGS), a2_phrase_mode);
             }
             else	// Use SRCDATA register...
             {
                srcdata = READ_RDATA(SRCDATA, a2, REG(A2_FLAGS), a2_phrase_mode);
 
-               if (cmd & 0x0001C020)		// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
+               if (cmd.WORD & 0x0001C020)		// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
                   srczdata = READ_RDATA(SRCZINT, a2, REG(A2_FLAGS), a2_phrase_mode);
             }
 
@@ -516,13 +519,13 @@ void blitter_generic(uint32_t cmd)
                srcdata = READ_PIXEL(a1, REG(A1_FLAGS));
                if (SRCENZ)
                   srczdata = READ_ZDATA(a1, REG(A1_FLAGS));
-               else if (cmd & 0x0001C020)	// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
+               else if (cmd.WORD & 0x0001C020)	// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
                   srczdata = READ_RDATA(SRCZINT, a1, REG(A1_FLAGS), a1_phrase_mode);
             }
             else
             {
                srcdata = READ_RDATA(SRCDATA, a1, REG(A1_FLAGS), a1_phrase_mode);
-               if (cmd & 0x001C020)	// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
+               if (cmd.WORD & 0x001C020)	// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
                   srczdata = READ_RDATA(SRCZINT, a1, REG(A1_FLAGS), a1_phrase_mode);
             }
 
@@ -756,20 +759,23 @@ void blitter_generic(uint32_t cmd)
    WREG(A2_PIXEL,  (a2_y & 0xFFFF0000) | ((a2_x >> 16) & 0xFFFF));
 }
 
-void blitter_blit(uint32_t cmd)
+void blitter_blit(uint32_t cmdi)
 {
+    Bits32 cmd;
+    cmd.WORD = cmdi;
+    
    uint32_t m, e;
    uint32_t pitchValue[4] = { 0, 1, 3, 2 };
    colour_index = 0;
-   src = cmd & 0x07;
-   dst = (cmd >> 3) & 0x07;
-   misc = (cmd >> 6) & 0x03;
-   a1ctl = (cmd >> 8) & 0x7;
-   mode = (cmd >> 11) & 0x07;
-   ity = (cmd >> 14) & 0x0F;
-   zop = (cmd >> 18) & 0x07;
-   op = (cmd >> 21) & 0x0F;
-   ctrl = (cmd >> 25) & 0x3F;
+   src = cmd.WORD & 0x07;
+   dst = (cmd.WORD >> 3) & 0x07;
+   misc = (cmd.WORD >> 6) & 0x03;
+   a1ctl = (cmd.WORD >> 8) & 0x7;
+   mode = (cmd.WORD >> 11) & 0x07;
+   ity = (cmd.WORD >> 14) & 0x0F;
+   zop = (cmd.WORD >> 18) & 0x07;
+   op = (cmd.WORD >> 21) & 0x0F;
+   ctrl = (cmd.WORD >> 25) & 0x3F;
 
    // Addresses in A1/2_BASE are *phrase* aligned, i.e., bottom three bits are ignored!
    // NOTE: This fixes Rayman's bad collision detection AND keeps T2K working!
@@ -952,7 +958,7 @@ void blitter_blit(uint32_t cmd)
          gd_ca = 0xFFFFFF00 | gd_ca;
    }
 
-   blitter_generic(cmd);
+   blitter_generic(cmd.WORD);
 }
 #endif
 /*******************************************************************************
@@ -1113,10 +1119,11 @@ void BlitterWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
 	// I.e., the second write of 32-bit value--not convinced this is the best way to do this!
 	// But then again, according to the Jaguar docs, this is correct...!
 	{
-		if (vjs.useFastBlitter)
-			blitter_blit(GET32(blitter_ram, 0x38));
-		else
-			BlitterMidsummer2();
+        if (vjs.useFastBlitter) {
+            blitter_blit(GET32(blitter_ram, 0x38));
+        } else {
+            BlitterMidsummer2();
+        }
 	}
 }
 //F02278,9,A,B
@@ -1135,10 +1142,10 @@ void BlitterWriteLong(uint32_t offset, uint32_t data, uint32_t who)
 void ADDRGEN(uint32_t *, uint32_t *, bool, bool,
 	uint16_t, uint16_t, uint32_t, uint8_t, uint8_t, uint8_t, uint8_t,
 	uint16_t, uint16_t, uint32_t, uint8_t, uint8_t, uint8_t, uint8_t);
-void ADDARRAY(uint16_t * addq, uint8_t daddasel, uint8_t daddbsel, uint8_t daddmode,
-	uint64_t dstd, uint32_t iinc, uint8_t initcin[], uint64_t initinc, uint16_t initpix,
-	uint32_t istep, uint64_t patd, uint64_t srcd, uint64_t srcz1, uint64_t srcz2,
-	uint32_t zinc, uint32_t zstep);
+void ADDARRAY(const uint16_t * addq, const uint8_t daddasel, const uint8_t daddbsel, const uint8_t daddmode,
+              const uint64_t dstd, const uint32_t iinc, const uint8_t initcin[], const uint64_t initinc, const uint16_t initpix,
+              const uint32_t istep, const uint64_t patd, const uint64_t srcd, const uint64_t srcz1, const uint64_t srcz2,
+              const uint32_t zinc, const uint32_t zstep);
 void ADD16SAT(uint16_t *r, uint8_t *co, uint16_t a, uint16_t b, uint8_t cin, bool sat, bool eightbit, bool hicinh);
 void ADDAMUX(int16_t *adda_x, int16_t *adda_y, uint8_t addasel, int16_t a1_step_x, int16_t a1_step_y,
 	int16_t a1_stepf_x, int16_t a1_stepf_y, int16_t a2_step_x, int16_t a2_step_y,
@@ -1166,7 +1173,8 @@ void BlitterMidsummer2(void)
    //Will remove stuff that isn't in Jaguar I once fully described (stuff like texture won't
    //be described here at all)...
 
-   uint32_t cmd = GET32(blitter_ram, COMMAND);
+    Bits32 cmd;
+    cmd.WORD = GET32(blitter_ram, COMMAND);
 
    // Line states passed in via the command register
 
@@ -1177,7 +1185,7 @@ void BlitterMidsummer2(void)
         patdsel = (PATDSEL), adddsel = (ADDDSEL), cmpdst = (CMPDST), bcompen = (BCOMPEN),
         dcompen = (DCOMPEN), bkgwren = (BKGWREN), srcshade = (SRCSHADE);
 
-   uint8_t zmode = (cmd & 0x01C0000) >> 18, lfufunc = (cmd & 0x1E00000) >> 21;
+   uint8_t zmode = (cmd.WORD & 0x01C0000) >> 18, lfufunc = (cmd.WORD & 0x1E00000) >> 21;
    //Missing: BUSHI
    //Where to find various lines:
    // clip_a1  -> inner
@@ -2396,11 +2404,11 @@ void ADDRGEN(uint32_t *address, uint32_t *pixa, bool gena2, bool zaddr,
 // Here's an important bit: The source data adder logic. Need to track down the inputs!!! //
 ////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////
-
-void ADDARRAY(uint16_t * addq, uint8_t daddasel, uint8_t daddbsel, uint8_t daddmode,
-	uint64_t dstd, uint32_t iinc, uint8_t initcin[], uint64_t initinc, uint16_t initpix,
-	uint32_t istep, uint64_t patd, uint64_t srcd, uint64_t srcz1, uint64_t srcz2,
-	uint32_t zinc, uint32_t zstep)
+#include <simd/simd.h>
+void ADDARRAY(const uint16_t * addq, const uint8_t daddasel, const uint8_t daddbsel, const uint8_t daddmode,
+	const uint64_t dstd, const uint32_t iinc, const uint8_t initcin[], const uint64_t initinc, const uint16_t initpix,
+	const uint32_t istep, const uint64_t patd, const uint64_t srcd, const uint64_t srcz1, const uint64_t srcz2,
+	const uint32_t zinc, const uint32_t zstep)
 {
    unsigned i;
    uint16_t adda[4];
@@ -2851,7 +2859,7 @@ Patdhi		:= JOIN (patdhi, patd[32..63]);*/
 	uint8_t dech38el[2][8] = { { 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80 },
 		{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } };
    int en;
-   uint64_t cmpd;
+   Bits64 cmpd;
 	uint8_t dbinht;
    uint16_t addq[4];
    uint8_t initcin[4] = { 0, 0, 0, 0 };
@@ -2875,23 +2883,23 @@ Zstep		:= JOIN (zstep, zstep[0..31]);*/
 /*Datacomp	:= DATACOMP (dcomp[0..7], cmpdst, dstdlo, dstdhi, patdlo, patdhi, srcdlo, srcdhi);*/
 ////////////////////////////////////// C++ CODE //////////////////////////////////////
 	*dcomp = 0;
-	cmpd = *patd ^ (cmpdst ? dstd : srcd);
+	cmpd.DATA = *patd ^ (cmpdst ? dstd : srcd);
 
-	if ((cmpd & 0x00000000000000FFLL) == 0)
+	if (cmpd.bytes.b0 == 0)
 		*dcomp |= 0x01u;
-	if ((cmpd & 0x000000000000FF00LL) == 0)
+	if (cmpd.bytes.b1 == 0)
 		*dcomp |= 0x02u;
-	if ((cmpd & 0x0000000000FF0000LL) == 0)
+	if (cmpd.bytes.b2 == 0)
 		*dcomp |= 0x04u;
-	if ((cmpd & 0x00000000FF000000LL) == 0)
+	if (cmpd.bytes.b3 == 0)
 		*dcomp |= 0x08u;
-	if ((cmpd & 0x000000FF00000000LL) == 0)
+	if (cmpd.bytes.b4 == 0)
 		*dcomp |= 0x10u;
-	if ((cmpd & 0x0000FF0000000000LL) == 0)
+	if (cmpd.bytes.b5 == 0)
 		*dcomp |= 0x20u;
-	if ((cmpd & 0x00FF000000000000LL) == 0)
+	if (cmpd.bytes.b6 == 0)
 		*dcomp |= 0x40u;
-	if ((cmpd & 0xFF00000000000000LL) == 0)
+	if (cmpd.bytes.b7 == 0)
 		*dcomp |= 0x80u;
 //////////////////////////////////////////////////////////////////////////////////////
 
@@ -2909,7 +2917,7 @@ with srcshift bits 4 & 5 selecting the start position
 */
 //So... basically what we have here is:
 	*zcomp = 0;
-
+    // TODO: Byte and bit this -jm provenance
 	if ((((*srcz & 0x000000000000FFFFLL) < (dstz & 0x000000000000FFFFLL)) && (zmode & 0x01))
 		|| (((*srcz & 0x000000000000FFFFLL) == (dstz & 0x000000000000FFFFLL)) && (zmode & 0x02))
 		|| (((*srcz & 0x000000000000FFFFLL) > (dstz & 0x000000000000FFFFLL)) && (zmode & 0x04)))
@@ -3040,6 +3048,8 @@ Sfine		:= DECH38EL (s_fine[0..7], dstart[0..2], sfen\);*/
 /*Maskt[0]	:= BUF1 (maskt[0], s_fine[0]);
 Maskt[1-7]	:= OAN1P (maskt[1-7], maskt[0-6], s_fine[1-7], e_fine\[1-7]);*/
 ////////////////////////////////////// C++ CODE //////////////////////////////////////
+    // TODO: Byte and bit this -jm provenance
+
 	maskt = s_fine & 0x0001;
 	maskt |= (((maskt & 0x0001) || (s_fine & 0x02u)) && (e_fine & 0x02u) ? 0x0002 : 0x0000);
 	maskt |= (((maskt & 0x0002) || (s_fine & 0x04u)) && (e_fine & 0x04u) ? 0x0004 : 0x0000);
@@ -3051,6 +3061,7 @@ Maskt[1-7]	:= OAN1P (maskt[1-7], maskt[0-6], s_fine[1-7], e_fine\[1-7]);*/
 //////////////////////////////////////////////////////////////////////////////////////
 
    /* Produce a look-ahead on the ripple carry */
+    // TODO: Byte and bit this - @joematt provenance
 	maskt |= (((s_coarse & e_coarse & 0x01u) || (s_coarse & 0x02u)) && (e_coarse & 0x02u) ? 0x0100 : 0x0000);
 	maskt |= (((maskt & 0x0100) || (s_coarse & 0x04u)) && (e_coarse & 0x04u) ? 0x0200 : 0x0000);
 	maskt |= (((maskt & 0x0200) || (s_coarse & 0x08u)) && (e_coarse & 0x08u) ? 0x0400 : 0x0000);
@@ -3087,6 +3098,7 @@ Masku[14]	:= MX2 (masku[14], maskt[14], maskt[0],  mir_byte);*/
 	mir_bit  = true/*big_pix*/ && !phrase_mode;
 	mir_byte = true/*big_pix*/ && phrase_mode;
 	masku    = maskt;
+    // TODO: Byte and bit this - @joematt provenance
 
 	if (mir_bit)
 	{

--- a/src/blitter.c
+++ b/src/blitter.c
@@ -2917,25 +2917,25 @@ with srcshift bits 4 & 5 selecting the start position
 */
 //So... basically what we have here is:
 	*zcomp = 0;
-    // TODO: Byte and bit this -jm provenance
-	if ((((*srcz & 0x000000000000FFFFLL) < (dstz & 0x000000000000FFFFLL)) && (zmode & 0x01))
-		|| (((*srcz & 0x000000000000FFFFLL) == (dstz & 0x000000000000FFFFLL)) && (zmode & 0x02))
-		|| (((*srcz & 0x000000000000FFFFLL) > (dstz & 0x000000000000FFFFLL)) && (zmode & 0x04)))
+    // TODO: Byte and bit this - @joematt provenance
+	if ((((*srcz & 0x000000000000FFFFLL) < (dstz & 0x000000000000FFFFLL)) && (zmode & 0x01u))
+		|| (((*srcz & 0x000000000000FFFFLL) == (dstz & 0x000000000000FFFFLL)) && (zmode & 0x02u))
+		|| (((*srcz & 0x000000000000FFFFLL) > (dstz & 0x000000000000FFFFLL)) && (zmode & 0x04u)))
 		*zcomp |= 0x01u;
 
-	if ((((*srcz & 0x00000000FFFF0000LL) < (dstz & 0x00000000FFFF0000LL)) && (zmode & 0x01))
-		|| (((*srcz & 0x00000000FFFF0000LL) == (dstz & 0x00000000FFFF0000LL)) && (zmode & 0x02))
-		|| (((*srcz & 0x00000000FFFF0000LL) > (dstz & 0x00000000FFFF0000LL)) && (zmode & 0x04)))
+	if ((((*srcz & 0x00000000FFFF0000LL) < (dstz & 0x00000000FFFF0000LL)) && (zmode & 0x01u))
+		|| (((*srcz & 0x00000000FFFF0000LL) == (dstz & 0x00000000FFFF0000LL)) && (zmode & 0x02u))
+		|| (((*srcz & 0x00000000FFFF0000LL) > (dstz & 0x00000000FFFF0000LL)) && (zmode & 0x04u)))
 		*zcomp |= 0x02u;
 
-	if ((((*srcz & 0x0000FFFF00000000LL) < (dstz & 0x0000FFFF00000000LL)) && (zmode & 0x01))
-		|| (((*srcz & 0x0000FFFF00000000LL) == (dstz & 0x0000FFFF00000000LL)) && (zmode & 0x02))
-		|| (((*srcz & 0x0000FFFF00000000LL) > (dstz & 0x0000FFFF00000000LL)) && (zmode & 0x04)))
+	if ((((*srcz & 0x0000FFFF00000000LL) < (dstz & 0x0000FFFF00000000LL)) && (zmode & 0x01u))
+		|| (((*srcz & 0x0000FFFF00000000LL) == (dstz & 0x0000FFFF00000000LL)) && (zmode & 0x02u))
+		|| (((*srcz & 0x0000FFFF00000000LL) > (dstz & 0x0000FFFF00000000LL)) && (zmode & 0x04u)))
 		*zcomp |= 0x04u;
 
-	if ((((*srcz & 0xFFFF000000000000LL) < (dstz & 0xFFFF000000000000LL)) && (zmode & 0x01))
-		|| (((*srcz & 0xFFFF000000000000LL) == (dstz & 0xFFFF000000000000LL)) && (zmode & 0x02))
-		|| (((*srcz & 0xFFFF000000000000LL) > (dstz & 0xFFFF000000000000LL)) && (zmode & 0x04)))
+	if ((((*srcz & 0xFFFF000000000000LL) < (dstz & 0xFFFF000000000000LL)) && (zmode & 0x01u))
+		|| (((*srcz & 0xFFFF000000000000LL) == (dstz & 0xFFFF000000000000LL)) && (zmode & 0x02u))
+		|| (((*srcz & 0xFFFF000000000000LL) > (dstz & 0xFFFF000000000000LL)) && (zmode & 0x04u)))
 		*zcomp |= 0x08u;
 
 //TEMP, TO TEST IF ZCOMP IS THE CULPRIT...

--- a/src/blitter.c
+++ b/src/blitter.c
@@ -2404,7 +2404,7 @@ void ADDRGEN(uint32_t *address, uint32_t *pixa, bool gena2, bool zaddr,
 // Here's an important bit: The source data adder logic. Need to track down the inputs!!! //
 ////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////
-#include <simd/simd.h>
+
 void ADDARRAY(const uint16_t * addq, const uint8_t daddasel, const uint8_t daddbsel, const uint8_t daddmode,
 	const uint64_t dstd, const uint32_t iinc, const uint8_t initcin[], const uint64_t initinc, const uint16_t initpix,
 	const uint32_t istep, const uint64_t patd, const uint64_t srcd, const uint64_t srcz1, const uint64_t srcz2,

--- a/src/blitter.c
+++ b/src/blitter.c
@@ -2475,12 +2475,14 @@ void ADDARRAY(uint16_t * addq, uint8_t daddasel, uint8_t daddbsel, uint8_t daddm
    hicinh = ((daddmode & 0x03) == 0x03);
 
    //Note that the carry out is saved between calls to this function...
-   for( i=0; i<4; i++)
-      ADD16SAT(&addq[i], &co[i], adda[i], addb[i], cin[i], sat, eightbit, hicinh);
+    ADD16SAT(&addq[0], &co[0], adda[0], addb[0], cin[0], sat, eightbit, hicinh);
+    ADD16SAT(&addq[1], &co[1], adda[1], addb[1], cin[1], sat, eightbit, hicinh);
+    ADD16SAT(&addq[2], &co[2], adda[2], addb[2], cin[2], sat, eightbit, hicinh);
+    ADD16SAT(&addq[3], &co[3], adda[3], addb[3], cin[3], sat, eightbit, hicinh);
 }
 
 
-void ADD16SAT(uint16_t *r, uint8_t *co, uint16_t a, uint16_t b, uint8_t cin, bool sat, bool eightbit, bool hicinh)
+void ADD16SAT(uint16_t *r, uint8_t *co, uint16_t a, const uint16_t b, const uint8_t cin, const bool sat, const bool eightbit, const bool hicinh)
 {
    uint8_t carry[4];
    uint8_t btop, ctop;

--- a/src/dac.c
+++ b/src/dac.c
@@ -164,12 +164,12 @@ void SoundCallback(void * userdata, uint16_t * buffer, int length)
    {
       double timeToNextEvent = GetTimeToNextEvent(EVENT_JERRY);
 
-		 DSPExec(USEC_TO_RISC_CYCLES(timeToNextEvent));
+      DSPExec(USEC_TO_RISC_CYCLES(timeToNextEvent));
 
-		 HandleNextEvent(EVENT_JERRY);
-	 }
-	while (!bufferDone);
-	audio_batch_cb((int16_t*)sampleBuffer, length / 2);
+      HandleNextEvent(EVENT_JERRY);
+   }
+   while (!bufferDone);
+   audio_batch_cb((int16_t*)sampleBuffer, length / 2);
 }
 
 // LTXD/RTXD/SCLK/SMODE ($F1A148/4C/50/54)

--- a/src/dac.c
+++ b/src/dac.c
@@ -52,7 +52,7 @@
 
 #include <libretro.h>
 
-//extern retro_audio_sample_batch_t audio_batch_cb;
+extern retro_audio_sample_batch_t audio_batch_cb;
 
 #define BUFFER_SIZE		0x10000	// Make the DAC buffers 64K x 16 bits
 #define DAC_AUDIO_RATE		48000	// Set the audio rate to 48 KHz
@@ -164,12 +164,12 @@ void SoundCallback(void * userdata, uint16_t * buffer, int length)
    {
       double timeToNextEvent = GetTimeToNextEvent(EVENT_JERRY);
 
-      DSPExec(USEC_TO_RISC_CYCLES(timeToNextEvent));
+		 DSPExec(USEC_TO_RISC_CYCLES(timeToNextEvent));
 
-      HandleNextEvent(EVENT_JERRY);
-   }
-   while (!bufferDone);
-//   audio_batch_cb((int16_t*)sampleBuffer, length / 2);
+		 HandleNextEvent(EVENT_JERRY);
+	 }
+	while (!bufferDone);
+	audio_batch_cb((int16_t*)sampleBuffer, length / 2);
 }
 
 // LTXD/RTXD/SCLK/SMODE ($F1A148/4C/50/54)

--- a/src/dac.c
+++ b/src/dac.c
@@ -52,7 +52,7 @@
 
 #include <libretro.h>
 
-extern retro_audio_sample_batch_t audio_batch_cb;
+//extern retro_audio_sample_batch_t audio_batch_cb;
 
 #define BUFFER_SIZE		0x10000	// Make the DAC buffers 64K x 16 bits
 #define DAC_AUDIO_RATE		48000	// Set the audio rate to 48 KHz
@@ -169,7 +169,7 @@ void SoundCallback(void * userdata, uint16_t * buffer, int length)
       HandleNextEvent(EVENT_JERRY);
    }
    while (!bufferDone);
-   audio_batch_cb((int16_t*)sampleBuffer, length / 2);
+//   audio_batch_cb((int16_t*)sampleBuffer, length / 2);
 }
 
 // LTXD/RTXD/SCLK/SMODE ($F1A148/4C/50/54)

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -771,7 +771,7 @@ void DSPHandleIRQs(void)
       return;
 
    // Get the active interrupt bits (latches) & interrupt mask (enables)
-   bits = ((dsp_control.WORD >> 10) & 0x20) | ((dsp_control.WORD >> 6) & 0x1F),
+   bits = ((dsp_control.WORD >> 10) & 0x20) | ((dsp_control.WORD >> 6) & 0x1F);
    mask = ((dsp_flags >> 11) & 0x20) | ((dsp_flags >> 4) & 0x1F);
 
    bits &= mask;
@@ -2051,7 +2051,7 @@ static void DSP_jr(void)
       }//*/
       dsp_pc += 2;	// For DSP_DIS_* accuracy
       DSPOpcode[pipeline[plPtrExec].opcode]();
-      dsp_opcode_use[pipeline[plPtrExec].opcode]++;
+//      dsp_opcode_use[pipeline[plPtrExec].opcode]++;
       pipeline[plPtrWrite] = pipeline[plPtrExec];
 
       // Step 3: Flush pipeline & set new PC
@@ -2127,7 +2127,7 @@ static void DSP_jump(void)
 		}
 	dsp_pc += 2;	// For DSP_DIS_* accuracy
 		DSPOpcode[pipeline[plPtrExec].opcode]();
-		dsp_opcode_use[pipeline[plPtrExec].opcode]++;
+//        dsp_opcode_use[pipeline[plPtrExec].opcode]++;
 		pipeline[plPtrWrite] = pipeline[plPtrExec];
 
 		// Step 3: Flush pipeline & set new PC

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -264,16 +264,136 @@ static uint32_t dsp_flags;
 static uint32_t dsp_matrix_control;
 static uint32_t dsp_pointer_to_matrix;
 static uint32_t dsp_data_organization;
-uint32_t dsp_control;
+
+typedef union Bits32 {
+    uint32_t WORD;
+    struct bits {
+#ifdef LITTLE_ENDIAN
+        unsigned int b0: 1;
+        unsigned int b1: 1;
+        unsigned int b2: 1;
+        unsigned int b3: 1;
+        unsigned int b4: 1;
+        unsigned int b5: 1;
+        unsigned int b6: 1;
+        unsigned int b7: 1;
+        unsigned int b8: 1;
+        unsigned int b9: 1;
+        unsigned int b10: 1;
+        unsigned int b11: 1;
+        unsigned int b12: 1;
+        unsigned int b13: 1;
+        unsigned int b14: 1;
+        unsigned int b15: 1;
+        unsigned int b16: 1;
+        unsigned int b17: 1;
+        unsigned int b18: 1;
+        unsigned int b19: 1;
+        unsigned int b20: 1;
+        unsigned int b21: 1;
+        unsigned int b22: 1;
+        unsigned int b23: 1;
+        unsigned int b24: 1;
+        unsigned int b25: 1;
+        unsigned int b26: 1;
+        unsigned int b27: 1;
+        unsigned int b28: 1;
+        unsigned int b29: 1;
+        unsigned int b30: 1;
+        unsigned int b31: 1;
+#else
+        // reverse the order of the bit fields.
+        unsigned int b31: 1;
+        unsigned int b30: 1;
+        unsigned int b29: 1;
+        unsigned int b28: 1;
+        unsigned int b27: 1;
+        unsigned int b26: 1;
+        unsigned int b25: 1;
+        unsigned int b24: 1;
+        unsigned int b23: 1;
+        unsigned int b22: 1;
+        unsigned int b21: 1;
+        unsigned int b20: 1;
+        unsigned int b19: 1;
+        unsigned int b18: 1;
+        unsigned int b17: 1;
+        unsigned int b16: 1;
+        unsigned int b15: 1;
+        unsigned int b14: 1;
+        unsigned int b13: 1;
+        unsigned int b12: 1;
+        unsigned int b11: 1;
+        unsigned int b10: 1;
+        unsigned int b9: 1;
+        unsigned int b8: 1;
+        unsigned int b7: 1;
+        unsigned int b6: 1;
+        unsigned int b5: 1;
+        unsigned int b4: 1;
+        unsigned int b3: 1;
+        unsigned int b2: 1;
+        unsigned int b1: 1;
+        unsigned int b0: 1;
+#endif
+    } bits;
+} Bits32;
+
+typedef union OpCode {
+    uint16_t WORD;
+#pragma pack(push, 1)
+    struct Codes {
+#ifdef LITTLE_ENDIAN
+        unsigned int second : 5;
+        unsigned int first : 5;
+        unsigned int index : 6;
+#else
+        unsigned int index : 6;
+        unsigned int first : 5;
+        unsigned int second : 5;
+#endif
+    } Codes;
+#pragma pack(pop)
+} OpCode;
+
+typedef union Offset {
+    uint32_t LONG;
+#pragma pack(push, 1)
+    struct Members {
+#ifdef LITTLE_ENDIAN
+        unsigned int offset : 31;
+        unsigned int bit : 1;
+#else
+        unsigned int bit : 1;
+        unsigned int offset : 31;
+#endif
+    } Members;
+#pragma pack(pop)
+} Offset;
+
+typedef union DSPLong {
+    uint32_t LONG;
+    struct Data {
+#ifdef LITTLE_ENDIAN
+        uint16_t LWORD;
+        uint16_t UWORD;
+#else
+        uint16_t UWORD;
+        uint16_t LWORD;
+#endif
+    } Data;
+} DSPLong;
+
+Bits32 dsp_control;
 static uint32_t dsp_div_control;
 static uint8_t dsp_flag_z, dsp_flag_n, dsp_flag_c;
 static uint32_t * dsp_reg = NULL, * dsp_alternate_reg = NULL;
 uint32_t dsp_reg_bank_0[32], dsp_reg_bank_1[32];
 
-static uint32_t dsp_opcode_first_parameter;
-static uint32_t dsp_opcode_second_parameter;
+static uint8_t dsp_opcode_first_parameter;
+static uint8_t dsp_opcode_second_parameter;
 
-#define DSP_RUNNING			(dsp_control & 0x01)
+#define DSP_RUNNING            (dsp_control.bits.b0)
 
 #define RM					dsp_reg[dsp_opcode_first_parameter]
 #define RN					dsp_reg[dsp_opcode_second_parameter]
@@ -393,8 +513,10 @@ uint8_t DSPReadByte(uint32_t offset, uint32_t who/*=UNKNOWN*/)
 
 uint16_t DSPReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
 {
-	offset &= 0xFFFFFFFE;
-
+    Offset offsett;
+    offsett.LONG = offset;
+    offset = offsett.Members.offset;
+    
 	if (offset >= DSP_WORK_RAM_BASE && offset <= DSP_WORK_RAM_BASE+0x1FFF)
 	{
 		offset -= DSP_WORK_RAM_BASE;
@@ -402,11 +524,14 @@ uint16_t DSPReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
 	}
 	else if ((offset>=DSP_CONTROL_RAM_BASE)&&(offset<DSP_CONTROL_RAM_BASE+0x20))
 	{
-		uint32_t data = DSPReadLong(offset & 0xFFFFFFFC, who);
-
-		if (offset & 0x03)
-			return data & 0xFFFF;
-      return data >> 16;
+        DSPLong data;
+        data.LONG = DSPReadLong(offset & 0xFFFFFFFC, who);
+        
+        if (offset & 0x03) {
+            return data.Data.LWORD;
+        } else {
+            return data.Data.UWORD;
+        }
 	}
 
 	return JaguarReadWord(offset, who);
@@ -438,7 +563,7 @@ uint32_t DSPReadLong(uint32_t offset, uint32_t who/*=UNKNOWN*/)
          case 0x10:
             return dsp_pc;
          case 0x14:
-            return dsp_control;
+            return dsp_control.WORD;
          case 0x18:
             return dsp_modulo;
          case 0x1C:
@@ -547,8 +672,8 @@ void DSPWriteLong(uint32_t offset, uint32_t data, uint32_t who/*=UNKNOWN*/)
                dsp_flag_c = (dsp_flags >> 1) & 0x01;
                dsp_flag_n = (dsp_flags >> 2) & 0x01;
                DSPUpdateRegisterBanks();
-               dsp_control &= ~((dsp_flags & CINT04FLAGS) >> 3);
-               dsp_control &= ~((dsp_flags & CINT5FLAG) >> 1);
+               dsp_control.WORD &= ~((dsp_flags & CINT04FLAGS) >> 3);
+               dsp_control.WORD &= ~((dsp_flags & CINT5FLAG) >> 1);
                break;
             }
          case 0x04:
@@ -592,7 +717,7 @@ void DSPWriteLong(uint32_t offset, uint32_t data, uint32_t who/*=UNKNOWN*/)
                }
                // Protect writes to VERSION and the interrupt latches...
                mask        = VERSION | INT_LAT0 | INT_LAT1 | INT_LAT2 | INT_LAT3 | INT_LAT4 | INT_LAT5;
-               dsp_control = (dsp_control & mask) | (data & ~mask);
+               dsp_control.WORD = (dsp_control.WORD & mask) | (data & ~mask);
                //CC only!
                //!!!!!!!!
 
@@ -646,7 +771,7 @@ void DSPHandleIRQs(void)
       return;
 
    // Get the active interrupt bits (latches) & interrupt mask (enables)
-   bits = ((dsp_control >> 10) & 0x20) | ((dsp_control >> 6) & 0x1F);
+   bits = ((dsp_control.WORD >> 10) & 0x20) | ((dsp_control.WORD >> 6) & 0x1F),
    mask = ((dsp_flags >> 11) & 0x20) | ((dsp_flags >> 4) & 0x1F);
 
    bits &= mask;
@@ -733,7 +858,7 @@ void DSPHandleIRQsNP(void)
 		return;
 
 	// Get the active interrupt bits (latches) & interrupt mask (enables)
-	bits = ((dsp_control >> 10) & 0x20) | ((dsp_control >> 6) & 0x1F);
+	bits = ((dsp_control.WORD >> 10) & 0x20) | ((dsp_control.WORD >> 6) & 0x1F);
    mask = ((dsp_flags >> 11) & 0x20) | ((dsp_flags >> 4) & 0x1F);
 
 	bits &= mask;
@@ -773,11 +898,11 @@ void DSPSetIRQLine(int irqline, int state)
 {
 //NOTE: This doesn't take INT_LAT5 into account. !!! FIX !!!
 	uint32_t mask = INT_LAT0 << irqline;
-	dsp_control &= ~mask;							// Clear the latch bit
+	dsp_control.WORD &= ~mask;							// Clear the latch bit
 
 	if (state)
 	{
-		dsp_control |= mask;						// Set the latch bit
+		dsp_control.WORD |= mask;						// Set the latch bit
 		DSPHandleIRQsNP();
 	}
 }
@@ -805,7 +930,7 @@ void DSPReset(void)
 	dsp_matrix_control    = 0x00000000;
 	dsp_pointer_to_matrix = 0x00000000;
 	dsp_data_organization = 0xFFFFFFFF;
-	dsp_control			  = 0x00002000;				// Report DSP version 2
+	dsp_control.WORD      = 0x00002000;				// Report DSP version 2
 	dsp_div_control		  = 0x00000000;
 	dsp_in_exec			  = 0;
 
@@ -845,22 +970,23 @@ void DSPExec(int32_t cycles)
 
 	while (cycles > 0 && DSP_RUNNING)
 	{
-      uint16_t opcode;
-      uint32_t index;
-
 		if (IMASKCleared)						// If IMASK was cleared,
 		{
 			DSPHandleIRQsNP();					// See if any other interrupts are pending!
 			IMASKCleared = false;
 		}
 
-		opcode = DSPReadWord(dsp_pc, DSP);
-		index = opcode >> 10;
-		dsp_opcode_first_parameter = (opcode >> 5) & 0x1F;
-		dsp_opcode_second_parameter = opcode & 0x1F;
-		dsp_pc += 2;
-		dsp_opcode[index]();
-		dsp_opcode_use[index]++;
+        OpCode opcode;
+        opcode.WORD = DSPReadWord(dsp_pc, DSP);
+        uint8_t index = opcode.Codes.index;
+        uint8_t fp = opcode.Codes.first;
+        uint8_t sp = opcode.Codes.second;
+        dsp_opcode_first_parameter = fp;
+        dsp_opcode_second_parameter = sp;
+        dsp_pc += 2;
+        dsp_opcode[index]();
+//     Counter is not necessary and expensive -jm prov
+//        dsp_opcode_use[index]++;
 		cycles -= dsp_opcode_cycles[index];
 	}
 

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -889,8 +889,6 @@ INLINE void DSPExec(int32_t cycles)
         dsp_opcode[index]();
         dsp_opcode_use[index]++;
 #endif
-//     Counter is not necessary and expensive -jm prov
-//        dsp_opcode_use[index]++;
 		cycles -= dsp_opcode_cycles[index];
 	}
 
@@ -1955,7 +1953,6 @@ INLINE static void DSP_jr(void)
       }//*/
       dsp_pc += 2;	// For DSP_DIS_* accuracy
       DSPOpcode[pipeline[plPtrExec].opcode]();
-//      dsp_opcode_use[pipeline[plPtrExec].opcode]++;
       pipeline[plPtrWrite] = pipeline[plPtrExec];
 
       // Step 3: Flush pipeline & set new PC

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -129,70 +129,70 @@ bool IMASKCleared = false;
 #define INT_LAT5		0x10000
 
 // Is opcode 62 *really* a NOP? Seems like it...
-static void dsp_opcode_abs(void);
-static void dsp_opcode_add(void);
-static void dsp_opcode_addc(void);
-static void dsp_opcode_addq(void);
-static void dsp_opcode_addqmod(void);
-static void dsp_opcode_addqt(void);
-static void dsp_opcode_and(void);
-static void dsp_opcode_bclr(void);
-static void dsp_opcode_bset(void);
-static void dsp_opcode_btst(void);
-static void dsp_opcode_cmp(void);
-static void dsp_opcode_cmpq(void);
-static void dsp_opcode_div(void);
-static void dsp_opcode_imacn(void);
-static void dsp_opcode_imult(void);
-static void dsp_opcode_imultn(void);
-static void dsp_opcode_jr(void);
-static void dsp_opcode_jump(void);
-static void dsp_opcode_load(void);
-static void dsp_opcode_loadb(void);
-static void dsp_opcode_loadw(void);
-static void dsp_opcode_load_r14_indexed(void);
-static void dsp_opcode_load_r14_ri(void);
-static void dsp_opcode_load_r15_indexed(void);
-static void dsp_opcode_load_r15_ri(void);
-static void dsp_opcode_mirror(void);
-static void dsp_opcode_mmult(void);
-static void dsp_opcode_move(void);
-static void dsp_opcode_movei(void);
-static void dsp_opcode_movefa(void);
-static void dsp_opcode_move_pc(void);
-static void dsp_opcode_moveq(void);
-static void dsp_opcode_moveta(void);
-static void dsp_opcode_mtoi(void);
-static void dsp_opcode_mult(void);
-static void dsp_opcode_neg(void);
-static void dsp_opcode_nop(void);
-static void dsp_opcode_normi(void);
-static void dsp_opcode_not(void);
-static void dsp_opcode_or(void);
-static void dsp_opcode_resmac(void);
-static void dsp_opcode_ror(void);
-static void dsp_opcode_rorq(void);
-static void dsp_opcode_xor(void);
-static void dsp_opcode_sat16s(void);
-static void dsp_opcode_sat32s(void);
-static void dsp_opcode_sh(void);
-static void dsp_opcode_sha(void);
-static void dsp_opcode_sharq(void);
-static void dsp_opcode_shlq(void);
-static void dsp_opcode_shrq(void);
-static void dsp_opcode_store(void);
-static void dsp_opcode_storeb(void);
-static void dsp_opcode_storew(void);
-static void dsp_opcode_store_r14_indexed(void);
-static void dsp_opcode_store_r14_ri(void);
-static void dsp_opcode_store_r15_indexed(void);
-static void dsp_opcode_store_r15_ri(void);
-static void dsp_opcode_sub(void);
-static void dsp_opcode_subc(void);
-static void dsp_opcode_subq(void);
-static void dsp_opcode_subqmod(void);
-static void dsp_opcode_subqt(void);
-static void dsp_opcode_illegal(void);
+INLINE static void dsp_opcode_abs(void);
+INLINE static void dsp_opcode_add(void);
+INLINE static void dsp_opcode_addc(void);
+INLINE static void dsp_opcode_addq(void);
+INLINE static void dsp_opcode_addqmod(void);
+INLINE static void dsp_opcode_addqt(void);
+INLINE static void dsp_opcode_and(void);
+INLINE static void dsp_opcode_bclr(void);
+INLINE static void dsp_opcode_bset(void);
+INLINE static void dsp_opcode_btst(void);
+INLINE static void dsp_opcode_cmp(void);
+INLINE static void dsp_opcode_cmpq(void);
+INLINE static void dsp_opcode_div(void);
+INLINE static void dsp_opcode_imacn(void);
+INLINE static void dsp_opcode_imult(void);
+INLINE static void dsp_opcode_imultn(void);
+INLINE static void dsp_opcode_jr(void);
+INLINE static void dsp_opcode_jump(void);
+INLINE static void dsp_opcode_load(void);
+INLINE static void dsp_opcode_loadb(void);
+INLINE static void dsp_opcode_loadw(void);
+INLINE static void dsp_opcode_load_r14_indexed(void);
+INLINE static void dsp_opcode_load_r14_ri(void);
+INLINE static void dsp_opcode_load_r15_indexed(void);
+INLINE static void dsp_opcode_load_r15_ri(void);
+INLINE static void dsp_opcode_mirror(void);
+INLINE static void dsp_opcode_mmult(void);
+INLINE static void dsp_opcode_move(void);
+INLINE static void dsp_opcode_movei(void);
+INLINE static void dsp_opcode_movefa(void);
+INLINE static void dsp_opcode_move_pc(void);
+INLINE static void dsp_opcode_moveq(void);
+INLINE static void dsp_opcode_moveta(void);
+INLINE static void dsp_opcode_mtoi(void);
+INLINE static void dsp_opcode_mult(void);
+INLINE static void dsp_opcode_neg(void);
+INLINE static void dsp_opcode_nop(void);
+INLINE static void dsp_opcode_normi(void);
+INLINE static void dsp_opcode_not(void);
+INLINE static void dsp_opcode_or(void);
+INLINE static void dsp_opcode_resmac(void);
+INLINE static void dsp_opcode_ror(void);
+INLINE static void dsp_opcode_rorq(void);
+INLINE static void dsp_opcode_xor(void);
+INLINE static void dsp_opcode_sat16s(void);
+INLINE static void dsp_opcode_sat32s(void);
+INLINE static void dsp_opcode_sh(void);
+INLINE static void dsp_opcode_sha(void);
+INLINE static void dsp_opcode_sharq(void);
+INLINE static void dsp_opcode_shlq(void);
+INLINE static void dsp_opcode_shrq(void);
+INLINE static void dsp_opcode_store(void);
+INLINE static void dsp_opcode_storeb(void);
+INLINE static void dsp_opcode_storew(void);
+INLINE static void dsp_opcode_store_r14_indexed(void);
+INLINE static void dsp_opcode_store_r14_ri(void);
+INLINE static void dsp_opcode_store_r15_indexed(void);
+INLINE static void dsp_opcode_store_r15_ri(void);
+INLINE static void dsp_opcode_sub(void);
+INLINE static void dsp_opcode_subc(void);
+INLINE static void dsp_opcode_subq(void);
+INLINE static void dsp_opcode_subqmod(void);
+INLINE static void dsp_opcode_subqt(void);
+INLINE static void dsp_opcode_illegal(void);
 
 //Here's a QnD kludge...
 //This is wrong, wrong, WRONG, but it seems to work for the time being...
@@ -264,125 +264,6 @@ static uint32_t dsp_flags;
 static uint32_t dsp_matrix_control;
 static uint32_t dsp_pointer_to_matrix;
 static uint32_t dsp_data_organization;
-
-typedef union Bits32 {
-    uint32_t WORD;
-    struct bits {
-#ifdef LITTLE_ENDIAN
-        unsigned int b0: 1;
-        unsigned int b1: 1;
-        unsigned int b2: 1;
-        unsigned int b3: 1;
-        unsigned int b4: 1;
-        unsigned int b5: 1;
-        unsigned int b6: 1;
-        unsigned int b7: 1;
-        unsigned int b8: 1;
-        unsigned int b9: 1;
-        unsigned int b10: 1;
-        unsigned int b11: 1;
-        unsigned int b12: 1;
-        unsigned int b13: 1;
-        unsigned int b14: 1;
-        unsigned int b15: 1;
-        unsigned int b16: 1;
-        unsigned int b17: 1;
-        unsigned int b18: 1;
-        unsigned int b19: 1;
-        unsigned int b20: 1;
-        unsigned int b21: 1;
-        unsigned int b22: 1;
-        unsigned int b23: 1;
-        unsigned int b24: 1;
-        unsigned int b25: 1;
-        unsigned int b26: 1;
-        unsigned int b27: 1;
-        unsigned int b28: 1;
-        unsigned int b29: 1;
-        unsigned int b30: 1;
-        unsigned int b31: 1;
-#else
-        // reverse the order of the bit fields.
-        unsigned int b31: 1;
-        unsigned int b30: 1;
-        unsigned int b29: 1;
-        unsigned int b28: 1;
-        unsigned int b27: 1;
-        unsigned int b26: 1;
-        unsigned int b25: 1;
-        unsigned int b24: 1;
-        unsigned int b23: 1;
-        unsigned int b22: 1;
-        unsigned int b21: 1;
-        unsigned int b20: 1;
-        unsigned int b19: 1;
-        unsigned int b18: 1;
-        unsigned int b17: 1;
-        unsigned int b16: 1;
-        unsigned int b15: 1;
-        unsigned int b14: 1;
-        unsigned int b13: 1;
-        unsigned int b12: 1;
-        unsigned int b11: 1;
-        unsigned int b10: 1;
-        unsigned int b9: 1;
-        unsigned int b8: 1;
-        unsigned int b7: 1;
-        unsigned int b6: 1;
-        unsigned int b5: 1;
-        unsigned int b4: 1;
-        unsigned int b3: 1;
-        unsigned int b2: 1;
-        unsigned int b1: 1;
-        unsigned int b0: 1;
-#endif
-    } bits;
-} Bits32;
-
-typedef union OpCode {
-    uint16_t WORD;
-#pragma pack(push, 1)
-    struct Codes {
-#ifdef LITTLE_ENDIAN
-        unsigned int second : 5;
-        unsigned int first : 5;
-        unsigned int index : 6;
-#else
-        unsigned int index : 6;
-        unsigned int first : 5;
-        unsigned int second : 5;
-#endif
-    } Codes;
-#pragma pack(pop)
-} OpCode;
-
-typedef union Offset {
-    uint32_t LONG;
-#pragma pack(push, 1)
-    struct Members {
-#ifdef LITTLE_ENDIAN
-        unsigned int offset : 31;
-        unsigned int bit : 1;
-#else
-        unsigned int bit : 1;
-        unsigned int offset : 31;
-#endif
-    } Members;
-#pragma pack(pop)
-} Offset;
-
-typedef union DSPLong {
-    uint32_t LONG;
-    struct Data {
-#ifdef LITTLE_ENDIAN
-        uint16_t LWORD;
-        uint16_t UWORD;
-#else
-        uint16_t UWORD;
-        uint16_t LWORD;
-#endif
-    } Data;
-} DSPLong;
 
 Bits32 dsp_control;
 static uint32_t dsp_div_control;
@@ -520,8 +401,8 @@ uint16_t DSPReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
 	if (offset >= DSP_WORK_RAM_BASE && offset <= DSP_WORK_RAM_BASE+0x1FFF)
 	{
 		offset -= DSP_WORK_RAM_BASE;
-		return GET16(dsp_ram_8, offset);
-	}
+        return GET16(dsp_ram_8, offset);
+    }
 	else if ((offset>=DSP_CONTROL_RAM_BASE)&&(offset<DSP_CONTROL_RAM_BASE+0x20))
 	{
         DSPLong data;
@@ -998,7 +879,7 @@ void DSPExec(int32_t cycles)
 // There is a problem here with interrupt handlers the JUMP and JR instructions that
 // can cause trouble because an interrupt can occur *before* the instruction following the
 // jump can execute... !!! FIX !!!
-static void dsp_opcode_jump(void)
+INLINE static void dsp_opcode_jump(void)
 {
 	// normalize flags
 /*	dsp_flag_c=dsp_flag_c?1:0;
@@ -1016,7 +897,7 @@ static void dsp_opcode_jump(void)
 }
 
 
-static void dsp_opcode_jr(void)
+INLINE static void dsp_opcode_jr(void)
 {
 	// normalize flags
 /*	dsp_flag_c=dsp_flag_c?1:0;
@@ -1035,7 +916,7 @@ static void dsp_opcode_jr(void)
 }
 
 
-static void dsp_opcode_add(void)
+INLINE static void dsp_opcode_add(void)
 {
 	uint32_t res = RN + RM;
 	SET_ZNC_ADD(RN, RM, res);
@@ -1043,7 +924,7 @@ static void dsp_opcode_add(void)
 }
 
 
-static void dsp_opcode_addc(void)
+INLINE static void dsp_opcode_addc(void)
 {
 	uint32_t res = RN + RM + dsp_flag_c;
 	uint32_t carry = dsp_flag_c;
@@ -1052,7 +933,7 @@ static void dsp_opcode_addc(void)
 }
 
 
-static void dsp_opcode_addq(void)
+INLINE static void dsp_opcode_addq(void)
 {
 	uint32_t r1 = dsp_convert_zero[IMM_1];
 	uint32_t res = RN + r1;
@@ -1061,7 +942,7 @@ static void dsp_opcode_addq(void)
 }
 
 
-static void dsp_opcode_sub(void)
+INLINE static void dsp_opcode_sub(void)
 {
 	uint32_t res = RN - RM;
 	SET_ZNC_SUB(RN, RM, res);
@@ -1069,7 +950,7 @@ static void dsp_opcode_sub(void)
 }
 
 
-static void dsp_opcode_subc(void)
+INLINE static void dsp_opcode_subc(void)
 {
 	// This is how the DSP ALU does it--Two's complement with inverted carry
 	uint64_t res = (uint64_t)RN + (uint64_t)(RM ^ 0xFFFFFFFF) + (dsp_flag_c ^ 1);
@@ -1080,7 +961,7 @@ static void dsp_opcode_subc(void)
 }
 
 
-static void dsp_opcode_subq(void)
+INLINE static void dsp_opcode_subq(void)
 {
 	uint32_t r1 = dsp_convert_zero[IMM_1];
 	uint32_t res = RN - r1;
@@ -1089,14 +970,14 @@ static void dsp_opcode_subq(void)
 }
 
 
-static void dsp_opcode_cmp(void)
+INLINE static void dsp_opcode_cmp(void)
 {
 	uint32_t res = RN - RM;
 	SET_ZNC_SUB(RN, RM, res);
 }
 
 
-static void dsp_opcode_cmpq(void)
+INLINE static void dsp_opcode_cmpq(void)
 {
 	static int32_t sqtable[32] =
 		{ 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,-16,-15,-14,-13,-12,-11,-10,-9,-8,-7,-6,-5,-4,-3,-2,-1 };
@@ -1106,41 +987,41 @@ static void dsp_opcode_cmpq(void)
 }
 
 
-static void dsp_opcode_and(void)
+INLINE static void dsp_opcode_and(void)
 {
 	RN = RN & RM;
 	SET_ZN(RN);
 }
 
 
-static void dsp_opcode_or(void)
+INLINE static void dsp_opcode_or(void)
 {
 	RN = RN | RM;
 	SET_ZN(RN);
 }
 
 
-static void dsp_opcode_xor(void)
+INLINE static void dsp_opcode_xor(void)
 {
 	RN = RN ^ RM;
 	SET_ZN(RN);
 }
 
 
-static void dsp_opcode_not(void)
+INLINE static void dsp_opcode_not(void)
 {
 	RN = ~RN;
 	SET_ZN(RN);
 }
 
 
-static void dsp_opcode_move_pc(void)
+INLINE static void dsp_opcode_move_pc(void)
 {
 	RN = dsp_pc - 2;
 }
 
 
-static void dsp_opcode_store_r14_indexed(void)
+INLINE static void dsp_opcode_store_r14_indexed(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT_STORE
 	DSPWriteLong((dsp_reg[14] & 0xFFFFFFFC) + (dsp_convert_zero[IMM_1] << 2), RN, DSP);
@@ -1150,7 +1031,7 @@ static void dsp_opcode_store_r14_indexed(void)
 }
 
 
-static void dsp_opcode_store_r15_indexed(void)
+INLINE static void dsp_opcode_store_r15_indexed(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT_STORE
 	DSPWriteLong((dsp_reg[15] & 0xFFFFFFFC) + (dsp_convert_zero[IMM_1] << 2), RN, DSP);
@@ -1160,7 +1041,7 @@ static void dsp_opcode_store_r15_indexed(void)
 }
 
 
-static void dsp_opcode_load_r14_ri(void)
+INLINE static void dsp_opcode_load_r14_ri(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	RN = DSPReadLong((dsp_reg[14] + RM) & 0xFFFFFFFC, DSP);
@@ -1170,7 +1051,7 @@ static void dsp_opcode_load_r14_ri(void)
 }
 
 
-static void dsp_opcode_load_r15_ri(void)
+INLINE static void dsp_opcode_load_r15_ri(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	RN = DSPReadLong((dsp_reg[15] + RM) & 0xFFFFFFFC, DSP);
@@ -1180,24 +1061,24 @@ static void dsp_opcode_load_r15_ri(void)
 }
 
 
-static void dsp_opcode_store_r14_ri(void)
+INLINE static void dsp_opcode_store_r14_ri(void)
 {
 	DSPWriteLong(dsp_reg[14] + RM, RN, DSP);
 }
 
 
-static void dsp_opcode_store_r15_ri(void)
+INLINE static void dsp_opcode_store_r15_ri(void)
 {
 	DSPWriteLong(dsp_reg[15] + RM, RN, DSP);
 }
 
 
-static void dsp_opcode_nop(void)
+INLINE static void dsp_opcode_nop(void)
 {
 }
 
 
-static void dsp_opcode_storeb(void)
+INLINE static void dsp_opcode_storeb(void)
 {
 	if (RM >= DSP_WORK_RAM_BASE && RM <= (DSP_WORK_RAM_BASE + 0x1FFF))
 		DSPWriteLong(RM, RN & 0xFF, DSP);
@@ -1206,7 +1087,7 @@ static void dsp_opcode_storeb(void)
 }
 
 
-static void dsp_opcode_storew(void)
+INLINE static void dsp_opcode_storew(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT_STORE
 	if (RM >= DSP_WORK_RAM_BASE && RM <= (DSP_WORK_RAM_BASE + 0x1FFF))
@@ -1222,7 +1103,7 @@ static void dsp_opcode_storew(void)
 }
 
 
-static void dsp_opcode_store(void)
+INLINE static void dsp_opcode_store(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT_STORE
 	DSPWriteLong(RM & 0xFFFFFFFC, RN, DSP);
@@ -1232,7 +1113,7 @@ static void dsp_opcode_store(void)
 }
 
 
-static void dsp_opcode_loadb(void)
+INLINE static void dsp_opcode_loadb(void)
 {
 	if (RM >= DSP_WORK_RAM_BASE && RM <= (DSP_WORK_RAM_BASE + 0x1FFF))
 		RN = DSPReadLong(RM, DSP) & 0xFF;
@@ -1241,7 +1122,7 @@ static void dsp_opcode_loadb(void)
 }
 
 
-static void dsp_opcode_loadw(void)
+INLINE static void dsp_opcode_loadw(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	if (RM >= DSP_WORK_RAM_BASE && RM <= (DSP_WORK_RAM_BASE + 0x1FFF))
@@ -1257,7 +1138,7 @@ static void dsp_opcode_loadw(void)
 }
 
 
-static void dsp_opcode_load(void)
+INLINE static void dsp_opcode_load(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	RN = DSPReadLong(RM & 0xFFFFFFFC, DSP);
@@ -1267,7 +1148,7 @@ static void dsp_opcode_load(void)
 }
 
 
-static void dsp_opcode_load_r14_indexed(void)
+INLINE static void dsp_opcode_load_r14_indexed(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	RN = DSPReadLong((dsp_reg[14] & 0xFFFFFFFC) + (dsp_convert_zero[IMM_1] << 2), DSP);
@@ -1277,7 +1158,7 @@ static void dsp_opcode_load_r14_indexed(void)
 }
 
 
-static void dsp_opcode_load_r15_indexed(void)
+INLINE static void dsp_opcode_load_r15_indexed(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	RN = DSPReadLong((dsp_reg[15] & 0xFFFFFFFC) + (dsp_convert_zero[IMM_1] << 2), DSP);
@@ -1287,7 +1168,7 @@ static void dsp_opcode_load_r15_indexed(void)
 }
 
 
-static void dsp_opcode_movei(void)
+INLINE static void dsp_opcode_movei(void)
 {
 	// This instruction is followed by 32-bit value in LSW / MSW format...
 	RN = (uint32_t)DSPReadWord(dsp_pc, DSP) | ((uint32_t)DSPReadWord(dsp_pc + 2, DSP) << 16);
@@ -1295,51 +1176,51 @@ static void dsp_opcode_movei(void)
 }
 
 
-static void dsp_opcode_moveta(void)
+INLINE static void dsp_opcode_moveta(void)
 {
 	ALTERNATE_RN = RM;
 }
 
 
-static void dsp_opcode_movefa(void)
+INLINE static void dsp_opcode_movefa(void)
 {
 	RN = ALTERNATE_RM;
 }
 
 
-static void dsp_opcode_move(void)
+INLINE static void dsp_opcode_move(void)
 {
 	RN = RM;
 }
 
 
-static void dsp_opcode_moveq(void)
+INLINE static void dsp_opcode_moveq(void)
 {
 	RN = IMM_1;
 }
 
 
-static void dsp_opcode_resmac(void)
+INLINE static void dsp_opcode_resmac(void)
 {
 	RN = (uint32_t)dsp_acc;
 }
 
 
-static void dsp_opcode_imult(void)
+INLINE static void dsp_opcode_imult(void)
 {
 	RN = (int16_t)RN * (int16_t)RM;
 	SET_ZN(RN);
 }
 
 
-static void dsp_opcode_mult(void)
+INLINE static void dsp_opcode_mult(void)
 {
 	RN = (uint16_t)RM * (uint16_t)RN;
 	SET_ZN(RN);
 }
 
 
-static void dsp_opcode_bclr(void)
+INLINE static void dsp_opcode_bclr(void)
 {
 	uint32_t res = RN & ~(1 << IMM_1);
 	RN = res;
@@ -1347,13 +1228,13 @@ static void dsp_opcode_bclr(void)
 }
 
 
-static void dsp_opcode_btst(void)
+INLINE static void dsp_opcode_btst(void)
 {
 	dsp_flag_z = (~RN >> IMM_1) & 1;
 }
 
 
-static void dsp_opcode_bset(void)
+INLINE static void dsp_opcode_bset(void)
 {
 	uint32_t res = RN | (1 << IMM_1);
 	RN = res;
@@ -1361,19 +1242,19 @@ static void dsp_opcode_bset(void)
 }
 
 
-static void dsp_opcode_subqt(void)
+INLINE static void dsp_opcode_subqt(void)
 {
 	RN -= dsp_convert_zero[IMM_1];
 }
 
 
-static void dsp_opcode_addqt(void)
+INLINE static void dsp_opcode_addqt(void)
 {
 	RN += dsp_convert_zero[IMM_1];
 }
 
 
-static void dsp_opcode_imacn(void)
+INLINE static void dsp_opcode_imacn(void)
 {
 	int32_t res = (int16_t)RM * (int16_t)RN;
 	dsp_acc += (int64_t)res;
@@ -1381,14 +1262,14 @@ static void dsp_opcode_imacn(void)
 }
 
 
-static void dsp_opcode_mtoi(void)
+INLINE static void dsp_opcode_mtoi(void)
 {
 	RN = (((int32_t)RM >> 8) & 0xFF800000) | (RM & 0x007FFFFF);
 	SET_ZN(RN);
 }
 
 
-static void dsp_opcode_normi(void)
+INLINE static void dsp_opcode_normi(void)
 {
 	uint32_t _Rm = RM;
 	uint32_t res = 0;
@@ -1411,7 +1292,7 @@ static void dsp_opcode_normi(void)
 }
 
 
-static void dsp_opcode_mmult(void)
+INLINE static void dsp_opcode_mmult(void)
 {
    uint32_t res;
    unsigned i;
@@ -1458,7 +1339,7 @@ static void dsp_opcode_mmult(void)
 }
 
 
-static void dsp_opcode_abs(void)
+INLINE static void dsp_opcode_abs(void)
 {
 	uint32_t _Rn = RN;
 
@@ -1476,7 +1357,7 @@ static void dsp_opcode_abs(void)
 }
 
 
-static void dsp_opcode_div(void)
+INLINE static void dsp_opcode_div(void)
 {
    unsigned i;
 	// Real algorithm, courtesy of SCPCD: NYAN!
@@ -1501,7 +1382,7 @@ static void dsp_opcode_div(void)
 }
 
 
-static void dsp_opcode_imultn(void)
+INLINE static void dsp_opcode_imultn(void)
 {
 	// This is OK, since this multiply won't overflow 32 bits...
 	int32_t res = (int32_t)((int16_t)RN * (int16_t)RM);
@@ -1510,7 +1391,7 @@ static void dsp_opcode_imultn(void)
 }
 
 
-static void dsp_opcode_neg(void)
+INLINE static void dsp_opcode_neg(void)
 {
 	uint32_t res = -RN;
 	SET_ZNC_SUB(0, RN, res);
@@ -1518,7 +1399,7 @@ static void dsp_opcode_neg(void)
 }
 
 
-static void dsp_opcode_shlq(void)
+INLINE static void dsp_opcode_shlq(void)
 {
 	// NB: This instruction is the *only* one that does (32 - immediate data).
 	int32_t r1 = 32 - IMM_1;
@@ -1528,7 +1409,7 @@ static void dsp_opcode_shlq(void)
 }
 
 
-static void dsp_opcode_shrq(void)
+INLINE static void dsp_opcode_shrq(void)
 {
 	int32_t r1 = dsp_convert_zero[IMM_1];
 	uint32_t res = RN >> r1;
@@ -1537,7 +1418,7 @@ static void dsp_opcode_shrq(void)
 }
 
 
-static void dsp_opcode_ror(void)
+INLINE static void dsp_opcode_ror(void)
 {
 	uint32_t r1 = RM & 0x1F;
 	uint32_t res = (RN >> r1) | (RN << (32 - r1));
@@ -1546,7 +1427,7 @@ static void dsp_opcode_ror(void)
 }
 
 
-static void dsp_opcode_rorq(void)
+INLINE static void dsp_opcode_rorq(void)
 {
 	uint32_t r1 = dsp_convert_zero[IMM_1 & 0x1F];
 	uint32_t r2 = RN;
@@ -1556,7 +1437,7 @@ static void dsp_opcode_rorq(void)
 }
 
 
-static void dsp_opcode_sha(void)
+INLINE static void dsp_opcode_sha(void)
 {
 	int32_t sRm=(int32_t)RM;
 	uint32_t _Rn=RN;
@@ -1588,7 +1469,7 @@ static void dsp_opcode_sha(void)
 }
 
 
-static void dsp_opcode_sharq(void)
+INLINE static void dsp_opcode_sharq(void)
 {
 	uint32_t res = (int32_t)RN >> dsp_convert_zero[IMM_1];
 	SET_ZN(res); dsp_flag_c = RN & 0x01;
@@ -1596,7 +1477,7 @@ static void dsp_opcode_sharq(void)
 }
 
 
-static void dsp_opcode_sh(void)
+INLINE static void dsp_opcode_sh(void)
 {
 	int32_t sRm=(int32_t)RM;
 	uint32_t _Rn=RN;
@@ -1678,70 +1559,70 @@ void dsp_opcode_illegal(void)
 
 /* New pipelined DSP core */
 
-static void DSP_abs(void);
-static void DSP_add(void);
-static void DSP_addc(void);
-static void DSP_addq(void);
-static void DSP_addqmod(void);
-static void DSP_addqt(void);
-static void DSP_and(void);
-static void DSP_bclr(void);
-static void DSP_bset(void);
-static void DSP_btst(void);
-static void DSP_cmp(void);
-static void DSP_cmpq(void);
-static void DSP_div(void);
-static void DSP_imacn(void);
-static void DSP_imult(void);
-static void DSP_imultn(void);
-static void DSP_illegal(void);
-static void DSP_jr(void);
-static void DSP_jump(void);
-static void DSP_load(void);
-static void DSP_loadb(void);
-static void DSP_loadw(void);
-static void DSP_load_r14_i(void);
-static void DSP_load_r14_r(void);
-static void DSP_load_r15_i(void);
-static void DSP_load_r15_r(void);
-static void DSP_mirror(void);
-static void DSP_mmult(void);
-static void DSP_move(void);
-static void DSP_movefa(void);
-static void DSP_movei(void);
-static void DSP_movepc(void);
-static void DSP_moveq(void);
-static void DSP_moveta(void);
-static void DSP_mtoi(void);
-static void DSP_mult(void);
-static void DSP_neg(void);
-static void DSP_nop(void);
-static void DSP_normi(void);
-static void DSP_not(void);
-static void DSP_or(void);
-static void DSP_resmac(void);
-static void DSP_ror(void);
-static void DSP_rorq(void);
-static void DSP_sat16s(void);
-static void DSP_sat32s(void);
-static void DSP_sh(void);
-static void DSP_sha(void);
-static void DSP_sharq(void);
-static void DSP_shlq(void);
-static void DSP_shrq(void);
-static void DSP_store(void);
-static void DSP_storeb(void);
-static void DSP_storew(void);
-static void DSP_store_r14_i(void);
-static void DSP_store_r14_r(void);
-static void DSP_store_r15_i(void);
-static void DSP_store_r15_r(void);
-static void DSP_sub(void);
-static void DSP_subc(void);
-static void DSP_subq(void);
-static void DSP_subqmod(void);
-static void DSP_subqt(void);
-static void DSP_xor(void);
+INLINE static void DSP_abs(void);
+INLINE static void DSP_add(void);
+INLINE static void DSP_addc(void);
+INLINE static void DSP_addq(void);
+INLINE static void DSP_addqmod(void);
+INLINE static void DSP_addqt(void);
+INLINE static void DSP_and(void);
+INLINE static void DSP_bclr(void);
+INLINE static void DSP_bset(void);
+INLINE static void DSP_btst(void);
+INLINE static void DSP_cmp(void);
+INLINE static void DSP_cmpq(void);
+INLINE static void DSP_div(void);
+INLINE static void DSP_imacn(void);
+INLINE static void DSP_imult(void);
+INLINE static void DSP_imultn(void);
+INLINE static void DSP_illegal(void);
+INLINE static void DSP_jr(void);
+INLINE static void DSP_jump(void);
+INLINE static void DSP_load(void);
+INLINE static void DSP_loadb(void);
+INLINE static void DSP_loadw(void);
+INLINE static void DSP_load_r14_i(void);
+INLINE static void DSP_load_r14_r(void);
+INLINE static void DSP_load_r15_i(void);
+INLINE static void DSP_load_r15_r(void);
+INLINE static void DSP_mirror(void);
+INLINE static void DSP_mmult(void);
+INLINE static void DSP_move(void);
+INLINE static void DSP_movefa(void);
+INLINE static void DSP_movei(void);
+INLINE static void DSP_movepc(void);
+INLINE static void DSP_moveq(void);
+INLINE static void DSP_moveta(void);
+INLINE static void DSP_mtoi(void);
+INLINE static void DSP_mult(void);
+INLINE static void DSP_neg(void);
+INLINE static void DSP_nop(void);
+INLINE static void DSP_normi(void);
+INLINE static void DSP_not(void);
+INLINE static void DSP_or(void);
+INLINE static void DSP_resmac(void);
+INLINE static void DSP_ror(void);
+INLINE static void DSP_rorq(void);
+INLINE static void DSP_sat16s(void);
+INLINE static void DSP_sat32s(void);
+INLINE static void DSP_sh(void);
+INLINE static void DSP_sha(void);
+INLINE static void DSP_sharq(void);
+INLINE static void DSP_shlq(void);
+INLINE static void DSP_shrq(void);
+INLINE static void DSP_store(void);
+INLINE static void DSP_storeb(void);
+INLINE static void DSP_storew(void);
+INLINE static void DSP_store_r14_i(void);
+INLINE static void DSP_store_r14_r(void);
+INLINE static void DSP_store_r15_i(void);
+INLINE static void DSP_store_r15_r(void);
+INLINE static void DSP_sub(void);
+INLINE static void DSP_subc(void);
+INLINE static void DSP_subq(void);
+INLINE static void DSP_subqmod(void);
+INLINE static void DSP_subqt(void);
+INLINE static void DSP_xor(void);
 
 void (* DSPOpcode[64])() =
 {
@@ -1833,7 +1714,7 @@ static uint32_t prevR1;
 #define DSP_PPC			dsp_pc - (pipeline[plPtrRead].opcode == 38 ? 6 : (pipeline[plPtrRead].opcode == PIPELINE_STALL ? 0 : 2)) - (pipeline[plPtrExec].opcode == 38 ? 6 : (pipeline[plPtrExec].opcode == PIPELINE_STALL ? 0 : 2))
 #define WRITEBACK_ADDR	pipeline[plPtrExec].writebackRegister = 0xFE
 
-static void DSP_abs(void)
+INLINE static void DSP_abs(void)
 {
 	uint32_t _Rn = PRN;
 
@@ -1847,14 +1728,14 @@ static void DSP_abs(void)
 	}
 }
 
-static void DSP_add(void)
+INLINE static void DSP_add(void)
 {
 	uint32_t res = PRN + PRM;
 	SET_ZNC_ADD(PRN, PRM, res);
 	PRES = res;
 }
 
-static void DSP_addc(void)
+INLINE static void DSP_addc(void)
 {
 	uint32_t res = PRN + PRM + dsp_flag_c;
 	uint32_t carry = dsp_flag_c;
@@ -1862,7 +1743,7 @@ static void DSP_addc(void)
 	PRES = res;
 }
 
-static void DSP_addq(void)
+INLINE static void DSP_addq(void)
 {
 	uint32_t r1 = dsp_convert_zero[PIMM1];
 	uint32_t res = PRN + r1;
@@ -1870,7 +1751,7 @@ static void DSP_addq(void)
 	PRES = res;
 }
 
-static void DSP_addqmod(void)
+INLINE static void DSP_addqmod(void)
 {
 	uint32_t r1 = dsp_convert_zero[PIMM1];
 	uint32_t r2 = PRN;
@@ -1880,43 +1761,43 @@ static void DSP_addqmod(void)
 	SET_ZNC_ADD(r2, r1, res);
 }
 
-static void DSP_addqt(void)
+INLINE static void DSP_addqt(void)
 {
 	PRES = PRN + dsp_convert_zero[PIMM1];
 }
 
-static void DSP_and(void)
+INLINE static void DSP_and(void)
 {
 	PRES = PRN & PRM;
 	SET_ZN(PRES);
 }
 
-static void DSP_bclr(void)
+INLINE static void DSP_bclr(void)
 {
 	PRES = PRN & ~(1 << PIMM1);
 	SET_ZN(PRES);
 }
 
-static void DSP_bset(void)
+INLINE static void DSP_bset(void)
 {
 	PRES = PRN | (1 << PIMM1);
 	SET_ZN(PRES);
 }
 
-static void DSP_btst(void)
+INLINE static void DSP_btst(void)
 {
 	dsp_flag_z = (~PRN >> PIMM1) & 1;
 	NO_WRITEBACK;
 }
 
-static void DSP_cmp(void)
+INLINE static void DSP_cmp(void)
 {
 	uint32_t res = PRN - PRM;
 	SET_ZNC_SUB(PRN, PRM, res);
 	NO_WRITEBACK;
 }
 
-static void DSP_cmpq(void)
+INLINE static void DSP_cmpq(void)
 {
 	static int32_t sqtable[32] =
 		{ 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,-16,-15,-14,-13,-12,-11,-10,-9,-8,-7,-6,-5,-4,-3,-2,-1 };
@@ -1926,7 +1807,7 @@ static void DSP_cmpq(void)
 	NO_WRITEBACK;
 }
 
-static void DSP_div(void)
+INLINE static void DSP_div(void)
 {
 	uint32_t _Rm = PRM, _Rn = PRN;
 
@@ -1951,7 +1832,7 @@ static void DSP_div(void)
 		PRES = 0xFFFFFFFF;
 }
 
-static void DSP_imacn(void)
+INLINE static void DSP_imacn(void)
 {
 	int32_t res = (int16_t)PRM * (int16_t)PRN;
 	dsp_acc += (int64_t)res;
@@ -1959,13 +1840,13 @@ static void DSP_imacn(void)
 	NO_WRITEBACK;
 }
 
-static void DSP_imult(void)
+INLINE static void DSP_imult(void)
 {
 	PRES = (int16_t)PRN * (int16_t)PRM;
 	SET_ZN(PRES);
 }
 
-static void DSP_imultn(void)
+INLINE static void DSP_imultn(void)
 {
 	// This is OK, since this multiply won't overflow 32 bits...
 	int32_t res = (int32_t)((int16_t)PRN * (int16_t)PRM);
@@ -1974,7 +1855,7 @@ static void DSP_imultn(void)
 	NO_WRITEBACK;
 }
 
-static void DSP_illegal(void)
+INLINE static void DSP_illegal(void)
 {
 	NO_WRITEBACK;
 }
@@ -1984,7 +1865,7 @@ static void DSP_illegal(void)
 // jump can execute... !!! FIX !!!
 // This can probably be solved by judicious coding in the pipeline execution core...
 // And should be fixed now...
-static void DSP_jr(void)
+INLINE static void DSP_jr(void)
 {
    // KLUDGE: Used by BRANCH_CONDITION macro
    uint32_t jaguar_flags = (dsp_flag_n << 2) | (dsp_flag_c << 1) | dsp_flag_z;
@@ -2062,7 +1943,7 @@ static void DSP_jr(void)
       NO_WRITEBACK;
 }
 
-static void DSP_jump(void)
+INLINE static void DSP_jump(void)
 {
 	// KLUDGE: Used by BRANCH_CONDITION macro
 	uint32_t jaguar_flags = (dsp_flag_n << 2) | (dsp_flag_c << 1) | dsp_flag_z;
@@ -2138,7 +2019,7 @@ static void DSP_jump(void)
 		NO_WRITEBACK;
 }
 
-static void DSP_load(void)
+INLINE static void DSP_load(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	PRES = DSPReadLong(PRM & 0xFFFFFFFC, DSP);
@@ -2147,7 +2028,7 @@ static void DSP_load(void)
 #endif
 }
 
-static void DSP_loadb(void)
+INLINE static void DSP_loadb(void)
 {
 	if (PRM >= DSP_WORK_RAM_BASE && PRM <= (DSP_WORK_RAM_BASE + 0x1FFF))
 		PRES = DSPReadLong(PRM, DSP) & 0xFF;
@@ -2155,7 +2036,7 @@ static void DSP_loadb(void)
 		PRES = JaguarReadByte(PRM, DSP);
 }
 
-static void DSP_loadw(void)
+INLINE static void DSP_loadw(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	if (PRM >= DSP_WORK_RAM_BASE && PRM <= (DSP_WORK_RAM_BASE + 0x1FFF))
@@ -2170,7 +2051,7 @@ static void DSP_loadw(void)
 #endif
 }
 
-static void DSP_load_r14_i(void)
+INLINE static void DSP_load_r14_i(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	PRES = DSPReadLong((dsp_reg[14] & 0xFFFFFFFC) + (dsp_convert_zero[PIMM1] << 2), DSP);
@@ -2179,7 +2060,7 @@ static void DSP_load_r14_i(void)
 #endif
 }
 
-static void DSP_load_r14_r(void)
+INLINE static void DSP_load_r14_r(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	PRES = DSPReadLong((dsp_reg[14] + PRM) & 0xFFFFFFFC, DSP);
@@ -2188,7 +2069,7 @@ static void DSP_load_r14_r(void)
 #endif
 }
 
-static void DSP_load_r15_i(void)
+INLINE static void DSP_load_r15_i(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	PRES = DSPReadLong((dsp_reg[15] &0xFFFFFFFC) + (dsp_convert_zero[PIMM1] << 2), DSP);
@@ -2197,7 +2078,7 @@ static void DSP_load_r15_i(void)
 #endif
 }
 
-static void DSP_load_r15_r(void)
+INLINE static void DSP_load_r15_r(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT
 	PRES = DSPReadLong((dsp_reg[15] + PRM) & 0xFFFFFFFC, DSP);
@@ -2206,14 +2087,14 @@ static void DSP_load_r15_r(void)
 #endif
 }
 
-static void DSP_mirror(void)
+INLINE static void DSP_mirror(void)
 {
 	uint32_t r1 = PRN;
 	PRES = (mirror_table[r1 & 0xFFFF] << 16) | mirror_table[r1 >> 16];
 	SET_ZN(PRES);
 }
 
-static void DSP_mmult(void)
+INLINE static void DSP_mmult(void)
 {
 	uint32_t res;
    unsigned i;
@@ -2260,64 +2141,64 @@ static void DSP_mmult(void)
 	SET_ZN(PRES);
 }
 
-static void DSP_move(void)
+INLINE static void DSP_move(void)
 {
 	PRES = PRM;
 }
 
-static void DSP_movefa(void)
+INLINE static void DSP_movefa(void)
 {
 	PRES = dsp_alternate_reg[PIMM1];
 }
 
-static void DSP_movei(void)
+INLINE static void DSP_movei(void)
 {
 //	// This instruction is followed by 32-bit value in LSW / MSW format...
 }
 
-static void DSP_movepc(void)
+INLINE static void DSP_movepc(void)
 {
 //Need to fix this to take into account pipelining effects... !!! FIX !!! [DONE]
 //Account for pipeline effects...
 	PRES = dsp_pc - 2 - (pipeline[plPtrRead].opcode == 38 ? 6 : (pipeline[plPtrRead].opcode == PIPELINE_STALL ? 0 : 2));
 }
 
-static void DSP_moveq(void)
+INLINE static void DSP_moveq(void)
 {
 	PRES = PIMM1;
 }
 
-static void DSP_moveta(void)
+INLINE static void DSP_moveta(void)
 {
 	dsp_alternate_reg[PIMM2] = PRM;
 	NO_WRITEBACK;
 }
 
-static void DSP_mtoi(void)
+INLINE static void DSP_mtoi(void)
 {
 	PRES = (((int32_t)PRM >> 8) & 0xFF800000) | (PRM & 0x007FFFFF);
 	SET_ZN(PRES);
 }
 
-static void DSP_mult(void)
+INLINE static void DSP_mult(void)
 {
 	PRES = (uint16_t)PRM * (uint16_t)PRN;
 	SET_ZN(PRES);
 }
 
-static void DSP_neg(void)
+INLINE static void DSP_neg(void)
 {
 	uint32_t res = -PRN;
 	SET_ZNC_SUB(0, PRN, res);
 	PRES = res;
 }
 
-static void DSP_nop(void)
+INLINE static void DSP_nop(void)
 {
 	NO_WRITEBACK;
 }
 
-static void DSP_normi(void)
+INLINE static void DSP_normi(void)
 {
 	uint32_t _Rm = PRM;
 	uint32_t res = 0;
@@ -2339,24 +2220,24 @@ static void DSP_normi(void)
 	SET_ZN(PRES);
 }
 
-static void DSP_not(void)
+INLINE static void DSP_not(void)
 {
 	PRES = ~PRN;
 	SET_ZN(PRES);
 }
 
-static void DSP_or(void)
+INLINE static void DSP_or(void)
 {
 	PRES = PRN | PRM;
 	SET_ZN(PRES);
 }
 
-static void DSP_resmac(void)
+INLINE static void DSP_resmac(void)
 {
 	PRES = (uint32_t)dsp_acc;
 }
 
-static void DSP_ror(void)
+INLINE static void DSP_ror(void)
 {
 	uint32_t r1 = PRM & 0x1F;
 	uint32_t res = (PRN >> r1) | (PRN << (32 - r1));
@@ -2364,7 +2245,7 @@ static void DSP_ror(void)
 	PRES = res;
 }
 
-static void DSP_rorq(void)
+INLINE static void DSP_rorq(void)
 {
 	uint32_t r1 = dsp_convert_zero[PIMM1 & 0x1F];
 	uint32_t r2 = PRN;
@@ -2373,7 +2254,7 @@ static void DSP_rorq(void)
 	SET_ZN(res); dsp_flag_c = (r2 >> 31) & 0x01;
 }
 
-static void DSP_sat16s(void)
+INLINE static void DSP_sat16s(void)
 {
 	int32_t r2 = PRN;
 	uint32_t res = (r2 < -32768) ? -32768 : (r2 > 32767) ? 32767 : r2;
@@ -2381,7 +2262,7 @@ static void DSP_sat16s(void)
 	SET_ZN(res);
 }
 
-static void DSP_sat32s(void)
+INLINE static void DSP_sat32s(void)
 {
 	int32_t r2 = (uint32_t)PRN;
 	int32_t temp = dsp_acc >> 32;
@@ -2390,7 +2271,7 @@ static void DSP_sat32s(void)
 	SET_ZN(res);
 }
 
-static void DSP_sh(void)
+INLINE static void DSP_sh(void)
 {
 	int32_t sRm = (int32_t)PRM;
 	uint32_t _Rn = PRN;
@@ -2430,7 +2311,7 @@ static void DSP_sh(void)
 	SET_ZN(PRES);
 }
 
-static void DSP_sha(void)
+INLINE static void DSP_sha(void)
 {
 	int32_t sRm = (int32_t)PRM;
 	uint32_t _Rn = PRN;
@@ -2470,14 +2351,14 @@ static void DSP_sha(void)
 	SET_ZN(PRES);
 }
 
-static void DSP_sharq(void)
+INLINE static void DSP_sharq(void)
 {
 	uint32_t res = (int32_t)PRN >> dsp_convert_zero[PIMM1];
 	SET_ZN(res); dsp_flag_c = PRN & 0x01;
 	PRES = res;
 }
 
-static void DSP_shlq(void)
+INLINE static void DSP_shlq(void)
 {
 	int32_t r1 = 32 - PIMM1;
 	uint32_t res = PRN << r1;
@@ -2485,7 +2366,7 @@ static void DSP_shlq(void)
 	PRES = res;
 }
 
-static void DSP_shrq(void)
+INLINE static void DSP_shrq(void)
 {
 	int32_t r1 = dsp_convert_zero[PIMM1];
 	uint32_t res = PRN >> r1;
@@ -2493,7 +2374,7 @@ static void DSP_shrq(void)
 	PRES = res;
 }
 
-static void DSP_store(void)
+INLINE static void DSP_store(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT_STORE
 	pipeline[plPtrExec].address = PRM & 0xFFFFFFFC;
@@ -2505,7 +2386,7 @@ static void DSP_store(void)
 	WRITEBACK_ADDR;
 }
 
-static void DSP_storeb(void)
+INLINE static void DSP_storeb(void)
 {
 	pipeline[plPtrExec].address = PRM;
 
@@ -2523,7 +2404,7 @@ static void DSP_storeb(void)
 	WRITEBACK_ADDR;
 }
 
-static void DSP_storew(void)
+INLINE static void DSP_storew(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT_STORE
 	pipeline[plPtrExec].address = PRM & 0xFFFFFFFE;
@@ -2544,7 +2425,7 @@ static void DSP_storew(void)
 	WRITEBACK_ADDR;
 }
 
-static void DSP_store_r14_i(void)
+INLINE static void DSP_store_r14_i(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT_STORE
 	pipeline[plPtrExec].address = (dsp_reg[14] & 0xFFFFFFFC) + (dsp_convert_zero[PIMM1] << 2);
@@ -2556,7 +2437,7 @@ static void DSP_store_r14_i(void)
 	WRITEBACK_ADDR;
 }
 
-static void DSP_store_r14_r(void)
+INLINE static void DSP_store_r14_r(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT_STORE
 	pipeline[plPtrExec].address = (dsp_reg[14] + PRM) & 0xFFFFFFFC;
@@ -2568,7 +2449,7 @@ static void DSP_store_r14_r(void)
 	WRITEBACK_ADDR;
 }
 
-static void DSP_store_r15_i(void)
+INLINE static void DSP_store_r15_i(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT_STORE
 	pipeline[plPtrExec].address = (dsp_reg[15] & 0xFFFFFFFC) + (dsp_convert_zero[PIMM1] << 2);
@@ -2580,7 +2461,7 @@ static void DSP_store_r15_i(void)
 	WRITEBACK_ADDR;
 }
 
-static void DSP_store_r15_r(void)
+INLINE static void DSP_store_r15_r(void)
 {
 #ifdef DSP_CORRECT_ALIGNMENT_STORE
 	pipeline[plPtrExec].address = (dsp_reg[15] + PRM) & 0xFFFFFFFC;
@@ -2592,14 +2473,14 @@ static void DSP_store_r15_r(void)
 	WRITEBACK_ADDR;
 }
 
-static void DSP_sub(void)
+INLINE static void DSP_sub(void)
 {
 	uint32_t res = PRN - PRM;
 	SET_ZNC_SUB(PRN, PRM, res);
 	PRES = res;
 }
 
-static void DSP_subc(void)
+INLINE static void DSP_subc(void)
 {
 	uint32_t res = PRN - PRM - dsp_flag_c;
 	uint32_t borrow = dsp_flag_c;
@@ -2607,7 +2488,7 @@ static void DSP_subc(void)
 	PRES = res;
 }
 
-static void DSP_subq(void)
+INLINE static void DSP_subq(void)
 {
 	uint32_t r1 = dsp_convert_zero[PIMM1];
 	uint32_t res = PRN - r1;
@@ -2615,7 +2496,7 @@ static void DSP_subq(void)
 	PRES = res;
 }
 
-static void DSP_subqmod(void)
+INLINE static void DSP_subqmod(void)
 {
 	uint32_t r1 = dsp_convert_zero[PIMM1];
 	uint32_t r2 = PRN;
@@ -2625,12 +2506,12 @@ static void DSP_subqmod(void)
 	SET_ZNC_SUB(r2, r1, res);
 }
 
-static void DSP_subqt(void)
+INLINE static void DSP_subqt(void)
 {
 	PRES = PRN - dsp_convert_zero[PIMM1];
 }
 
-static void DSP_xor(void)
+INLINE static void DSP_xor(void)
 {
 	PRES = PRN ^ PRM;
 	SET_ZN(PRES);

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -857,6 +857,7 @@ void DSPExec(int32_t cycles)
 			IMASKCleared = false;
 		}
 
+#ifdef USE_STRUCTS
         OpCode opcode;
         opcode.WORD = DSPReadWord(dsp_pc, DSP);
         uint8_t index = opcode.Codes.index;
@@ -866,6 +867,17 @@ void DSPExec(int32_t cycles)
         dsp_opcode_second_parameter = sp;
         dsp_pc += 2;
         dsp_opcode[index]();
+#else
+        uint16_t opcode;
+        uint32_t index;
+        opcode = DSPReadWord(dsp_pc, DSP);
+        index = opcode >> 10;
+        dsp_opcode_first_parameter = (opcode >> 5) & 0x1F;
+        dsp_opcode_second_parameter = opcode & 0x1F;
+        dsp_pc += 2;
+        dsp_opcode[index]();
+        dsp_opcode_use[index]++;
+#endif
 //     Counter is not necessary and expensive -jm prov
 //        dsp_opcode_use[index]++;
 		cycles -= dsp_opcode_cycles[index];

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -394,10 +394,13 @@ uint8_t DSPReadByte(uint32_t offset, uint32_t who/*=UNKNOWN*/)
 
 uint16_t DSPReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
 {
+#ifdef USE_STRUCTS
     Offset offsett;
     offsett.LONG = offset;
     offset = offsett.Members.offset;
-    
+#else
+    offset &= 0xFFFFFFFE;
+#endif
 	if (offset >= DSP_WORK_RAM_BASE && offset <= DSP_WORK_RAM_BASE+0x1FFF)
 	{
 		offset -= DSP_WORK_RAM_BASE;
@@ -405,6 +408,7 @@ uint16_t DSPReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
     }
 	else if ((offset>=DSP_CONTROL_RAM_BASE)&&(offset<DSP_CONTROL_RAM_BASE+0x20))
 	{
+#ifdef USE_STRUCTS
         DSPLong data;
         data.LONG = DSPReadLong(offset & 0xFFFFFFFC, who);
         
@@ -413,6 +417,13 @@ uint16_t DSPReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
         } else {
             return data.Data.UWORD;
         }
+#else
+        uint32_t data = DSPReadLong(offset & 0xFFFFFFFC, who);
+        
+        if (offset & 0x03)
+            return data & 0xFFFF;
+        return data >> 16;
+#endif
 	}
 
 	return JaguarReadWord(offset, who);

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -848,7 +848,7 @@ void DSPDone(void)
 
 /* DSP execution core */
 
-void DSPExec(int32_t cycles)
+INLINE void DSPExec(int32_t cycles)
 {
 #ifdef DSP_SINGLE_STEPPING
 	if (dsp_control & 0x18)

--- a/src/gpu.c
+++ b/src/gpu.c
@@ -301,16 +301,11 @@ INLINE uint16_t GPUReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
 	if ((offset >= GPU_WORK_RAM_BASE) && (offset < GPU_WORK_RAM_BASE+0x1000))
 	{
         offset &= 0xFFF;
-#ifdef USE_STRUCTS
+
         OpCode data;
         data.Bytes.UBYTE = (uint16_t)gpu_ram_8[offset];
         data.Bytes.LBYTE = (uint16_t)gpu_ram_8[offset+1];
         return data.WORD;
-#else
-        uint16_t data;
-		data    = ((uint16_t)gpu_ram_8[offset] << 8) | (uint16_t)gpu_ram_8[offset+1];
-		return data;
-#endif
 	}
 	else if ((offset >= GPU_CONTROL_RAM_BASE) && (offset < GPU_CONTROL_RAM_BASE+0x20))
 	{
@@ -1572,7 +1567,6 @@ INLINE static void gpu_opcode_abs(void)
 }
 
 
-#ifdef USE_STRUCTS
 INLINE static void gpu_opcode_div(void)	// RN / RM
 {
     
@@ -1603,33 +1597,6 @@ INLINE static void gpu_opcode_div(void)	// RN / RM
    RN = q.WORD;
    gpu_remain = r.WORD;
 }
-#else
-INLINE static void gpu_opcode_div(void)    // RN / RM
-{
-    unsigned i;
-    // Real algorithm, courtesy of SCPCD: NYAN!
-    uint32_t q = RN;
-    uint32_t r = 0;
-    
-    // If 16.16 division, stuff top 16 bits of RN into remainder and put the
-    // bottom 16 of RN in top 16 of quotient
-    if (gpu_div_control & 0x01)
-        q <<= 16, r = RN >> 16;
-    
-    for(i=0; i<32; i++)
-    {
-        uint32_t sign = r & 0x80000000;
-        r = (r << 1) | ((q >> 31) & 0x01);
-        r += (sign ? RM : -RM);
-        q = (q << 1) | (((~r) >> 31) & 0x01);
-    }
-    
-    RN = q;
-    gpu_remain = r;
-    
-}
-#endif
-
 
 INLINE static void gpu_opcode_imultn(void)
 {

--- a/src/gpu.c
+++ b/src/gpu.c
@@ -714,16 +714,11 @@ void GPUExec(int32_t cycles)
       //$E400 -> 1110 01 -> $39 -> 57
       //GPU #1
       gpu_pc += 2;
-#if 0
-      gpu_opcode[index]();
-#else
        executeOpcode(index);
-#endif
+
       // BIOS hacking
       //GPU: [00F03548] jr      nz,00F03560 (0xd561) (RM=00F03114, RN=00000004) ->     --> JR: Branch taken.
       //GPU: [00F0354C] jump    nz,(r29) (0xd3a1) (RM=00F03314, RN=00000004) -> (RM=00F03314, RN=00000004)
-#if 0
-      cycles -= gpu_opcode_cycles[index];
    }
 
    gpu_in_exec--;

--- a/src/gpu.c
+++ b/src/gpu.c
@@ -374,7 +374,7 @@ INLINE uint32_t GPUReadLong(uint32_t offset, uint32_t who/*=UNKNOWN*/)
          case 0x1C:
             return gpu_remain;
          default:								// unaligned long read
-            return break;
+            break;
       }
         return 0;
 	}
@@ -907,7 +907,6 @@ INLINE static void executeOpcode(uint32_t index) {
             gpu_opcode_load_r15_ri();
             break;
         case 60:
-            
             gpu_opcode_store_r14_ri();
             break;
         case 61:
@@ -920,7 +919,7 @@ INLINE static void executeOpcode(uint32_t index) {
             gpu_opcode_pack();
             break;
         default:
-            WriteLog("\nUnknown opcode %i\n", index);
+            // WriteLog("\nUnknown opcode %i\n", index);
             break;
     }
 }

--- a/src/gpu.c
+++ b/src/gpu.c
@@ -69,70 +69,72 @@
 
 void GPUUpdateRegisterBanks(void);
 
-static void gpu_opcode_add(void);
-static void gpu_opcode_addc(void);
-static void gpu_opcode_addq(void);
-static void gpu_opcode_addqt(void);
-static void gpu_opcode_sub(void);
-static void gpu_opcode_subc(void);
-static void gpu_opcode_subq(void);
-static void gpu_opcode_subqt(void);
-static void gpu_opcode_neg(void);
-static void gpu_opcode_and(void);
-static void gpu_opcode_or(void);
-static void gpu_opcode_xor(void);
-static void gpu_opcode_not(void);
-static void gpu_opcode_btst(void);
-static void gpu_opcode_bset(void);
-static void gpu_opcode_bclr(void);
-static void gpu_opcode_mult(void);
-static void gpu_opcode_imult(void);
-static void gpu_opcode_imultn(void);
-static void gpu_opcode_resmac(void);
-static void gpu_opcode_imacn(void);
-static void gpu_opcode_div(void);
-static void gpu_opcode_abs(void);
-static void gpu_opcode_sh(void);
-static void gpu_opcode_shlq(void);
-static void gpu_opcode_shrq(void);
-static void gpu_opcode_sha(void);
-static void gpu_opcode_sharq(void);
-static void gpu_opcode_ror(void);
-static void gpu_opcode_rorq(void);
-static void gpu_opcode_cmp(void);
-static void gpu_opcode_cmpq(void);
-static void gpu_opcode_sat8(void);
-static void gpu_opcode_sat16(void);
-static void gpu_opcode_move(void);
-static void gpu_opcode_moveq(void);
-static void gpu_opcode_moveta(void);
-static void gpu_opcode_movefa(void);
-static void gpu_opcode_movei(void);
-static void gpu_opcode_loadb(void);
-static void gpu_opcode_loadw(void);
-static void gpu_opcode_load(void);
-static void gpu_opcode_loadp(void);
-static void gpu_opcode_load_r14_indexed(void);
-static void gpu_opcode_load_r15_indexed(void);
-static void gpu_opcode_storeb(void);
-static void gpu_opcode_storew(void);
-static void gpu_opcode_store(void);
-static void gpu_opcode_storep(void);
-static void gpu_opcode_store_r14_indexed(void);
-static void gpu_opcode_store_r15_indexed(void);
-static void gpu_opcode_move_pc(void);
-static void gpu_opcode_jump(void);
-static void gpu_opcode_jr(void);
-static void gpu_opcode_mmult(void);
-static void gpu_opcode_mtoi(void);
-static void gpu_opcode_normi(void);
-static void gpu_opcode_nop(void);
-static void gpu_opcode_load_r14_ri(void);
-static void gpu_opcode_load_r15_ri(void);
-static void gpu_opcode_store_r14_ri(void);
-static void gpu_opcode_store_r15_ri(void);
-static void gpu_opcode_sat24(void);
-static void gpu_opcode_pack(void);
+INLINE static void gpu_opcode_add(void);
+INLINE static void gpu_opcode_addc(void);
+INLINE static void gpu_opcode_addq(void);
+INLINE static void gpu_opcode_addqt(void);
+INLINE static void gpu_opcode_sub(void);
+INLINE static void gpu_opcode_subc(void);
+INLINE static void gpu_opcode_subq(void);
+INLINE static void gpu_opcode_subqt(void);
+INLINE static void gpu_opcode_neg(void);
+INLINE static void gpu_opcode_and(void);
+INLINE static void gpu_opcode_or(void);
+INLINE static void gpu_opcode_xor(void);
+INLINE static void gpu_opcode_not(void);
+INLINE static void gpu_opcode_btst(void);
+INLINE static void gpu_opcode_bset(void);
+INLINE static void gpu_opcode_bclr(void);
+INLINE static void gpu_opcode_mult(void);
+INLINE static void gpu_opcode_imult(void);
+INLINE static void gpu_opcode_imultn(void);
+INLINE static void gpu_opcode_resmac(void);
+INLINE static void gpu_opcode_imacn(void);
+INLINE static void gpu_opcode_div(void);
+INLINE static void gpu_opcode_abs(void);
+INLINE static void gpu_opcode_sh(void);
+INLINE static void gpu_opcode_shlq(void);
+INLINE static void gpu_opcode_shrq(void);
+INLINE static void gpu_opcode_sha(void);
+INLINE static void gpu_opcode_sharq(void);
+INLINE static void gpu_opcode_ror(void);
+INLINE static void gpu_opcode_rorq(void);
+INLINE static void gpu_opcode_cmp(void);
+INLINE static void gpu_opcode_cmpq(void);
+INLINE static void gpu_opcode_sat8(void);
+INLINE static void gpu_opcode_sat16(void);
+INLINE static void gpu_opcode_move(void);
+INLINE static void gpu_opcode_moveq(void);
+INLINE static void gpu_opcode_moveta(void);
+INLINE static void gpu_opcode_movefa(void);
+INLINE static void gpu_opcode_movei(void);
+INLINE static void gpu_opcode_loadb(void);
+INLINE static void gpu_opcode_loadw(void);
+INLINE static void gpu_opcode_load(void);
+INLINE static void gpu_opcode_loadp(void);
+INLINE static void gpu_opcode_load_r14_indexed(void);
+INLINE static void gpu_opcode_load_r15_indexed(void);
+INLINE static void gpu_opcode_storeb(void);
+INLINE static void gpu_opcode_storew(void);
+INLINE static void gpu_opcode_store(void);
+INLINE static void gpu_opcode_storep(void);
+INLINE static void gpu_opcode_store_r14_indexed(void);
+INLINE static void gpu_opcode_store_r15_indexed(void);
+INLINE static void gpu_opcode_move_pc(void);
+INLINE static void gpu_opcode_jump(void);
+INLINE static void gpu_opcode_jr(void);
+INLINE static void gpu_opcode_mmult(void);
+INLINE static void gpu_opcode_mtoi(void);
+INLINE static void gpu_opcode_normi(void);
+INLINE static void gpu_opcode_nop(void);
+INLINE static void gpu_opcode_load_r14_ri(void);
+INLINE static void gpu_opcode_load_r15_ri(void);
+INLINE static void gpu_opcode_store_r14_ri(void);
+INLINE static void gpu_opcode_store_r15_ri(void);
+INLINE static void gpu_opcode_sat24(void);
+INLINE static void gpu_opcode_pack(void);
+
+INLINE static void executeOpcode(uint32_t index);
 
 uint8_t gpu_opcode_cycles[64] =
 {
@@ -705,8 +707,11 @@ void GPUExec(int32_t cycles)
       //$E400 -> 1110 01 -> $39 -> 57
       //GPU #1
       gpu_pc += 2;
+#if 0
       gpu_opcode[index]();
-
+#else
+       executeOpcode(index);
+#endif
       // BIOS hacking
       //GPU: [00F03548] jr      nz,00F03560 (0xd561) (RM=00F03114, RN=00000004) ->     --> JR: Branch taken.
       //GPU: [00F0354C] jump    nz,(r29) (0xd3a1) (RM=00F03314, RN=00000004) -> (RM=00F03314, RN=00000004)
@@ -715,6 +720,207 @@ void GPUExec(int32_t cycles)
    }
 
    gpu_in_exec--;
+}
+
+INLINE static void executeOpcode(uint32_t index) {
+    switch (index) {
+        case 0:
+            gpu_opcode_add();
+            break;
+        case 1:
+            gpu_opcode_addc();
+            break;
+        case 2:
+            gpu_opcode_addq();
+            break;
+        case 3:
+            gpu_opcode_addqt();
+            break;
+        case 4:
+            gpu_opcode_sub();
+            break;
+        case 5:
+            gpu_opcode_subc();
+            break;
+        case 6:
+            gpu_opcode_subq();
+            break;
+        case 7:
+            gpu_opcode_subqt();
+            break;
+        case 8:
+            gpu_opcode_neg();
+            break;
+        case 9:
+            gpu_opcode_and();
+            break;
+        case 10:
+            gpu_opcode_or();
+            break;
+        case 11:
+            gpu_opcode_xor();
+            break;
+        case 12:
+            gpu_opcode_not();
+            break;
+        case 13:
+            gpu_opcode_btst();
+            break;
+        case 14:
+            gpu_opcode_bset();
+            break;
+        case 15:
+            gpu_opcode_bclr();
+            break;
+        case 16:
+            gpu_opcode_mult();
+            break;
+        case 17:
+            gpu_opcode_imult();
+            break;
+        case 18:
+            gpu_opcode_imultn();
+            break;
+        case 19:
+            gpu_opcode_resmac();
+            break;
+        case 20:
+            gpu_opcode_imacn();
+            break;
+        case 21:
+            gpu_opcode_div();
+            break;
+        case 22:
+            gpu_opcode_abs();
+            break;
+        case 23:
+            gpu_opcode_sh();
+            break;
+        case 24:
+            gpu_opcode_shlq();
+            break;
+        case 25:
+            gpu_opcode_shrq();
+            break;
+        case 26:
+            gpu_opcode_sha();
+            break;
+        case 27:
+            gpu_opcode_sharq();
+            break;
+        case 28:
+            gpu_opcode_ror();
+            break;
+        case 29:
+            gpu_opcode_rorq();
+            break;
+        case 30:
+            gpu_opcode_cmp();
+            break;
+        case 31:
+            gpu_opcode_cmpq();
+            break;
+        case 32:
+            gpu_opcode_sat8();
+            break;
+        case 33:
+            gpu_opcode_sat16();
+            break;
+        case 34:
+            gpu_opcode_move();
+            break;
+        case 35:
+            gpu_opcode_moveq();
+            break;
+        case 36:
+            gpu_opcode_moveta();
+            break;
+        case 37:
+            gpu_opcode_movefa();
+            break;
+        case 38:
+            gpu_opcode_movei();
+            break;
+        case 39:
+            gpu_opcode_loadb();
+            break;
+        case 40:
+            gpu_opcode_loadw();
+            break;
+        case 41:
+            gpu_opcode_load();
+            break;
+        case 42:
+            gpu_opcode_loadp();
+            break;
+        case 43:
+            gpu_opcode_load_r14_indexed();
+            break;
+        case 44:
+            gpu_opcode_load_r15_indexed();
+            break;
+        case 45:
+            gpu_opcode_storeb();
+            break;
+        case 46:
+            gpu_opcode_storew();
+            break;
+        case 47:
+            gpu_opcode_store();
+            break;
+        case 48:
+            gpu_opcode_storep();
+            break;
+        case 49:
+            gpu_opcode_store_r14_indexed();
+            break;
+        case 50:
+            gpu_opcode_store_r15_indexed();
+            break;
+        case 51:
+            gpu_opcode_move_pc();
+            break;
+        case 52:
+            gpu_opcode_jump();
+            break;
+        case 53:
+            gpu_opcode_jr();
+            break;
+        case 54:
+            gpu_opcode_mmult();
+            break;
+        case 55:
+            gpu_opcode_mtoi();
+            break;
+        case 56:
+            gpu_opcode_normi();
+            break;
+        case 57:
+            gpu_opcode_nop();
+            break;
+        case 58:
+            gpu_opcode_load_r14_ri();
+            break;
+        case 59:
+            gpu_opcode_load_r15_ri();
+            break;
+        case 60:
+            
+            gpu_opcode_store_r14_ri();
+            break;
+        case 61:
+            gpu_opcode_store_r15_ri();
+            break;
+        case 62:
+            gpu_opcode_sat24();
+            break;
+        case 63:
+            gpu_opcode_pack();
+            break;
+        default:
+            WriteLog("\nUnknown opcode %i\n", index);
+            break;
+    }
 }
 
 // GPU opcodes
@@ -755,7 +961,7 @@ void GPUExec(int32_t cycles)
    */
 
 
-static void gpu_opcode_jump(void)
+INLINE static void gpu_opcode_jump(void)
 {
    // normalize flags
    /*	gpu_flag_c = (gpu_flag_c ? 1 : 0);
@@ -773,7 +979,7 @@ static void gpu_opcode_jump(void)
 }
 
 
-static void gpu_opcode_jr(void)
+INLINE static void gpu_opcode_jr(void)
 {
    uint32_t jaguar_flags = (gpu_flag_n << 2) | (gpu_flag_c << 1) | gpu_flag_z;
 
@@ -787,7 +993,7 @@ static void gpu_opcode_jr(void)
 }
 
 
-static void gpu_opcode_add(void)
+INLINE static void gpu_opcode_add(void)
 {
    uint32_t res = RN + RM;
    CLR_ZNC; SET_ZNC_ADD(RN, RM, res);
@@ -795,7 +1001,7 @@ static void gpu_opcode_add(void)
 }
 
 
-static void gpu_opcode_addc(void)
+INLINE static void gpu_opcode_addc(void)
 {
    uint32_t res = RN + RM + gpu_flag_c;
    uint32_t carry = gpu_flag_c;
@@ -804,7 +1010,7 @@ static void gpu_opcode_addc(void)
 }
 
 
-static void gpu_opcode_addq(void)
+INLINE static void gpu_opcode_addq(void)
 {
    uint32_t r1 = gpu_convert_zero[IMM_1];
    uint32_t res = RN + r1;
@@ -813,13 +1019,13 @@ static void gpu_opcode_addq(void)
 }
 
 
-static void gpu_opcode_addqt(void)
+INLINE static void gpu_opcode_addqt(void)
 {
    RN += gpu_convert_zero[IMM_1];
 }
 
 
-static void gpu_opcode_sub(void)
+INLINE static void gpu_opcode_sub(void)
 {
    uint32_t res = RN - RM;
    SET_ZNC_SUB(RN, RM, res);
@@ -827,7 +1033,7 @@ static void gpu_opcode_sub(void)
 }
 
 
-static void gpu_opcode_subc(void)
+INLINE static void gpu_opcode_subc(void)
 {
    // This is how the GPU ALU does it--Two's complement with inverted carry
    uint64_t res = (uint64_t)RN + (uint64_t)(RM ^ 0xFFFFFFFF) + (gpu_flag_c ^ 1);
@@ -838,7 +1044,7 @@ static void gpu_opcode_subc(void)
 }
 
 
-static void gpu_opcode_subq(void)
+INLINE static void gpu_opcode_subq(void)
 {
    uint32_t r1 = gpu_convert_zero[IMM_1];
    uint32_t res = RN - r1;
@@ -847,20 +1053,20 @@ static void gpu_opcode_subq(void)
 }
 
 
-static void gpu_opcode_subqt(void)
+INLINE static void gpu_opcode_subqt(void)
 {
    RN -= gpu_convert_zero[IMM_1];
 }
 
 
-static void gpu_opcode_cmp(void)
+INLINE static void gpu_opcode_cmp(void)
 {
    uint32_t res = RN - RM;
    SET_ZNC_SUB(RN, RM, res);
 }
 
 
-static void gpu_opcode_cmpq(void)
+INLINE static void gpu_opcode_cmpq(void)
 {
    static int32_t sqtable[32] =
    { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,-16,-15,-14,-13,-12,-11,-10,-9,-8,-7,-6,-5,-4,-3,-2,-1 };
@@ -870,35 +1076,35 @@ static void gpu_opcode_cmpq(void)
 }
 
 
-static void gpu_opcode_and(void)
+INLINE static void gpu_opcode_and(void)
 {
    RN = RN & RM;
    SET_ZN(RN);
 }
 
 
-static void gpu_opcode_or(void)
+INLINE static void gpu_opcode_or(void)
 {
    RN = RN | RM;
    SET_ZN(RN);
 }
 
 
-static void gpu_opcode_xor(void)
+INLINE static void gpu_opcode_xor(void)
 {
    RN = RN ^ RM;
    SET_ZN(RN);
 }
 
 
-static void gpu_opcode_not(void)
+INLINE static void gpu_opcode_not(void)
 {
    RN = ~RN;
    SET_ZN(RN);
 }
 
 
-static void gpu_opcode_move_pc(void)
+INLINE static void gpu_opcode_move_pc(void)
 {
    // Should be previous PC--this might not always be previous instruction!
    // Then again, this will point right at the *current* instruction, i.e., MOVE PC,R!
@@ -906,27 +1112,27 @@ static void gpu_opcode_move_pc(void)
 }
 
 
-static void gpu_opcode_sat8(void)
+INLINE static void gpu_opcode_sat8(void)
 {
    RN = ((int32_t)RN < 0 ? 0 : (RN > 0xFF ? 0xFF : RN));
    SET_ZN(RN);
 }
 
 
-static void gpu_opcode_sat16(void)
+INLINE static void gpu_opcode_sat16(void)
 {
    RN = ((int32_t)RN < 0 ? 0 : (RN > 0xFFFF ? 0xFFFF : RN));
    SET_ZN(RN);
 }
 
-static void gpu_opcode_sat24(void)
+INLINE static void gpu_opcode_sat24(void)
 {
    RN = ((int32_t)RN < 0 ? 0 : (RN > 0xFFFFFF ? 0xFFFFFF : RN));
    SET_ZN(RN);
 }
 
 
-static void gpu_opcode_store_r14_indexed(void)
+INLINE static void gpu_opcode_store_r14_indexed(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
@@ -941,7 +1147,7 @@ static void gpu_opcode_store_r14_indexed(void)
 }
 
 
-static void gpu_opcode_store_r15_indexed(void)
+INLINE static void gpu_opcode_store_r15_indexed(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
@@ -956,7 +1162,7 @@ static void gpu_opcode_store_r15_indexed(void)
 }
 
 
-static void gpu_opcode_load_r14_ri(void)
+INLINE static void gpu_opcode_load_r14_ri(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + RM;
@@ -971,7 +1177,7 @@ static void gpu_opcode_load_r14_ri(void)
 }
 
 
-static void gpu_opcode_load_r15_ri(void)
+INLINE static void gpu_opcode_load_r15_ri(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + RM;
@@ -986,7 +1192,7 @@ static void gpu_opcode_load_r15_ri(void)
 }
 
 
-static void gpu_opcode_store_r14_ri(void)
+INLINE static void gpu_opcode_store_r14_ri(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + RM;
@@ -1001,7 +1207,7 @@ static void gpu_opcode_store_r14_ri(void)
 }
 
 
-static void gpu_opcode_store_r15_ri(void)
+INLINE static void gpu_opcode_store_r15_ri(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT_STORE
    uint32_t address = gpu_reg[15] + RM;
@@ -1016,12 +1222,12 @@ static void gpu_opcode_store_r15_ri(void)
 }
 
 
-static void gpu_opcode_nop(void)
+INLINE static void gpu_opcode_nop(void)
 {
 }
 
 
-static void gpu_opcode_pack(void)
+INLINE static void gpu_opcode_pack(void)
 {
    uint32_t val = RN;
 
@@ -1032,7 +1238,7 @@ static void gpu_opcode_pack(void)
 }
 
 
-static void gpu_opcode_storeb(void)
+INLINE static void gpu_opcode_storeb(void)
 {
    //Is this right???
    // Would appear to be so...!
@@ -1043,7 +1249,7 @@ static void gpu_opcode_storeb(void)
 }
 
 
-static void gpu_opcode_storew(void)
+INLINE static void gpu_opcode_storew(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
@@ -1059,7 +1265,7 @@ static void gpu_opcode_storew(void)
 }
 
 
-static void gpu_opcode_store(void)
+INLINE static void gpu_opcode_store(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
@@ -1072,7 +1278,7 @@ static void gpu_opcode_store(void)
 }
 
 
-static void gpu_opcode_storep(void)
+INLINE static void gpu_opcode_storep(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
@@ -1091,7 +1297,7 @@ static void gpu_opcode_storep(void)
 #endif
 }
 
-static void gpu_opcode_loadb(void)
+INLINE static void gpu_opcode_loadb(void)
 {
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       RN = GPUReadLong(RM, GPU) & 0xFF;
@@ -1100,7 +1306,7 @@ static void gpu_opcode_loadb(void)
 }
 
 
-static void gpu_opcode_loadw(void)
+INLINE static void gpu_opcode_loadw(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
@@ -1133,7 +1339,7 @@ static void gpu_opcode_loadw(void)
    to test that. They seem to be stable, though, which would indicate such a mechanism.
    Sometimes, however, the off by 2 case returns $12345678!
    */
-static void gpu_opcode_load(void)
+INLINE static void gpu_opcode_load(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    RN = GPUReadLong(RM & 0xFFFFFFFC, GPU);
@@ -1143,7 +1349,7 @@ static void gpu_opcode_load(void)
 }
 
 
-static void gpu_opcode_loadp(void)
+INLINE static void gpu_opcode_loadp(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
@@ -1163,7 +1369,7 @@ static void gpu_opcode_loadp(void)
 }
 
 
-static void gpu_opcode_load_r14_indexed(void)
+INLINE static void gpu_opcode_load_r14_indexed(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
@@ -1178,7 +1384,7 @@ static void gpu_opcode_load_r14_indexed(void)
 }
 
 
-static void gpu_opcode_load_r15_indexed(void)
+INLINE static void gpu_opcode_load_r15_indexed(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
@@ -1193,7 +1399,7 @@ static void gpu_opcode_load_r15_indexed(void)
 }
 
 
-static void gpu_opcode_movei(void)
+INLINE static void gpu_opcode_movei(void)
 {
    // This instruction is followed by 32-bit value in LSW / MSW format...
    RN = (uint32_t)GPUReadWord(gpu_pc, GPU) | ((uint32_t)GPUReadWord(gpu_pc + 2, GPU) << 16);
@@ -1201,51 +1407,51 @@ static void gpu_opcode_movei(void)
 }
 
 
-static void gpu_opcode_moveta(void)
+INLINE static void gpu_opcode_moveta(void)
 {
    ALTERNATE_RN = RM;
 }
 
 
-static void gpu_opcode_movefa(void)
+INLINE static void gpu_opcode_movefa(void)
 {
    RN = ALTERNATE_RM;
 }
 
 
-static void gpu_opcode_move(void)
+INLINE static void gpu_opcode_move(void)
 {
    RN = RM;
 }
 
 
-static void gpu_opcode_moveq(void)
+INLINE static void gpu_opcode_moveq(void)
 {
    RN = IMM_1;
 }
 
 
-static void gpu_opcode_resmac(void)
+INLINE static void gpu_opcode_resmac(void)
 {
    RN = gpu_acc;
 }
 
 
-static void gpu_opcode_imult(void)
+INLINE static void gpu_opcode_imult(void)
 {
    RN = (int16_t)RN * (int16_t)RM;
    SET_ZN(RN);
 }
 
 
-static void gpu_opcode_mult(void)
+INLINE static void gpu_opcode_mult(void)
 {
    RN = (uint16_t)RM * (uint16_t)RN;
    SET_ZN(RN);
 }
 
 
-static void gpu_opcode_bclr(void)
+INLINE static void gpu_opcode_bclr(void)
 {
    uint32_t res = RN & ~(1 << IMM_1);
    RN = res;
@@ -1253,13 +1459,13 @@ static void gpu_opcode_bclr(void)
 }
 
 
-static void gpu_opcode_btst(void)
+INLINE static void gpu_opcode_btst(void)
 {
    gpu_flag_z = (~RN >> IMM_1) & 1;
 }
 
 
-static void gpu_opcode_bset(void)
+INLINE static void gpu_opcode_bset(void)
 {
    uint32_t res = RN | (1 << IMM_1);
    RN = res;
@@ -1267,14 +1473,14 @@ static void gpu_opcode_bset(void)
 }
 
 
-static void gpu_opcode_imacn(void)
+INLINE static void gpu_opcode_imacn(void)
 {
    uint32_t res = (int16_t)RM * (int16_t)(RN);
    gpu_acc += res;
 }
 
 
-static void gpu_opcode_mtoi(void)
+INLINE static void gpu_opcode_mtoi(void)
 {
    uint32_t _RM = RM;
    uint32_t res = RN = (((int32_t)_RM >> 8) & 0xFF800000) | (_RM & 0x007FFFFF);
@@ -1282,7 +1488,7 @@ static void gpu_opcode_mtoi(void)
 }
 
 
-static void gpu_opcode_normi(void)
+INLINE static void gpu_opcode_normi(void)
 {
    uint32_t _RM = RM;
    uint32_t res = 0;
@@ -1304,7 +1510,7 @@ static void gpu_opcode_normi(void)
    SET_ZN(res);
 }
 
-static void gpu_opcode_mmult(void)
+INLINE static void gpu_opcode_mmult(void)
 {
    unsigned i;
    int count	= gpu_matrix_control & 0x0F;	// Matrix width
@@ -1350,7 +1556,7 @@ static void gpu_opcode_mmult(void)
 }
 
 
-static void gpu_opcode_abs(void)
+INLINE static void gpu_opcode_abs(void)
 {
    gpu_flag_c = RN >> 31;
    if (RN == 0x80000000)
@@ -1365,7 +1571,7 @@ static void gpu_opcode_abs(void)
 }
 
 
-static void gpu_opcode_div(void)	// RN / RM
+INLINE static void gpu_opcode_div(void)	// RN / RM
 {
    unsigned i;
    // Real algorithm, courtesy of SCPCD: NYAN!
@@ -1391,7 +1597,7 @@ static void gpu_opcode_div(void)	// RN / RM
 }
 
 
-static void gpu_opcode_imultn(void)
+INLINE static void gpu_opcode_imultn(void)
 {
    uint32_t res = (int32_t)((int16_t)RN * (int16_t)RM);
    gpu_acc = (int32_t)res;
@@ -1400,7 +1606,7 @@ static void gpu_opcode_imultn(void)
 }
 
 
-static void gpu_opcode_neg(void)
+INLINE static void gpu_opcode_neg(void)
 {
    uint32_t res = -RN;
    SET_ZNC_SUB(0, RN, res);
@@ -1408,7 +1614,7 @@ static void gpu_opcode_neg(void)
 }
 
 
-static void gpu_opcode_shlq(void)
+INLINE static void gpu_opcode_shlq(void)
 {
    int32_t r1 = 32 - IMM_1;
    uint32_t res = RN << r1;
@@ -1417,7 +1623,7 @@ static void gpu_opcode_shlq(void)
 }
 
 
-static void gpu_opcode_shrq(void)
+INLINE static void gpu_opcode_shrq(void)
 {
    int32_t r1 = gpu_convert_zero[IMM_1];
    uint32_t res = RN >> r1;
@@ -1426,7 +1632,7 @@ static void gpu_opcode_shrq(void)
 }
 
 
-static void gpu_opcode_ror(void)
+INLINE static void gpu_opcode_ror(void)
 {
    uint32_t r1 = RM & 0x1F;
    uint32_t res = (RN >> r1) | (RN << (32 - r1));
@@ -1435,7 +1641,7 @@ static void gpu_opcode_ror(void)
 }
 
 
-static void gpu_opcode_rorq(void)
+INLINE static void gpu_opcode_rorq(void)
 {
    uint32_t r1 = gpu_convert_zero[IMM_1 & 0x1F];
    uint32_t r2 = RN;
@@ -1445,7 +1651,7 @@ static void gpu_opcode_rorq(void)
 }
 
 
-static void gpu_opcode_sha(void)
+INLINE static void gpu_opcode_sha(void)
 {
    uint32_t res;
 
@@ -1464,7 +1670,7 @@ static void gpu_opcode_sha(void)
 }
 
 
-static void gpu_opcode_sharq(void)
+INLINE static void gpu_opcode_sharq(void)
 {
    uint32_t res = (int32_t)RN >> gpu_convert_zero[IMM_1];
    SET_ZN(res); gpu_flag_c = RN & 0x01;
@@ -1472,7 +1678,7 @@ static void gpu_opcode_sharq(void)
 }
 
 
-static void gpu_opcode_sh(void)
+INLINE static void gpu_opcode_sh(void)
 {
    if (RM & 0x80000000)		// Shift left
    {

--- a/src/gpu.c
+++ b/src/gpu.c
@@ -175,7 +175,8 @@ static uint32_t gpu_flags;
 static uint32_t gpu_matrix_control;
 static uint32_t gpu_pointer_to_matrix;
 static uint32_t gpu_data_organization;
-static uint32_t gpu_control;
+static GPUControl gpu_control;
+
 static uint32_t gpu_div_control;
 // There is a distinct advantage to having these separated out--there's no need to clear
 // a bit before writing a result. I.e., if the result of an operation leaves a zero in
@@ -190,7 +191,7 @@ static uint32_t gpu_instruction;
 static uint32_t gpu_opcode_first_parameter;
 static uint32_t gpu_opcode_second_parameter;
 
-#define GPU_RUNNING	(gpu_control & 0x01)
+#define GPU_RUNNING     (gpu_control.bits.b0)
 
 #define RM		gpu_reg[gpu_opcode_first_parameter]
 #define RN		gpu_reg[gpu_opcode_second_parameter]
@@ -340,34 +341,33 @@ uint32_t GPUReadLong(uint32_t offset, uint32_t who/*=UNKNOWN*/)
 	{
 		offset &= 0x1F;
 		switch (offset)
-		{
-			case 0x00:
-				gpu_flag_c = (gpu_flag_c ? 1 : 0);
-				gpu_flag_z = (gpu_flag_z ? 1 : 0);
-				gpu_flag_n = (gpu_flag_n ? 1 : 0);
+      {
+         case 0x00:
+            gpu_flag_c = (gpu_flag_c ? 1 : 0);
+            gpu_flag_z = (gpu_flag_z ? 1 : 0);
+            gpu_flag_n = (gpu_flag_n ? 1 : 0);
 
-				gpu_flags = (gpu_flags & 0xFFFFFFF8) | (gpu_flag_n << 2) | (gpu_flag_c << 1) | gpu_flag_z;
+            gpu_flags = (gpu_flags & 0xFFFFFFF8) | (gpu_flag_n << 2) | (gpu_flag_c << 1) | gpu_flag_z;
 
-				return gpu_flags & 0xFFFFC1FF;
-			case 0x04:
-				return gpu_matrix_control;
-			case 0x08:
-				return gpu_pointer_to_matrix;
-			case 0x0C:
-				return gpu_data_organization;
-			case 0x10:
-				return gpu_pc;
-			case 0x14:
-				return gpu_control;
-			case 0x18:
-				return gpu_hidata;
-			case 0x1C:
-				return gpu_remain;
-			default:								// unaligned long read
-				break;
-		}
-
-		return 0;
+            return gpu_flags & 0xFFFFC1FF;
+         case 0x04:
+            return gpu_matrix_control;
+         case 0x08:
+            return gpu_pointer_to_matrix;
+         case 0x0C:
+            return gpu_data_organization;
+         case 0x10:
+            return gpu_pc;
+         case 0x14:
+            return gpu_control.WORD;
+         case 0x18:
+            return gpu_hidata;
+         case 0x1C:
+            return gpu_remain;
+         default:								// unaligned long read
+            return break;
+      }
+        return 0;
 	}
 
 	return (JaguarReadWord(offset, who) << 16) | JaguarReadWord(offset + 2, who);
@@ -471,7 +471,7 @@ void GPUWriteLong(uint32_t offset, uint32_t data, uint32_t who/*=UNKNOWN*/)
                gpu_flag_c = (gpu_flags & CARRY_FLAG) >> 1;
                gpu_flag_n = (gpu_flags & NEGA_FLAG) >> 2;
                GPUUpdateRegisterBanks();
-               gpu_control &= ~((gpu_flags & CINT04FLAGS) >> 3);	// Interrupt latch clear bits
+               gpu_control.WORD &= ~((gpu_flags & CINT04FLAGS) >> 3);	// Interrupt latch clear bits
                //Writing here is only an interrupt enable--this approach is just plain wrong!
                //			GPUHandleIRQs();
                //This, however, is A-OK! ;-)
@@ -521,7 +521,7 @@ void GPUWriteLong(uint32_t offset, uint32_t data, uint32_t who/*=UNKNOWN*/)
                   data &= ~0x04;
                }
 
-               gpu_control = (gpu_control & 0xF7C0) | (data & (~0xF7C0));
+               gpu_control.WORD = (gpu_control.WORD & 0xF7C0) | (data & (~0xF7C0));
 
                // if gpu wasn't running but is now running, execute a few cycles
 #ifdef GPU_SINGLE_STEPPING
@@ -577,7 +577,7 @@ void GPUHandleIRQs(void)
       return;
 
    // Get the interrupt latch & enable bits
-   bits = (gpu_control >> 6) & 0x1F;
+    bits = gpu_control.gpuIRQ.irqMask; //(gpu_control >> 6) & 0x1F;
    mask = (gpu_flags >> 4) & 0x1F;
 
    // Bail out if latched interrupts aren't enabled
@@ -616,11 +616,11 @@ void GPUHandleIRQs(void)
 void GPUSetIRQLine(int irqline, int state)
 {
    uint32_t mask = 0x0040 << irqline;
-   gpu_control &= ~mask;				// Clear the interrupt latch
+   gpu_control.WORD &= ~mask;				// Clear the interrupt latch
 
    if (state)
    {
-      gpu_control |= mask;			// Assert the interrupt latch
+      gpu_control.WORD |= mask;			// Assert the interrupt latch
       GPUHandleIRQs();				// And handle the interrupt...
    }
 }
@@ -642,7 +642,7 @@ void GPUReset(void)
    gpu_pointer_to_matrix = 0x00000000;
    gpu_data_organization = 0xFFFFFFFF;
    gpu_pc				  = 0x00F03000;
-   gpu_control			  = 0x00002800;			// Correctly sets this as TOM Rev. 2
+   gpu_control.WORD			  = 0x00002800;			// Correctly sets this as TOM Rev. 2
    gpu_hidata			  = 0x00000000;
    gpu_remain			  = 0x00000000;			// These two registers are RO/WO
    gpu_div_control		  = 0x00000000;

--- a/src/joystick.c
+++ b/src/joystick.c
@@ -66,8 +66,9 @@ uint16_t JoystickReadWord(uint32_t offset)
 		uint8_t offset0, offset1;
 		uint16_t data = 0xFFFF;
 
-		if (!joysticksEnabled)
+        if (!joysticksEnabled) {
 			return 0xFFFF;
+        }
 
 		// Joystick data returns active low for buttons pressed, high for non-
 		// pressed.

--- a/src/joystick.c
+++ b/src/joystick.c
@@ -120,14 +120,14 @@ uint16_t JoystickReadWord(uint32_t offset)
 		if (offset0 != 0xFF)
 		{
 			data &= (joypad0Buttons[mask[offset0][0]] ? 0xFFFD : 0xFFFF);
-			if (mask[offset0][1] != 0xFF)
+			if (mask[offset0][1] != 0xF)
 				data &= (joypad0Buttons[mask[offset0][1]] ? 0xFFFE : 0xFFFF);
 		}
 
 		if (offset1 != 0xFF)
 		{
 			data &= (joypad1Buttons[mask[offset1][0]] ? 0xFFF7 : 0xFFFF);
-			if (mask[offset1][1] != 0xFF)
+			if (mask[offset1][1] != 0xF)
 				data &= (joypad1Buttons[mask[offset1][1]] ? 0xFFFB : 0xFFFF);
 		}
 

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-enum
+typedef enum BUTTON
 {
    BUTTON_FIRST = 0,
    BUTTON_U = 0,
@@ -40,7 +40,7 @@ enum
    BUTTON_OPTION = 19,
    BUTTON_PAUSE = 20,
    BUTTON_LAST = 20
-};
+} BUTTON;
 
 void JoystickInit(void);
 void JoystickReset(void);

--- a/src/m68000/inlines.h
+++ b/src/m68000/inlines.h
@@ -10,6 +10,10 @@
 #ifndef __INLINES_H__
 #define __INLINES_H__
 
+#ifndef INLINE
+#define INLINE __inline__
+#endif /* INLINE */
+
 #include "cpudefs.h"
 #include "m68kinterface.h"
 

--- a/src/m68000/readcpu.c
+++ b/src/m68000/readcpu.c
@@ -22,6 +22,7 @@
 #include <ctype.h>
 #include <string.h>
 
+#include "inlines.h"
 #include "readcpu.h"
 
 int nr_cpuop_funcs;

--- a/src/m68000/readcpu.h
+++ b/src/m68000/readcpu.h
@@ -88,6 +88,7 @@ struct instr_def {
 extern const struct instr_def defs68k[];
 extern int n_defs68k;
 
+#pragma pack(push, 1)
 extern struct instr {
     long int handler;
     unsigned char dreg;
@@ -110,6 +111,7 @@ extern struct instr {
     unsigned int isjmp:1;
     unsigned int unused2:4;
 } *table68k;
+#pragma pack(pop)
 
 extern void read_table68k(void);
 extern void do_merges(void);

--- a/src/vjag_memory.h
+++ b/src/vjag_memory.h
@@ -96,6 +96,9 @@ typedef union Bits32 {
     } bits;
 } Bits32;
 
+#ifdef USE_STRUCTS
+
+    
 #pragma pack(push, 1)
 typedef union OpCode {
     uint16_t WORD;
@@ -124,6 +127,8 @@ typedef union OpCode {
 
 typedef OpCode U16Union;
 
+#endif
+    
 typedef union Offset {
     uint32_t LONG;
 #pragma pack(push, 1)
@@ -217,12 +222,16 @@ extern const char * whoName[10];
 #define SET16(r, a, v)	r[(a)] = ((v) & 0xFF00) >> 8, r[(a)+1] = (v) & 0xFF
 
 
-INLINE static uint16_t GET16(uint8_t* r,uint32_t a) {
-    U16Union u16;
-    u16.Bytes.UBYTE = r[a];
-    u16.Bytes.LBYTE = r[a+1];
-    return u16.WORD;
-}
+#ifdef USE_STRUCTS
+    INLINE static uint16_t GET16(uint8_t* r,uint32_t a) {
+        U16Union u16;
+        u16.Bytes.UBYTE = r[a];
+        u16.Bytes.LBYTE = r[a+1];
+        return u16.WORD;
+    }
+#else
+    #define GET16(r, a)        ((r[(a)] << 8) | r[(a)+1])
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/vjag_memory.h
+++ b/src/vjag_memory.h
@@ -170,7 +170,6 @@ typedef union GPUControl {
 
 } GPUControl;
     
-#ifdef USE_STRUCTS
 #pragma pack(push, 1)
     typedef union OpCode {
         uint16_t WORD;
@@ -198,9 +197,7 @@ typedef union GPUControl {
 #pragma pack(pop)
     
     typedef OpCode U16Union;
-#endif //USE_STRUCTS
 
-#ifdef USE_STRUCTS
 typedef union Offset {
     uint32_t LONG;
 #pragma pack(push, 1)
@@ -215,7 +212,6 @@ typedef union Offset {
     } Members;
 #pragma pack(pop)
 } Offset;
-#endif //USE_STRUCTS
     
 typedef union DSPLong {
     uint32_t LONG;

--- a/src/vjag_memory.h
+++ b/src/vjag_memory.h
@@ -8,6 +8,7 @@
 #define __MEMORY_H__
 
 #include <stdint.h>
+#include <assert.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,7 +40,8 @@ extern "C" {
         } bytes;
     } Bits64;
 #pragma pack(pop)
-    
+	_Static_assert( sizeof(Bits64) == sizeof(uint64_t), "Pack error");
+
 #pragma pack(push, 1)
 typedef union Bits32 {
     uint32_t WORD;
@@ -146,6 +148,7 @@ typedef union Bits32 {
     } bits;
 } Bits32;
 #pragma pack(pop)
+	_Static_assert( sizeof(Bits32) == sizeof(uint32_t), "Pack error");
 
 #pragma pack(push, 1)
 typedef union GPUControl {

--- a/src/vjag_memory.h
+++ b/src/vjag_memory.h
@@ -39,6 +39,8 @@ extern "C" {
         } bytes;
     } Bits64;
 #pragma pack(pop)
+    
+#pragma pack(push, 1)
 typedef union Bits32 {
     uint32_t WORD;
     struct Words {
@@ -50,6 +52,28 @@ typedef union Bits32 {
         uint16_t LWORD;
 #endif
     } words;
+    struct Bytes4 {
+#ifdef LITTLE_ENDIAN
+        uint8_t LL;
+        uint8_t LU;
+        uint8_t UL;
+        uint8_t UU; // Upper upper [UU, UL, LU, LL]
+#else
+        uint8_t UU; // Upper upper [UU, UL, LU, LL]
+        uint8_t UL;
+        uint8_t LU;
+        uint8_t LL;
+#endif
+    } bytes;
+    struct TopThreeOne {
+#ifdef LITTLE_ENDIAN
+        unsigned int : 1;
+        uint32_t value : 31;
+#else
+        uint32_t value : 31;
+        unsigned int : 1;
+#endif
+    } topThreeOne;
     struct Bits {
 #ifdef LITTLE_ENDIAN
         unsigned int b0: 1;
@@ -121,7 +145,9 @@ typedef union Bits32 {
 #endif
     } bits;
 } Bits32;
-    
+#pragma pack(pop)
+
+#pragma pack(push, 1)
 typedef union GPUControl {
     uint32_t WORD;
     struct Words words;
@@ -136,15 +162,16 @@ typedef union GPUControl {
         unsigned int irqMask: 5;
         unsigned int : 6;
 #endif
-    } gpuIRQ;
-    
+} gpuIRQ;
+#pragma pack(pop)
+
 } GPUControl;
     
 #ifdef USE_STRUCTS
 #pragma pack(push, 1)
     typedef union OpCode {
         uint16_t WORD;
-        struct Bytes {
+        struct Bytes2 {
 #ifdef LITTLE_ENDIAN
             uint8_t LBYTE;
             uint8_t UBYTE;

--- a/src/vjag_memory.h
+++ b/src/vjag_memory.h
@@ -95,40 +95,38 @@ typedef union Bits32 {
 #endif
     } bits;
 } Bits32;
+    
+#ifdef USE_STRUCTS
+#pragma pack(push, 1)
+    typedef union OpCode {
+        uint16_t WORD;
+        struct Bytes {
+#ifdef LITTLE_ENDIAN
+            uint8_t LBYTE;
+            uint8_t UBYTE;
+#else
+            uint8_t UBYTE;
+            uint8_t LBYTE;
+#endif
+        } Bytes;
+        struct Codes {
+#ifdef LITTLE_ENDIAN
+            unsigned int second : 5;
+            unsigned int first : 5;
+            unsigned int index : 6;
+#else
+            unsigned int index : 6;
+            unsigned int first : 5;
+            unsigned int second : 5;
+#endif
+        } Codes;
+    } OpCode;
+#pragma pack(pop)
+    
+    typedef OpCode U16Union;
+#endif //USE_STRUCTS
 
 #ifdef USE_STRUCTS
-
-    
-#pragma pack(push, 1)
-typedef union OpCode {
-    uint16_t WORD;
-    struct Bytes {
-#ifdef LITTLE_ENDIAN
-        uint8_t LBYTE;
-        uint8_t UBYTE;
-#else
-        uint8_t UBYTE;
-        uint8_t LBYTE;
-#endif
-    } Bytes;
-    struct Codes {
-#ifdef LITTLE_ENDIAN
-        unsigned int second : 5;
-        unsigned int first : 5;
-        unsigned int index : 6;
-#else
-        unsigned int index : 6;
-        unsigned int first : 5;
-        unsigned int second : 5;
-#endif
-    } Codes;
-} OpCode;
-#pragma pack(pop)
-
-typedef OpCode U16Union;
-
-#endif
-    
 typedef union Offset {
     uint32_t LONG;
 #pragma pack(push, 1)
@@ -143,7 +141,8 @@ typedef union Offset {
     } Members;
 #pragma pack(pop)
 } Offset;
-
+#endif //USE_STRUCTS
+    
 typedef union DSPLong {
     uint32_t LONG;
     struct Data {

--- a/src/vjag_memory.h
+++ b/src/vjag_memory.h
@@ -23,8 +23,8 @@ typedef union Bits32 {
         uint16_t UWORD;
         uint16_t LWORD;
 #endif
-    } Words;
-    struct bits {
+    } words;
+    struct Bits {
 #ifdef LITTLE_ENDIAN
         unsigned int b0: 1;
         unsigned int b1: 1;
@@ -95,6 +95,24 @@ typedef union Bits32 {
 #endif
     } bits;
 } Bits32;
+    
+typedef union GPUControl {
+    uint32_t WORD;
+    struct Words words;
+    struct Bits bits;
+    struct  __attribute__ ((__packed__)) {
+#ifdef LITTLE_ENDIAN
+        unsigned int : 6;
+        unsigned int irqMask: 5;
+        unsigned int : 21;
+#else
+        unsigned int : 21;
+        unsigned int irqMask: 5;
+        unsigned int : 6;
+#endif
+    } gpuIRQ;
+    
+} GPUControl;
     
 #ifdef USE_STRUCTS
 #pragma pack(push, 1)
@@ -221,16 +239,16 @@ extern const char * whoName[10];
 #define SET16(r, a, v)	r[(a)] = ((v) & 0xFF00) >> 8, r[(a)+1] = (v) & 0xFF
 
 
-#ifdef USE_STRUCTS
-    INLINE static uint16_t GET16(uint8_t* r,uint32_t a) {
-        U16Union u16;
-        u16.Bytes.UBYTE = r[a];
-        u16.Bytes.LBYTE = r[a+1];
-        return u16.WORD;
-    }
-#else
+//#ifdef USE_STRUCTS
+//    INLINE static uint16_t GET16(uint8_t* r,uint32_t a) {
+//        U16Union u16;
+//        u16.Bytes.UBYTE = r[a];
+//        u16.Bytes.LBYTE = r[a+1];
+//        return u16.WORD;
+//    }
+//#else
     #define GET16(r, a)        ((r[(a)] << 8) | r[(a)+1])
-#endif
+//#endif
 
 #ifdef __cplusplus
 }

--- a/src/vjag_memory.h
+++ b/src/vjag_memory.h
@@ -13,6 +13,145 @@
 extern "C" {
 #endif
 
+typedef union Bits32 {
+    uint32_t WORD;
+    struct Words {
+#ifdef LITTLE_ENDIAN
+        uint16_t LWORD;
+        uint16_t UWORD;
+#else
+        uint16_t UWORD;
+        uint16_t LWORD;
+#endif
+    } Words;
+    struct bits {
+#ifdef LITTLE_ENDIAN
+        unsigned int b0: 1;
+        unsigned int b1: 1;
+        unsigned int b2: 1;
+        unsigned int b3: 1;
+        unsigned int b4: 1;
+        unsigned int b5: 1;
+        unsigned int b6: 1;
+        unsigned int b7: 1;
+        unsigned int b8: 1;
+        unsigned int b9: 1;
+        unsigned int b10: 1;
+        unsigned int b11: 1;
+        unsigned int b12: 1;
+        unsigned int b13: 1;
+        unsigned int b14: 1;
+        unsigned int b15: 1;
+        unsigned int b16: 1;
+        unsigned int b17: 1;
+        unsigned int b18: 1;
+        unsigned int b19: 1;
+        unsigned int b20: 1;
+        unsigned int b21: 1;
+        unsigned int b22: 1;
+        unsigned int b23: 1;
+        unsigned int b24: 1;
+        unsigned int b25: 1;
+        unsigned int b26: 1;
+        unsigned int b27: 1;
+        unsigned int b28: 1;
+        unsigned int b29: 1;
+        unsigned int b30: 1;
+        unsigned int b31: 1;
+#else
+        // reverse the order of the bit fields.
+        unsigned int b31: 1;
+        unsigned int b30: 1;
+        unsigned int b29: 1;
+        unsigned int b28: 1;
+        unsigned int b27: 1;
+        unsigned int b26: 1;
+        unsigned int b25: 1;
+        unsigned int b24: 1;
+        unsigned int b23: 1;
+        unsigned int b22: 1;
+        unsigned int b21: 1;
+        unsigned int b20: 1;
+        unsigned int b19: 1;
+        unsigned int b18: 1;
+        unsigned int b17: 1;
+        unsigned int b16: 1;
+        unsigned int b15: 1;
+        unsigned int b14: 1;
+        unsigned int b13: 1;
+        unsigned int b12: 1;
+        unsigned int b11: 1;
+        unsigned int b10: 1;
+        unsigned int b9: 1;
+        unsigned int b8: 1;
+        unsigned int b7: 1;
+        unsigned int b6: 1;
+        unsigned int b5: 1;
+        unsigned int b4: 1;
+        unsigned int b3: 1;
+        unsigned int b2: 1;
+        unsigned int b1: 1;
+        unsigned int b0: 1;
+#endif
+    } bits;
+} Bits32;
+
+#pragma pack(push, 1)
+typedef union OpCode {
+    uint16_t WORD;
+    struct Bytes {
+#ifdef LITTLE_ENDIAN
+        uint8_t LBYTE;
+        uint8_t UBYTE;
+#else
+        uint8_t UBYTE;
+        uint8_t LBYTE;
+#endif
+    } Bytes;
+    struct Codes {
+#ifdef LITTLE_ENDIAN
+        unsigned int second : 5;
+        unsigned int first : 5;
+        unsigned int index : 6;
+#else
+        unsigned int index : 6;
+        unsigned int first : 5;
+        unsigned int second : 5;
+#endif
+    } Codes;
+} OpCode;
+#pragma pack(pop)
+
+typedef OpCode U16Union;
+
+typedef union Offset {
+    uint32_t LONG;
+#pragma pack(push, 1)
+    struct Members {
+#ifdef LITTLE_ENDIAN
+        unsigned int offset : 31;
+        unsigned int bit : 1;
+#else
+        unsigned int bit : 1;
+        unsigned int offset : 31;
+#endif
+    } Members;
+#pragma pack(pop)
+} Offset;
+
+typedef union DSPLong {
+    uint32_t LONG;
+    struct Data {
+#ifdef LITTLE_ENDIAN
+        uint16_t LWORD;
+        uint16_t UWORD;
+#else
+        uint16_t UWORD;
+        uint16_t LWORD;
+#endif
+    } Data;
+} DSPLong;
+    
 extern uint8_t jagMemSpace[];
 
 extern uint8_t * jaguarMainRAM;
@@ -76,7 +215,14 @@ extern const char * whoName[10];
 						r[(a)+2] = ((v) & 0x0000FF00) >> 8, r[(a)+3] = (v) & 0x000000FF
 #define GET32(r, a)		((r[(a)] << 24) | (r[(a)+1] << 16) | (r[(a)+2] << 8) | r[(a)+3])
 #define SET16(r, a, v)	r[(a)] = ((v) & 0xFF00) >> 8, r[(a)+1] = (v) & 0xFF
-#define GET16(r, a)		((r[(a)] << 8) | r[(a)+1])
+
+
+INLINE static uint16_t GET16(uint8_t* r,uint32_t a) {
+    U16Union u16;
+    u16.Bytes.UBYTE = r[a];
+    u16.Bytes.LBYTE = r[a+1];
+    return u16.WORD;
+}
 
 #ifdef __cplusplus
 }

--- a/src/vjag_memory.h
+++ b/src/vjag_memory.h
@@ -13,6 +13,32 @@
 extern "C" {
 #endif
 
+#pragma pack(push, 1)
+    typedef union Bits64 {
+        uint64_t DATA;
+        struct Bytes8 {
+#ifdef LITTLE_ENDIAN
+            uint8_t b0;
+            uint8_t b1;
+            uint8_t b2;
+            uint8_t b3;
+            uint8_t b4;
+            uint8_t b5;
+            uint8_t b6;
+            uint8_t b7;
+#else
+            uint8_t b7;
+            uint8_t b6;
+            uint8_t b5;
+            uint8_t b4;
+            uint8_t b3;
+            uint8_t b2;
+            uint8_t b1;
+            uint8_t b0;
+#endif
+        } bytes;
+    } Bits64;
+#pragma pack(pop)
 typedef union Bits32 {
     uint32_t WORD;
     struct Words {


### PR DESCRIPTION
Rebase of #53 as per @twinaphex requests.

There are diff's around controller input fixes that I reverted from #53 that should be looked into in a new PR.

specifically these commits

fb695b1b0e1f104136428834b2b609c2139c7f8c
f4ebb99aa85369f774d41ba764a17a3e45a6889d
681a1f3ab40c60833e886f0f461b3d47d1ee4524
34ca42f3339dc83d1fcf68ed21802db2cd4c1df5

## Original PR
---

I'm making a PR for some old optimizations I made for an iOS fork.

This PR is more for the devs to test and cherry-pick, I don't expect this code to be "merge quality", but certainly buildable/testable at least.

For instance, probably don't want these hacks that were specific to iOS loading,
https://github.com/libretro/virtualjaguar-libretro/pull/53/commits/811e73f8b574ec2b34a69934fa36f66c3202f45b

The blitter really is the slowest part. I wanted to write something with SIMD or better vectorization or improved memcpy or something. That was by far the slowest part when I profiled this pretty heavily a while ago (at least it was excruciatingly slow on ARM without my C struct hacks to help the compiler optimize better.

---
Update:
Forgot to mention I have these macros defined in my build (in XCode) that need to be added to a header or C compile flags

C
```c
#define INLINE=inline 
#define USE_STRUCTS=1
```

flags
```sh
-DINLINE=inline -DUSE_STRUCTS=1 -D__GCCUNIX__  
```

Inline macro may need to be customized based on arch. Mac OS is using Clang/C99/gnu++11 syntax for inline.

I also have `unroll loops` aka `-qunroll=no` but i forget why.