### PR TITLE
blitter: remove erroneous 64-bit register hi/lo swap

### DIFF
--- a/src/tom/blitter_mmio.c
+++ b/src/tom/blitter_mmio.c
@@ -134,24 +134,6 @@ void BlitterWriteByte(uint32_t offset, uint8_t data, uint32_t who/*=UNKNOWN*/)
       case PHRASEZ3 + 3: blitter_ram[SRCZFRAC + 1] = data; break;
       }
    }
-   else if (((offset >= SRCDATA + 0) && (offset <= SRCDATA + 3))
-         || ((offset >= DSTDATA + 0) && (offset <= DSTDATA + 3))
-         || ((offset >= DSTZ + 0) && (offset <= DSTZ + 3))
-         || ((offset >= SRCZINT + 0) && (offset <= SRCZINT + 3))
-         || ((offset >= SRCZFRAC + 0) && (offset <= SRCZFRAC + 3))
-         || ((offset >= PATTERNDATA + 0) && (offset <= PATTERNDATA + 3)))
-   {
-      blitter_ram[offset + 4] = data;
-   }
-   else if (((offset >= SRCDATA + 4) && (offset <= SRCDATA + 7))
-         || ((offset >= DSTDATA + 4) && (offset <= DSTDATA + 7))
-         || ((offset >= DSTZ + 4) && (offset <= DSTZ + 7))
-         || ((offset >= SRCZINT + 4) && (offset <= SRCZINT + 7))
-         || ((offset >= SRCZFRAC + 4) && (offset <= SRCZFRAC + 7))
-         || ((offset >= PATTERNDATA + 4) && (offset <= PATTERNDATA + 7)))
-   {
-      blitter_ram[offset - 4] = data;
-   }
    else
       blitter_ram[offset] = data;
 }


### PR DESCRIPTION
## Summary
- Removes the hi/lo 32-bit half-swap in `BlitterWriteByte` for 64-bit data registers (SRCDATA, DSTDATA, DSTZ, SRCZINT, SRCZFRAC, PATTERNDATA)
- The swap caused `GET64` to read transposed values, corrupting pattern fills and Z-buffer data written through direct register writes
- Gouraud byte-level reads (`blitter.c:945-959`) already use correct big-endian offsets — they become correct once the swap is removed
- PHRASEINT/PHRASEZ writes are unaffected (separate direct-mapped path)
- **Fixes the `pattern_fill` acid test** (134 → 135 of 142 passing)

## Background
The swap was a long-standing emulation bug inherited from upstream Virtual Jaguar. It swapped the two 32-bit halves when the 68K (or GPU) wrote to any of the blitter's 64-bit data registers. The Gouraud initialization code compensated by reading bytes in a reversed order, creating a "two wrongs cancel out" situation — but only for Gouraud. Pattern fills, Z-buffer, and other uses of `GET64` on these registers were silently broken.

## Test plan
- [x] `make` — clean build, no warnings
- [x] `bash scripts/c89-lint.sh src/tom/blitter_mmio.c` — passes
- [x] `make test` — all unit tests pass
- [x] `make acid` — 135/142 (was 134/142; `pattern_fill` now passes)
- [ ] Regression test with Gouraud-heavy games (AvP, Tempest 2000, Wolfenstein 3D)
- [ ] Regression test with Z-buffered games (Iron Soldier, AvP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)