### PR TITLE
tom: PIT clock divisor — half system clock per JTRM §3.7

### DIFF
--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -1296,7 +1296,10 @@ void TOMResetPIT(void)
 
    if (tomTimerPrescaler)
    {
-      double usecs = (float)(tomTimerPrescaler + 1) * (float)(tomTimerDivider + 1) * RISC_CYCLE_IN_USEC;
+      /* Per JTRM §3.7, the PIT runs at half the system clock --
+         13.295 MHz NTSC / 13.296 MHz PAL, the same rate as the 68K. */
+      double usecs = (double)(tomTimerPrescaler + 1) * (double)(tomTimerDivider + 1)
+         * (vjs.hardwareTypeNTSC ? M68K_CYCLE_IN_USEC : M68K_CYCLE_PAL_IN_USEC);
       SetCallbackTime(TOMPITCallback, usecs, EVENT_MAIN);
    }
 #endif


### PR DESCRIPTION
## Summary

- TOM PIT was using `RISC_CYCLE_IN_USEC` (26.6 MHz) but the JTRM specifies the PIT runs at half the system clock (13.3 MHz / M68K rate), making TOM PIT interrupts fire at exactly 2× the correct rate
- Mirrors the JERRY PIT fix in 8dd82a7 (PR #134); also upgrades float→double casts and adds NTSC/PAL clock selection
- Games using TOM PIT for game-tick timing (e.g. Doom) ran ~2× too fast

Fixes #131

## Test plan

- [x] `make` builds clean
- [x] `scripts/c89-lint.sh src/tom/tom.c` passes
- [x] `make test` — all unit tests pass
- [x] `make acid` — 134/142, same pass/fail as baseline (no regressions)
- [ ] Verify Doom game speed is correct on device (RetroArch)
- [ ] Check that games using TOM PIT timers (Iron Soldier, etc.) still run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)