### PR TITLE
Fix SIMD build on MSVC + add Emscripten/WASM support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -46,6 +46,12 @@ jobs:
             cxx: 'g++'
             shell: 'msys2 {0}'
 
+          # Emscripten (WebAssembly)
+          - displayTargetName: 'Emscripten (WASM)'
+            artifact: 'virtualjaguar_libretro_emscripten.bc'
+            os: ubuntu-latest
+            emscripten: true
+
     name: build-${{ matrix.config.displayTargetName }}
     runs-on: ${{ matrix.config.os }}
 
@@ -66,12 +72,21 @@ jobs:
           mingw-w64-x86_64-gcc
           make
 
+    - name: Set up Emscripten
+      if: matrix.config.emscripten
+      uses: mymindstorm/setup-emsdk@v14
+
     - name: Build
+      if: ${{ !matrix.config.emscripten }}
       run: make -j4 CC=${{ matrix.config.cc }} CXX=${{ matrix.config.cxx }}
 
+    - name: Build (Emscripten)
+      if: matrix.config.emscripten
+      run: emmake make -j4 platform=emscripten
+
     - name: Run SIMD blitter tests
+      if: ${{ !matrix.config.emscripten }}
       run: |
-        # Detect which SIMD impl to test based on runner architecture
         ARCH=$(uname -m)
         case "$ARCH" in
           x86_64|i686|i386)  SIMD_SRC=src/blitter_simd_sse2.c; EXTRA="-msse2" ;;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,6 +80,10 @@ include:
     file: '/tvos-arm64.yml'
 
   #################################### MISC ##################################
+  # Emscripten (WebAssembly)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/emscripten-static.yml'
+
   # webOS 32-bit (LGTV)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/webos-make.yml'
@@ -212,6 +216,12 @@ libretro-build-libnx-aarch64:
     - .core-defs
 
 #################################### MISC ####################################
+# Emscripten (WebAssembly)
+libretro-build-emscripten:
+  extends:
+    - .libretro-emscripten-static-retroarch-master
+    - .core-defs
+
 # webOS 32-bit
 libretro-build-webos-armv7a:
   extends:

--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,6 @@ else ifeq ($(platform), emscripten)
 	AR = emar
 	STATIC_LINKING = 1
 	FLAGS += -DHAVE_EMSCRIPTEN
-	CFLAGS += -O2
 
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))

--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,15 @@ else ifeq ($(platform), switch)
 	STATIC_LINKING=1
 	fpic := -nostdlib
 
-# emscripten
+# emscripten (WebAssembly / asm.js for RetroArch Web Player)
 else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
+	CC = emcc
+	CXX = em++
+	AR = emar
+	STATIC_LINKING = 1
+	FLAGS += -DHAVE_EMSCRIPTEN
+	CFLAGS += -O2
 
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))

--- a/Makefile.common
+++ b/Makefile.common
@@ -93,12 +93,16 @@ ifneq (,$(filter MINGW64% MINGW32%,$(MSYSTEM)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
 endif
 # 32-bit x86 needs explicit -msse2 (x86_64 has it baseline).
+# Skip for MSVC (cl.exe) — it enables SSE2 by default on x86 and does
+# not understand the GCC -msse2 flag.
 ifeq ($(BLITTER_SIMD_SRC),$(CORE_DIR)/src/blitter_simd_sse2.c)
+ifeq (,$(findstring msvc,$(platform)))
 ifneq (,$(filter i686 i386 x86 win32,$(ARCH) $(platform)))
    CFLAGS += -msse2
 endif
 ifneq (,$(filter MINGW32%,$(MSYSTEM)))
    CFLAGS += -msse2
+endif
 endif
 endif
 


### PR DESCRIPTION
## Summary

- **Fix MSVC SIMD build**: Guard the GCC `-msse2` flag in `Makefile.common` so it is not passed to `cl.exe` on MSVC build-bot targets. The libretro CI templates for MSVC set `MSYSTEM=MINGW32` which incorrectly triggered the GCC-specific flag.
- **Add Emscripten/WASM platform support**: Expand the `platform=emscripten` Makefile section (`emcc`/`emar`, static linking, `-DHAVE_EMSCRIPTEN`) and add CI jobs to both `.gitlab-ci.yml` (using `emscripten-static.yml` template) and GitHub Actions for the [RetroArch Web Player](https://web.libretro.com).

## Test plan

- [x] Local native build passes (macOS arm64, NEON)
- [x] `make print-BLITTER_SIMD_SRC platform=emscripten` → scalar (correct)
- [x] `make print-BLITTER_SIMD_SRC platform=vita` → scalar (correct)
- [x] `make print-BLITTER_SIMD_SRC platform=windows_msvc2010_x64 MSYSTEM=MINGW64` → SSE2 (correct, no `-msse2` flag)
- [ ] CI: GitLab emscripten-static pipeline
- [ ] CI: GitHub Actions Emscripten matrix entry
- [ ] CI: MSVC build-bot pipelines (no more `-msse2` to `cl.exe`)


Made with [Cursor](https://cursor.com)