### PR TITLE
libretro: add webOS to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,6 +76,9 @@ include:
     file: '/tvos-arm64.yml'
 
   #################################### MISC ##################################
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
 
 # Stages for building
 stages:
@@ -196,4 +199,11 @@ libretro-build-vita:
 libretro-build-libnx-aarch64:
   extends:
     - .libretro-libnx-static-retroarch-master
+    - .core-defs
+
+#################################### MISC ####################################
+# webOS 32-bit
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-make-default
     - .core-defs


### PR DESCRIPTION
## Summary

- Adds webOS build target to CI

Cherry-picked from #88 by @cscd98 (rebased onto current master).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)