### PR TITLE
acid: fix copy_simple count, document pattern_fill root cause

### DIFF
--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -5,7 +5,6 @@
 [FAIL tests/blitter/copy_pix2_pixel.jag
 [FAIL tests/blitter/copy_pix4_phrase.jag
 [FAIL tests/blitter/copy_pix4_pixel.jag
-[FAIL tests/blitter/copy_simple.jag
 [FAIL tests/blitter/pattern_fill.jag
 [FAIL tests/bus/bus_blitter_starves_cpu.jag
 [FAIL tests/bus/bus_cpu_starves_blitter.jag
@@ -24,6 +23,7 @@
 [PASS tests/blitter/copy_pix32.jag
 [PASS tests/blitter/copy_pix8_pixel.jag
 [PASS tests/blitter/copy_pix8.jag
+[PASS tests/blitter/copy_simple.jag
 [PASS tests/blitter/dsta2_swap.jag
 [PASS tests/blitter/gourd_basic.jag
 [PASS tests/blitter/lfu_and.jag

--- a/test/acid/tests/blitter/copy_simple.s
+++ b/test/acid/tests/blitter/copy_simple.s
@@ -1,5 +1,5 @@
 ;
-; tests/blitter/copy_simple.s - 4-pixel 16bpp blitter copy round-trip.
+; tests/blitter/copy_simple.s - 16-pixel 16bpp blitter copy round-trip.
 ;
 ; Detail codes:
 ;   1 = blitter never finished (BUSY stayed set)
@@ -50,7 +50,9 @@ entry:
                 move.l  #$00001020,B_A2_FLAGS
                 move.l  #0,B_A2_PIXEL
 
-                move.l  #$00010004,B_COUNT
+                ;; 16 px @ 16bpp = 32 bytes = 8 longwords (matches the
+                ;; 8-longword compare loop below).
+                move.l  #$00010010,B_COUNT
                 move.l  #$01800001,B_COMMAND    ; SRCEN | LFU=src
 
                 ;; Blitter is synchronous in this emulator; no wait needed.

--- a/test/acid/tests/blitter/pattern_fill.s
+++ b/test/acid/tests/blitter/pattern_fill.s
@@ -4,8 +4,29 @@
 ; Programs the blitter without SRCEN, with PATDSEL set, and a known
 ; pattern in B_PATD.  Each phrase write should land the pattern.
 ;
+; **KNOWN-FAIL** (root cause documented):
+;
+; BlitterWriteByte() in src/tom/blitter_mmio.c swaps the high and low
+; halves of B_PATD on CPU writes (offset+4 / offset-4 mapping).  This
+; means `move.l #X, B_PATD; move.l #Y, B_PATD+4` ends up with X in the
+; *low* 32 bits and Y in the *high* 32 bits of the internal 64-bit
+; pattern register, the inverse of JTRM addressing.  Phrase write to
+; dest then produces dest[0..3]=Y, dest[4..7]=X -- swapped from the
+; expected ordering.  The same swap applies to SRCDATA / DSTDATA / DSTZ
+; / SRCZINT / SRCZFRAC, but pattern_fill is the only test that uses
+; *asymmetric* halves of those registers from CPU writes, so it's the
+; only one that surfaces the bug.
+;
+; Removing the swap is non-trivial: the Gouraud reads in
+; src/tom/blitter.c (gd_c[]/gd_i[] near line 945) read PATTERNDATA in
+; reverse byte order -- pixel 0 reads PATD+6, pixel 3 reads PATD+0 --
+; which only produces correct per-pixel data because of the swap.  A
+; coordinated fix needs to drop the swap *and* reverse the Gouraud
+; index mapping, with regression coverage for games that depend on
+; Gouraud (Tempest 2000, Atari Karts) before it can ship.
+;
 ; Detail codes:
-;   1 = blitter never finished
+;   1 = blitter never finished, OR PATD high/low swap (current bug)
 ;   N = first mismatched longword (1-based, 1..2)
 ;
                 include "include/jaguar_header.s"

--- a/test/acid/tests/blitter/pattern_fill.s
+++ b/test/acid/tests/blitter/pattern_fill.s
@@ -25,9 +25,11 @@
 ; index mapping, with regression coverage for games that depend on
 ; Gouraud (Tempest 2000, Atari Karts) before it can ship.
 ;
-; Detail codes:
-;   1 = blitter never finished, OR PATD high/low swap (current bug)
-;   N = first mismatched longword (1-based, 1..2)
+; Detail codes (the test does not poll BUSY -- emulator blitter is
+; synchronous -- so detail values come strictly from the compare):
+;   1 = first  longword (DST+0) mismatched expected PAT_HI (= $DEADBEEF)
+;   2 = second longword (DST+4) mismatched expected PAT_LO (= $CAFEBABE)
+; Currently fails with detail=1 due to the PATD swap described above.
 ;
                 include "include/jaguar_header.s"
                 include "include/acid_test.s"


### PR DESCRIPTION
## Summary

First slice of acid-suite blitter fixes (PR #130 follow-up). Narrow scope: one PASS flip + clearer documentation. Other 7 blitter FAILs (pix1/2/4 phrase+pixel, bcompen, pattern_fill, copy_simple) split into follow-up PRs because each needs its own focused change with its own regression scope.

- **copy_simple.s**: count was `4 px` (1 phrase = 2 longs) but the compare loop walked 8 longs — internal inconsistency in the test itself, not the blitter. Both fast and accurate blitters were faithfully completing the 4-px blit and "failing" the over-eager assertion. Bumped count to 16 px (8 longs) so the test matches its own compare loop. **FAIL → PASS.**
- **pattern_fill.s**: real emulator bug, not a test bug. Annotated the root cause in the `.s` header: `BlitterWriteByte()` in `blitter_mmio.c` swaps the high/low halves of `B_PATD` on CPU writes (`offset+4` / `offset-4`), inverse of JTRM addressing. Same swap covers SRCDATA/DSTDATA/DSTZ/SRCZ*, but pattern_fill is the only test using asymmetric halves of those registers from CPU writes — so it's the only one that surfaces the bug today. The swap is load-bearing on the Gouraud reads in `blitter.c:945-959` (gd_c[]/gd_i[] read PATD bytes in reverse pixel order), so unwinding it requires a coordinated fix plus regression coverage for Gouraud-using games (Tempest 2000, Atari Karts) before it can ship. Out of scope for this PR.
- **BASELINE.txt**: regenerated, copy_simple flips FAIL → PASS, nothing else moved (123/142 PASS, 19 documented FAILs).

## Test plan

- [x] `make -C test/acid all` — clean
- [x] `./acid_run virtualjaguar_libretro.dylib test/acid/tests/blitter/copy_simple.jag` — PASS
- [x] `./acid_run virtualjaguar_libretro.dylib test/acid/tests/blitter/pattern_fill.jag` — still FAIL with same `detail=1 observed=0xcafebabe expected=0xdeadbeef` signature
- [x] `make -C test/acid check-baseline` — `OK: no regressions.` (1 improvement, 0 regressions across 142 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)