### PR TITLE
SIMD-accelerated blitter operations (SSE2, NEON)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -69,6 +69,26 @@ jobs:
     - name: Build
       run: make -j4 CC=${{ matrix.config.cc }} CXX=${{ matrix.config.cxx }}
 
+    - name: Run SIMD blitter tests
+      run: |
+        # Detect which SIMD impl to test based on runner architecture
+        ARCH=$(uname -m)
+        case "$ARCH" in
+          x86_64|i686|i386)  SIMD_SRC=src/blitter_simd_sse2.c; EXTRA="-msse2" ;;
+          aarch64|arm64)     SIMD_SRC=src/blitter_simd_neon.c;  EXTRA="" ;;
+          *)                 SIMD_SRC=src/blitter_simd_scalar.c; EXTRA="" ;;
+        esac
+
+        echo "==> Testing ${SIMD_SRC}..."
+        ${{ matrix.config.cc }} -O2 -Wall ${EXTRA} -I src \
+          -o test_blitter_simd test/test_blitter_simd.c ${SIMD_SRC}
+        ./test_blitter_simd
+
+        echo "==> Cross-checking against scalar..."
+        ${{ matrix.config.cc }} -O2 -Wall -I src \
+          -o test_blitter_scalar test/test_blitter_simd.c src/blitter_simd_scalar.c
+        ./test_blitter_scalar
+
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .DS_Store
 .build
 /.claude
+test/test_blitter_simd

--- a/Makefile.common
+++ b/Makefile.common
@@ -50,7 +50,7 @@ SOURCES_C :=  \
 
 # SIMD-accelerated blitter operations: select arch-specific implementation.
 # BLITTER_SIMD may be set explicitly to one of: scalar, sse2, neon.
-BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_scalar.c
+BLITTER_SIMD_SRC :=
 
 ifneq ($(BLITTER_SIMD),)
 ifeq (,$(filter scalar sse2 neon,$(BLITTER_SIMD)))
@@ -72,16 +72,21 @@ endif
 ifneq (,$(filter ios-arm64 tvos-arm64,$(platform)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
 endif
-ifneq (,$(filter aarch64 arm64 arm,$(ARCH)))
+# Only aarch64/arm64 guaranteed to have NEON; plain 'arm' may lack it
+ifneq (,$(filter aarch64 arm64,$(ARCH)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
 endif
-ifneq (,$(filter arm64 armv8% armv7% armhf arm,$(platform)))
+ifneq (,$(filter arm64 armv8% armv7% armhf,$(platform)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
 endif
 
 # x86/x64 targets: use SSE2.
 ifneq (,$(filter x86_64 x86 i686 i386,$(ARCH)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+   # 32-bit x86 may need explicit SSE2 enable
+   ifneq (,$(filter i686 i386 x86,$(ARCH)))
+      CFLAGS += -msse2
+   endif
 endif
 ifneq (,$(filter x86_64 x86 i686 i386 win-x64 win32,$(platform)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
@@ -91,13 +96,22 @@ ifneq (,$(filter MINGW64%,$(MSYSTEM)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
 endif
 
-# Native build fallback: auto-detect from host architecture
+# Native build fallback: auto-detect from host when no SIMD was selected above.
+ifeq ($(BLITTER_SIMD_SRC),)
 ifneq (,$(filter x86_64 x86 i686 i386,$(shell uname -m 2>/dev/null)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
 endif
+endif
+ifeq ($(BLITTER_SIMD_SRC),)
 ifneq (,$(filter aarch64 arm64,$(shell uname -m 2>/dev/null)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
 endif
+endif
+endif
+
+# Fall back to scalar if no SIMD was selected (e.g., exotic platforms)
+ifeq ($(BLITTER_SIMD_SRC),)
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_scalar.c
 endif
 
 SOURCES_C += $(BLITTER_SIMD_SRC)

--- a/Makefile.common
+++ b/Makefile.common
@@ -49,23 +49,30 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/wavetable.c
 
 # SIMD-accelerated blitter operations: select arch-specific implementation.
+# Override with BLITTER_SIMD=scalar|sse2|neon for cross-compilation.
 # Default to portable scalar fallback.
 BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_scalar.c
 
-# x86/x64: use SSE2 (baseline for all x86_64, available since Pentium 4)
-ifneq (,$(filter x86_64 x86 i686 i386,$(shell uname -m 2>/dev/null)))
-   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
-endif
-# MSYS2/MinGW on x86_64
-ifneq (,$(filter MINGW64%,$(MSYSTEM)))
-   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+ifdef BLITTER_SIMD
+   # Explicit override for cross-compilation or custom builds
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_$(BLITTER_SIMD).c
+else
+   # Auto-detect from host architecture (native builds only)
+   # x86/x64: use SSE2 (baseline for all x86_64, available since Pentium 4)
+   ifneq (,$(filter x86_64 x86 i686 i386,$(shell uname -m 2>/dev/null)))
+      BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+   endif
+   # MSYS2/MinGW on x86_64
+   ifneq (,$(filter MINGW64%,$(MSYSTEM)))
+      BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+   endif
+   # ARM64 (AArch64): NEON is always available
+   ifneq (,$(filter aarch64 arm64,$(shell uname -m 2>/dev/null)))
+      BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+   endif
 endif
 
-# ARM64 (AArch64): NEON is always available
-ifneq (,$(filter aarch64 arm64,$(shell uname -m 2>/dev/null)))
-   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
-endif
-# iOS/tvOS ARM64 cross-compilation
+# Platform-based overrides (cross-compilation targets)
 ifneq (,$(filter ios-arm64 tvos-arm64,$(platform)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
 endif

--- a/Makefile.common
+++ b/Makefile.common
@@ -65,46 +65,54 @@ else ifeq ($(BLITTER_SIMD),neon)
 else ifeq ($(BLITTER_SIMD),scalar)
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_scalar.c
 else
-# ARM targets: prefer NEON when the target configuration says it is available.
+# ARM targets: prefer NEON when guaranteed or explicitly enabled.
 ifeq ($(HAVE_NEON), 1)
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
 endif
 ifneq (,$(filter ios-arm64 tvos-arm64,$(platform)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
 endif
-# Only aarch64/arm64 guaranteed to have NEON; plain 'arm' may lack it
+# aarch64/arm64 always have NEON; plain 'arm' may lack it.
 ifneq (,$(filter aarch64 arm64,$(ARCH)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
 endif
-ifneq (,$(filter arm64 armv8% armv7% armhf,$(platform)))
+# armv8+ implies NEON; armv7/armhf only use NEON if HAVE_NEON was set above.
+ifneq (,$(filter arm64 armv8%,$(platform)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
 endif
 
 # x86/x64 targets: use SSE2.
 ifneq (,$(filter x86_64 x86 i686 i386,$(ARCH)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
-   # 32-bit x86 may need explicit SSE2 enable
-   ifneq (,$(filter i686 i386 x86,$(ARCH)))
-      CFLAGS += -msse2
-   endif
 endif
 ifneq (,$(filter x86_64 x86 i686 i386 win-x64 win32,$(platform)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
 endif
-# MSYS2/MinGW on x86_64
-ifneq (,$(filter MINGW64%,$(MSYSTEM)))
+# MSYS2/MinGW
+ifneq (,$(filter MINGW64% MINGW32%,$(MSYSTEM)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+endif
+# 32-bit x86 needs explicit -msse2 (x86_64 has it baseline).
+ifeq ($(BLITTER_SIMD_SRC),$(CORE_DIR)/src/blitter_simd_sse2.c)
+ifneq (,$(filter i686 i386 x86 win32,$(ARCH) $(platform)))
+   CFLAGS += -msse2
+endif
+ifneq (,$(filter MINGW32%,$(MSYSTEM)))
+   CFLAGS += -msse2
+endif
 endif
 
-# Native build fallback: auto-detect from host when no SIMD was selected above.
+# Native build fallback: auto-detect from host architecture, but only for
+# native-build platforms (unix/osx/win). Cross-compile targets (vita, ps3,
+# libnx, etc.) set platform explicitly and should not use host detection.
 ifeq ($(BLITTER_SIMD_SRC),)
-ifneq (,$(filter x86_64 x86 i686 i386,$(shell uname -m 2>/dev/null)))
+ifneq (,$(filter unix osx win,$(platform)))
+ifneq (,$(filter x86_64 i686 i386,$(shell uname -m 2>/dev/null)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
 endif
-endif
-ifeq ($(BLITTER_SIMD_SRC),)
 ifneq (,$(filter aarch64 arm64,$(shell uname -m 2>/dev/null)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+endif
 endif
 endif
 endif

--- a/Makefile.common
+++ b/Makefile.common
@@ -49,36 +49,55 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/wavetable.c
 
 # SIMD-accelerated blitter operations: select arch-specific implementation.
-# Override with BLITTER_SIMD=scalar|sse2|neon for cross-compilation.
-# Default to portable scalar fallback.
+# BLITTER_SIMD may be set explicitly to one of: scalar, sse2, neon.
 BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_scalar.c
 
-ifdef BLITTER_SIMD
-   # Explicit override for cross-compilation or custom builds
-   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_$(BLITTER_SIMD).c
-else
-   # Auto-detect from host architecture (native builds only)
-   # x86/x64: use SSE2 (baseline for all x86_64, available since Pentium 4)
-   ifneq (,$(filter x86_64 x86 i686 i386,$(shell uname -m 2>/dev/null)))
-      BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
-   endif
-   # MSYS2/MinGW on x86_64
-   ifneq (,$(filter MINGW64%,$(MSYSTEM)))
-      BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
-   endif
-   # ARM64 (AArch64): NEON is always available
-   ifneq (,$(filter aarch64 arm64,$(shell uname -m 2>/dev/null)))
-      BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
-   endif
+ifneq ($(BLITTER_SIMD),)
+ifeq (,$(filter scalar sse2 neon,$(BLITTER_SIMD)))
+$(error Unsupported BLITTER_SIMD '$(BLITTER_SIMD)'; expected one of: scalar sse2 neon)
+endif
 endif
 
-# Platform-based overrides (cross-compilation targets)
+ifeq ($(BLITTER_SIMD),sse2)
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+else ifeq ($(BLITTER_SIMD),neon)
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+else ifeq ($(BLITTER_SIMD),scalar)
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_scalar.c
+else
+# ARM targets: prefer NEON when the target configuration says it is available.
+ifeq ($(HAVE_NEON), 1)
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+endif
 ifneq (,$(filter ios-arm64 tvos-arm64,$(platform)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
 endif
-# ARMv7 with NEON (set by Makefile for classic_armv7 targets)
-ifeq ($(HAVE_NEON), 1)
+ifneq (,$(filter aarch64 arm64 arm,$(ARCH)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+endif
+ifneq (,$(filter arm64 armv8% armv7% armhf arm,$(platform)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+endif
+
+# x86/x64 targets: use SSE2.
+ifneq (,$(filter x86_64 x86 i686 i386,$(ARCH)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+endif
+ifneq (,$(filter x86_64 x86 i686 i386 win-x64 win32,$(platform)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+endif
+# MSYS2/MinGW on x86_64
+ifneq (,$(filter MINGW64%,$(MSYSTEM)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+endif
+
+# Native build fallback: auto-detect from host architecture
+ifneq (,$(filter x86_64 x86 i686 i386,$(shell uname -m 2>/dev/null)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+endif
+ifneq (,$(filter aarch64 arm64,$(shell uname -m 2>/dev/null)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+endif
 endif
 
 SOURCES_C += $(BLITTER_SIMD_SRC)

--- a/Makefile.common
+++ b/Makefile.common
@@ -48,6 +48,34 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/universalhdr.c \
 	$(CORE_DIR)/src/wavetable.c
 
+# SIMD-accelerated blitter operations: select arch-specific implementation.
+# Default to portable scalar fallback.
+BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_scalar.c
+
+# x86/x64: use SSE2 (baseline for all x86_64, available since Pentium 4)
+ifneq (,$(filter x86_64 x86 i686 i386,$(shell uname -m 2>/dev/null)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+endif
+# MSYS2/MinGW on x86_64
+ifneq (,$(filter MINGW64%,$(MSYSTEM)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
+endif
+
+# ARM64 (AArch64): NEON is always available
+ifneq (,$(filter aarch64 arm64,$(shell uname -m 2>/dev/null)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+endif
+# iOS/tvOS ARM64 cross-compilation
+ifneq (,$(filter ios-arm64 tvos-arm64,$(platform)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+endif
+# ARMv7 with NEON (set by Makefile for classic_armv7 targets)
+ifeq ($(HAVE_NEON), 1)
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+endif
+
+SOURCES_C += $(BLITTER_SIMD_SRC)
+
 ifneq ($(STATIC_LINKING), 1)
 SOURCES_C += \
 	     $(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \

--- a/src/blitter.c
+++ b/src/blitter.c
@@ -21,6 +21,7 @@
 //
 
 #include "blitter.h"
+#include "blitter_simd.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -2833,12 +2834,7 @@ Patdhi		:= JOIN (patdhi, patd[32..63]);*/
 
 /*Lfu		:= LFU (lfu[0..1], srcdlo, srcdhi, dstdlo, dstdhi, lfu_func[0..3]);*/
 ////////////////////////////////////// C++ CODE //////////////////////////////////////
-	uint64_t funcmask[2] = { 0, 0xFFFFFFFFFFFFFFFFLL };
-	uint64_t func0 = funcmask[lfu_func & 0x01];
-	uint64_t func1 = funcmask[(lfu_func >> 1) & 0x01];
-	uint64_t func2 = funcmask[(lfu_func >> 2) & 0x01];
-	uint64_t func3 = funcmask[(lfu_func >> 3) & 0x01];
-	uint64_t lfu = (~srcd & ~dstd & func0) | (~srcd & dstd & func1) | (srcd & ~dstd & func2) | (srcd & dstd & func3);
+	uint64_t lfu = blitter_simd_ops.lfu(srcd, dstd, lfu_func);
    bool mir_bit, mir_byte;
    uint16_t masku;
    uint8_t e_coarse, e_fine;
@@ -2850,14 +2846,12 @@ Patdhi		:= JOIN (patdhi, patd[32..63]);*/
 	uint8_t dech38el[2][8] = { { 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80 },
 		{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } };
    int en;
-   uint64_t cmpd;
 	uint8_t dbinht;
    uint16_t addq[4];
    uint8_t initcin[4] = { 0, 0, 0, 0 };
    uint16_t mask;
    uint64_t dmux[4];
    uint64_t ddat;
-	uint64_t zwdata;
 //////////////////////////////////////////////////////////////////////////////////////
 
 // Increment and Step Registers
@@ -2873,25 +2867,7 @@ Zstep		:= JOIN (zstep, zstep[0..31]);*/
 
 /*Datacomp	:= DATACOMP (dcomp[0..7], cmpdst, dstdlo, dstdhi, patdlo, patdhi, srcdlo, srcdhi);*/
 ////////////////////////////////////// C++ CODE //////////////////////////////////////
-	*dcomp = 0;
-	cmpd = *patd ^ (cmpdst ? dstd : srcd);
-
-	if ((cmpd & 0x00000000000000FFLL) == 0)
-		*dcomp |= 0x01u;
-	if ((cmpd & 0x000000000000FF00LL) == 0)
-		*dcomp |= 0x02u;
-	if ((cmpd & 0x0000000000FF0000LL) == 0)
-		*dcomp |= 0x04u;
-	if ((cmpd & 0x00000000FF000000LL) == 0)
-		*dcomp |= 0x08u;
-	if ((cmpd & 0x000000FF00000000LL) == 0)
-		*dcomp |= 0x10u;
-	if ((cmpd & 0x0000FF0000000000LL) == 0)
-		*dcomp |= 0x20u;
-	if ((cmpd & 0x00FF000000000000LL) == 0)
-		*dcomp |= 0x40u;
-	if ((cmpd & 0xFF00000000000000LL) == 0)
-		*dcomp |= 0x80u;
+	*dcomp = blitter_simd_ops.dcomp(*patd, srcd, dstd, cmpdst);
 //////////////////////////////////////////////////////////////////////////////////////
 
 // Zed comparator for Z-buffer operations
@@ -2907,27 +2883,7 @@ Zstep		:= JOIN (zstep, zstep[0..31]);*/
 with srcshift bits 4 & 5 selecting the start position
 */
 //So... basically what we have here is:
-	*zcomp = 0;
-
-	if ((((*srcz & 0x000000000000FFFFLL) < (dstz & 0x000000000000FFFFLL)) && (zmode & 0x01))
-		|| (((*srcz & 0x000000000000FFFFLL) == (dstz & 0x000000000000FFFFLL)) && (zmode & 0x02))
-		|| (((*srcz & 0x000000000000FFFFLL) > (dstz & 0x000000000000FFFFLL)) && (zmode & 0x04)))
-		*zcomp |= 0x01u;
-
-	if ((((*srcz & 0x00000000FFFF0000LL) < (dstz & 0x00000000FFFF0000LL)) && (zmode & 0x01))
-		|| (((*srcz & 0x00000000FFFF0000LL) == (dstz & 0x00000000FFFF0000LL)) && (zmode & 0x02))
-		|| (((*srcz & 0x00000000FFFF0000LL) > (dstz & 0x00000000FFFF0000LL)) && (zmode & 0x04)))
-		*zcomp |= 0x02u;
-
-	if ((((*srcz & 0x0000FFFF00000000LL) < (dstz & 0x0000FFFF00000000LL)) && (zmode & 0x01))
-		|| (((*srcz & 0x0000FFFF00000000LL) == (dstz & 0x0000FFFF00000000LL)) && (zmode & 0x02))
-		|| (((*srcz & 0x0000FFFF00000000LL) > (dstz & 0x0000FFFF00000000LL)) && (zmode & 0x04)))
-		*zcomp |= 0x04u;
-
-	if ((((*srcz & 0xFFFF000000000000LL) < (dstz & 0xFFFF000000000000LL)) && (zmode & 0x01))
-		|| (((*srcz & 0xFFFF000000000000LL) == (dstz & 0xFFFF000000000000LL)) && (zmode & 0x02))
-		|| (((*srcz & 0xFFFF000000000000LL) > (dstz & 0xFFFF000000000000LL)) && (zmode & 0x04)))
-		*zcomp |= 0x08u;
+	*zcomp = blitter_simd_ops.zcomp(*srcz, dstz, zmode);
 
 //TEMP, TO TEST IF ZCOMP IS THE CULPRIT...
 //Nope, this is NOT the problem...
@@ -3159,25 +3115,8 @@ Dat[40-47]	:= MX4 (dat[40-47], dstdhi{8-15},  ddathi{8-15},  dstzhi{8-15},  srcz
 Dat[48-55]	:= MX4 (dat[48-55], dstdhi{16-23}, ddathi{16-23}, dstzhi{16-23}, srczhi{16-23}, mask[13],  zed_selb[1]);
 Dat[56-63]	:= MX4 (dat[56-63], dstdhi{24-31}, ddathi{24-31}, dstzhi{24-31}, srczhi{24-31}, mask[14],  zed_selb[1]);*/
 ////////////////////////////////////// C++ CODE //////////////////////////////////////
-	*wdata = ((ddat & mask) | (dstd & ~mask)) & 0x00000000000000FFLL;
-	*wdata |= ((mask & 0x0100) ? ddat : dstd) & 0x000000000000FF00LL;
-	*wdata |= ((mask & 0x0200) ? ddat : dstd) & 0x0000000000FF0000LL;
-	*wdata |= ((mask & 0x0400) ? ddat : dstd) & 0x00000000FF000000LL;
-	*wdata |= ((mask & 0x0800) ? ddat : dstd) & 0x000000FF00000000LL;
-	*wdata |= ((mask & 0x1000) ? ddat : dstd) & 0x0000FF0000000000LL;
-	*wdata |= ((mask & 0x2000) ? ddat : dstd) & 0x00FF000000000000LL;
-	*wdata |= ((mask & 0x4000) ? ddat : dstd) & 0xFF00000000000000LL;
-
-//This is a crappy way of handling this, but it should work for now...
-	zwdata = ((*srcz & mask) | (dstz & ~mask)) & 0x00000000000000FFLL;
-	zwdata |= ((mask & 0x0100) ? *srcz : dstz) & 0x000000000000FF00LL;
-	zwdata |= ((mask & 0x0200) ? *srcz : dstz) & 0x0000000000FF0000LL;
-	zwdata |= ((mask & 0x0400) ? *srcz : dstz) & 0x00000000FF000000LL;
-	zwdata |= ((mask & 0x0800) ? *srcz : dstz) & 0x000000FF00000000LL;
-	zwdata |= ((mask & 0x1000) ? *srcz : dstz) & 0x0000FF0000000000LL;
-	zwdata |= ((mask & 0x2000) ? *srcz : dstz) & 0x00FF000000000000LL;
-	zwdata |= ((mask & 0x4000) ? *srcz : dstz) & 0xFF00000000000000LL;
-	*srcz = zwdata;
+	*wdata = blitter_simd_ops.byte_merge(ddat, dstd, mask);
+	*srcz = blitter_simd_ops.byte_merge(*srcz, dstz, mask);
 //////////////////////////////////////////////////////////////////////////////////////
 
 /*Data_enab[0-1]	:= BUF8 (data_enab[0-1], data_ena);

--- a/src/blitter_simd.h
+++ b/src/blitter_simd.h
@@ -30,7 +30,8 @@ typedef struct
    uint8_t  (*zcomp)(uint64_t srcz, uint64_t dstz, uint8_t zmode);
 
    /* Byte Mask Merge: select bytes from src or dst based on 16-bit mask.
-    * Bit 0 controls byte 0 (per-bit within byte 0), bits 8-14 control bytes 1-7.
+    * Bits 0-7 control byte 0 (per-bit blend within the lowest byte).
+    * Bits 8-14 control bytes 1-7 (whole-byte select, one bit each).
     * Used for both pixel data (ddat/dstd) and Z data (srcz/dstz). */
    uint64_t (*byte_merge)(uint64_t src, uint64_t dst, uint16_t mask);
 } blitter_simd_ops_t;

--- a/src/blitter_simd.h
+++ b/src/blitter_simd.h
@@ -1,0 +1,40 @@
+/*
+ * SIMD-accelerated blitter operations for Virtual Jaguar
+ *
+ * Provides architecture-specific implementations of the blitter's
+ * hottest data-path operations. Only one implementation file is
+ * compiled per build (selected in Makefile.common).
+ *
+ * Each arch file defines:
+ *   const blitter_simd_ops_t blitter_simd_ops = { ... };
+ */
+
+#ifndef BLITTER_SIMD_H
+#define BLITTER_SIMD_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct
+{
+   /* Logic Function Unit: 64-bit truth table over srcd/dstd.
+    * lfu_func is a 4-bit selector (0-15). */
+   uint64_t (*lfu)(uint64_t srcd, uint64_t dstd, uint8_t lfu_func);
+
+   /* Data Comparator: per-byte equality of patd vs (cmpdst ? dstd : srcd).
+    * Returns 8-bit mask, one bit per byte. */
+   uint8_t  (*dcomp)(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst);
+
+   /* Z-buffer Comparator: 4 independent 16-bit comparisons.
+    * zmode bits: 0=LT, 1=EQ, 2=GT. Returns 4-bit mask. */
+   uint8_t  (*zcomp)(uint64_t srcz, uint64_t dstz, uint8_t zmode);
+
+   /* Byte Mask Merge: select bytes from src or dst based on 16-bit mask.
+    * Bit 0 controls byte 0 (per-bit within byte 0), bits 8-14 control bytes 1-7.
+    * Used for both pixel data (ddat/dstd) and Z data (srcz/dstz). */
+   uint64_t (*byte_merge)(uint64_t src, uint64_t dst, uint16_t mask);
+} blitter_simd_ops_t;
+
+extern const blitter_simd_ops_t blitter_simd_ops;
+
+#endif /* BLITTER_SIMD_H */

--- a/src/blitter_simd_neon.c
+++ b/src/blitter_simd_neon.c
@@ -54,17 +54,20 @@ static uint8_t neon_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpd
    uint8x8_t vzero = vdup_n_u8(0);
    uint8x8_t vcmp = vceq_u8(vxor, vzero);  /* 0xFF where equal, 0 otherwise */
 
-   /* Extract one bit per byte using power-of-2 weights.
-    * vcreate avoids a static const load on every call. */
-   uint8x8_t vw = vcreate_u8(0x8040201008040201ULL);
-   uint8x8_t vbits = vand_u8(vcmp, vw);
+   /* Convert compare lanes from 0xFF/0x00 to 1/0, then pack into
+    * the result byte via lane extraction — avoids weights load
+    * and vpadd chain. */
+   uint8x8_t vbits = vshr_n_u8(vcmp, 7);
 
-   /* Pairwise horizontal add: 8 -> 4 -> 2 -> 1 */
-   uint8x8_t sum1 = vpadd_u8(vbits, vbits);
-   uint8x8_t sum2 = vpadd_u8(sum1, sum1);
-   uint8x8_t sum3 = vpadd_u8(sum2, sum2);
-
-   return vget_lane_u8(sum3, 0);
+   return (uint8_t)(
+      (vget_lane_u8(vbits, 0) << 0) |
+      (vget_lane_u8(vbits, 1) << 1) |
+      (vget_lane_u8(vbits, 2) << 2) |
+      (vget_lane_u8(vbits, 3) << 3) |
+      (vget_lane_u8(vbits, 4) << 4) |
+      (vget_lane_u8(vbits, 5) << 5) |
+      (vget_lane_u8(vbits, 6) << 6) |
+      (vget_lane_u8(vbits, 7) << 7));
 }
 
 /* Z-buffer Comparator — NEON

--- a/src/blitter_simd_neon.c
+++ b/src/blitter_simd_neon.c
@@ -108,18 +108,20 @@ static uint8_t neon_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
  */
 static uint64_t neon_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
 {
-   /* Build 8-byte selection mask */
-   uint8_t sel[8];
-   sel[0] = (uint8_t)(mask & 0xFF);
-   sel[1] = (mask & 0x0100) ? 0xFF : 0x00;
-   sel[2] = (mask & 0x0200) ? 0xFF : 0x00;
-   sel[3] = (mask & 0x0400) ? 0xFF : 0x00;
-   sel[4] = (mask & 0x0800) ? 0xFF : 0x00;
-   sel[5] = (mask & 0x1000) ? 0xFF : 0x00;
-   sel[6] = (mask & 0x2000) ? 0xFF : 0x00;
-   sel[7] = (mask & 0x4000) ? 0xFF : 0x00;
+   /* Build 8-byte selection mask entirely in registers.
+    * Byte 0 uses the low 8 bits directly; bytes 1-7 are all-ones or
+    * all-zero based on mask bits 8-14. */
+   uint64_t sel =
+      ((uint64_t)(mask & 0x00FF)) |
+      ((uint64_t)((mask & 0x0100) ? 0xFF : 0x00) <<  8) |
+      ((uint64_t)((mask & 0x0200) ? 0xFF : 0x00) << 16) |
+      ((uint64_t)((mask & 0x0400) ? 0xFF : 0x00) << 24) |
+      ((uint64_t)((mask & 0x0800) ? 0xFF : 0x00) << 32) |
+      ((uint64_t)((mask & 0x1000) ? 0xFF : 0x00) << 40) |
+      ((uint64_t)((mask & 0x2000) ? 0xFF : 0x00) << 48) |
+      ((uint64_t)((mask & 0x4000) ? 0xFF : 0x00) << 56);
 
-   uint8x8_t vmask = vld1_u8(sel);
+   uint8x8_t vmask = vreinterpret_u8_u64(vcreate_u64(sel));
    uint8x8_t vsrc  = vreinterpret_u8_u64(vcreate_u64(src));
    uint8x8_t vdst  = vreinterpret_u8_u64(vcreate_u64(dst));
 

--- a/src/blitter_simd_neon.c
+++ b/src/blitter_simd_neon.c
@@ -1,0 +1,138 @@
+/*
+ * Blitter SIMD ops — ARM NEON implementation
+ *
+ * NEON is mandatory on AArch64 and available on most ARMv7-A with
+ * VFPv3. The Makefile selects this file when targeting ARM64 or
+ * when HAVE_NEON=1.
+ */
+
+#include "blitter_simd.h"
+#include <arm_neon.h>
+
+/* Logic Function Unit — NEON
+ *
+ * Same truth-table approach as scalar, but using 64-bit NEON
+ * integer operations (uint64x1_t).
+ */
+static uint64_t neon_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
+{
+   uint64x1_t vs  = vcreate_u64(srcd);
+   uint64x1_t vd  = vcreate_u64(dstd);
+   /* NEON vmvn only works up to 32-bit, so we use EOR with all-ones */
+   uint64x1_t ones = vcreate_u64(0xFFFFFFFFFFFFFFFFULL);
+   uint64x1_t vns = veor_u64(vs, ones);  /* ~srcd */
+   uint64x1_t vnd = veor_u64(vd, ones);  /* ~dstd */
+
+   uint64x1_t vf0 = vcreate_u64((lfu_func & 0x01) ? 0xFFFFFFFFFFFFFFFFULL : 0);
+   uint64x1_t vf1 = vcreate_u64((lfu_func & 0x02) ? 0xFFFFFFFFFFFFFFFFULL : 0);
+   uint64x1_t vf2 = vcreate_u64((lfu_func & 0x04) ? 0xFFFFFFFFFFFFFFFFULL : 0);
+   uint64x1_t vf3 = vcreate_u64((lfu_func & 0x08) ? 0xFFFFFFFFFFFFFFFFULL : 0);
+
+   /* (~s & ~d & f0) | (~s & d & f1) | (s & ~d & f2) | (s & d & f3) */
+   uint64x1_t t0 = vand_u64(vand_u64(vns, vnd), vf0);
+   uint64x1_t t1 = vand_u64(vand_u64(vns, vd),  vf1);
+   uint64x1_t t2 = vand_u64(vand_u64(vs,  vnd), vf2);
+   uint64x1_t t3 = vand_u64(vand_u64(vs,  vd),  vf3);
+
+   uint64x1_t result = vorr_u64(vorr_u64(t0, t1), vorr_u64(t2, t3));
+   return vget_lane_u64(result, 0);
+}
+
+/* Data Comparator — NEON
+ *
+ * XOR + per-byte zero check. NEON vceq gives 0xFF per matching byte,
+ * then we extract one bit per byte.
+ */
+static uint8_t neon_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
+{
+   uint64_t other = cmpdst ? dstd : srcd;
+   uint8x8_t vp = vreinterpret_u8_u64(vcreate_u64(patd));
+   uint8x8_t vo = vreinterpret_u8_u64(vcreate_u64(other));
+
+   /* XOR then compare each byte to zero */
+   uint8x8_t vxor = veor_u8(vp, vo);
+   uint8x8_t vzero = vdup_n_u8(0);
+   uint8x8_t vcmp = vceq_u8(vxor, vzero);  /* 0xFF where equal, 0 otherwise */
+
+   /* Extract one bit per byte.
+    * Multiply each lane by a power-of-2 weight and horizontal add.
+    * Weights: 1, 2, 4, 8, 16, 32, 64, 128 */
+   static const uint8_t weights[8] = { 1, 2, 4, 8, 16, 32, 64, 128 };
+   uint8x8_t vw = vld1_u8(weights);
+
+   /* AND with weights (0xFF & weight = weight, 0 & weight = 0) */
+   uint8x8_t vbits = vand_u8(vcmp, vw);
+
+   /* Pairwise add to collapse 8 bytes -> 4 -> 2 -> 1 */
+   uint8x8_t sum1 = vpadd_u8(vbits, vbits);  /* 4 sums */
+   uint8x8_t sum2 = vpadd_u8(sum1, sum1);     /* 2 sums */
+   uint8x8_t sum3 = vpadd_u8(sum2, sum2);     /* 1 sum  */
+
+   return vget_lane_u8(sum3, 0);
+}
+
+/* Z-buffer Comparator — NEON
+ *
+ * 4 packed unsigned 16-bit comparisons. NEON has native unsigned
+ * compare instructions (vclt_u16, vceq_u16, vcgt_u16).
+ */
+static uint8_t neon_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
+{
+   uint16x4_t vs = vreinterpret_u16_u64(vcreate_u64(srcz));
+   uint16x4_t vd = vreinterpret_u16_u64(vcreate_u64(dstz));
+   uint16x4_t vresult = vdup_n_u16(0);
+
+   if (zmode & 0x01)  /* LT */
+      vresult = vorr_u16(vresult, vclt_u16(vs, vd));
+   if (zmode & 0x02)  /* EQ */
+      vresult = vorr_u16(vresult, vceq_u16(vs, vd));
+   if (zmode & 0x04)  /* GT */
+      vresult = vorr_u16(vresult, vcgt_u16(vs, vd));
+
+   /* Extract one bit per 16-bit lane.
+    * vresult lanes are 0xFFFF or 0x0000. Narrow and extract. */
+   /* Shift each lane: lane0 >> 0, lane1 >> 1, lane2 >> 2, lane3 >> 3
+    * But easier: just read each lane */
+   uint8_t result = 0;
+   if (vget_lane_u16(vresult, 0)) result |= 0x01;
+   if (vget_lane_u16(vresult, 1)) result |= 0x02;
+   if (vget_lane_u16(vresult, 2)) result |= 0x04;
+   if (vget_lane_u16(vresult, 3)) result |= 0x08;
+
+   return result;
+}
+
+/* Byte Mask Merge — NEON
+ *
+ * Build a byte-level mask, then use vbsl (bitwise select) to blend.
+ * vbsl(mask, src, dst) = (src & mask) | (dst & ~mask)
+ */
+static uint64_t neon_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
+{
+   /* Build 8-byte selection mask */
+   uint8_t sel[8];
+   sel[0] = (uint8_t)(mask & 0xFF);
+   sel[1] = (mask & 0x0100) ? 0xFF : 0x00;
+   sel[2] = (mask & 0x0200) ? 0xFF : 0x00;
+   sel[3] = (mask & 0x0400) ? 0xFF : 0x00;
+   sel[4] = (mask & 0x0800) ? 0xFF : 0x00;
+   sel[5] = (mask & 0x1000) ? 0xFF : 0x00;
+   sel[6] = (mask & 0x2000) ? 0xFF : 0x00;
+   sel[7] = (mask & 0x4000) ? 0xFF : 0x00;
+
+   uint8x8_t vmask = vld1_u8(sel);
+   uint8x8_t vsrc  = vreinterpret_u8_u64(vcreate_u64(src));
+   uint8x8_t vdst  = vreinterpret_u8_u64(vcreate_u64(dst));
+
+   /* vbsl: for each bit, selects src where mask=1, dst where mask=0 */
+   uint8x8_t result = vbsl_u8(vmask, vsrc, vdst);
+
+   return vget_lane_u64(vreinterpret_u64_u8(result), 0);
+}
+
+const blitter_simd_ops_t blitter_simd_ops = {
+   neon_lfu,
+   neon_dcomp,
+   neon_zcomp,
+   neon_byte_merge
+};

--- a/src/blitter_simd_neon.c
+++ b/src/blitter_simd_neon.c
@@ -54,19 +54,15 @@ static uint8_t neon_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpd
    uint8x8_t vzero = vdup_n_u8(0);
    uint8x8_t vcmp = vceq_u8(vxor, vzero);  /* 0xFF where equal, 0 otherwise */
 
-   /* Extract one bit per byte.
-    * Multiply each lane by a power-of-2 weight and horizontal add.
-    * Weights: 1, 2, 4, 8, 16, 32, 64, 128 */
-   static const uint8_t weights[8] = { 1, 2, 4, 8, 16, 32, 64, 128 };
-   uint8x8_t vw = vld1_u8(weights);
-
-   /* AND with weights (0xFF & weight = weight, 0 & weight = 0) */
+   /* Extract one bit per byte using power-of-2 weights.
+    * vcreate avoids a static const load on every call. */
+   uint8x8_t vw = vcreate_u8(0x8040201008040201ULL);
    uint8x8_t vbits = vand_u8(vcmp, vw);
 
-   /* Pairwise add to collapse 8 bytes -> 4 -> 2 -> 1 */
-   uint8x8_t sum1 = vpadd_u8(vbits, vbits);  /* 4 sums */
-   uint8x8_t sum2 = vpadd_u8(sum1, sum1);     /* 2 sums */
-   uint8x8_t sum3 = vpadd_u8(sum2, sum2);     /* 1 sum  */
+   /* Pairwise horizontal add: 8 -> 4 -> 2 -> 1 */
+   uint8x8_t sum1 = vpadd_u8(vbits, vbits);
+   uint8x8_t sum2 = vpadd_u8(sum1, sum1);
+   uint8x8_t sum3 = vpadd_u8(sum2, sum2);
 
    return vget_lane_u8(sum3, 0);
 }

--- a/src/blitter_simd_scalar.c
+++ b/src/blitter_simd_scalar.c
@@ -1,0 +1,114 @@
+/*
+ * Blitter SIMD ops — portable scalar reference implementation
+ *
+ * These are extracted verbatim from blitter.c DATA() and serve as:
+ *   1. The fallback for platforms without SIMD
+ *   2. The reference for bit-exactness testing of SIMD variants
+ */
+
+#include "blitter_simd.h"
+
+/* Logic Function Unit
+ *
+ * Implements a 4-input truth table over each bit position of two
+ * 64-bit words (srcd, dstd). lfu_func selects one of 16 boolean
+ * functions (AND, OR, XOR, etc.).
+ */
+static uint64_t scalar_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
+{
+   uint64_t funcmask[2] = { 0, 0xFFFFFFFFFFFFFFFFULL };
+   uint64_t func0 = funcmask[lfu_func & 0x01];
+   uint64_t func1 = funcmask[(lfu_func >> 1) & 0x01];
+   uint64_t func2 = funcmask[(lfu_func >> 2) & 0x01];
+   uint64_t func3 = funcmask[(lfu_func >> 3) & 0x01];
+
+   return (~srcd & ~dstd & func0)
+        | (~srcd &  dstd & func1)
+        | ( srcd & ~dstd & func2)
+        | ( srcd &  dstd & func3);
+}
+
+/* Data Comparator
+ *
+ * XORs patd with either dstd or srcd (selected by cmpdst), then
+ * checks each of the 8 bytes for equality (zero). Returns an 8-bit
+ * mask with bit N set when byte N matches.
+ */
+static uint8_t scalar_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
+{
+   uint8_t result = 0;
+   uint64_t cmpd = patd ^ (cmpdst ? dstd : srcd);
+
+   if ((cmpd & 0x00000000000000FFULL) == 0) result |= 0x01;
+   if ((cmpd & 0x000000000000FF00ULL) == 0) result |= 0x02;
+   if ((cmpd & 0x0000000000FF0000ULL) == 0) result |= 0x04;
+   if ((cmpd & 0x00000000FF000000ULL) == 0) result |= 0x08;
+   if ((cmpd & 0x000000FF00000000ULL) == 0) result |= 0x10;
+   if ((cmpd & 0x0000FF0000000000ULL) == 0) result |= 0x20;
+   if ((cmpd & 0x00FF000000000000ULL) == 0) result |= 0x40;
+   if ((cmpd & 0xFF00000000000000ULL) == 0) result |= 0x80;
+
+   return result;
+}
+
+/* Z-buffer Comparator
+ *
+ * Compares 4 packed 16-bit Z values. For each of the 4 lanes,
+ * sets the output bit if the comparison selected by zmode is true:
+ *   bit 0 (0x01): less-than
+ *   bit 1 (0x02): equal
+ *   bit 2 (0x04): greater-than
+ */
+static uint8_t scalar_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
+{
+   uint8_t result = 0;
+   int i;
+
+   for (i = 0; i < 4; i++)
+   {
+      uint16_t s = (uint16_t)(srcz >> (i * 16));
+      uint16_t d = (uint16_t)(dstz >> (i * 16));
+
+      if (((s < d) && (zmode & 0x01))
+       || ((s == d) && (zmode & 0x02))
+       || ((s > d) && (zmode & 0x04)))
+         result |= (1u << i);
+   }
+
+   return result;
+}
+
+/* Byte Mask Merge
+ *
+ * Selects bytes from src or dst based on a 16-bit mask:
+ *   - Byte 0: per-bit blend (src where mask bit is 1, dst where 0)
+ *   - Bytes 1-7: whole-byte select via mask bits 8-14
+ *
+ * Used for both pixel data (ddat/dstd -> wdata) and Z-buffer data
+ * (srcz/dstz -> zwdata).
+ */
+static uint64_t scalar_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
+{
+   uint64_t result;
+
+   /* Byte 0: per-bit mask (low 8 bits of mask) */
+   result = ((src & mask) | (dst & ~(uint64_t)mask)) & 0x00000000000000FFULL;
+
+   /* Bytes 1-7: whole-byte select via mask bits 8-14 */
+   result |= ((mask & 0x0100) ? src : dst) & 0x000000000000FF00ULL;
+   result |= ((mask & 0x0200) ? src : dst) & 0x0000000000FF0000ULL;
+   result |= ((mask & 0x0400) ? src : dst) & 0x00000000FF000000ULL;
+   result |= ((mask & 0x0800) ? src : dst) & 0x000000FF00000000ULL;
+   result |= ((mask & 0x1000) ? src : dst) & 0x0000FF0000000000ULL;
+   result |= ((mask & 0x2000) ? src : dst) & 0x00FF000000000000ULL;
+   result |= ((mask & 0x4000) ? src : dst) & 0xFF00000000000000ULL;
+
+   return result;
+}
+
+const blitter_simd_ops_t blitter_simd_ops = {
+   scalar_lfu,
+   scalar_dcomp,
+   scalar_zcomp,
+   scalar_byte_merge
+};

--- a/src/blitter_simd_sse2.c
+++ b/src/blitter_simd_sse2.c
@@ -1,0 +1,161 @@
+/*
+ * Blitter SIMD ops — x86/x64 SSE2 implementation
+ *
+ * SSE2 is baseline for all x86_64 processors and available on x86
+ * since Pentium 4 (2001). No runtime feature detection needed.
+ *
+ * Operations work on 64-bit values loaded into 128-bit SSE registers
+ * (upper 64 bits unused or zeroed).
+ */
+
+#include "blitter_simd.h"
+#include <emmintrin.h>  /* SSE2 */
+
+/* Logic Function Unit — SSE2
+ *
+ * The truth table has 4 terms, each gated by one bit of lfu_func.
+ * We broadcast each gate to all 64 bits, then AND/OR in registers.
+ */
+static uint64_t sse2_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
+{
+   /* Build 64-bit masks from each lfu_func bit */
+   uint64_t func0 = (lfu_func & 0x01) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+   uint64_t func1 = (lfu_func & 0x02) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+   uint64_t func2 = (lfu_func & 0x04) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+   uint64_t func3 = (lfu_func & 0x08) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+
+   __m128i vs   = _mm_set_epi64x(0, (int64_t)srcd);
+   __m128i vd   = _mm_set_epi64x(0, (int64_t)dstd);
+   __m128i vns  = _mm_andnot_si128(vs, _mm_set1_epi32(-1)); /* ~srcd */
+   __m128i vnd  = _mm_andnot_si128(vd, _mm_set1_epi32(-1)); /* ~dstd */
+
+   __m128i vf0  = _mm_set_epi64x(0, (int64_t)func0);
+   __m128i vf1  = _mm_set_epi64x(0, (int64_t)func1);
+   __m128i vf2  = _mm_set_epi64x(0, (int64_t)func2);
+   __m128i vf3  = _mm_set_epi64x(0, (int64_t)func3);
+
+   /* (~s & ~d & f0) | (~s & d & f1) | (s & ~d & f2) | (s & d & f3) */
+   __m128i t0 = _mm_and_si128(_mm_and_si128(vns, vnd), vf0);
+   __m128i t1 = _mm_and_si128(_mm_and_si128(vns, vd),  vf1);
+   __m128i t2 = _mm_and_si128(_mm_and_si128(vs,  vnd), vf2);
+   __m128i t3 = _mm_and_si128(_mm_and_si128(vs,  vd),  vf3);
+
+   __m128i result = _mm_or_si128(_mm_or_si128(t0, t1), _mm_or_si128(t2, t3));
+   return (uint64_t)_mm_cvtsi128_si64(result);
+}
+
+/* Data Comparator — SSE2
+ *
+ * XOR the two 64-bit values, then check each byte for zero.
+ * _mm_cmpeq_epi8 + _mm_movemask_epi8 gives us all 8 byte-equality
+ * bits in one shot.
+ */
+static uint8_t sse2_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
+{
+   uint64_t other = cmpdst ? dstd : srcd;
+   __m128i vp = _mm_set_epi64x(0, (int64_t)patd);
+   __m128i vo = _mm_set_epi64x(0, (int64_t)other);
+   __m128i vxor = _mm_xor_si128(vp, vo);
+
+   /* Compare each byte against zero */
+   __m128i vzero = _mm_setzero_si128();
+   __m128i vcmp = _mm_cmpeq_epi8(vxor, vzero);
+
+   /* movemask gives us 16 bits (one per byte of 128-bit reg).
+    * We only care about the low 8 bytes. */
+   return (uint8_t)(_mm_movemask_epi8(vcmp) & 0xFF);
+}
+
+/* Z-buffer Comparator — SSE2
+ *
+ * 4 packed 16-bit comparisons. SSE2 has _mm_cmpeq_epi16 and
+ * _mm_cmpgt_epi16 (signed), but Z values are unsigned. We handle
+ * this by biasing both operands by -32768 before signed compare.
+ */
+static uint8_t sse2_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
+{
+   uint8_t result = 0;
+
+   __m128i vs = _mm_set_epi64x(0, (int64_t)srcz);
+   __m128i vd = _mm_set_epi64x(0, (int64_t)dstz);
+
+   /* Bias for unsigned comparison via signed instructions */
+   __m128i bias = _mm_set1_epi16((short)0x8000);
+   __m128i vs_biased = _mm_sub_epi16(vs, bias);
+   __m128i vd_biased = _mm_sub_epi16(vd, bias);
+
+   /* EQ: src == dst */
+   if (zmode & 0x02)
+   {
+      __m128i veq = _mm_cmpeq_epi16(vs, vd);
+      result |= (uint8_t)(_mm_movemask_epi8(veq) & 0xFF);
+   }
+
+   /* LT: src < dst (signed compare after bias = unsigned compare) */
+   if (zmode & 0x01)
+   {
+      __m128i vlt = _mm_cmplt_epi16(vs_biased, vd_biased);
+      result |= (uint8_t)(_mm_movemask_epi8(vlt) & 0xFF);
+   }
+
+   /* GT: src > dst */
+   if (zmode & 0x04)
+   {
+      __m128i vgt = _mm_cmpgt_epi16(vs_biased, vd_biased);
+      result |= (uint8_t)(_mm_movemask_epi8(vgt) & 0xFF);
+   }
+
+   /* movemask gives 2 bits per 16-bit lane (one per byte).
+    * Convert to 1 bit per lane: lanes at positions 0,2,4,6 */
+   uint8_t packed = 0;
+   if (result & 0x03) packed |= 0x01;  /* lane 0: bytes 0-1 */
+   if (result & 0x0C) packed |= 0x02;  /* lane 1: bytes 2-3 */
+   if (result & 0x30) packed |= 0x04;  /* lane 2: bytes 4-5 */
+   if (result & 0xC0) packed |= 0x08;  /* lane 3: bytes 6-7 */
+
+   return packed;
+}
+
+/* Byte Mask Merge — SSE2
+ *
+ * Byte 0 is per-bit blended, bytes 1-7 are whole-byte selected.
+ * We build a byte-level mask from the 16-bit input, then use
+ * AND/ANDNOT/OR to blend.
+ */
+static uint64_t sse2_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
+{
+   /* Build an 8-byte selection mask:
+    * byte 0 = low 8 bits of mask (per-bit)
+    * bytes 1-7 = 0xFF or 0x00 based on mask bits 8-14 */
+   uint8_t sel[8];
+   sel[0] = (uint8_t)(mask & 0xFF);
+   sel[1] = (mask & 0x0100) ? 0xFF : 0x00;
+   sel[2] = (mask & 0x0200) ? 0xFF : 0x00;
+   sel[3] = (mask & 0x0400) ? 0xFF : 0x00;
+   sel[4] = (mask & 0x0800) ? 0xFF : 0x00;
+   sel[5] = (mask & 0x1000) ? 0xFF : 0x00;
+   sel[6] = (mask & 0x2000) ? 0xFF : 0x00;
+   sel[7] = (mask & 0x4000) ? 0xFF : 0x00;
+
+   uint64_t sel64;
+   __builtin_memcpy(&sel64, sel, 8);
+
+   __m128i vmask = _mm_set_epi64x(0, (int64_t)sel64);
+   __m128i vsrc  = _mm_set_epi64x(0, (int64_t)src);
+   __m128i vdst  = _mm_set_epi64x(0, (int64_t)dst);
+
+   /* result = (src & mask) | (dst & ~mask) */
+   __m128i r = _mm_or_si128(
+      _mm_and_si128(vsrc, vmask),
+      _mm_andnot_si128(vmask, vdst)
+   );
+
+   return (uint64_t)_mm_cvtsi128_si64(r);
+}
+
+const blitter_simd_ops_t blitter_simd_ops = {
+   sse2_lfu,
+   sse2_dcomp,
+   sse2_zcomp,
+   sse2_byte_merge
+};

--- a/src/blitter_simd_sse2.c
+++ b/src/blitter_simd_sse2.c
@@ -124,21 +124,18 @@ static uint8_t sse2_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
  */
 static uint64_t sse2_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
 {
-   /* Build an 8-byte selection mask:
-    * byte 0 = low 8 bits of mask (per-bit)
-    * bytes 1-7 = 0xFF or 0x00 based on mask bits 8-14 */
-   uint8_t sel[8];
-   sel[0] = (uint8_t)(mask & 0xFF);
-   sel[1] = (mask & 0x0100) ? 0xFF : 0x00;
-   sel[2] = (mask & 0x0200) ? 0xFF : 0x00;
-   sel[3] = (mask & 0x0400) ? 0xFF : 0x00;
-   sel[4] = (mask & 0x0800) ? 0xFF : 0x00;
-   sel[5] = (mask & 0x1000) ? 0xFF : 0x00;
-   sel[6] = (mask & 0x2000) ? 0xFF : 0x00;
-   sel[7] = (mask & 0x4000) ? 0xFF : 0x00;
-
-   uint64_t sel64;
-   __builtin_memcpy(&sel64, sel, 8);
+   /* Build an 8-byte selection mask directly via bit arithmetic.
+    * Byte 0 = low 8 bits of mask (per-bit blend).
+    * Bytes 1-7 = 0xFF or 0x00 from mask bits 8-14 (whole-byte select).
+    * We expand each bit to a full 0xFF byte using sign-extension. */
+   uint64_t sel64 = (uint64_t)(mask & 0xFF);  /* byte 0: per-bit */
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 8)  & 1))) << 8;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 9)  & 1))) << 16;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 10) & 1))) << 24;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 11) & 1))) << 32;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 12) & 1))) << 40;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 13) & 1))) << 48;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 14) & 1))) << 56;
 
    __m128i vmask = _mm_set_epi64x(0, (int64_t)sel64);
    __m128i vsrc  = _mm_set_epi64x(0, (int64_t)src);

--- a/test/test_blitter_simd.c
+++ b/test/test_blitter_simd.c
@@ -1,0 +1,426 @@
+/*
+ * Bit-exactness and performance test for blitter SIMD operations.
+ *
+ * Build (from repo root):
+ *   # On macOS ARM64 (NEON):
+ *   cc -O2 -o test/test_blitter_simd test/test_blitter_simd.c \
+ *      src/blitter_simd_neon.c src/blitter_simd_scalar.c
+ *
+ *   # On x86_64 (SSE2):
+ *   cc -O2 -msse2 -o test/test_blitter_simd test/test_blitter_simd.c \
+ *      src/blitter_simd_sse2.c src/blitter_simd_scalar.c
+ *
+ *   # Scalar-only (any platform):
+ *   cc -O2 -o test/test_blitter_simd test/test_blitter_simd.c \
+ *      src/blitter_simd_scalar.c
+ *
+ * Usage:
+ *   ./test/test_blitter_simd           # Run bit-exactness tests
+ *   ./test/test_blitter_simd --bench   # Run performance benchmark
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <time.h>
+
+/* The active (possibly SIMD) implementation */
+#include "../src/blitter_simd.h"
+
+/* --- Scalar reference (linked from blitter_simd_scalar.c) --- */
+
+/* We need the scalar reference for comparison. Since blitter_simd_scalar.c
+ * defines blitter_simd_ops when it's the only impl linked, we need a
+ * separate copy for comparison. We inline the reference here. */
+
+static uint64_t ref_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
+{
+   uint64_t funcmask[2] = { 0, 0xFFFFFFFFFFFFFFFFULL };
+   uint64_t func0 = funcmask[lfu_func & 0x01];
+   uint64_t func1 = funcmask[(lfu_func >> 1) & 0x01];
+   uint64_t func2 = funcmask[(lfu_func >> 2) & 0x01];
+   uint64_t func3 = funcmask[(lfu_func >> 3) & 0x01];
+   return (~srcd & ~dstd & func0)
+        | (~srcd &  dstd & func1)
+        | ( srcd & ~dstd & func2)
+        | ( srcd &  dstd & func3);
+}
+
+static uint8_t ref_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
+{
+   uint8_t result = 0;
+   uint64_t cmpd = patd ^ (cmpdst ? dstd : srcd);
+   if ((cmpd & 0x00000000000000FFULL) == 0) result |= 0x01;
+   if ((cmpd & 0x000000000000FF00ULL) == 0) result |= 0x02;
+   if ((cmpd & 0x0000000000FF0000ULL) == 0) result |= 0x04;
+   if ((cmpd & 0x00000000FF000000ULL) == 0) result |= 0x08;
+   if ((cmpd & 0x000000FF00000000ULL) == 0) result |= 0x10;
+   if ((cmpd & 0x0000FF0000000000ULL) == 0) result |= 0x20;
+   if ((cmpd & 0x00FF000000000000ULL) == 0) result |= 0x40;
+   if ((cmpd & 0xFF00000000000000ULL) == 0) result |= 0x80;
+   return result;
+}
+
+static uint8_t ref_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
+{
+   uint8_t result = 0;
+   int i;
+   for (i = 0; i < 4; i++)
+   {
+      uint16_t s = (uint16_t)(srcz >> (i * 16));
+      uint16_t d = (uint16_t)(dstz >> (i * 16));
+      if (((s < d) && (zmode & 0x01))
+       || ((s == d) && (zmode & 0x02))
+       || ((s > d) && (zmode & 0x04)))
+         result |= (1u << i);
+   }
+   return result;
+}
+
+static uint64_t ref_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
+{
+   uint64_t result;
+   result = ((src & mask) | (dst & ~(uint64_t)mask)) & 0x00000000000000FFULL;
+   result |= ((mask & 0x0100) ? src : dst) & 0x000000000000FF00ULL;
+   result |= ((mask & 0x0200) ? src : dst) & 0x0000000000FF0000ULL;
+   result |= ((mask & 0x0400) ? src : dst) & 0x00000000FF000000ULL;
+   result |= ((mask & 0x0800) ? src : dst) & 0x000000FF00000000ULL;
+   result |= ((mask & 0x1000) ? src : dst) & 0x0000FF0000000000ULL;
+   result |= ((mask & 0x2000) ? src : dst) & 0x00FF000000000000ULL;
+   result |= ((mask & 0x4000) ? src : dst) & 0xFF00000000000000ULL;
+   return result;
+}
+
+/* --- Simple xorshift64 PRNG --- */
+static uint64_t prng_state = 0x123456789ABCDEF0ULL;
+
+static uint64_t xorshift64(void)
+{
+   uint64_t x = prng_state;
+   x ^= x << 13;
+   x ^= x >> 7;
+   x ^= x << 17;
+   prng_state = x;
+   return x;
+}
+
+/* --- Test helpers --- */
+static int failures = 0;
+static int tests_run = 0;
+
+#define CHECK(cond, fmt, ...) do { \
+   tests_run++; \
+   if (!(cond)) { \
+      failures++; \
+      printf("  FAIL: " fmt "\n", ##__VA_ARGS__); \
+   } \
+} while (0)
+
+/* --- LFU tests --- */
+static void test_lfu(void)
+{
+   uint8_t func;
+   int i;
+
+   printf("Testing LFU...\n");
+
+   /* Exhaustive test of all 16 functions with known values */
+   for (func = 0; func < 16; func++)
+   {
+      /* All zeros */
+      uint64_t got = blitter_simd_ops.lfu(0, 0, func);
+      uint64_t exp = ref_lfu(0, 0, func);
+      CHECK(got == exp, "lfu(0,0,%u): got 0x%016llx exp 0x%016llx",
+            func, (unsigned long long)got, (unsigned long long)exp);
+
+      /* All ones */
+      got = blitter_simd_ops.lfu(~0ULL, ~0ULL, func);
+      exp = ref_lfu(~0ULL, ~0ULL, func);
+      CHECK(got == exp, "lfu(~0,~0,%u): got 0x%016llx exp 0x%016llx",
+            func, (unsigned long long)got, (unsigned long long)exp);
+
+      /* Mixed */
+      got = blitter_simd_ops.lfu(0xAAAAAAAAAAAAAAAAULL, 0x5555555555555555ULL, func);
+      exp = ref_lfu(0xAAAAAAAAAAAAAAAAULL, 0x5555555555555555ULL, func);
+      CHECK(got == exp, "lfu(0xAA..,0x55..,%u): got 0x%016llx exp 0x%016llx",
+            func, (unsigned long long)got, (unsigned long long)exp);
+   }
+
+   /* Random inputs */
+   for (i = 0; i < 10000; i++)
+   {
+      uint64_t s = xorshift64();
+      uint64_t d = xorshift64();
+      uint8_t f = (uint8_t)(xorshift64() & 0x0F);
+      uint64_t got = blitter_simd_ops.lfu(s, d, f);
+      uint64_t exp = ref_lfu(s, d, f);
+      CHECK(got == exp, "lfu random #%d: func=%u got 0x%016llx exp 0x%016llx",
+            i, f, (unsigned long long)got, (unsigned long long)exp);
+      if (got != exp) break;
+   }
+}
+
+/* --- DCOMP tests --- */
+static void test_dcomp(void)
+{
+   int i;
+   printf("Testing DCOMP...\n");
+
+   /* Identical values -> all bytes match -> 0xFF */
+   uint64_t val = 0x0102030405060708ULL;
+   CHECK(blitter_simd_ops.dcomp(val, val, 0, false) == 0xFF,
+         "dcomp identical (cmpdst=false)");
+   CHECK(blitter_simd_ops.dcomp(val, 0, val, true) == 0xFF,
+         "dcomp identical (cmpdst=true)");
+
+   /* All different -> 0x00 */
+   CHECK(blitter_simd_ops.dcomp(0, ~0ULL, 0, false) == 0x00,
+         "dcomp all-different");
+
+   /* Only byte 0 differs (rest are all zero = matching) */
+   CHECK(blitter_simd_ops.dcomp(0x00000000000000FFULL, 0x0000000000000000ULL, 0, false) == 0xFE,
+         "dcomp byte 0 differs only");
+
+   /* patd=0xFF, srcd=0xFF -> XOR=0 -> all bytes match */
+   CHECK(blitter_simd_ops.dcomp(0xFF, 0xFF, 0, false) == 0xFF,
+         "dcomp low bytes identical, upper zero=zero -> all match");
+
+   /* Random inputs */
+   for (i = 0; i < 10000; i++)
+   {
+      uint64_t p = xorshift64();
+      uint64_t s = xorshift64();
+      uint64_t d = xorshift64();
+      bool c = (xorshift64() & 1) != 0;
+      uint8_t got = blitter_simd_ops.dcomp(p, s, d, c);
+      uint8_t exp = ref_dcomp(p, s, d, c);
+      CHECK(got == exp, "dcomp random #%d: cmpdst=%d got 0x%02x exp 0x%02x",
+            i, c, got, exp);
+      if (got != exp) break;
+   }
+}
+
+/* --- ZCOMP tests --- */
+static void test_zcomp(void)
+{
+   int i;
+   uint8_t zmode;
+
+   printf("Testing ZCOMP...\n");
+
+   /* Equal values with EQ mode -> all bits set */
+   CHECK(blitter_simd_ops.zcomp(0x1234123412341234ULL,
+                                 0x1234123412341234ULL, 0x02) == 0x0F,
+         "zcomp equal values, EQ mode");
+
+   /* src < dst with LT mode */
+   CHECK(blitter_simd_ops.zcomp(0x0001000100010001ULL,
+                                 0x0002000200020002ULL, 0x01) == 0x0F,
+         "zcomp src<dst, LT mode");
+
+   /* src > dst with GT mode */
+   CHECK(blitter_simd_ops.zcomp(0x0002000200020002ULL,
+                                 0x0001000100010001ULL, 0x04) == 0x0F,
+         "zcomp src>dst, GT mode");
+
+   /* All zmodes with known values */
+   for (zmode = 0; zmode < 8; zmode++)
+   {
+      uint64_t s = 0x0001000200030004ULL;
+      uint64_t d = 0x0002000200020002ULL;
+      uint8_t got = blitter_simd_ops.zcomp(s, d, zmode);
+      uint8_t exp = ref_zcomp(s, d, zmode);
+      CHECK(got == exp, "zcomp zmode=%u: got 0x%02x exp 0x%02x",
+            zmode, got, exp);
+   }
+
+   /* Random inputs */
+   for (i = 0; i < 10000; i++)
+   {
+      uint64_t s = xorshift64();
+      uint64_t d = xorshift64();
+      uint8_t zm = (uint8_t)(xorshift64() & 0x07);
+      uint8_t got = blitter_simd_ops.zcomp(s, d, zm);
+      uint8_t exp = ref_zcomp(s, d, zm);
+      CHECK(got == exp, "zcomp random #%d: zmode=%u got 0x%02x exp 0x%02x",
+            i, zm, got, exp);
+      if (got != exp) break;
+   }
+}
+
+/* --- Byte Merge tests --- */
+static void test_byte_merge(void)
+{
+   int i;
+
+   printf("Testing byte_merge...\n");
+
+   /* All-select-src: mask = 0x7FFF -> all bytes from src */
+   uint64_t got = blitter_simd_ops.byte_merge(0xAAAAAAAAAAAAAAAAULL,
+                                               0x5555555555555555ULL, 0x7FFF);
+   uint64_t exp = ref_byte_merge(0xAAAAAAAAAAAAAAAAULL,
+                                  0x5555555555555555ULL, 0x7FFF);
+   CHECK(got == exp, "byte_merge all-src: got 0x%016llx exp 0x%016llx",
+         (unsigned long long)got, (unsigned long long)exp);
+
+   /* All-select-dst: mask = 0x0000 -> all bytes from dst */
+   got = blitter_simd_ops.byte_merge(0xAAAAAAAAAAAAAAAAULL,
+                                      0x5555555555555555ULL, 0x0000);
+   exp = ref_byte_merge(0xAAAAAAAAAAAAAAAAULL,
+                         0x5555555555555555ULL, 0x0000);
+   CHECK(got == exp, "byte_merge all-dst: got 0x%016llx exp 0x%016llx",
+         (unsigned long long)got, (unsigned long long)exp);
+
+   /* Per-bit mask in byte 0 */
+   got = blitter_simd_ops.byte_merge(0xFF, 0x00, 0x00AA);
+   exp = ref_byte_merge(0xFF, 0x00, 0x00AA);
+   CHECK(got == exp, "byte_merge per-bit byte0: got 0x%016llx exp 0x%016llx",
+         (unsigned long long)got, (unsigned long long)exp);
+
+   /* Random inputs */
+   for (i = 0; i < 10000; i++)
+   {
+      uint64_t s = xorshift64();
+      uint64_t d = xorshift64();
+      uint16_t m = (uint16_t)(xorshift64() & 0x7FFF);
+      got = blitter_simd_ops.byte_merge(s, d, m);
+      exp = ref_byte_merge(s, d, m);
+      CHECK(got == exp, "byte_merge random #%d: mask=0x%04x got 0x%016llx exp 0x%016llx",
+            i, m, (unsigned long long)got, (unsigned long long)exp);
+      if (got != exp) break;
+   }
+}
+
+/* --- Performance benchmark --- */
+
+#define BENCH_ITERS 1000000
+
+static double elapsed_ns(struct timespec start, struct timespec end)
+{
+   return (double)(end.tv_sec - start.tv_sec) * 1e9
+        + (double)(end.tv_nsec - start.tv_nsec);
+}
+
+static void bench_lfu(void)
+{
+   struct timespec t0, t1;
+   volatile uint64_t sink = 0;
+   int i;
+
+   /* Ref */
+   clock_gettime(CLOCK_MONOTONIC, &t0);
+   for (i = 0; i < BENCH_ITERS; i++)
+      sink += ref_lfu(0xAAAAAAAAAAAAAAAAULL, 0x5555555555555555ULL, (uint8_t)(i & 0x0F));
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   double ref_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+
+   /* SIMD */
+   clock_gettime(CLOCK_MONOTONIC, &t0);
+   for (i = 0; i < BENCH_ITERS; i++)
+      sink += blitter_simd_ops.lfu(0xAAAAAAAAAAAAAAAAULL, 0x5555555555555555ULL, (uint8_t)(i & 0x0F));
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   double simd_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+
+   printf("  LFU:        ref=%6.1f ns/op  simd=%6.1f ns/op  speedup=%.2fx\n",
+          ref_ns, simd_ns, ref_ns / simd_ns);
+   (void)sink;
+}
+
+static void bench_dcomp(void)
+{
+   struct timespec t0, t1;
+   volatile uint8_t sink = 0;
+   int i;
+
+   clock_gettime(CLOCK_MONOTONIC, &t0);
+   for (i = 0; i < BENCH_ITERS; i++)
+      sink += ref_dcomp(0x0102030405060708ULL, (uint64_t)i, 0, false);
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   double ref_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+
+   clock_gettime(CLOCK_MONOTONIC, &t0);
+   for (i = 0; i < BENCH_ITERS; i++)
+      sink += blitter_simd_ops.dcomp(0x0102030405060708ULL, (uint64_t)i, 0, false);
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   double simd_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+
+   printf("  DCOMP:      ref=%6.1f ns/op  simd=%6.1f ns/op  speedup=%.2fx\n",
+          ref_ns, simd_ns, ref_ns / simd_ns);
+   (void)sink;
+}
+
+static void bench_zcomp(void)
+{
+   struct timespec t0, t1;
+   volatile uint8_t sink = 0;
+   int i;
+
+   clock_gettime(CLOCK_MONOTONIC, &t0);
+   for (i = 0; i < BENCH_ITERS; i++)
+      sink += ref_zcomp(0x0001000200030004ULL, 0x0002000200020002ULL, (uint8_t)(i & 0x07));
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   double ref_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+
+   clock_gettime(CLOCK_MONOTONIC, &t0);
+   for (i = 0; i < BENCH_ITERS; i++)
+      sink += blitter_simd_ops.zcomp(0x0001000200030004ULL, 0x0002000200020002ULL, (uint8_t)(i & 0x07));
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   double simd_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+
+   printf("  ZCOMP:      ref=%6.1f ns/op  simd=%6.1f ns/op  speedup=%.2fx\n",
+          ref_ns, simd_ns, ref_ns / simd_ns);
+   (void)sink;
+}
+
+static void bench_byte_merge(void)
+{
+   struct timespec t0, t1;
+   volatile uint64_t sink = 0;
+   int i;
+
+   clock_gettime(CLOCK_MONOTONIC, &t0);
+   for (i = 0; i < BENCH_ITERS; i++)
+      sink += ref_byte_merge(0xAAAAAAAAAAAAAAAAULL, 0x5555555555555555ULL, (uint16_t)(i & 0x7FFF));
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   double ref_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+
+   clock_gettime(CLOCK_MONOTONIC, &t0);
+   for (i = 0; i < BENCH_ITERS; i++)
+      sink += blitter_simd_ops.byte_merge(0xAAAAAAAAAAAAAAAAULL, 0x5555555555555555ULL, (uint16_t)(i & 0x7FFF));
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   double simd_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+
+   printf("  byte_merge: ref=%6.1f ns/op  simd=%6.1f ns/op  speedup=%.2fx\n",
+          ref_ns, simd_ns, ref_ns / simd_ns);
+   (void)sink;
+}
+
+int main(int argc, char *argv[])
+{
+   bool bench = (argc > 1 && strcmp(argv[1], "--bench") == 0);
+
+   if (bench)
+   {
+      printf("==> Blitter SIMD Performance Benchmark (%d iterations)\n\n", BENCH_ITERS);
+      bench_lfu();
+      bench_dcomp();
+      bench_zcomp();
+      bench_byte_merge();
+      printf("\nDone.\n");
+      return 0;
+   }
+
+   printf("==> Blitter SIMD Bit-Exactness Tests\n\n");
+
+   test_lfu();
+   test_dcomp();
+   test_zcomp();
+   test_byte_merge();
+
+   printf("\n==> Results: %d tests, %d passed, %d failed\n",
+          tests_run, tests_run - failures, failures);
+
+   return failures > 0 ? 1 : 0;
+}

--- a/test/test_blitter_simd.c
+++ b/test/test_blitter_simd.c
@@ -1,14 +1,14 @@
 /*
  * Bit-exactness and performance test for blitter SIMD operations.
  *
- * Build (from repo root):
+ * Build (from repo root — link exactly one SIMD implementation):
  *   # On macOS ARM64 (NEON):
  *   cc -O2 -o test/test_blitter_simd test/test_blitter_simd.c \
- *      src/blitter_simd_neon.c src/blitter_simd_scalar.c
+ *      src/blitter_simd_neon.c
  *
  *   # On x86_64 (SSE2):
  *   cc -O2 -msse2 -o test/test_blitter_simd test/test_blitter_simd.c \
- *      src/blitter_simd_sse2.c src/blitter_simd_scalar.c
+ *      src/blitter_simd_sse2.c
  *
  *   # Scalar-only (any platform):
  *   cc -O2 -o test/test_blitter_simd test/test_blitter_simd.c \
@@ -297,31 +297,51 @@ static void test_byte_merge(void)
 
 #define BENCH_ITERS 1000000
 
-static double elapsed_ns(struct timespec start, struct timespec end)
+/* Portable high-resolution timer.
+ * Uses clock_gettime on POSIX, QueryPerformanceCounter on Windows.
+ * Declare TIMER_DECL() once per scope, then use START/STOP/NS freely. */
+#ifdef _WIN32
+#include <windows.h>
+static double get_time_ns(void)
 {
-   return (double)(end.tv_sec - start.tv_sec) * 1e9
-        + (double)(end.tv_nsec - start.tv_nsec);
+   static LARGE_INTEGER freq = {0};
+   LARGE_INTEGER count;
+   if (freq.QuadPart == 0)
+      QueryPerformanceFrequency(&freq);
+   QueryPerformanceCounter(&count);
+   return (double)count.QuadPart / (double)freq.QuadPart * 1e9;
 }
+#define TIMER_DECL()  double _timer_t0, _timer_t1
+#define TIMER_START() (_timer_t0 = get_time_ns())
+#define TIMER_STOP()  (_timer_t1 = get_time_ns())
+#define TIMER_NS()    (_timer_t1 - _timer_t0)
+#else
+#define TIMER_DECL()  struct timespec _timer_ts0, _timer_ts1
+#define TIMER_START() clock_gettime(CLOCK_MONOTONIC, &_timer_ts0)
+#define TIMER_STOP()  clock_gettime(CLOCK_MONOTONIC, &_timer_ts1)
+#define TIMER_NS()    (((double)(_timer_ts1.tv_sec - _timer_ts0.tv_sec) * 1e9) + (double)(_timer_ts1.tv_nsec - _timer_ts0.tv_nsec))
+#endif
 
 static void bench_lfu(void)
 {
-   struct timespec t0, t1;
+   TIMER_DECL();
    volatile uint64_t sink = 0;
    int i;
+   double ref_ns, simd_ns;
 
    /* Ref */
-   clock_gettime(CLOCK_MONOTONIC, &t0);
+   TIMER_START();
    for (i = 0; i < BENCH_ITERS; i++)
       sink += ref_lfu(0xAAAAAAAAAAAAAAAAULL, 0x5555555555555555ULL, (uint8_t)(i & 0x0F));
-   clock_gettime(CLOCK_MONOTONIC, &t1);
-   double ref_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+   TIMER_STOP();
+   ref_ns = TIMER_NS() / BENCH_ITERS;
 
    /* SIMD */
-   clock_gettime(CLOCK_MONOTONIC, &t0);
+   TIMER_START();
    for (i = 0; i < BENCH_ITERS; i++)
       sink += blitter_simd_ops.lfu(0xAAAAAAAAAAAAAAAAULL, 0x5555555555555555ULL, (uint8_t)(i & 0x0F));
-   clock_gettime(CLOCK_MONOTONIC, &t1);
-   double simd_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+   TIMER_STOP();
+   simd_ns = TIMER_NS() / BENCH_ITERS;
 
    printf("  LFU:        ref=%6.1f ns/op  simd=%6.1f ns/op  speedup=%.2fx\n",
           ref_ns, simd_ns, ref_ns / simd_ns);
@@ -330,21 +350,22 @@ static void bench_lfu(void)
 
 static void bench_dcomp(void)
 {
-   struct timespec t0, t1;
+   TIMER_DECL();
    volatile uint8_t sink = 0;
    int i;
+   double ref_ns, simd_ns;
 
-   clock_gettime(CLOCK_MONOTONIC, &t0);
+   TIMER_START();
    for (i = 0; i < BENCH_ITERS; i++)
       sink += ref_dcomp(0x0102030405060708ULL, (uint64_t)i, 0, false);
-   clock_gettime(CLOCK_MONOTONIC, &t1);
-   double ref_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+   TIMER_STOP();
+   ref_ns = TIMER_NS() / BENCH_ITERS;
 
-   clock_gettime(CLOCK_MONOTONIC, &t0);
+   TIMER_START();
    for (i = 0; i < BENCH_ITERS; i++)
       sink += blitter_simd_ops.dcomp(0x0102030405060708ULL, (uint64_t)i, 0, false);
-   clock_gettime(CLOCK_MONOTONIC, &t1);
-   double simd_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+   TIMER_STOP();
+   simd_ns = TIMER_NS() / BENCH_ITERS;
 
    printf("  DCOMP:      ref=%6.1f ns/op  simd=%6.1f ns/op  speedup=%.2fx\n",
           ref_ns, simd_ns, ref_ns / simd_ns);
@@ -353,21 +374,22 @@ static void bench_dcomp(void)
 
 static void bench_zcomp(void)
 {
-   struct timespec t0, t1;
+   TIMER_DECL();
    volatile uint8_t sink = 0;
    int i;
+   double ref_ns, simd_ns;
 
-   clock_gettime(CLOCK_MONOTONIC, &t0);
+   TIMER_START();
    for (i = 0; i < BENCH_ITERS; i++)
       sink += ref_zcomp(0x0001000200030004ULL, 0x0002000200020002ULL, (uint8_t)(i & 0x07));
-   clock_gettime(CLOCK_MONOTONIC, &t1);
-   double ref_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+   TIMER_STOP();
+   ref_ns = TIMER_NS() / BENCH_ITERS;
 
-   clock_gettime(CLOCK_MONOTONIC, &t0);
+   TIMER_START();
    for (i = 0; i < BENCH_ITERS; i++)
       sink += blitter_simd_ops.zcomp(0x0001000200030004ULL, 0x0002000200020002ULL, (uint8_t)(i & 0x07));
-   clock_gettime(CLOCK_MONOTONIC, &t1);
-   double simd_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+   TIMER_STOP();
+   simd_ns = TIMER_NS() / BENCH_ITERS;
 
    printf("  ZCOMP:      ref=%6.1f ns/op  simd=%6.1f ns/op  speedup=%.2fx\n",
           ref_ns, simd_ns, ref_ns / simd_ns);
@@ -376,21 +398,22 @@ static void bench_zcomp(void)
 
 static void bench_byte_merge(void)
 {
-   struct timespec t0, t1;
+   TIMER_DECL();
    volatile uint64_t sink = 0;
    int i;
+   double ref_ns, simd_ns;
 
-   clock_gettime(CLOCK_MONOTONIC, &t0);
+   TIMER_START();
    for (i = 0; i < BENCH_ITERS; i++)
       sink += ref_byte_merge(0xAAAAAAAAAAAAAAAAULL, 0x5555555555555555ULL, (uint16_t)(i & 0x7FFF));
-   clock_gettime(CLOCK_MONOTONIC, &t1);
-   double ref_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+   TIMER_STOP();
+   ref_ns = TIMER_NS() / BENCH_ITERS;
 
-   clock_gettime(CLOCK_MONOTONIC, &t0);
+   TIMER_START();
    for (i = 0; i < BENCH_ITERS; i++)
       sink += blitter_simd_ops.byte_merge(0xAAAAAAAAAAAAAAAAULL, 0x5555555555555555ULL, (uint16_t)(i & 0x7FFF));
-   clock_gettime(CLOCK_MONOTONIC, &t1);
-   double simd_ns = elapsed_ns(t0, t1) / BENCH_ITERS;
+   TIMER_STOP();
+   simd_ns = TIMER_NS() / BENCH_ITERS;
 
    printf("  byte_merge: ref=%6.1f ns/op  simd=%6.1f ns/op  speedup=%.2fx\n",
           ref_ns, simd_ns, ref_ns / simd_ns);
@@ -423,4 +446,6 @@ int main(int argc, char *argv[])
           tests_run, tests_run - failures, failures);
 
    return failures > 0 ? 1 : 0;
+}
+? 1 : 0;
 }

--- a/test/test_blitter_simd.c
+++ b/test/test_blitter_simd.c
@@ -447,5 +447,3 @@ int main(int argc, char *argv[])
 
    return failures > 0 ? 1 : 0;
 }
-? 1 : 0;
-}


### PR DESCRIPTION
## Summary

- Extracts four hot-path operations from `blitter.c DATA()` into a dispatch interface (`blitter_simd_ops_t`) with architecture-specific implementations
- **SSE2** (x86/x64), **NEON** (ARM/ARM64), and **scalar** (portable fallback) implementations
- Compile-time architecture selection via `Makefile.common` — zero runtime dispatch overhead
- 40,000+ bit-exactness tests with performance benchmarking

### Operations accelerated

| Operation | What it does | SIMD approach |
|-----------|-------------|---------------|
| **LFU** | 64-bit boolean truth table (16 functions) | Parallel AND/OR/XOR |
| **DCOMP** | 8-byte equality comparator | `cmpeq_epi8` + `movemask` / `vceq_u8` |
| **ZCOMP** | 4×16-bit Z-buffer comparison | `cmpgt_epi16` (biased) / `vclt_u16` |
| **byte_merge** | Per-byte mask select | `blendv` / `vbsl` |

### Files

- `src/blitter_simd.h` — dispatch struct typedef
- `src/blitter_simd_scalar.c` — portable C reference (fallback for any platform)
- `src/blitter_simd_sse2.c` — x86/x64 SSE2 intrinsics
- `src/blitter_simd_neon.c` — ARM NEON intrinsics
- `src/blitter.c` — 5 call sites replaced (net -57 lines)
- `Makefile.common` — arch-conditional source selection
- `test/test_blitter_simd.c` — bit-exactness + benchmark

Addresses #99.

## Test plan

- [x] Core builds on macOS ARM64 (NEON selected)
- [x] 40,067 bit-exactness tests pass (all ops, all edge cases, 10k random inputs each)
- [x] Performance benchmark runs (`./test/test_blitter_simd --bench`)
- [x] CI build on Ubuntu x86_64 (SSE2 selected)
- [x] CI build on Windows (SSE2 via MSYS2)
- [ ] Regression test with JagNICCC2000 baseline (pixel-identical output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)