### PR TITLE
Fix DSP 40-bit MAC accumulator (pink-noise / long IIR)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -190,6 +190,10 @@ jobs:
           -o test_blitter_scalar test/test_blitter_simd.c src/blitter_simd_scalar.c
         ./test_blitter_scalar
 
+        echo "==> DSP 40-bit MAC accumulator regression (dsp_acc40.h)..."
+        $CC -O2 -Wall -I src -o test_dsp_mac40 test/test_dsp_mac40.c
+        ./test_dsp_mac40
+
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Key docs:
 ### Testing
 
 See `docs/test-infrastructure.md` for all test harnesses:
+- `test/test_dsp_mac40.c` — Jaguar DSP **40-bit MAC** accumulator semantics (`dsp_acc40.h`), run in CI with SIMD tests; relevant for long IIR chains (e.g. pink-noise generators on DSP).
 - `test/headless.py` — Python headless runner via libretro.py (screenshots, frame control)
 - `test/regression_test.sh` — screenshot regression suite with baseline comparison
 - `test/test_cd_boot.c` — low-level C harness with dlsym access to 68K registers and RAM

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -15,6 +15,7 @@
 //
 
 #include "dsp.h"
+#include "dsp_acc40.h"
 
 #include <stdlib.h>
 #include "dac.h"
@@ -1250,8 +1251,8 @@ INLINE static void dsp_opcode_addqt(void)
 INLINE static void dsp_opcode_imacn(void)
 {
 	int32_t res = (int16_t)RM * (int16_t)RN;
-	dsp_acc += (int64_t)res;
-//Should we AND the result to fit into 40 bits here???
+
+	dsp_acc_mac_apply(&dsp_acc, res);
 }
 
 
@@ -1379,7 +1380,8 @@ INLINE static void dsp_opcode_imultn(void)
 {
 	// This is OK, since this multiply won't overflow 32 bits...
 	int32_t res = (int32_t)((int16_t)RN * (int16_t)RM);
-	dsp_acc = (int64_t)res;
+
+	dsp_acc_set_from_i32(&dsp_acc, res);
 	SET_ZN(res);
 }
 
@@ -1828,8 +1830,8 @@ INLINE static void DSP_div(void)
 INLINE static void DSP_imacn(void)
 {
 	int32_t res = (int16_t)PRM * (int16_t)PRN;
-	dsp_acc += (int64_t)res;
-//Should we AND the result to fit into 40 bits here???
+
+	dsp_acc_mac_apply(&dsp_acc, res);
 	NO_WRITEBACK;
 }
 
@@ -1843,7 +1845,8 @@ INLINE static void DSP_imultn(void)
 {
 	// This is OK, since this multiply won't overflow 32 bits...
 	int32_t res = (int32_t)((int16_t)PRN * (int16_t)PRM);
-	dsp_acc = (int64_t)res;
+
+	dsp_acc_set_from_i32(&dsp_acc, res);
 	SET_ZN(res);
 	NO_WRITEBACK;
 }

--- a/src/dsp_acc40.h
+++ b/src/dsp_acc40.h
@@ -1,0 +1,53 @@
+/*
+ * Jaguar DSP MAC accumulator is 40-bit signed two's complement.
+ * Store only bits 39..0 in the low bits of uint64_t (bits 63..40 must stay zero)
+ * so RESMAC and control-register reads (dsp_acc >> 32) stay correct.
+ */
+
+#ifndef DSP_ACC40_H
+#define DSP_ACC40_H
+
+#include <stdint.h>
+
+#ifndef DSP_ACC40_INLINE
+#if defined(_MSC_VER)
+#define DSP_ACC40_INLINE static __inline
+#else
+#define DSP_ACC40_INLINE static inline
+#endif
+#endif
+
+#define DSP_ACC_U40_MASK UINT64_C(0xFFFFFFFFFF)
+
+DSP_ACC40_INLINE int64_t dsp_acc_i40_signed(uint64_t raw)
+{
+	uint64_t u = raw & DSP_ACC_U40_MASK;
+	if (u & (UINT64_C(1) << 39))
+		return (int64_t)(u | UINT64_C(0xFFFFFF0000000000));
+	return (int64_t)u;
+}
+
+DSP_ACC40_INLINE uint64_t dsp_acc_wrap_store_i40(int64_t v)
+{
+	int64_t t;
+
+	t = v & (((int64_t)1 << 40) - 1);
+	if (t & ((int64_t)1 << 39))
+		t |= ~(((int64_t)1 << 40) - 1);
+	return (uint64_t)t & DSP_ACC_U40_MASK;
+}
+
+DSP_ACC40_INLINE void dsp_acc_mac_apply(uint64_t *acc, int32_t prod)
+{
+	int64_t a;
+
+	a = dsp_acc_i40_signed(*acc);
+	*acc = dsp_acc_wrap_store_i40(a + (int64_t)prod);
+}
+
+DSP_ACC40_INLINE void dsp_acc_set_from_i32(uint64_t *acc, int32_t res)
+{
+	*acc = dsp_acc_wrap_store_i40((int64_t)res);
+}
+
+#endif

--- a/test/test_dsp_mac40.c
+++ b/test/test_dsp_mac40.c
@@ -1,0 +1,56 @@
+/*
+ * Unit tests for src/dsp_acc40.h (Jaguar DSP 40-bit MAC semantics).
+ * Build: cc -O2 -Wall -I../src -o test_dsp_mac40 test/test_dsp_mac40.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "dsp_acc40.h"
+
+int main(void)
+{
+	uint64_t acc;
+	int i;
+	int failed = 0;
+
+	/* Only 40 physical bits; high 24 must stay clear */
+	acc = 0;
+	for (i = 0; i < 50000; i++)
+		dsp_acc_mac_apply(&acc, 7777);
+	if (acc & ~(DSP_ACC_U40_MASK))
+	{
+		fprintf(stderr, "FAIL: bits above 39 set after MAC loop (acc=%llx)\n",
+				(unsigned long long)acc);
+		failed++;
+	}
+
+	/* RESMAC-style low 32 must be stable across wraps */
+	acc = DSP_ACC_U40_MASK;
+	dsp_acc_mac_apply(&acc, 1);
+	if ((uint32_t)acc != 0)
+	{
+		fprintf(stderr, "FAIL: wrap +1 from 40-bit all-ones (got low32=%x)\n",
+				(unsigned int)(uint32_t)acc);
+		failed++;
+	}
+
+	/* Load int32 -1 into acc (sign-extended in 40-bit domain) */
+	dsp_acc_set_from_i32(&acc, -1);
+	if (acc != DSP_ACC_U40_MASK)
+	{
+		fprintf(stderr, "FAIL: set -1 (acc=%llx expected %llx)\n",
+				(unsigned long long)acc, (unsigned long long)DSP_ACC_U40_MASK);
+		failed++;
+	}
+
+	if (failed)
+	{
+		fprintf(stderr, "test_dsp_mac40: %d failure(s)\n", failed);
+		return 1;
+	}
+
+	printf("test_dsp_mac40: OK\n");
+	return 0;
+}


### PR DESCRIPTION
## Summary

The Jaguar DSP MAC is a **40-bit signed** accumulator. The core kept `dsp_acc` in a 64-bit variable and only **added** products with `dsp_acc += (int64_t)prod` without folding to 40 bits. After many `IMACN` steps (typical of IIR / pink-noise style synthesis on the DSP), the emulated value diverged from hardware, with **RESMAC** and the high-byte read path (`dsp_acc >> 32` in `DSPReadLong`) no longer matching a real 40-bit register (and **bits 63..40** should stay **zero** for those reads).

This change introduces `src/dsp_acc40.h` with wrap/sign-extend helpers, uses them from `dsp_opcode_imacn` / `DSP_imacn` and `dsp_opcode_imultn` / `DSP_imultn`, and adds `test/test_dsp_mac40.c` plus a CI step (next to the blitter SIMD tests).

## Context (240p / pink noise)

Long IIR MAC chains are sensitive to accumulator width. A prior hypothesis involved **host** `__muldi3` on 32-bit libretro builds; this fix addresses **emulation accuracy** of the DSP MAC itself. If any platform still shows issues after this, the next place to check is **linking** `libgcc` / compiler-rt for 64-bit soft-mul on that target.

## Test plan

- [x] `cc -I./src -o test/test_dsp_mac40 test/test_dsp_mac40.c && ./test/test_dsp_mac40`
- [x] Full `make` on macOS
- [x] CI: new step runs with existing native SIMD test job

Made with [Cursor](https://cursor.com)