### PR TITLE
Advertise Jaguar memory map for RetroAchievements support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -199,6 +199,18 @@ jobs:
         $CC -O2 -Wall -I src -o test_dsp_mac40 test/test_dsp_mac40.c
         ./test_dsp_mac40
 
+    - name: Run memory map test
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
+      run: |
+        CC="${{ matrix.config.cc }}"
+        if [ "$(uname)" = "Linux" ]; then
+          LDFLAGS="-ldl"
+        else
+          LDFLAGS=""
+        fi
+        $CC -O2 -Wall -o test/tools/test_memory_map test/tools/test_memory_map.c $LDFLAGS
+        ./test/tools/test_memory_map ./${{ matrix.config.artifact }}
+
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -214,7 +214,8 @@ jobs:
     - name: RetroAchievements rc_libretro E2E test
       if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
       env:
-        RCHEEVOS_REF: v12.3.0
+        # Immutable pin (rcheevos v12.3.0); tarball via .../archive/${SHA}.tar.gz
+        RCHEEVOS_REF: fd57e900758a9e3de343e7b0316b8a6059dce228
         CC: ${{ matrix.config.cc }}
       run: bash test/tools/test_rcheevos_e2e.sh ./${{ matrix.config.artifact }}
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -211,6 +211,13 @@ jobs:
         $CC -O2 -Wall -o test/tools/test_memory_map test/tools/test_memory_map.c $LDFLAGS
         ./test/tools/test_memory_map ./${{ matrix.config.artifact }}
 
+    - name: Cache pinned rcheevos E2E build
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
+      uses: actions/cache@v4
+      with:
+        path: build/rcheevos-static
+        key: rcheevos-e2e-fd57e900-${{ runner.os }}-${{ matrix.config.cc }}-${{ matrix.config.displayTargetName }}
+
     - name: RetroAchievements rc_libretro E2E test
       if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
       env:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -211,6 +211,13 @@ jobs:
         $CC -O2 -Wall -o test/tools/test_memory_map test/tools/test_memory_map.c $LDFLAGS
         ./test/tools/test_memory_map ./${{ matrix.config.artifact }}
 
+    - name: RetroAchievements rc_libretro E2E test
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
+      env:
+        RCHEEVOS_REF: v12.3.0
+        CC: ${{ matrix.config.cc }}
+      run: bash test/tools/test_rcheevos_e2e.sh ./${{ matrix.config.artifact }}
+
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local E2E test build (downloads rcheevos tarball)
+/build/
+
 # Build artifacts
 *.o
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local E2E test build (downloads rcheevos tarball)
 /build/
 
+# Legacy local path (older CI recipe); keep ignored if present
+/test_memory_map
+
 # Build artifacts
 *.o
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ test/test_*
 !test/test_*.c
 !test/test_*.sh
 !test/test_*.py
+test/tools/test_memory_map
+test/tools/sram_test
 test/dump_caller
 test/dump_pc
 test/heap_search

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,10 +92,10 @@ Key docs:
 
 ### Testing
 
-RetroAchievements-related (no network; offline):
+RetroAchievements-related (no RetroAchievements server/API access; local validation only):
 
 - `test/tools/test_memory_map.c` — asserts `SET_MEMORY_MAPS` / `SET_SUPPORT_ACHIEVEMENTS` and descriptor layout vs `retro_get_memory_data(SYSTEM_RAM)`.
-- `test/tools/test_rcheevos_e2e.sh` — downloads pinned **rcheevos** (`RCHEEVOS_REF`, default `v12.3.0`), builds `librcheevos.a`, runs `test_rcheevos_e2e` to verify **rc_libretro** memory resolution (`RC_CONSOLE_ATARI_JAGUAR`) matches host RAM — same mapping stack RetroArch uses before hitting the RA API.
+- `test/tools/test_rcheevos_e2e.sh` — does not contact RetroAchievements services; it downloads pinned **rcheevos** (`RCHEEVOS_REF`, default `v12.3.0`) when needed in a clean environment, builds `librcheevos.a`, then runs `test_rcheevos_e2e` to verify **rc_libretro** memory resolution (`RC_CONSOLE_ATARI_JAGUAR`) matches host RAM — the same mapping stack RetroArch uses before any RA API call. If the pinned tarball/build output is already cached locally, this external download step is avoided.
 
 See `docs/test-infrastructure.md` for all test harnesses:
 - `test/test_dsp_mac40.c` — Jaguar DSP **40-bit MAC** accumulator semantics (`dsp_acc40.h`), run in CI with SIMD tests; relevant for long IIR chains (e.g. pink-noise generators on DSP).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,11 @@ Key docs:
 
 ### Testing
 
+RetroAchievements-related (no network; offline):
+
+- `test/tools/test_memory_map.c` — asserts `SET_MEMORY_MAPS` / `SET_SUPPORT_ACHIEVEMENTS` and descriptor layout vs `retro_get_memory_data(SYSTEM_RAM)`.
+- `test/tools/test_rcheevos_e2e.sh` — downloads pinned **rcheevos** (`RCHEEVOS_REF`, default `v12.3.0`), builds `librcheevos.a`, runs `test_rcheevos_e2e` to verify **rc_libretro** memory resolution (`RC_CONSOLE_ATARI_JAGUAR`) matches host RAM — same mapping stack RetroArch uses before hitting the RA API.
+
 See `docs/test-infrastructure.md` for all test harnesses:
 - `test/test_dsp_mac40.c` — Jaguar DSP **40-bit MAC** accumulator semantics (`dsp_acc40.h`), run in CI with SIMD tests; relevant for long IIR chains (e.g. pink-noise generators on DSP).
 - `test/headless.py` — Python headless runner via libretro.py (screenshots, frame control)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,10 +92,10 @@ Key docs:
 
 ### Testing
 
-RetroAchievements-related (no RetroAchievements server/API access; local validation only):
+RetroAchievements-related — **no RetroAchievements account, API, or gameplay server**; local validation only. The E2E harness still **fetches the pinned rcheevos source tarball from GitHub** when `build/rcheevos-static` is missing (CI may cache that directory); that is unrelated to contacting RetroAchievements services.
 
-- `test/tools/test_memory_map.c` — asserts `SET_MEMORY_MAPS` / `SET_SUPPORT_ACHIEVEMENTS` and descriptor layout vs `retro_get_memory_data(SYSTEM_RAM)`.
-- `test/tools/test_rcheevos_e2e.sh` — does not contact RetroAchievements services; it downloads pinned **rcheevos** (`RCHEEVOS_REF`, default `v12.3.0`) when needed in a clean environment, builds `librcheevos.a`, then runs `test_rcheevos_e2e` to verify **rc_libretro** memory resolution (`RC_CONSOLE_ATARI_JAGUAR`) matches host RAM — the same mapping stack RetroArch uses before any RA API call. If the pinned tarball/build output is already cached locally, this external download step is avoided.
+- `test/tools/test_memory_map.c` — asserts `SET_MEMORY_MAPS`, `SET_SUPPORT_ACHIEVEMENTS` with **`true`**, and descriptor layout vs `retro_get_memory_data(SYSTEM_RAM)`.
+- `test/tools/test_rcheevos_e2e.sh` — downloads pinned **rcheevos** (`RCHEEVOS_REF`) when needed, builds `librcheevos.a`, then runs `test_rcheevos_e2e` to verify **rc_libretro** memory resolution (`RC_CONSOLE_ATARI_JAGUAR`) matches host RAM — the same mapping stack RetroArch uses before any RA cloud call.
 
 See `docs/test-infrastructure.md` for all test harnesses:
 - `test/test_dsp_mac40.c` — Jaguar DSP **40-bit MAC** accumulator semantics (`dsp_acc40.h`), run in CI with SIMD tests; relevant for long IIR chains (e.g. pink-noise generators on DSP).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,16 @@ See `docs/test-infrastructure.md` for all test harnesses:
 - `test/test_cd_boot.c` — low-level C harness with dlsym access to 68K registers and RAM
 - `test/sram_test.sh` — SRAM interface round-trip testing
 
+#### Headless framebuffer / 240p suite — how to report issues
+
+Profiling symbols like **`__muldi3`** (64-bit multiply helpers on some 32-bit ABIs) are a **compiler/performance** concern, **not** evidence that the Jaguar 240p test ROM’s DSP pink-noise path or NTSC timing is wrong. Do **not** frame “240p fails” primarily as a **`__muldi3`** bug unless you are optimizing a 32-bit build for speed.
+
+The **useful** regression story for automated screenshot / libretro.py / SessionBuilder runs is:
+
+- **Symptom:** On some cores or builds, a **non-RetroArch headless session** does not expose the **same composited framebuffer** via the libretro API (`video_screenshot`, etc.) as **RetroArch with the same core binary** — e.g. main menu of **jag_240p_test_suite v1.0.0** shows only a **thin band** (~order of **1k** non-black RGB pixels) vs **tens of thousands** on a known-good path.
+- **Interpretation:** Suspect **presentation / pixel source** — Object Processor and blitter output vs **what headless clients actually read** — until disproven with hardware or reference captures. This is **not** “prove 240p timing is wrong first.”
+- **Checks:** Use in-repo gates (e.g. **screenshots-preflight** / main-menu sanity, non-black pixel floor on the **~2000+** scale). Passing preflight ⇒ the **headless read-path** issue is resolved for that artifact; failing preflight ⇒ file a **framebuffer/compositing** bug for **headless libretro** consumption (logs, **two artifacts**: broken vs good), not a long **`__muldi3`** narrative.
+
 ### Known Limitations
 
 - Blitter not fully cycle-accurate (some games need fast blitter mode)

--- a/libretro.c
+++ b/libretro.c
@@ -295,6 +295,7 @@ void retro_set_environment(retro_environment_t cb)
    struct retro_core_options_update_display_callback update_display_cb;
    struct retro_log_callback logging;
    bool option_categories = false;
+   bool achievements = true;
    environ_cb = cb;
 
    logging.log = NULL;
@@ -311,6 +312,8 @@ void retro_set_environment(retro_environment_t cb)
    vfs_iface_info.iface                      = NULL;
    if (cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
       filestream_vfs_init(&vfs_iface_info);
+
+   environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS, &achievements);
 }
 
 static void check_variables(void)
@@ -1032,6 +1035,24 @@ bool retro_load_game(const struct retro_game_info *info)
    SET32(jaguarMainRAM, 0, 0x00200000);
    JaguarLoadFile((uint8_t*)info->data, info->size);
    JaguarReset();
+
+   /* Advertise the Jaguar memory map so frontends (RetroArch, etc.) can
+    * resolve emulated addresses to host buffers. Required for rcheevos. */
+   {
+      static struct retro_memory_descriptor descs[1];
+      static struct retro_memory_map memmap;
+
+      memset(descs, 0, sizeof(descs));
+      descs[0].flags     = RETRO_MEMDESC_SYSTEM_RAM | RETRO_MEMDESC_BIGENDIAN;
+      descs[0].ptr       = jaguarMainRAM;
+      descs[0].start     = 0x000000;
+      descs[0].len       = 0x200000;
+      descs[0].addrspace = "RAM";
+
+      memmap.descriptors     = descs;
+      memmap.num_descriptors = 1;
+      environ_cb(RETRO_ENVIRONMENT_SET_MEMORY_MAPS, &memmap);
+   }
 
    /* The frontend will load .srm data into our save buffer (returned by
     * retro_get_memory_data) after this function returns but before the

--- a/libretro.c
+++ b/libretro.c
@@ -1037,7 +1037,13 @@ bool retro_load_game(const struct retro_game_info *info)
    JaguarReset();
 
    /* Advertise the Jaguar memory map so frontends (RetroArch, etc.) can
-    * resolve emulated addresses to host buffers. Required for rcheevos. */
+    * resolve emulated addresses to host buffers. Required for rcheevos.
+    *
+    * rcheevos defines one logical system-RAM region for RC_CONSOLE_ATARI_JAGUAR:
+    * $000000-$1FFFFF (see rcheevos consoleinfo). RetroAchievements addresses for
+    * Jaguar are authored in that space. GPU-style paths mirror 2 MiB within
+    * $000000-$7FFFFF in JaguarReadByte, but M68K direct access in this core is
+    * only linear $000000-$1FFFFF without those mirrors (m68k_read_memory_*). */
    {
       static struct retro_memory_descriptor descs[1];
       static struct retro_memory_map memmap;

--- a/test/tools/build_rcheevos_static.sh
+++ b/test/tools/build_rcheevos_static.sh
@@ -1,26 +1,29 @@
 #!/usr/bin/env bash
-# Builds a static librcherros.a from the official RetroAchievements/rcheevos repo.
-# Used by test_rcheevos_e2e.sh. Pin RCHEEVOS_REF (tag or SHA) for reproducibility.
+# Builds a static librcheevos.a from the official RetroAchievements/rcheevos repo.
+# Used by test_rcheevos_e2e.sh. Pin RCHEEVOS_REF to a tag or full commit SHA.
+# Tarball URL: https://github.com/RetroAchievements/rcheevos/archive/${REF}.tar.gz
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 DEST="${DEST:-$ROOT/build/rcheevos-static}"
-TAG="${RCHEEVOS_REF:-v12.3.0}"
+REF="${RCHEEVOS_REF:-v12.3.0}"
 CC="${CC:-cc}"
 
 mkdir -p "$DEST"
 
-if [[ ! -f "$DEST/.extracted_${TAG}" ]]; then
-   rm -rf "${DEST:?}/"* "$DEST/.extracted_"*
+CACHE_MARK="$DEST/.extracted_${REF//\//_}"
+
+if [[ ! -f "$CACHE_MARK" ]]; then
+   rm -rf "${DEST:?}/"* "${DEST:?}/".extracted_* 2>/dev/null || true
    TMP="$DEST/dl"
    mkdir -p "$TMP"
-   echo "Downloading rcheevos ${TAG}..."
-   curl -fsSL -o "$TMP/rc.tgz" "https://github.com/RetroAchievements/rcheevos/archive/refs/tags/${TAG}.tar.gz"
+   echo "Downloading rcheevos ${REF}..."
+   curl -fsSL -o "$TMP/rc.tgz" "https://github.com/RetroAchievements/rcheevos/archive/${REF}.tar.gz"
    tar -xzf "$TMP/rc.tgz" -C "$DEST"
    rm -rf "$TMP"
    SRC="$(echo "$DEST"/rcheevos-* | head -1)"
    mv "$SRC" "$DEST/rcheevos-src"
-   touch "$DEST/.extracted_${TAG}"
+   touch "$CACHE_MARK"
 fi
 
 SRCROOT="$DEST/rcheevos-src"

--- a/test/tools/build_rcheevos_static.sh
+++ b/test/tools/build_rcheevos_static.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Builds a static librcherros.a from the official RetroAchievements/rcheevos repo.
+# Used by test_rcheevos_e2e.sh. Pin RCHEEVOS_REF (tag or SHA) for reproducibility.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEST="${DEST:-$ROOT/build/rcheevos-static}"
+TAG="${RCHEEVOS_REF:-v12.3.0}"
+CC="${CC:-cc}"
+
+mkdir -p "$DEST"
+
+if [[ ! -f "$DEST/.extracted_${TAG}" ]]; then
+   rm -rf "${DEST:?}/"* "$DEST/.extracted_"*
+   TMP="$DEST/dl"
+   mkdir -p "$TMP"
+   echo "Downloading rcheevos ${TAG}..."
+   curl -fsSL -o "$TMP/rc.tgz" "https://github.com/RetroAchievements/rcheevos/archive/refs/tags/${TAG}.tar.gz"
+   tar -xzf "$TMP/rc.tgz" -C "$DEST"
+   rm -rf "$TMP"
+   SRC="$(echo "$DEST"/rcheevos-* | head -1)"
+   mv "$SRC" "$DEST/rcheevos-src"
+   touch "$DEST/.extracted_${TAG}"
+fi
+
+SRCROOT="$DEST/rcheevos-src"
+OBJDIR="$DEST/obj"
+rm -rf "$OBJDIR"
+mkdir -p "$OBJDIR"
+
+CFLAGS="-O2 -I${SRCROOT}/include -I${SRCROOT}/src -I${ROOT}/libretro-common/include -DRC_DISABLE_LUA -DRC_CLIENT_SUPPORTS_HASH"
+
+echo "Compiling rcheevos sources..."
+while IFS= read -r -d '' f; do
+   bn="$(basename "$f" .c)"
+   $CC -c $CFLAGS -o "$OBJDIR/${bn}.o" "$f"
+done < <(find "$SRCROOT/src" -name '*.c' -print0)
+
+ar rcs "$DEST/librcheevos.a" "$OBJDIR"/*.o
+echo "Built $DEST/librcheevos.a"

--- a/test/tools/test_memory_map.c
+++ b/test/tools/test_memory_map.c
@@ -2,8 +2,8 @@
  * test_memory_map.c — Verify RetroAchievements memory map advertisement.
  *
  * Loads the core, feeds a minimal dummy ROM, and checks that
- * RETRO_ENVIRONMENT_SET_MEMORY_MAPS and SET_SUPPORT_ACHIEVEMENTS
- * are called with correct values.
+ * RETRO_ENVIRONMENT_SET_MEMORY_MAPS is advertised and SET_SUPPORT_ACHIEVEMENTS
+ * is called with a non-NULL pointer to bool true (per libretro.h).
  *
  * Build:
  *   cc -o test/tools/test_memory_map test/tools/test_memory_map.c -ldl  (Linux)
@@ -44,6 +44,8 @@ typedef size_t (*retro_get_memory_size_t)(unsigned);
 
 static bool got_memory_maps;
 static bool got_achievements;
+static bool achievements_data_ok;
+static bool achievements_enabled_true;
 static const struct retro_memory_map *captured_memmap;
 
 static bool env_cb(unsigned cmd, void *data)
@@ -56,6 +58,11 @@ static bool env_cb(unsigned cmd, void *data)
         return true;
     case RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS:
         got_achievements = true;
+        if (data)
+        {
+            achievements_data_ok = true;
+            achievements_enabled_true = *(const bool *)data;
+        }
         return true;
     case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
     case RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME:
@@ -168,6 +175,8 @@ int main(int argc, char **argv)
 
     got_memory_maps = false;
     got_achievements = false;
+    achievements_data_ok = false;
+    achievements_enabled_true = false;
     captured_memmap = NULL;
 
     core_set_env(env_cb);
@@ -178,13 +187,23 @@ int main(int argc, char **argv)
     core_set_input_state(input_state);
     core_init();
 
-    /* Test 1: SET_SUPPORT_ACHIEVEMENTS called during retro_set_environment */
-    printf("Test 1: SET_SUPPORT_ACHIEVEMENTS ... ");
-    if (got_achievements)
+    /* Test 1: SET_SUPPORT_ACHIEVEMENTS during retro_set_environment — non-NULL bool, true */
+    printf("Test 1: SET_SUPPORT_ACHIEVEMENTS (true) ... ");
+    if (got_achievements && achievements_data_ok && achievements_enabled_true)
         printf("PASS\n");
-    else
+    else if (!got_achievements)
     {
         printf("FAIL (not called)\n");
+        failures++;
+    }
+    else if (!achievements_data_ok)
+    {
+        printf("FAIL (NULL data)\n");
+        failures++;
+    }
+    else
+    {
+        printf("FAIL (expected true, got false)\n");
         failures++;
     }
 

--- a/test/tools/test_memory_map.c
+++ b/test/tools/test_memory_map.c
@@ -1,0 +1,316 @@
+/*
+ * test_memory_map.c — Verify RetroAchievements memory map advertisement.
+ *
+ * Loads the core, feeds a minimal dummy ROM, and checks that
+ * RETRO_ENVIRONMENT_SET_MEMORY_MAPS and SET_SUPPORT_ACHIEVEMENTS
+ * are called with correct values.
+ *
+ * Build:
+ *   cc -o test/tools/test_memory_map test/tools/test_memory_map.c -ldl  (Linux)
+ *   cc -o test/tools/test_memory_map test/tools/test_memory_map.c       (macOS)
+ *
+ * Usage:
+ *   ./test/tools/test_memory_map <core.dylib|so>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __APPLE__
+#include <dlfcn.h>
+#define LIBEXT "dylib"
+#else
+#include <dlfcn.h>
+#define LIBEXT "so"
+#endif
+
+#include "../../libretro-common/include/libretro.h"
+
+typedef void   (*retro_init_t)(void);
+typedef void   (*retro_deinit_t)(void);
+typedef void   (*retro_set_environment_t)(retro_environment_t);
+typedef void   (*retro_set_video_refresh_t)(retro_video_refresh_t);
+typedef void   (*retro_set_audio_sample_t)(retro_audio_sample_t);
+typedef void   (*retro_set_audio_sample_batch_t)(retro_audio_sample_batch_t);
+typedef void   (*retro_set_input_poll_t)(retro_input_poll_t);
+typedef void   (*retro_set_input_state_t)(retro_input_state_t);
+typedef bool   (*retro_load_game_t)(const struct retro_game_info *);
+typedef void   (*retro_unload_game_t)(void);
+typedef void  *(*retro_get_memory_data_t)(unsigned);
+typedef size_t (*retro_get_memory_size_t)(unsigned);
+
+static bool got_memory_maps;
+static bool got_achievements;
+static const struct retro_memory_map *captured_memmap;
+
+static bool env_cb(unsigned cmd, void *data)
+{
+    switch (cmd)
+    {
+    case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+        got_memory_maps = true;
+        captured_memmap = (const struct retro_memory_map *)data;
+        return true;
+    case RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS:
+        got_achievements = true;
+        return true;
+    case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+    case RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME:
+        return true;
+    case RETRO_ENVIRONMENT_GET_VARIABLE:
+        return false;
+    case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE:
+        if (data) *(bool *)data = false;
+        return true;
+    case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+    case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+        if (data) *(const char **)data = ".";
+        return true;
+    case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
+        if (data) *(unsigned *)data = 0;
+        return true;
+    case RETRO_ENVIRONMENT_GET_INPUT_BITMASKS:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void video_cb(const void *d, unsigned w, unsigned h, size_t p)
+{ (void)d; (void)w; (void)h; (void)p; }
+static void audio_cb(int16_t l, int16_t r)
+{ (void)l; (void)r; }
+static size_t audio_batch(const int16_t *d, size_t f)
+{ (void)d; return f; }
+static void input_poll(void) {}
+static int16_t input_state(unsigned p, unsigned d, unsigned i, unsigned id)
+{ (void)p; (void)d; (void)i; (void)id; return 0; }
+
+static void *load_sym(void *handle, const char *name)
+{
+    void *sym = dlsym(handle, name);
+    if (!sym)
+    {
+        fprintf(stderr, "ERROR: Missing symbol: %s\n", name);
+        exit(1);
+    }
+    return sym;
+}
+
+/*
+ * Build a minimal 8 KB Jaguar ROM with a valid header.
+ * The ROM header at 0x400 sets the entry point at 0x802000.
+ * We place an infinite loop (BRA.S $802000) at the entry point.
+ */
+static uint8_t *make_dummy_rom(size_t *size_out)
+{
+    size_t sz = 8192;
+    uint8_t *rom = calloc(1, sz);
+    if (!rom) { perror("calloc"); exit(1); }
+
+    /* Jaguar ROM header at offset 0x400 */
+    /* 0x404: run address (big-endian) = 0x00802000 */
+    rom[0x404] = 0x00; rom[0x405] = 0x80;
+    rom[0x406] = 0x20; rom[0x407] = 0x00;
+
+    /* At offset 0x2000 (maps to 0x802000): BRA.S self (0x60FE) */
+    rom[0x2000] = 0x60; rom[0x2001] = 0xFE;
+
+    *size_out = sz;
+    return rom;
+}
+
+int main(int argc, char **argv)
+{
+    void *handle;
+    retro_init_t                core_init;
+    retro_deinit_t              core_deinit;
+    retro_set_environment_t     core_set_env;
+    retro_set_video_refresh_t   core_set_video;
+    retro_set_audio_sample_t    core_set_audio;
+    retro_set_audio_sample_batch_t core_set_audio_batch;
+    retro_set_input_poll_t      core_set_input_poll;
+    retro_set_input_state_t     core_set_input_state;
+    retro_load_game_t           core_load_game;
+    retro_unload_game_t         core_unload_game;
+    retro_get_memory_data_t     core_get_memory_data;
+    retro_get_memory_size_t     core_get_memory_size;
+    struct retro_game_info info;
+    uint8_t *rom;
+    size_t rom_size;
+    int failures = 0;
+
+    if (argc < 2)
+    {
+        fprintf(stderr, "Usage: %s <core." LIBEXT ">\n", argv[0]);
+        return 1;
+    }
+
+    handle = dlopen(argv[1], RTLD_LAZY);
+    if (!handle) { fprintf(stderr, "dlopen: %s\n", dlerror()); return 1; }
+
+    core_init             = (retro_init_t)load_sym(handle, "retro_init");
+    core_deinit           = (retro_deinit_t)load_sym(handle, "retro_deinit");
+    core_set_env          = (retro_set_environment_t)load_sym(handle, "retro_set_environment");
+    core_set_video        = (retro_set_video_refresh_t)load_sym(handle, "retro_set_video_refresh");
+    core_set_audio        = (retro_set_audio_sample_t)load_sym(handle, "retro_set_audio_sample");
+    core_set_audio_batch  = (retro_set_audio_sample_batch_t)load_sym(handle, "retro_set_audio_sample_batch");
+    core_set_input_poll   = (retro_set_input_poll_t)load_sym(handle, "retro_set_input_poll");
+    core_set_input_state  = (retro_set_input_state_t)load_sym(handle, "retro_set_input_state");
+    core_load_game        = (retro_load_game_t)load_sym(handle, "retro_load_game");
+    core_unload_game      = (retro_unload_game_t)load_sym(handle, "retro_unload_game");
+    core_get_memory_data  = (retro_get_memory_data_t)load_sym(handle, "retro_get_memory_data");
+    core_get_memory_size  = (retro_get_memory_size_t)load_sym(handle, "retro_get_memory_size");
+
+    got_memory_maps = false;
+    got_achievements = false;
+    captured_memmap = NULL;
+
+    core_set_env(env_cb);
+    core_set_video(video_cb);
+    core_set_audio(audio_cb);
+    core_set_audio_batch(audio_batch);
+    core_set_input_poll(input_poll);
+    core_set_input_state(input_state);
+    core_init();
+
+    /* Test 1: SET_SUPPORT_ACHIEVEMENTS called during retro_set_environment */
+    printf("Test 1: SET_SUPPORT_ACHIEVEMENTS ... ");
+    if (got_achievements)
+        printf("PASS\n");
+    else
+    {
+        printf("FAIL (not called)\n");
+        failures++;
+    }
+
+    /* Load the dummy ROM to trigger SET_MEMORY_MAPS */
+    rom = make_dummy_rom(&rom_size);
+    memset(&info, 0, sizeof(info));
+    info.path = "dummy.j64";
+    info.data = rom;
+    info.size = rom_size;
+
+    if (!core_load_game(&info))
+    {
+        fprintf(stderr, "ERROR: retro_load_game returned false\n");
+        free(rom);
+        core_deinit();
+        dlclose(handle);
+        return 1;
+    }
+
+    /* Test 2: SET_MEMORY_MAPS called during retro_load_game */
+    printf("Test 2: SET_MEMORY_MAPS called ... ");
+    if (got_memory_maps)
+        printf("PASS\n");
+    else
+    {
+        printf("FAIL (not called)\n");
+        failures++;
+    }
+
+    /* Test 3: Memory map has exactly 1 descriptor */
+    printf("Test 3: num_descriptors == 1 ... ");
+    if (captured_memmap && captured_memmap->num_descriptors == 1)
+        printf("PASS\n");
+    else
+    {
+        printf("FAIL (got %u)\n",
+               captured_memmap ? (unsigned)captured_memmap->num_descriptors : 0);
+        failures++;
+    }
+
+    /* Test 4: Descriptor covers 2 MB system RAM at address 0 */
+    if (captured_memmap && captured_memmap->num_descriptors >= 1)
+    {
+        const struct retro_memory_descriptor *d = &captured_memmap->descriptors[0];
+
+        printf("Test 4: descriptor start == 0x000000 ... ");
+        if (d->start == 0x000000)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (0x%06zx)\n", d->start);
+            failures++;
+        }
+
+        printf("Test 5: descriptor len == 0x200000 ... ");
+        if (d->len == 0x200000)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (0x%06zx)\n", d->len);
+            failures++;
+        }
+
+        printf("Test 6: RETRO_MEMDESC_SYSTEM_RAM flag set ... ");
+        if (d->flags & RETRO_MEMDESC_SYSTEM_RAM)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (flags=0x%llx)\n", (unsigned long long)d->flags);
+            failures++;
+        }
+
+        printf("Test 7: RETRO_MEMDESC_BIGENDIAN flag set ... ");
+        if (d->flags & RETRO_MEMDESC_BIGENDIAN)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (flags=0x%llx)\n", (unsigned long long)d->flags);
+            failures++;
+        }
+
+        printf("Test 8: descriptor ptr is non-NULL ... ");
+        if (d->ptr != NULL)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL\n");
+            failures++;
+        }
+
+        printf("Test 9: descriptor ptr matches retro_get_memory_data(SYSTEM_RAM) ... ");
+        {
+            void *sysram = core_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
+            if (d->ptr == sysram)
+                printf("PASS\n");
+            else
+            {
+                printf("FAIL (map=%p, get_memory=%p)\n", d->ptr, sysram);
+                failures++;
+            }
+        }
+    }
+    else
+    {
+        printf("Tests 4-9: SKIPPED (no descriptor)\n");
+        failures += 6;
+    }
+
+    /* Test 10: retro_get_memory_size(SYSTEM_RAM) == 0x200000 */
+    printf("Test 10: retro_get_memory_size(SYSTEM_RAM) == 0x200000 ... ");
+    {
+        size_t sz = core_get_memory_size(RETRO_MEMORY_SYSTEM_RAM);
+        if (sz == 0x200000)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (0x%zx)\n", sz);
+            failures++;
+        }
+    }
+
+    core_unload_game();
+    core_deinit();
+    free(rom);
+    dlclose(handle);
+
+    printf("\n%s: %d test(s) failed.\n",
+           failures ? "FAIL" : "OK", failures);
+    return failures ? 1 : 0;
+}

--- a/test/tools/test_memory_map.c
+++ b/test/tools/test_memory_map.c
@@ -107,7 +107,8 @@ static void *load_sym(void *handle, const char *name)
  */
 static uint8_t *make_dummy_rom(size_t *size_out)
 {
-    size_t sz = 8192;
+    /* 0x2000 bytes is not enough: we patch instructions at file offset 0x2000 (8 KiB). */
+    size_t sz = 12288;
     uint8_t *rom = calloc(1, sz);
     if (!rom) { perror("calloc"); exit(1); }
 

--- a/test/tools/test_memory_map.c
+++ b/test/tools/test_memory_map.c
@@ -180,20 +180,14 @@ int main(int argc, char **argv)
     captured_memmap = NULL;
 
     core_set_env(env_cb);
-    core_set_video(video_cb);
-    core_set_audio(audio_cb);
-    core_set_audio_batch(audio_batch);
-    core_set_input_poll(input_poll);
-    core_set_input_state(input_state);
-    core_init();
 
-    /* Test 1: SET_SUPPORT_ACHIEVEMENTS during retro_set_environment — non-NULL bool, true */
+    /* Test 1: must fire from retro_set_environment before retro_init (not after init) */
     printf("Test 1: SET_SUPPORT_ACHIEVEMENTS (true) ... ");
     if (got_achievements && achievements_data_ok && achievements_enabled_true)
         printf("PASS\n");
     else if (!got_achievements)
     {
-        printf("FAIL (not called)\n");
+        printf("FAIL (not called during retro_set_environment)\n");
         failures++;
     }
     else if (!achievements_data_ok)
@@ -206,6 +200,13 @@ int main(int argc, char **argv)
         printf("FAIL (expected true, got false)\n");
         failures++;
     }
+
+    core_set_video(video_cb);
+    core_set_audio(audio_cb);
+    core_set_audio_batch(audio_batch);
+    core_set_input_poll(input_poll);
+    core_set_input_state(input_state);
+    core_init();
 
     /* Load the dummy ROM to trigger SET_MEMORY_MAPS */
     rom = make_dummy_rom(&rom_size);

--- a/test/tools/test_memory_map.c
+++ b/test/tools/test_memory_map.c
@@ -237,7 +237,15 @@ int main(int argc, char **argv)
     /* Test 3: Memory map has exactly 1 descriptor */
     printf("Test 3: num_descriptors == 1 ... ");
     if (captured_memmap && captured_memmap->num_descriptors == 1)
-        printf("PASS\n");
+    {
+        if (captured_memmap->descriptors != NULL)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (descriptors is NULL)\n");
+            failures++;
+        }
+    }
     else
     {
         printf("FAIL (got %u)\n",
@@ -245,8 +253,18 @@ int main(int argc, char **argv)
         failures++;
     }
 
-    /* Test 4: Descriptor covers 2 MB system RAM at address 0 */
-    if (captured_memmap && captured_memmap->num_descriptors >= 1)
+    /* Tests 4–9: descriptor [0] (requires non-NULL descriptors table) */
+    if (!captured_memmap || captured_memmap->num_descriptors < 1)
+    {
+        printf("Tests 4-9: SKIPPED (no descriptor)\n");
+        failures += 6;
+    }
+    else if (!captured_memmap->descriptors)
+    {
+        printf("Tests 4-9: FAIL (descriptors is NULL)\n");
+        failures += 6;
+    }
+    else
     {
         const struct retro_memory_descriptor *d = &captured_memmap->descriptors[0];
 
@@ -306,11 +324,6 @@ int main(int argc, char **argv)
                 failures++;
             }
         }
-    }
-    else
-    {
-        printf("Tests 4-9: SKIPPED (no descriptor)\n");
-        failures += 6;
     }
 
     /* Test 10: retro_get_memory_size(SYSTEM_RAM) == 0x200000 */

--- a/test/tools/test_rcheevos_e2e.c
+++ b/test/tools/test_rcheevos_e2e.c
@@ -1,0 +1,268 @@
+/*
+ * test_rcheevos_e2e.c — Load Virtual Jaguar, feed rcheevos rc_libretro with the same
+ * SET_MEMORY_MAPS descriptor RetroArch receives, then verify address resolution matches
+ * host RAM (offline; no RetroAchievements server).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __APPLE__
+#include <dlfcn.h>
+#else
+#include <dlfcn.h>
+#endif
+
+#include "../../libretro-common/include/libretro.h"
+#include "rc_libretro.h"
+#include "rc_consoles.h"
+
+typedef void   (*retro_init_t)(void);
+typedef void   (*retro_deinit_t)(void);
+typedef void   (*retro_set_environment_t)(retro_environment_t);
+typedef void   (*retro_set_video_refresh_t)(retro_video_refresh_t);
+typedef void   (*retro_set_audio_sample_t)(retro_audio_sample_t);
+typedef void   (*retro_set_audio_sample_batch_t)(retro_audio_sample_batch_t);
+typedef void   (*retro_set_input_poll_t)(retro_input_poll_t);
+typedef void   (*retro_set_input_state_t)(retro_input_state_t);
+typedef bool   (*retro_load_game_t)(const struct retro_game_info *);
+typedef void   (*retro_unload_game_t)(void);
+typedef void  *(*retro_get_memory_data_t)(unsigned);
+typedef size_t (*retro_get_memory_size_t)(unsigned);
+
+static const struct retro_memory_map *g_mmap;
+static retro_get_memory_data_t g_get_memory_data;
+static retro_get_memory_size_t g_get_memory_size;
+
+static bool env_cb(unsigned cmd, void *data)
+{
+    switch (cmd)
+    {
+    case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+        g_mmap = (const struct retro_memory_map *)data;
+        return true;
+    case RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS:
+        return true;
+    case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+    case RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME:
+        return true;
+    case RETRO_ENVIRONMENT_GET_VARIABLE:
+        return false;
+    case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE:
+        if (data) *(bool *)data = false;
+        return true;
+    case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+    case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+        if (data) *(const char **)data = ".";
+        return true;
+    case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
+        if (data) *(unsigned *)data = 0;
+        return true;
+    case RETRO_ENVIRONMENT_GET_INPUT_BITMASKS:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void libretro_get_core_memory_info(uint32_t id, rc_libretro_core_memory_info_t *info)
+{
+    if (!g_get_memory_data || !g_get_memory_size)
+    {
+        info->data = NULL;
+        info->size = 0;
+        return;
+    }
+    info->data = (uint8_t *)g_get_memory_data(id);
+    info->size = g_get_memory_size(id);
+}
+
+static void video_cb(const void *d, unsigned w, unsigned h, size_t p)
+{ (void)d; (void)w; (void)h; (void)p; }
+static void audio_cb(int16_t l, int16_t r)
+{ (void)l; (void)r; }
+static size_t audio_batch(const int16_t *d, size_t f)
+{ (void)d; return f; }
+static void input_poll(void) {}
+static int16_t input_state(unsigned p, unsigned d, unsigned i, unsigned id)
+{ (void)p; (void)d; (void)i; (void)id; return 0; }
+
+static void *load_sym(void *handle, const char *name)
+{
+    void *sym = dlsym(handle, name);
+    if (!sym)
+    {
+        fprintf(stderr, "ERROR: Missing symbol: %s\n", name);
+        exit(1);
+    }
+    return sym;
+}
+
+static uint8_t *make_dummy_rom(size_t *size_out)
+{
+    size_t sz = 8192;
+    uint8_t *rom = calloc(1, sz);
+    if (!rom) { perror("calloc"); exit(1); }
+    rom[0x404] = 0x00; rom[0x405] = 0x80;
+    rom[0x406] = 0x20; rom[0x407] = 0x00;
+    rom[0x2000] = 0x60; rom[0x2001] = 0xFE;
+    *size_out = sz;
+    return rom;
+}
+
+int main(int argc, char **argv)
+{
+    void *handle;
+    retro_init_t core_init;
+    retro_deinit_t core_deinit;
+    retro_set_environment_t core_set_env;
+    retro_set_video_refresh_t core_set_video;
+    retro_set_audio_sample_t core_set_audio;
+    retro_set_audio_sample_batch_t core_set_audio_batch;
+    retro_set_input_poll_t core_set_input_poll;
+    retro_set_input_state_t core_set_input_state;
+    retro_load_game_t core_load_game;
+    retro_unload_game_t core_unload_game;
+    retro_get_memory_data_t core_get_memory_data;
+    retro_get_memory_size_t core_get_memory_size;
+    struct retro_game_info info;
+    uint8_t *rom;
+    size_t rom_size;
+    rc_libretro_memory_regions_t regions;
+    uint8_t *sysram;
+    uint8_t buf[4];
+    uint32_t avail;
+    uint8_t *pfind;
+    int failures = 0;
+
+    if (argc < 2)
+    {
+        fprintf(stderr, "Usage: %s <core.so|dylib>\n", argv[0]);
+        return 1;
+    }
+
+    handle = dlopen(argv[1], RTLD_LAZY);
+    if (!handle) { fprintf(stderr, "dlopen: %s\n", dlerror()); return 1; }
+
+    core_init             = (retro_init_t)load_sym(handle, "retro_init");
+    core_deinit           = (retro_deinit_t)load_sym(handle, "retro_deinit");
+    core_set_env          = (retro_set_environment_t)load_sym(handle, "retro_set_environment");
+    core_set_video        = (retro_set_video_refresh_t)load_sym(handle, "retro_set_video_refresh");
+    core_set_audio        = (retro_set_audio_sample_t)load_sym(handle, "retro_set_audio_sample");
+    core_set_audio_batch  = (retro_set_audio_sample_batch_t)load_sym(handle, "retro_set_audio_sample_batch");
+    core_set_input_poll   = (retro_set_input_poll_t)load_sym(handle, "retro_set_input_poll");
+    core_set_input_state  = (retro_set_input_state_t)load_sym(handle, "retro_set_input_state");
+    core_load_game        = (retro_load_game_t)load_sym(handle, "retro_load_game");
+    core_unload_game      = (retro_unload_game_t)load_sym(handle, "retro_unload_game");
+    core_get_memory_data  = (retro_get_memory_data_t)load_sym(handle, "retro_get_memory_data");
+    core_get_memory_size  = (retro_get_memory_size_t)load_sym(handle, "retro_get_memory_size");
+
+    g_mmap = NULL;
+    g_get_memory_data = core_get_memory_data;
+    g_get_memory_size = core_get_memory_size;
+
+    core_set_env(env_cb);
+    core_set_video(video_cb);
+    core_set_audio(audio_cb);
+    core_set_audio_batch(audio_batch);
+    core_set_input_poll(input_poll);
+    core_set_input_state(input_state);
+    core_init();
+
+    rom = make_dummy_rom(&rom_size);
+    memset(&info, 0, sizeof(info));
+    info.path = "dummy.j64";
+    info.data = rom;
+    info.size = rom_size;
+
+    if (!core_load_game(&info))
+    {
+        fprintf(stderr, "retro_load_game failed\n");
+        free(rom);
+        core_deinit();
+        dlclose(handle);
+        return 1;
+    }
+
+    printf("Test 1: SET_MEMORY_MAPS captured ... ");
+    if (!g_mmap || !g_mmap->descriptors || g_mmap->num_descriptors < 1)
+    {
+        printf("FAIL\n");
+        failures++;
+    }
+    else
+        printf("PASS\n");
+
+    memset(&regions, 0, sizeof(regions));
+    printf("Test 2: rc_libretro_memory_init(Jaguar) ... ");
+    if (!rc_libretro_memory_init(&regions, g_mmap, libretro_get_core_memory_info,
+                                 RC_CONSOLE_ATARI_JAGUAR))
+    {
+        printf("FAIL\n");
+        failures++;
+    }
+    else
+        printf("PASS\n");
+
+    sysram = (uint8_t *)core_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
+    if (sysram)
+    {
+        sysram[0xABCD] = 0x42;
+        sysram[0x1FFFFE] = 0x11;
+        sysram[0x1FFFFF] = 0x22;
+    }
+
+    printf("Test 3: rc_libretro_memory_read(0xABCD) ... ");
+    memset(buf, 0, sizeof(buf));
+    if (rc_libretro_memory_read(&regions, 0xABCDU, buf, 1) == 1 && buf[0] == 0x42)
+        printf("PASS\n");
+    else
+    {
+        printf("FAIL\n");
+        failures++;
+    }
+
+    printf("Test 4: rc_libretro_memory_find(0xABCD) matches host ptr ... ");
+    pfind = rc_libretro_memory_find(&regions, 0xABCDU);
+    if (sysram && pfind == sysram + 0xABCD)
+        printf("PASS\n");
+    else
+    {
+        printf("FAIL\n");
+        failures++;
+    }
+
+    printf("Test 5: cross-boundary read at end of RAM ... ");
+    memset(buf, 0, sizeof(buf));
+    if (rc_libretro_memory_read(&regions, 0x1FFFFEU, buf, 2) == 2
+        && buf[0] == 0x11 && buf[1] == 0x22)
+        printf("PASS\n");
+    else
+    {
+        printf("FAIL\n");
+        failures++;
+    }
+
+    printf("Test 6: rc_libretro_memory_find_avail ... ");
+    pfind = rc_libretro_memory_find_avail(&regions, 0x1FFFFEU, &avail);
+    if (pfind && avail >= 2 && pfind == sysram + 0x1FFFFE)
+        printf("PASS\n");
+    else
+    {
+        printf("FAIL\n");
+        failures++;
+    }
+
+    rc_libretro_memory_destroy(&regions);
+
+    core_unload_game();
+    core_deinit();
+    free(rom);
+    dlclose(handle);
+
+    printf("\n%s: %d test(s) failed.\n", failures ? "FAIL" : "OK", failures);
+    return failures ? 1 : 0;
+}

--- a/test/tools/test_rcheevos_e2e.c
+++ b/test/tools/test_rcheevos_e2e.c
@@ -10,11 +10,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef __APPLE__
 #include <dlfcn.h>
-#else
-#include <dlfcn.h>
-#endif
 
 #include "../../libretro-common/include/libretro.h"
 #include "rc_libretro.h"

--- a/test/tools/test_rcheevos_e2e.c
+++ b/test/tools/test_rcheevos_e2e.c
@@ -103,7 +103,7 @@ static void *load_sym(void *handle, const char *name)
 
 static uint8_t *make_dummy_rom(size_t *size_out)
 {
-    size_t sz = 8192;
+    size_t sz = 12288;
     uint8_t *rom = calloc(1, sz);
     if (!rom) { perror("calloc"); exit(1); }
     rom[0x404] = 0x00; rom[0x405] = 0x80;

--- a/test/tools/test_rcheevos_e2e.c
+++ b/test/tools/test_rcheevos_e2e.c
@@ -248,7 +248,7 @@ int main(int argc, char **argv)
 
     printf("Test 6: rc_libretro_memory_find_avail ... ");
     pfind = rc_libretro_memory_find_avail(&regions, 0x1FFFFEU, &avail);
-    if (pfind && avail >= 2 && pfind == sysram + 0x1FFFFE)
+    if (pfind && avail >= 2 && sysram && pfind == sysram + 0x1FFFFE)
         printf("PASS\n");
     else
     {

--- a/test/tools/test_rcheevos_e2e.c
+++ b/test/tools/test_rcheevos_e2e.c
@@ -137,6 +137,8 @@ int main(int argc, char **argv)
     uint32_t avail;
     uint8_t *pfind;
     int failures = 0;
+    int mmap_ok;
+    int regions_inited = 0;
 
     if (argc < 2)
     {
@@ -187,8 +189,11 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    mmap_ok = (g_mmap != NULL && g_mmap->descriptors != NULL
+               && g_mmap->num_descriptors >= 1);
+
     printf("Test 1: SET_MEMORY_MAPS captured ... ");
-    if (!g_mmap || !g_mmap->descriptors || g_mmap->num_descriptors < 1)
+    if (!mmap_ok)
     {
         printf("FAIL\n");
         failures++;
@@ -197,66 +202,92 @@ int main(int argc, char **argv)
         printf("PASS\n");
 
     memset(&regions, 0, sizeof(regions));
-    printf("Test 2: rc_libretro_memory_init(Jaguar) ... ");
-    if (!rc_libretro_memory_init(&regions, g_mmap, libretro_get_core_memory_info,
-                                 RC_CONSOLE_ATARI_JAGUAR))
+
+    if (!mmap_ok)
     {
-        printf("FAIL\n");
-        failures++;
+        printf("Test 2: rc_libretro_memory_init(Jaguar) ... SKIPPED (no SET_MEMORY_MAPS)\n");
+        printf("Test 3: rc_libretro_memory_read(0xABCD) ... SKIPPED\n");
+        printf("Test 4: rc_libretro_memory_find(0xABCD) matches host ptr ... SKIPPED\n");
+        printf("Test 5: cross-boundary read at end of RAM ... SKIPPED\n");
+        printf("Test 6: rc_libretro_memory_find_avail ... SKIPPED\n");
     }
     else
-        printf("PASS\n");
-
-    sysram = (uint8_t *)core_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
-    if (sysram)
     {
-        sysram[0xABCD] = 0x42;
-        sysram[0x1FFFFE] = 0x11;
-        sysram[0x1FFFFF] = 0x22;
-    }
+        printf("Test 2: rc_libretro_memory_init(Jaguar) ... ");
+        if (!rc_libretro_memory_init(&regions, g_mmap, libretro_get_core_memory_info,
+                                     RC_CONSOLE_ATARI_JAGUAR))
+        {
+            printf("FAIL\n");
+            failures++;
+        }
+        else
+        {
+            printf("PASS\n");
+            regions_inited = 1;
+        }
 
-    printf("Test 3: rc_libretro_memory_read(0xABCD) ... ");
-    memset(buf, 0, sizeof(buf));
-    if (rc_libretro_memory_read(&regions, 0xABCDU, buf, 1) == 1 && buf[0] == 0x42)
-        printf("PASS\n");
-    else
-    {
-        printf("FAIL\n");
-        failures++;
-    }
+        if (!regions_inited)
+        {
+            printf("Test 3: rc_libretro_memory_read(0xABCD) ... SKIPPED\n");
+            printf("Test 4: rc_libretro_memory_find(0xABCD) matches host ptr ... SKIPPED\n");
+            printf("Test 5: cross-boundary read at end of RAM ... SKIPPED\n");
+            printf("Test 6: rc_libretro_memory_find_avail ... SKIPPED\n");
+        }
+        else
+        {
+            sysram = (uint8_t *)core_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
+            if (sysram)
+            {
+                sysram[0xABCD] = 0x42;
+                sysram[0x1FFFFE] = 0x11;
+                sysram[0x1FFFFF] = 0x22;
+            }
 
-    printf("Test 4: rc_libretro_memory_find(0xABCD) matches host ptr ... ");
-    pfind = rc_libretro_memory_find(&regions, 0xABCDU);
-    if (sysram && pfind == sysram + 0xABCD)
-        printf("PASS\n");
-    else
-    {
-        printf("FAIL\n");
-        failures++;
-    }
+            printf("Test 3: rc_libretro_memory_read(0xABCD) ... ");
+            memset(buf, 0, sizeof(buf));
+            if (rc_libretro_memory_read(&regions, 0xABCDU, buf, 1) == 1 && buf[0] == 0x42)
+                printf("PASS\n");
+            else
+            {
+                printf("FAIL\n");
+                failures++;
+            }
 
-    printf("Test 5: cross-boundary read at end of RAM ... ");
-    memset(buf, 0, sizeof(buf));
-    if (rc_libretro_memory_read(&regions, 0x1FFFFEU, buf, 2) == 2
-        && buf[0] == 0x11 && buf[1] == 0x22)
-        printf("PASS\n");
-    else
-    {
-        printf("FAIL\n");
-        failures++;
-    }
+            printf("Test 4: rc_libretro_memory_find(0xABCD) matches host ptr ... ");
+            pfind = rc_libretro_memory_find(&regions, 0xABCDU);
+            if (sysram && pfind == sysram + 0xABCD)
+                printf("PASS\n");
+            else
+            {
+                printf("FAIL\n");
+                failures++;
+            }
 
-    printf("Test 6: rc_libretro_memory_find_avail ... ");
-    pfind = rc_libretro_memory_find_avail(&regions, 0x1FFFFEU, &avail);
-    if (pfind && avail >= 2 && sysram && pfind == sysram + 0x1FFFFE)
-        printf("PASS\n");
-    else
-    {
-        printf("FAIL\n");
-        failures++;
-    }
+            printf("Test 5: cross-boundary read at end of RAM ... ");
+            memset(buf, 0, sizeof(buf));
+            if (rc_libretro_memory_read(&regions, 0x1FFFFEU, buf, 2) == 2
+                && buf[0] == 0x11 && buf[1] == 0x22)
+                printf("PASS\n");
+            else
+            {
+                printf("FAIL\n");
+                failures++;
+            }
 
-    rc_libretro_memory_destroy(&regions);
+            printf("Test 6: rc_libretro_memory_find_avail ... ");
+            pfind = rc_libretro_memory_find_avail(&regions, 0x1FFFFEU, &avail);
+            if (pfind && avail >= 2 && sysram && pfind == sysram + 0x1FFFFE)
+                printf("PASS\n");
+            else
+            {
+                printf("FAIL\n");
+                failures++;
+            }
+        }
+
+        if (regions_inited)
+            rc_libretro_memory_destroy(&regions);
+    }
 
     core_unload_game();
     core_deinit();

--- a/test/tools/test_rcheevos_e2e.sh
+++ b/test/tools/test_rcheevos_e2e.sh
@@ -3,7 +3,7 @@
 # memory initialization (same path RetroArch uses for Jaguar / console 17), then read
 # bytes via rc_libretro_memory_read / rc_libretro_memory_find.
 #
-# Requires: bash, curl, cc, ar, dlopen (libc)
+# Requires: bash, curl, cc, ar, libdl (Linux, for dlopen via -ldl)
 # Usage: ./test/tools/test_rcheevos_e2e.sh path/to/virtualjaguar_libretro.{so,dylib}
 set -euo pipefail
 

--- a/test/tools/test_rcheevos_e2e.sh
+++ b/test/tools/test_rcheevos_e2e.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# End-to-end check: load the core, capture SET_MEMORY_MAPS, run rcheevos rc_libretro
+# memory initialization (same path RetroArch uses for Jaguar / console 17), then read
+# bytes via rc_libretro_memory_read / rc_libretro_memory_find.
+#
+# Requires: bash, curl, cc, ar, dlopen (libc)
+# Usage: ./test/tools/test_rcheevos_e2e.sh path/to/virtualjaguar_libretro.{so,dylib}
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CORE="${1:?Usage: $0 path/to/core}"
+export CC="${CC:-cc}"
+
+"$ROOT/test/tools/build_rcheevos_static.sh"
+
+DEST="${DEST:-$ROOT/build/rcheevos-static}"
+LIBRC="$DEST/librcheevos.a"
+
+if [[ "$(uname)" == Linux ]]; then
+   LDFLAGS="-ldl"
+else
+   LDFLAGS=""
+fi
+
+$CC -O2 -Wall \
+   -I"$ROOT/libretro-common/include" \
+   -I"$DEST/rcheevos-src/include" \
+   -I"$DEST/rcheevos-src/src" \
+   -o "$ROOT/build/test_rcheevos_e2e" \
+   "$ROOT/test/tools/test_rcheevos_e2e.c" \
+   "$LIBRC" \
+   $LDFLAGS
+
+"$ROOT/build/test_rcheevos_e2e" "$CORE"


### PR DESCRIPTION
## Summary

- Advertises the Jaguar's 2 MB system RAM via `RETRO_ENVIRONMENT_SET_MEMORY_MAPS` in `retro_load_game`, enabling RetroAchievements (rcheevos) memory lookups
- Calls `RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS` in `retro_set_environment` to signal achievement support
- Uses `static` storage for the memory descriptor and map structs to prevent dangling pointers after `retro_load_game` returns
- All declarations are C89-compliant (no mid-block declarations)

### Memory Map Descriptor

| Field | Value |
|-------|-------|
| flags | `RETRO_MEMDESC_SYSTEM_RAM \| RETRO_MEMDESC_BIGENDIAN` |
| ptr | `jaguarMainRAM` (2 MB) |
| start | `0x000000` |
| len | `0x200000` |
| addrspace | `"RAM"` |

## Test Plan

- [x] New `test/tools/test_memory_map.c` with 10 automated checks:
  1. `SET_SUPPORT_ACHIEVEMENTS` called during `retro_set_environment`
  2. `SET_MEMORY_MAPS` called during `retro_load_game`
  3. Exactly 1 descriptor
  4. Descriptor start == `0x000000`
  5. Descriptor len == `0x200000`
  6. `RETRO_MEMDESC_SYSTEM_RAM` flag set
  7. `RETRO_MEMDESC_BIGENDIAN` flag set
  8. Descriptor ptr is non-NULL
  9. Descriptor ptr matches `retro_get_memory_data(SYSTEM_RAM)`
  10. `retro_get_memory_size(SYSTEM_RAM)` == `0x200000`
- [x] Memory map test added to CI workflow for all native (non-cross, non-emscripten, non-android) platforms
- [x] Builds clean on macOS (tested locally)
- [x] All 10 tests pass locally

Supersedes #112.


Made with [Cursor](https://cursor.com)