### PR TITLE
blitter(accurate): RMW dest byte for sub-byte pixel-mode writes

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -2428,8 +2428,15 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
 
                //Phrase mode needs destination data for start/end mask byte merging,
                //but NOT when bkgwren is set (hardware uses DSTDATA register value).
+               //Pixel mode at pixsize < 3 (1bpp/2bpp/4bpp) writes a single byte
+               //via JaguarWriteByte below, but the byte holds multiple pixels --
+               //byte_merge must see the existing dest byte in the low 8 bits of
+               //dstd or the unmodified pixel slots in that byte get zeroed
+               //(matches WRITE_PIXEL_1/2/4 RMW in the fast blitter).
                if (phrase_mode && !dsten && !bkgwren)
                   dstd = ((uint64_t)JaguarReadLong(address, BLITTER) << 32) | (uint64_t)JaguarReadLong(address + 4, BLITTER);
+               else if (!phrase_mode && pixsize < 3 && !dsten && !bkgwren)
+                  dstd = (uint64_t)JaguarReadByte(address, BLITTER);
 
                // Write data combines srcd and dstd through ADDDSEL, PATDSEL, or LFU.
                // Precedence is ADDDSEL > PATDSEL > LFU.

--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -1,10 +1,7 @@
 [FAIL tests/blitter/bcompen_basic.jag
 [FAIL tests/blitter/copy_pix1_phrase.jag
-[FAIL tests/blitter/copy_pix1_pixel.jag
 [FAIL tests/blitter/copy_pix2_phrase.jag
-[FAIL tests/blitter/copy_pix2_pixel.jag
 [FAIL tests/blitter/copy_pix4_phrase.jag
-[FAIL tests/blitter/copy_pix4_pixel.jag
 [FAIL tests/blitter/pattern_fill.jag
 [FAIL tests/bus/bus_blitter_starves_cpu.jag
 [FAIL tests/bus/bus_cpu_starves_blitter.jag
@@ -18,9 +15,12 @@
 [FAIL tests/timing/pit_countdown_rate.jag
 [FAIL tests/timing/vblank_60hz_exact.jag
 [PASS tests/blitter/bkgwren_test.jag
+[PASS tests/blitter/copy_pix1_pixel.jag
 [PASS tests/blitter/copy_pix16_pixel.jag
+[PASS tests/blitter/copy_pix2_pixel.jag
 [PASS tests/blitter/copy_pix32_pixel.jag
 [PASS tests/blitter/copy_pix32.jag
+[PASS tests/blitter/copy_pix4_pixel.jag
 [PASS tests/blitter/copy_pix8_pixel.jag
 [PASS tests/blitter/copy_pix8.jag
 [PASS tests/blitter/copy_simple.jag


### PR DESCRIPTION
## Summary

Fix the accurate blitter (`BlitterMidsummer2`) for pixel-mode (xadd=PIX) writes at pixsize<3 (1bpp / 2bpp / 4bpp). The fast blitter already handles this correctly via the WRITE_PIXEL_1/2/4 read-modify-write macros at `src/tom/blitter.c:247`.

### Bug

`dstd` (existing dest data fed into the byte_merge step) was loaded once at the top of `BlitterMidsummer2` from the DSTDATA register (typically 0) and never refreshed for the pixel-mode non-DSTEN path. The state-machine `dread` phase only fires when DSTEN is set, but games doing 1/2/4bpp pixel-mode copies don't set DSTEN — the hardware does the RMW implicitly because the write unit (1 byte) is larger than the pixel size.

`byte_merge(ddat, dstd, mask)` then merges the new pixel from `ddat` per the per-bit mask and falls back to `dstd` for the rest of the byte. With `dstd=0`, every iteration wrote a byte with only its target pixel slot set and the other pixels in that byte zeroed — so each write clobbered the previous pixels in the same byte.

Symptoms (from the acid `copy_pix*_pixel` tests):

```
copy_pix1_pixel:  src 0xF0F00F0F -> dst 0x00000101  (only 2 of 8 src bits land)
copy_pix2_pixel:  src 0x33333333 -> dst 0x03030303  (low pixel of each byte only)
copy_pix4_pixel:  src 0xABCDEF01 -> dst 0x0B0D0F01  (top nibble of each pair zeroed)
```

### Fix

Mirror the existing phrase-mode RMW load right above (`blitter.c:2432`): when the write granularity is sub-byte (pixsize<3 in pixel mode) and the user hasn't already requested DSTEN/BKGWREN, read the existing dest byte into the low 8 bits of `dstd` before `DATA()` runs. `byte_merge` then correctly preserves the unmodified pixel slots — same effective behavior as `WRITE_PIXEL_1/2/4` in the fast blitter.

```c
if (phrase_mode && !dsten && !bkgwren)
   dstd = ((uint64_t)JaguarReadLong(address, BLITTER) << 32) | JaguarReadLong(address + 4, BLITTER);
else if (!phrase_mode && pixsize < 3 && !dsten && !bkgwren)
   dstd = (uint64_t)JaguarReadByte(address, BLITTER);
```

### Acid baseline

| | Before | After |
|---|---|---|
| copy_pix1_pixel | FAIL | **PASS** |
| copy_pix2_pixel | FAIL | **PASS** |
| copy_pix4_pixel | FAIL | **PASS** |
| All other tests | (unchanged) | (unchanged) |

`make -C test/acid check-baseline`: 3 improvements, 0 regressions, 16 known FAILs remaining (down from 19).

## Test plan

- [x] `make -C test/acid check-baseline CORE=$(pwd)/virtualjaguar_libretro.dylib` — `OK: no regressions.` 3 FAIL → PASS, 0 regressions.
- [x] `./test/acid/acid_run` on each pix*_pixel test — all 6 (1/2/4/8/16/32 bpp) PASS.
- [x] `test/regression_test.sh ./virtualjaguar_libretro.dylib` — all 10 ROM screenshot / determinism / frameskip / save state / rewind checks PASS (jagniccc, yarc).
- [x] `bash scripts/c89-lint.sh src/tom/blitter.c` (auto-run by pre-commit hook) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)