### PR TITLE
[CI/CD] GitHub Actions 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @JoeMatt @twinaphex 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+      - name: build application
+        run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
 name: Build
 
 on:
-  push:
-    branches: [master]
   pull_request:
-    branches: [master]
+    types: [opened, edited, ready_for_review, reopened]
 
 jobs:
   build:
@@ -16,5 +14,25 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v2
+
       - name: build application
         run: make
+
+      - name: upload artifacts
+      - uses: actions/upload-artifact@v2
+        with:
+          name: results
+          path: virtualjaguar_libretro.*
+          if-no-files-found: error
+
+      - name: download artifacts
+      - uses: actions/download-artifact@v2
+        with:
+          name: results
+
+      # - name: comment PR
+      #   uses: machine-learning-apps/pr-comment@master
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     path: results/results.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - name: checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,19 @@
+name: Pull Request on Branch Push
+on:
+  push:
+    branches-ignore:
+      - staging
+      - launchpad
+      - production
+jobs:
+  auto-pull-request:
+    name: PullRequestAction
+    runs-on: ubuntu-latest
+    steps:
+      - name: pull-request-action
+        uses: vsoch/pull-request-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_PREFIX: 'feature/'
+          PULL_REQUEST_BRANCH: 'master'
+          PULL_REQUEST_DRAFT: true

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,20 @@
+# https://github.com/marketplace/actions/automatic-rebase
+name: Automatic Rebase
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.exe
 *.js
 *.bc
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.js
 *.bc
 .DS_Store
+.build


### PR DESCRIPTION
For some reason the GitHub Action for building from #64 isn't being recognized so I pulled this action into a separate PR.

I intend to attach links to PRs, but a limitation of the GitHub Actions api is you can't get the perm url of a build asset in an action, hence the second action to run after the first completes.

--- changelog

git ignore .DS_Store
Add �CODEOWNERS
Add rebase.yml rebase action
Add build.yml ci action
gitignore .build