### PR TITLE
acid: fix command bits / register address in 2 tests (bcompen, op_gpu_int)

### DIFF
--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -1,4 +1,3 @@
-[FAIL tests/blitter/bcompen_basic.jag
 [FAIL tests/blitter/copy_pix1_phrase.jag
 [FAIL tests/blitter/copy_pix2_phrase.jag
 [FAIL tests/blitter/copy_pix4_phrase.jag
@@ -9,8 +8,11 @@
 [FAIL tests/dsp/dsp_basic_run.jag
 [FAIL tests/dsp/dsp_irq_to_68k.jag
 [FAIL tests/gpu/gpu_basic_run.jag
-[FAIL tests/op/op_gpu_int_object.jag
 [FAIL tests/quirks/divl_zero_traps.jag
+[FAIL tests/timing/halfline_period_us.jag
+[FAIL tests/timing/pit_countdown_rate.jag
+[FAIL tests/timing/vblank_60hz_exact.jag
+[PASS tests/blitter/bcompen_basic.jag
 [PASS tests/blitter/bkgwren_test.jag
 [PASS tests/blitter/copy_pix1_pixel.jag
 [PASS tests/blitter/copy_pix16_pixel.jag
@@ -105,6 +107,7 @@
 [PASS tests/op/op_bitmap_render.jag
 [PASS tests/op/op_branch_conditional.jag
 [PASS tests/op/op_branch_object.jag
+[PASS tests/op/op_gpu_int_object.jag
 [PASS tests/op/op_olp_alignment.jag
 [PASS tests/op/op_palette_8bpp.jag
 [PASS tests/op/op_reflect_modifier.jag
@@ -128,12 +131,9 @@
 [PASS tests/stress/many_blits.jag
 [PASS tests/stress/rapid_irq_pump.jag
 [PASS tests/timing/halfline_count_per_frame.jag
-[PASS tests/timing/halfline_period_us.jag
 [PASS tests/timing/hc_advance.jag
 [PASS tests/timing/hc_within_scanline_range.jag
 [PASS tests/timing/jerry_pit_setup.jag
-[PASS tests/timing/pit_countdown_rate.jag
-[PASS tests/timing/vblank_60hz_exact.jag
 [PASS tests/timing/vc_advance.jag
 [PASS tests/timing/vc_field_bit.jag
 [PASS tests/timing/vc_increments.jag

--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -9,9 +9,6 @@
 [FAIL tests/dsp/dsp_irq_to_68k.jag
 [FAIL tests/gpu/gpu_basic_run.jag
 [FAIL tests/quirks/divl_zero_traps.jag
-[FAIL tests/timing/halfline_period_us.jag
-[FAIL tests/timing/pit_countdown_rate.jag
-[FAIL tests/timing/vblank_60hz_exact.jag
 [PASS tests/blitter/bcompen_basic.jag
 [PASS tests/blitter/bkgwren_test.jag
 [PASS tests/blitter/copy_pix1_pixel.jag
@@ -131,9 +128,12 @@
 [PASS tests/stress/many_blits.jag
 [PASS tests/stress/rapid_irq_pump.jag
 [PASS tests/timing/halfline_count_per_frame.jag
+[PASS tests/timing/halfline_period_us.jag
 [PASS tests/timing/hc_advance.jag
 [PASS tests/timing/hc_within_scanline_range.jag
 [PASS tests/timing/jerry_pit_setup.jag
+[PASS tests/timing/pit_countdown_rate.jag
+[PASS tests/timing/vblank_60hz_exact.jag
 [PASS tests/timing/vc_advance.jag
 [PASS tests/timing/vc_field_bit.jag
 [PASS tests/timing/vc_increments.jag

--- a/test/acid/tests/blitter/bcompen_basic.s
+++ b/test/acid/tests/blitter/bcompen_basic.s
@@ -14,13 +14,17 @@
 ; Expected dest 8 bytes (MSB first across pixels):
 ;   $11 $00 $11 $00  $00 $11 $00 $11
 ;
-; Command bits:
-;   SRCEN  = $0001
-;   PATDSEL= $00010000  (use B_PATD for the foreground colour)
-;   BCOMPEN= $0200
-;   LFU = doesn't really matter when BCOMPEN+PATDSEL drive output;
-;         leave LFU = $C (S short-form ity = $C000) for a sane default.
-; -> $0001C201
+; Command bits (per src/tom/blitter.c, which is authoritative for this
+; emulator and differs from JTRM's older bit numbering):
+;   SRCEN   = $00000001  (bit 0)
+;   PATDSEL = $00010000  (bit 16 -- use B_PATD for the foreground colour)
+;   BCOMPEN = $04000000  (bit 26)
+;   LFU function code lives in bits 21..24; leave 0 (zero-fill) since
+;   BCOMPEN+PATDSEL drive the output bytes when a source bit is 1.
+; -> $05810001  (BCOMPEN | PATDSEL | SRCEN)
+;
+; (Bit numbers per src/tom/blitter.c, which differ from JTRM's older
+;  numbering -- emulator authoritative.)
 ;
 ; A?_FLAGS for 8bpp phrase mode: pixsize=3, e=2 (8-px phrase),
 ; xadd=phrase=00 -> $00001018.
@@ -69,7 +73,7 @@ entry:
 
                 ;; 1 line, 8 pixels.
                 move.l  #$00010008,B_COUNT
-                move.l  #$05800001,B_COMMAND    ; SRCEN | PATDSEL? + BCOMPEN | ity=S
+                move.l  #$05810001,B_COMMAND    ; SRCEN | PATDSEL | BCOMPEN | ity=S
 
                 ;; Verify each of 8 dest bytes against the expected
                 ;; pattern.  Walk a small table.

--- a/test/acid/tests/blitter/bcompen_basic.s
+++ b/test/acid/tests/blitter/bcompen_basic.s
@@ -1,10 +1,11 @@
 ;
 ; tests/blitter/bcompen_basic.s - BCOMPEN bit-mask compositing (font path).
 ;
-; With BCOMPEN (command bit 9 = $0200), source data is treated as a
-; bit-mask: each source bit selects whether the corresponding dest
-; pixel gets the pattern colour (1) or is left alone (0).  This is the
-; path many games use to render bitmap fonts.
+; With BCOMPEN (this emulator: command bit 26 = $04000000, see
+; src/tom/blitter.c:137), source data is treated as a bit-mask: each
+; source bit selects whether the corresponding dest pixel gets the
+; pattern colour (1) or is left alone (0).  This is the path many
+; games use to render bitmap fonts.
 ;
 ; Setup:
 ;   src bitmask byte = $A5 = 1010_0101
@@ -16,15 +17,16 @@
 ;
 ; Command bits (per src/tom/blitter.c, which is authoritative for this
 ; emulator and differs from JTRM's older bit numbering):
-;   SRCEN   = $00000001  (bit 0)
-;   PATDSEL = $00010000  (bit 16 -- use B_PATD for the foreground colour)
-;   BCOMPEN = $04000000  (bit 26)
-;   LFU function code lives in bits 21..24; leave 0 (zero-fill) since
-;   BCOMPEN+PATDSEL drive the output bytes when a source bit is 1.
-; -> $05810001  (BCOMPEN | PATDSEL | SRCEN)
-;
-; (Bit numbers per src/tom/blitter.c, which differ from JTRM's older
-;  numbering -- emulator authoritative.)
+;   SRCEN    = $00000001  (bit 0)
+;   PATDSEL  = $00010000  (bit 16 -- use B_PATD for the foreground colour)
+;   LFU_AN   = $00800000  (bit 23) -- LFU term: src AND ~dst
+;   LFU_A    = $01000000  (bit 24) -- LFU term: src AND dst
+;   BCOMPEN  = $04000000  (bit 26)
+;   LFU_AN | LFU_A = function code $C ("passthrough src"); doesn't
+;   matter for the output since PATDSEL takes precedence in the data
+;   mux when set, but a sane default keeps the test consistent with
+;   how real games typically program BCOMPEN.
+; -> $05810001  (BCOMPEN | LFU_A | LFU_AN | PATDSEL | SRCEN)
 ;
 ; A?_FLAGS for 8bpp phrase mode: pixsize=3, e=2 (8-px phrase),
 ; xadd=phrase=00 -> $00001018.

--- a/test/acid/tests/op/op_gpu_int_object.s
+++ b/test/acid/tests/op/op_gpu_int_object.s
@@ -3,18 +3,18 @@
 ;
 ; The GPU-INT object causes the OP to assert IRQ3 on the GPU and stop
 ; processing the list (so the GPU sees the object in OB before it
-; gets overwritten).  We don't need the GPU to actually run a handler
-; -- we can verify the IRQ-line latch by reading TOM_INT1, which holds
-; a pending bit for IRQ_GPU (bit 1) when the GPU asserted an IRQ to
-; the 68K.
+; gets overwritten).  We verify by reading the GPU's IRQ-pending
+; latch directly from the 68K side.
 ;
-; Wait -- IRQ_GPU bit in TOM_INT1 latches when the GPU asserts an IRQ
-; back at the 68K, not when the OP IRQs the GPU.  To detect the OP->GPU
-; IRQ we'd need to read GPU's own G_FLAGS register (bit for IRQ3
-; pending).  That register is at GPU_BASE + $4 (G_FLAGS).
+; The IRQ latches live in `gpu_control` at GPU_BASE + $14 (NOT
+; gpu_flags at +$00 -- that register holds Z/N/C condition codes).
+; Per src/tom/gpu.c::GPUSetIRQLine, asserting IRQ line N sets bit
+; (0x0040 << N) in gpu_control.  The OP's GPU-INT path calls
+; GPUSetIRQLine(3, ASSERT_LINE) (src/tom/op.c:463), so the bit we
+; expect to see latched is 0x0040 << 3 = 0x00000200 (bit 9).
 ;
 ; Strategy: build OP list with a GPU-INT object, run OP for many
-; halflines, then read G_FLAGS and check if bit 11 (IRQ3 latch) is set.
+; halflines, then read gpu_control and check if bit 9 is set.
 ;
 ; GPU-INT object encoding (type 2, single 64-bit phrase):
 ;   p0 bits 0..2 = TYPE = 2
@@ -22,8 +22,7 @@
 ;   so the GPU IRQ handler can read what triggered it.
 ;
 ; Detail codes:
-;   1 = GPU IRQ3 latch never asserted (G_FLAGS bit 11 stayed 0)
-;   99 = encoding placeholder
+;   1 = GPU IRQ3 latch never asserted (gpu_control bit 9 stayed 0)
 ;
                 include "include/jaguar_header.s"
                 include "include/acid_test.s"
@@ -34,7 +33,7 @@ GPU_INT_OBJ     equ     OPLIST + 0
 STOP_OBJ        equ     OPLIST + 8
 SPIN_LIMIT      equ     500000
 
-G_FLAGS         equ     GPU_BASE + $00          ; GPU flags / IRQ latches
+G_CTRL          equ     GPU_BASE + $14          ; GPU control / IRQ latches
 
                 org     $802000
 entry:
@@ -60,33 +59,22 @@ entry:
 .spin:          subq.l  #1,d2
                 bne.s   .spin
 
-                ;; Read G_FLAGS.  IRQ3 (CPU_IRQ in some docs, OP_IRQ in
-                ;; others) latches in bit 11 ($0800).  The GPU has the
-                ;; CPU_IRQ_MASK in bits 4..8 -- if not enabled, the latch
-                ;; bit may not actually set.  Check both the latch (low
-                ;; bits) and any pending status.
-                ;;
-                ;; Simpler: the OP code calls GPUSetIRQLine(3, ASSERT_LINE)
-                ;; which sets gpu_flag_c (bit 11) IF bit 7 of G_FLAGS
-                ;; (CPU_IRQ_ENABLE bit) is set.  Without enabling, the
-                ;; assert may be a no-op.
-                ;;
-                ;; This test is therefore *fragile*; it relies on
-                ;; emulator behaviour where the IRQ line state is
-                ;; observable somehow.  Mark as detail=99 if we can't
-                ;; observe the assertion at all.
-                ;;
-                ;; Try reading G_FLAGS as 32-bit value.
-                move.l  G_FLAGS.l,d5
-                ;; Test: any bit in $0F80 (IRQ3 latch + nearby) set?
+                ;; Read gpu_control (GPU_BASE+$14).  Per
+                ;; src/tom/op.c:463 the GPU-INT object calls
+                ;; GPUSetIRQLine(3, ASSERT_LINE), and per
+                ;; src/tom/gpu.c::GPUSetIRQLine that sets bit
+                ;; (0x0040 << 3) = $00000200 (bit 9) in gpu_control.
+                ;; That latch is unconditional -- no enable bit gates
+                ;; the latch itself; the enable mask only gates whether
+                ;; the GPU CPU vectors to its ISR.  So reading bit 9
+                ;; from 68K side is a reliable observation.
+                move.l  G_CTRL.l,d5
                 move.l  d5,d6
-                and.l   #$00000F80,d6
+                and.l   #$00000200,d6
                 bne     .saw_irq
 
-                ;; Couldn't observe the IRQ assert from 68K side without
-                ;; full GPU configuration.  Mark as placeholder fail so
-                ;; this gap is visible but not a regression on a working
-                ;; emulator.
-                ACID_FAIL #99,d5,#$00000F80
+                ;; IRQ3 latch never set -- OP did not fire GPU-INT, or
+                ;; the OP->GPU IRQ wiring is broken.
+                ACID_FAIL #1,d5,#$00000200
 
 .saw_irq:       ACID_PASS


### PR DESCRIPTION
## Summary

Two acid tests had wrong setup that prevented them from validating their target emulator code path. **Both emulator code paths are correct**; only the test wiring was broken. Each tracking with a single-bit / single-register correction.

| Test | Before | After |
|---|---|---|
| bcompen_basic | FAIL (observed 0xa5) | **PASS** |
| op_gpu_int_object | FAIL (observed 0x0) | **PASS** |

## Per-test fix

### `tests/blitter/bcompen_basic.s`

The test command was `\$05800001` with comment `; SRCEN | PATDSEL? + BCOMPEN | ity=S` — the literal `?` is the test author's uncertainty about whether PATDSEL was set. The test header at lines 17-23 explicitly says `PATDSEL=\$00010000` should be set (\"use B_PATD for the foreground colour\"). Without PATDSEL, the BCOMPEN bit-mask gates which dest pixels are written but the data is whatever LFU produces (= the source byte itself, = `\$A5` in this test, not the pattern `\$11`).

Fix: `B_COMMAND \$05800001 → \$05810001` (added PATDSEL bit 16 = `\$00010000`). With both PATDSEL and BCOMPEN set, both fast and accurate blitters compose font-style writes correctly: src bit gates which pixel is written, pattern provides the foreground color.

The header bit-table also referenced JTRM bit numbers (BCOMPEN at bit 9) which don't match this emulator's command bit layout (BCOMPEN at bit 26 per `src/tom/blitter.c:113-147`). Rewrote the header to cite emulator authoritative numbering.

### `tests/op/op_gpu_int_object.s`

The test defined `G_FLAGS equ GPU_BASE+\$00` and read it to check the GPU IRQ latch — but `GPU_BASE+\$00` is the `gpu_flags` register (Z/N/C condition codes), **not** the IRQ latch. The IRQ latches live in `gpu_control` at `GPU_BASE+\$14` (`src/tom/gpu.c:372`). When the OP fires GPU-INT, `OPProcessList` calls `GPUSetIRQLine(3, ASSERT_LINE)` (`src/tom/op.c:463`), which sets bit 9 of `gpu_control` via `0x0040 << 3 = 0x0200`.

Fix:
- `G_FLAGS equ GPU_BASE+\$00` → `G_CTRL equ GPU_BASE+\$14`
- Updated the read site from G_FLAGS → G_CTRL
- Recomputed expected mask: `\$00000F80 → \$00000200` (bit 9 only)
- Rewrote the header to reference `src/tom/op.c:463` and `GPUSetIRQLine`; dropped the placeholder detail=99

The OP itself works correctly — it walks the object list, hits the GPU-INT object, and signals the GPU IRQ. The test was just looking at the wrong register.

## Test plan

- [x] `acid_run ./test/acid/tests/blitter/bcompen_basic.jag` — PASS
- [x] `acid_run ./test/acid/tests/op/op_gpu_int_object.jag` — PASS
- [x] `make -C test/acid check-baseline` — 0 regressions
- [x] No emulator C changes — purely test-side fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)