### PR TITLE
acid(gpu/dsp): fix slab-overflow basic_run + dsp_irq_to_68k vector

### DIFF
--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -1,3 +1,4 @@
+[FAIL tests/blitter/bcompen_basic.jag
 [FAIL tests/blitter/copy_pix1_phrase.jag
 [FAIL tests/blitter/copy_pix2_phrase.jag
 [FAIL tests/blitter/copy_pix4_phrase.jag
@@ -5,11 +6,12 @@
 [FAIL tests/bus/bus_blitter_starves_cpu.jag
 [FAIL tests/bus/bus_cpu_starves_blitter.jag
 [FAIL tests/bus/bus_refresh_steals.jag
-[FAIL tests/dsp/dsp_basic_run.jag
 [FAIL tests/dsp/dsp_irq_to_68k.jag
-[FAIL tests/gpu/gpu_basic_run.jag
+[FAIL tests/op/op_gpu_int_object.jag
 [FAIL tests/quirks/divl_zero_traps.jag
-[PASS tests/blitter/bcompen_basic.jag
+[FAIL tests/timing/halfline_period_us.jag
+[FAIL tests/timing/pit_countdown_rate.jag
+[FAIL tests/timing/vblank_60hz_exact.jag
 [PASS tests/blitter/bkgwren_test.jag
 [PASS tests/blitter/copy_pix1_pixel.jag
 [PASS tests/blitter/copy_pix16_pixel.jag
@@ -42,6 +44,7 @@
 [PASS tests/blitter/zzz_smoke.jag
 [PASS tests/bus/blitter_back_to_back.jag
 [PASS tests/bus/cpu_blitter_concurrent.jag
+[PASS tests/dsp/dsp_basic_run.jag
 [PASS tests/dsp/dsp_mailbox.jag
 [PASS tests/dsp/dsp_op_abs.jag
 [PASS tests/dsp/dsp_op_add.jag
@@ -61,6 +64,7 @@
 [PASS tests/dsp/dsp_op_sub.jag
 [PASS tests/dsp/dsp_op_xor.jag
 [PASS tests/dsp/dsp_reg_access.jag
+[PASS tests/gpu/gpu_basic_run.jag
 [PASS tests/gpu/gpu_op_abs.jag
 [PASS tests/gpu/gpu_op_add.jag
 [PASS tests/gpu/gpu_op_and.jag
@@ -104,7 +108,6 @@
 [PASS tests/op/op_bitmap_render.jag
 [PASS tests/op/op_branch_conditional.jag
 [PASS tests/op/op_branch_object.jag
-[PASS tests/op/op_gpu_int_object.jag
 [PASS tests/op/op_olp_alignment.jag
 [PASS tests/op/op_palette_8bpp.jag
 [PASS tests/op/op_reflect_modifier.jag
@@ -128,12 +131,9 @@
 [PASS tests/stress/many_blits.jag
 [PASS tests/stress/rapid_irq_pump.jag
 [PASS tests/timing/halfline_count_per_frame.jag
-[PASS tests/timing/halfline_period_us.jag
 [PASS tests/timing/hc_advance.jag
 [PASS tests/timing/hc_within_scanline_range.jag
 [PASS tests/timing/jerry_pit_setup.jag
-[PASS tests/timing/pit_countdown_rate.jag
-[PASS tests/timing/vblank_60hz_exact.jag
 [PASS tests/timing/vc_advance.jag
 [PASS tests/timing/vc_field_bit.jag
 [PASS tests/timing/vc_increments.jag

--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -1,4 +1,3 @@
-[FAIL tests/blitter/bcompen_basic.jag
 [FAIL tests/blitter/copy_pix1_phrase.jag
 [FAIL tests/blitter/copy_pix2_phrase.jag
 [FAIL tests/blitter/copy_pix4_phrase.jag
@@ -6,11 +5,8 @@
 [FAIL tests/bus/bus_blitter_starves_cpu.jag
 [FAIL tests/bus/bus_cpu_starves_blitter.jag
 [FAIL tests/bus/bus_refresh_steals.jag
-[FAIL tests/op/op_gpu_int_object.jag
 [FAIL tests/quirks/divl_zero_traps.jag
-[FAIL tests/timing/halfline_period_us.jag
-[FAIL tests/timing/pit_countdown_rate.jag
-[FAIL tests/timing/vblank_60hz_exact.jag
+[PASS tests/blitter/bcompen_basic.jag
 [PASS tests/blitter/bkgwren_test.jag
 [PASS tests/blitter/copy_pix1_pixel.jag
 [PASS tests/blitter/copy_pix16_pixel.jag
@@ -108,6 +104,7 @@
 [PASS tests/op/op_bitmap_render.jag
 [PASS tests/op/op_branch_conditional.jag
 [PASS tests/op/op_branch_object.jag
+[PASS tests/op/op_gpu_int_object.jag
 [PASS tests/op/op_olp_alignment.jag
 [PASS tests/op/op_palette_8bpp.jag
 [PASS tests/op/op_reflect_modifier.jag
@@ -131,9 +128,12 @@
 [PASS tests/stress/many_blits.jag
 [PASS tests/stress/rapid_irq_pump.jag
 [PASS tests/timing/halfline_count_per_frame.jag
+[PASS tests/timing/halfline_period_us.jag
 [PASS tests/timing/hc_advance.jag
 [PASS tests/timing/hc_within_scanline_range.jag
 [PASS tests/timing/jerry_pit_setup.jag
+[PASS tests/timing/pit_countdown_rate.jag
+[PASS tests/timing/vblank_60hz_exact.jag
 [PASS tests/timing/vc_advance.jag
 [PASS tests/timing/vc_field_bit.jag
 [PASS tests/timing/vc_increments.jag

--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -6,7 +6,6 @@
 [FAIL tests/bus/bus_blitter_starves_cpu.jag
 [FAIL tests/bus/bus_cpu_starves_blitter.jag
 [FAIL tests/bus/bus_refresh_steals.jag
-[FAIL tests/dsp/dsp_irq_to_68k.jag
 [FAIL tests/op/op_gpu_int_object.jag
 [FAIL tests/quirks/divl_zero_traps.jag
 [FAIL tests/timing/halfline_period_us.jag
@@ -45,6 +44,7 @@
 [PASS tests/bus/blitter_back_to_back.jag
 [PASS tests/bus/cpu_blitter_concurrent.jag
 [PASS tests/dsp/dsp_basic_run.jag
+[PASS tests/dsp/dsp_irq_to_68k.jag
 [PASS tests/dsp/dsp_mailbox.jag
 [PASS tests/dsp/dsp_op_abs.jag
 [PASS tests/dsp/dsp_op_add.jag

--- a/test/acid/tests/dsp/dsp_basic_run.s
+++ b/test/acid/tests/dsp/dsp_basic_run.s
@@ -12,14 +12,20 @@
 ; dsp_ram_8[0x2000]) at $F1B000..$F1CFFF.  An earlier version of
 ; this test filled only the first 1024 NOPs (2 KB) and spun the
 ; 68K for 500 loop iterations (each ~18 68K cycles, so ~9000 68K
-; cycles wall) -- the DSP walked clean off the slab into
-; the upper, uninitialised half of dsp_ram_8 (and beyond, into the
-; JERRY register window) where bytes decode as random opcodes.
+; cycles wall) -- the DSP walked clean off the 2 KB NOP slab into
+; the trailing portion of dsp_ram_8 (DSPReset zero-fills this in
+; HLE mode -- the acid harness's mode -- and randomizes only when
+; vjs.useJaguarBIOS is set).  Zero opcodes decode as `add r0,r0`,
+; not NOPs and not branches, so PC keeps advancing linearly until
+; it falls off the end of dsp_ram_8 entirely and starts reading
+; from the JERRY register window where reads can return arbitrary
+; values that occasionally decode as JR / MOVEI-with-jump.
 ; Observed D_PC for that case: $00F1D1C8, well past DSP_RAM end.
 ; The fix is to (1) fill the entire 8 KB of DSP local RAM with
-; NOPs so an overshoot is caught by N_MAX rather than masked by
-; random branches, and (2) shrink the 68K spin so the DSP is
-; safely inside the slab when we sample D_PC.
+; real NOPs ($E400) so an overshoot is caught by N_MAX rather
+; than masked by add-r0-r0 walking us off the end, and (2) shrink
+; the 68K spin so the DSP is safely inside the slab when we sample
+; D_PC.
 ;
 ; Same MMIO-dispatch quirk as gpu_basic_run: long-aligned reads in
 ; the DSP control range may be intercepted as DSP register reads

--- a/test/acid/tests/dsp/dsp_basic_run.s
+++ b/test/acid/tests/dsp/dsp_basic_run.s
@@ -11,7 +11,8 @@
 ; *Sizing notes*: DSP local RAM is 8 KB (src/jerry/dsp.c
 ; dsp_ram_8[0x2000]) at $F1B000..$F1CFFF.  An earlier version of
 ; this test filled only the first 1024 NOPs (2 KB) and spun the
-; 68K for 500 cycles -- the DSP walked clean off the slab into
+; 68K for 500 loop iterations (each ~18 68K cycles, so ~9000 68K
+; cycles wall) -- the DSP walked clean off the slab into
 ; the upper, uninitialised half of dsp_ram_8 (and beyond, into the
 ; JERRY register window) where bytes decode as random opcodes.
 ; Observed D_PC for that case: $00F1D1C8, well past DSP_RAM end.

--- a/test/acid/tests/dsp/dsp_basic_run.s
+++ b/test/acid/tests/dsp/dsp_basic_run.s
@@ -8,6 +8,18 @@
 ; number of DSP instructions executed; require N in [N_MIN, N_MAX]
 ; so D_PC stays inside our NOP slab.
 ;
+; *Sizing notes*: DSP local RAM is 8 KB (src/jerry/dsp.c
+; dsp_ram_8[0x2000]) at $F1B000..$F1CFFF.  An earlier version of
+; this test filled only the first 1024 NOPs (2 KB) and spun the
+; 68K for 500 cycles -- the DSP walked clean off the slab into
+; the upper, uninitialised half of dsp_ram_8 (and beyond, into the
+; JERRY register window) where bytes decode as random opcodes.
+; Observed D_PC for that case: $00F1D1C8, well past DSP_RAM end.
+; The fix is to (1) fill the entire 8 KB of DSP local RAM with
+; NOPs so an overshoot is caught by N_MAX rather than masked by
+; random branches, and (2) shrink the 68K spin so the DSP is
+; safely inside the slab when we sample D_PC.
+;
 ; Same MMIO-dispatch quirk as gpu_basic_run: long-aligned reads in
 ; the DSP control range may be intercepted as DSP register reads
 ; before the control-RAM dispatch, returning a register value
@@ -29,7 +41,9 @@ D_CTRL          equ     DSP_BASE + $14          ; bit 0 = GO
 GO              equ     $00000001
 NOP_OP          equ     $E400
 
-NOP_SLOTS       equ     1024
+;; Full 8 KB DSP local RAM (4096 NOP slots).
+NOP_SLOTS       equ     4096
+SPIN_COUNT      equ     50
 N_MIN           equ     1
 N_MAX           equ     NOP_SLOTS
 PC_MIN          equ     DSP_RAM + (N_MIN*2)
@@ -48,7 +62,7 @@ entry:
                 move.l  #DSP_RAM,D_PC
                 move.l  #GO,D_CTRL
 
-                move.l  #500,d2
+                move.l  #SPIN_COUNT,d2
 .spin:          nop
                 subq.l  #1,d2
                 bne.s   .spin

--- a/test/acid/tests/dsp/dsp_irq_to_68k.s
+++ b/test/acid/tests/dsp/dsp_irq_to_68k.s
@@ -2,26 +2,31 @@
 ; tests/dsp/dsp_irq_to_68k.s - DSP triggers JERRY DSP IRQ to the 68K.
 ;
 ; Sequence:
-;   1. 68K enables JERRY IRQ2_DSP mask via J_INT ($F10020 low byte = $02).
-;   2. 68K loads a tiny DSP program that writes CPUINT (=$0002) to its
+;   1. 68K installs a hardware IRQ handler at vector 64 ($100).
+;      (Jaguar TOM/JERRY return user vector 64 on IACK -- they don't
+;      assert VPA -- so even a level-2 IRQ goes to $100, not the
+;      autovector slot at $68.)
+;   2. 68K enables JERRY IRQ2_DSP mask via J_INT ($F10020 low byte = $02).
+;   3. 68K loads a tiny DSP program that writes CPUINT (=$0002) to its
 ;      own D_CTRL.  That asks JERRY to fire IRQ2_DSP.
-;   3. 68K starts DSP, waits, stops DSP.
-;   4. 68K reads J_INT.  The JERRY pending-IRQ register should now show
-;      IRQ2_DSP=$0002 set.
-;   5. 68K also installs an autovector-2 IRQ handler that writes a
-;      marker; if 68K IRQs are unmasked the handler runs and the marker
-;      is set in addition to the pending-bit check.
+;   4. 68K runs in supervisor with IPL=0 so level-2 IRQs unmask.
+;   5. 68K starts DSP, spins, stops DSP.
+;   6. The IRQ handler runs during the spin, writes a known marker.
 ;
-; PASS = IRQ2_DSP bit set in the pending register AND the IRQ marker
-; was written by the handler.
+; PASS = IRQ marker written by the handler.
 ;
-; The IRQ marker check confirms the IRQ was actually delivered to the
-; 68K (the pending-bit check alone only confirms JERRY queued it).
+; (We don't separately check the J_INT pending bit because the
+; handler acks it via the high-byte clear.  Reading pending after
+; the handler runs would always return 0, which would make a
+; pending-bit assertion internally contradictory with the handler
+; the test installs.  Marker presence proves the full chain:
+; DSP CPUINT write -> JERRY pending latch -> m68k_set_irq(2) ->
+; CPU IACK -> vector 64 fetch -> handler entry.)
 ;
 ; Detail codes:
-;   1 = J_INT pending didn't include IRQ2_DSP (DSP didn't trigger or
-;       JERRY didn't latch it)
-;   2 = IRQ marker not written (IRQ wasn't delivered to 68K)
+;   1 = IRQ marker not written (IRQ wasn't delivered to 68K --
+;       chain broken at DSP CPUINT, JERRY latch, m68k_set_irq, or
+;       vector dispatch).
 ;
                 include "include/jaguar_header.s"
                 include "include/acid_test.s"
@@ -38,7 +43,13 @@ J_INT           equ     $00F10020
 IRQ_MARKER_ADDR equ     $00080010
 IRQ_MARKER_VAL  equ     $C0FFEE01
 
-VECTOR_AUTOIRQ2 equ     $00000068       ; autovector level 2 = vector 26 = address 0x68
+;; Jaguar HW does NOT assert VPA on IACK -- TOM/JERRY return user
+;; vector 64 ($100) for all hardware IRQs (see irq_ack_handler in
+;; src/core/jaguar.c).  So even though the 68K SR uses level-2
+;; (autovector) interrupts, the actual exception vector is 64, not
+;; the 68K-architectural autovector slot at $68.  This matches the
+;; convention used by the passing tests/irq/vblank_delivery.s.
+HW_IRQ_VECTOR   equ     $00000100
 
                 org     $802000
 entry:
@@ -52,7 +63,7 @@ entry:
 
                 ;; Install autovector-2 IRQ handler.
                 lea     irq2_handler(pc),a1
-                move.l  a1,VECTOR_AUTOIRQ2.l
+                move.l  a1,HW_IRQ_VECTOR.l
 
                 ;; Enable JERRY DSP IRQ mask (clear any pending too).
                 move.w  #$FF02,J_INT.l   ; low byte mask=$02 (IRQ2_DSP);
@@ -88,23 +99,17 @@ entry:
 
                 move.l  #0,D_CTRL
 
-                ;; Check J_INT pending byte for IRQ2_DSP.
-                ;; (Reading $F10020 returns jerryPendingInterrupt.)
-                move.w  J_INT.l,d5
-                move.w  d5,d4
-                and.w   #$0002,d4        ; mask to IRQ2_DSP bit
-                tst.w   d4
-                beq.s   .no_pending
-
-                ;; Check IRQ handler ran.
+                ;; Check IRQ handler ran.  The handler acks the JERRY
+                ;; pending bit via the high-byte clear, so reading
+                ;; jerryPendingInterrupt here would always be 0 --
+                ;; marker presence is the load-bearing evidence.
                 move.l  IRQ_MARKER_ADDR.l,d6
                 cmp.l   #IRQ_MARKER_VAL,d6
                 bne.s   .no_handler
 
                 ACID_PASS
 
-.no_pending:    ACID_FAIL #1,d5,#$0002
-.no_handler:    ACID_FAIL #2,d6,#IRQ_MARKER_VAL
+.no_handler:    ACID_FAIL #1,d6,#IRQ_MARKER_VAL
 
 ;; -----------------------------------------------------------------
 ;; IRQ2 handler: write marker, ack JERRY DSP pending bit, RTE.

--- a/test/acid/tests/dsp/dsp_irq_to_68k.s
+++ b/test/acid/tests/dsp/dsp_irq_to_68k.s
@@ -61,7 +61,11 @@ entry:
                 ;; Init markers.
                 move.l  #$00000000,IRQ_MARKER_ADDR.l
 
-                ;; Install autovector-2 IRQ handler.
+                ;; Install hardware IRQ handler at vector 64 ($100).
+                ;; (The CPU takes a level-2 autovector interrupt, but
+                ;; Jaguar HW returns user vector 64 on IACK rather than
+                ;; asserting VPA -- so the handler lives at $100, not
+                ;; the 68K-architectural autovector slot at $68.)
                 lea     irq2_handler(pc),a1
                 move.l  a1,HW_IRQ_VECTOR.l
 

--- a/test/acid/tests/gpu/gpu_basic_run.s
+++ b/test/acid/tests/gpu/gpu_basic_run.s
@@ -17,7 +17,9 @@
 ; 68K at 13.3 MHz, and the GPU executes far more NOPs per host-tick
 ; than the naive 2x ratio implies.  An earlier version of this test
 ; filled only the first 1024 NOPs (2 KB) and spun the 68K for 500
-; cycles -- the GPU walked clear off the slab into the trailing
+; loop iterations (each ~18 68K cycles, so ~9000 68K cycles =
+; ~18000 GPU cycles wall) -- the GPU walked clear off the slab
+; into the trailing
 ; randomized portion of gpu_ram_8 (src/tom/gpu.c reset fills
 ; gpu_ram_8 with JaguarRand()), where random bytes decode as
 ; JUMP/JR with bogus targets, landing PC at low addresses like

--- a/test/acid/tests/gpu/gpu_basic_run.s
+++ b/test/acid/tests/gpu/gpu_basic_run.s
@@ -1,17 +1,32 @@
 ;
 ; tests/gpu/gpu_basic_run.s - GPU starts and runs.
 ;
-; Loads 256 NOP opcodes (each $E400, opcode 57) into GPU work RAM at
-; GPU_RAM, sets G_PC to the start, asserts GO in G_CTRL, runs the
-; 68K through a *short* spin (so the GPU doesn't walk off the NOP
-; slab), stops the GPU, and reads G_PC back.
+; Loads NOP opcodes (each $E400, opcode 57) into the *entire* 4 KB
+; GPU local RAM at GPU_RAM, sets G_PC to the start, asserts GO in
+; G_CTRL, runs the 68K through a short spin, stops the GPU, and
+; reads G_PC back.
 ;
-; Strict assertion: G_PC must equal GPU_RAM + 2*N where N is
-; the number of GPU instructions executed.  We require N to be in
+; Strict assertion: G_PC must equal GPU_RAM + 2*N where N is the
+; number of GPU instructions executed.  We require N to be in
 ; [N_MIN, N_MAX] -- N_MIN ensures the GPU actually ran (not just
 ; "G_PC > start"), and N_MAX ensures G_PC stayed inside the NOP
 ; slab (so we know the value reflects real fetches, not garbage past
 ; the program).
+;
+; *Sizing notes*: This emulator runs the GPU/DSP at 26.6 MHz vs the
+; 68K at 13.3 MHz, and the GPU executes far more NOPs per host-tick
+; than the naive 2x ratio implies.  An earlier version of this test
+; filled only the first 1024 NOPs (2 KB) and spun the 68K for 500
+; cycles -- the GPU walked clear off the slab into the trailing
+; randomized portion of gpu_ram_8 (src/tom/gpu.c reset fills
+; gpu_ram_8 with JaguarRand()), where random bytes decode as
+; JUMP/JR with bogus targets, landing PC at low addresses like
+; $9F0E.  The fix is twofold:
+;   (1) fill the entire 4 KB of GPU local RAM with NOPs so a slab
+;       overshoot is provably caught by N_MAX rather than masked
+;       by random bytes happening to decode as branches, and
+;   (2) shrink the 68K spin so the GPU is comfortably inside the
+;       slab when we sample G_PC.
 ;
 ; *Known emulator quirk*: the dispatch in src/tom/gpu.c:GPUReadLong
 ; intercepts every long-aligned read in $F02000..$F020FF as a GPU
@@ -38,11 +53,10 @@ G_CTRL          equ     GPU_BASE + $14          ; bit 0 = GO/RUN
 GO              equ     $00000001
 NOP_OP          equ     $E400                   ; opcode 57 << 10
 
-;; GPU runs at 26.6 MHz vs 68K @ 13.3 MHz; in this emulator the
-;; GPU eats many more instructions per host-tick than naive ratio
-;; suggests.  Use a large NOP slab so we can confidently bound the
-;; final PC inside it.
-NOP_SLOTS       equ     1024                    ; 2 KB of NOPs
+;; Fill the *entire* 4 KB GPU local RAM with NOPs.  See sizing
+;; notes above for why.
+NOP_SLOTS       equ     2048                    ; 4 KB of NOPs, full slab
+SPIN_COUNT      equ     20                      ; 68K spin iterations
 N_MIN           equ     1                       ; >=1 GPU insn fetched
 N_MAX           equ     NOP_SLOTS               ; <= slab size
 PC_MIN          equ     GPU_RAM + (N_MIN*2)
@@ -65,7 +79,7 @@ entry:
 
                 ;; Short spin so the GPU executes some NOPs without
                 ;; walking past the slab.
-                move.l  #500,d2
+                move.l  #SPIN_COUNT,d2
 .spin:          nop
                 subq.l  #1,d2
                 bne.s   .spin


### PR DESCRIPTION
## Summary

Three failing acid tests in the GPU/DSP buckets had broken test setup — the emulator code paths are correct in all three. **3 FAIL → PASS**, 0 regressions, screenshot suite clean.

| Test | Before | After |
|---|---|---|
| `gpu_basic_run` | FAIL (PC overshot to 0x9F0E) | **PASS** |
| `dsp_basic_run` | FAIL (PC overshot to 0xF1D1C8) | **PASS** |
| `dsp_irq_to_68k` | FAIL (handler never ran) | **PASS** |

## Per-test fix

### 1. `tests/gpu/gpu_basic_run.s` — slab too small for spin window

Test filled GPU local RAM at `$F03000` with 1024 NOPs (2 KB), then spun **500** 68K cycles. In this emulator the GPU executes way more than 1024 instructions in 500 68K cycles (GPU runs at 2× 68K rate plus higher IPC), so PC walked off the slab into `gpu_ram_8`'s upper half — initialized with `JaguarRand()` (`src/tom/gpu.c:683-690`). Random opcodes decoded as JUMP/JR with bogus targets, landing PC at low addresses like `0x9F0E`.

Fix: `NOP_SLOTS 1024 → 2048` (full 4 KB GPU RAM fill); `SPIN_COUNT 500 → 20`. GPU PC now lands cleanly within slab.

### 2. `tests/dsp/dsp_basic_run.s` — same shape

Same defect pattern. Test filled only first 2 KB of DSP RAM (which is 8 KB total). PC walked past `$F1B800` into `$F1D1C8` (past end of DSP RAM into JERRY ROM space).

Fix: `NOP_SLOTS 1024 → 4096` (full 8 KB DSP RAM fill); `SPIN_COUNT 500 → 50`.

### 3. `tests/dsp/dsp_irq_to_68k.s` — wrong IRQ vector + contradictory assertion

**Bug A**: Test installed handler at `$00000068` (68K-architectural autovector slot for level 2). On Jaguar hardware, TOM/JERRY don't assert VPA on IACK — they return user vector 64 (`$100`) on the data bus for ALL hardware IRQs. The handler at `$68` was never reached; the CPU instead jumped to the HLE BIOS RTE stub pre-installed at `$100`.

Fix: install at `HW_IRQ_VECTOR = $100`, matching the convention used by the passing `tests/irq/vblank_delivery.s`.

**Bug B**: Test asserted both that the handler ran (marker written) AND that the JERRY pending bit was still set. But the handler explicitly acks pending via `move.w #$0202,J_INT.l` — so reading pending after the handler runs always returns 0. The test could never pass even with a working IRQ chain.

Fix: drop the redundant pending-bit check; the marker alone proves the full chain (DSP CPUINT → JERRY pending latch → `m68k_set_irq(2)` → IACK → vector 64 → handler entry).

**Verified empirically** (printf trace, then reverted) that the IRQ delivery chain works correctly — `checkForIRQToHandle` is consumed at the very next instruction in the same `m68k_execute` slice. A prior research agent had hypothesized a deferred-IRQ-during-spin-loop bug; that hypothesis was disproved.

## Test plan

- [x] `acid_run` on each of the 3 fixed tests — all PASS
- [x] `make -C test/acid check-baseline` — 0 regressions across 142 tests, 3 improvements absorbed into baseline
- [x] `test/regression_test.sh` — 10/10 PASS (screenshot, determinism, frameskip, save state, rewind for jagniccc + yarc)
- [x] No emulator C changes — all 3 fixes are test-side. Each emulator code path was verified correct via tracing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)