### PR TITLE
Fix logical OR bug in GPU address range check

### DIFF
--- a/src/gpu.c
+++ b/src/gpu.c
@@ -442,7 +442,7 @@ void GPUWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
 
       return;
    }
-   else if ((offset == GPU_WORK_RAM_BASE + 0x0FFF) || (GPU_CONTROL_RAM_BASE + 0x1F))
+   else if ((offset == GPU_WORK_RAM_BASE + 0x0FFF) || (offset == GPU_CONTROL_RAM_BASE + 0x1F))
       return;
 
    // Have to be careful here--this can cause an infinite loop!


### PR DESCRIPTION
## Summary

- Fix always-true condition in `GPUWriteWord` address range check (`src/gpu.c:445`)
- `(GPU_CONTROL_RAM_BASE + 0x1F)` is a bare constant (always truthy), should be `(offset == GPU_CONTROL_RAM_BASE + 0x1F)`

This means the else-if branch was always taken regardless of the offset, causing the early `return` to skip the `JaguarWriteWord` fallback on every call that reached this point.

Verified that `GPUWriteByte` (line 379) does not have the same issue — it uses a proper range check with `>=`/`<=`.

## Test plan

- [x] Builds clean
- [x] CI matrix passes (8/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)