### PR TITLE
perf(risc): add computed-goto opcode dispatch for GCC/Clang

### DIFF
--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -971,7 +971,7 @@ INLINE static void dsp_executeOpcode(uint32_t index)
 	dsp_op_store_r14_ri:    dsp_opcode_store_r14_ri();    return;
 	dsp_op_store_r15_ri:    dsp_opcode_store_r15_ri();    return;
 	dsp_op_illegal:         dsp_opcode_illegal();         return;
-	dsp_op_addqmod:         dsp_opcode_addqmod();         return;
+	dsp_op_addqmod:         dsp_opcode_addqmod();         return; /* NOLINT(readability-redundant-control-flow) -- goto target */
 #else
 	/* Switch fallback for MSVC and other non-GNU compilers */
 	switch (index)

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -864,18 +864,128 @@ INLINE void DSPExec(int32_t cycles)
 
 INLINE static void dsp_executeOpcode(uint32_t index)
 {
+#ifdef __GNUC__
+	/* Computed-goto dispatch table -- one label per RISC opcode.
+	 * GCC/Clang extension: &&label yields the address of a label;
+	 * goto *ptr jumps through an arbitrary code address.  This
+	 * eliminates the single indirect-branch bottleneck of switch
+	 * dispatch and lets the branch predictor track each opcode
+	 * independently. */
+	static const void *dsp_dispatch[64] = {
+		&&dsp_op_add,             &&dsp_op_addc,
+		&&dsp_op_addq,            &&dsp_op_addqt,
+		&&dsp_op_sub,             &&dsp_op_subc,
+		&&dsp_op_subq,            &&dsp_op_subqt,
+		&&dsp_op_neg,             &&dsp_op_and,
+		&&dsp_op_or,              &&dsp_op_xor,
+		&&dsp_op_not,             &&dsp_op_btst,
+		&&dsp_op_bset,            &&dsp_op_bclr,
+		&&dsp_op_mult,            &&dsp_op_imult,
+		&&dsp_op_imultn,          &&dsp_op_resmac,
+		&&dsp_op_imacn,           &&dsp_op_div,
+		&&dsp_op_abs,             &&dsp_op_sh,
+		&&dsp_op_shlq,            &&dsp_op_shrq,
+		&&dsp_op_sha,             &&dsp_op_sharq,
+		&&dsp_op_ror,             &&dsp_op_rorq,
+		&&dsp_op_cmp,             &&dsp_op_cmpq,
+		&&dsp_op_subqmod,         &&dsp_op_sat16s,
+		&&dsp_op_move,            &&dsp_op_moveq,
+		&&dsp_op_moveta,          &&dsp_op_movefa,
+		&&dsp_op_movei,           &&dsp_op_loadb,
+		&&dsp_op_loadw,           &&dsp_op_load,
+		&&dsp_op_sat32s,          &&dsp_op_load_r14_indexed,
+		&&dsp_op_load_r15_indexed,&&dsp_op_storeb,
+		&&dsp_op_storew,          &&dsp_op_store,
+		&&dsp_op_mirror,          &&dsp_op_store_r14_indexed,
+		&&dsp_op_store_r15_indexed,&&dsp_op_move_pc,
+		&&dsp_op_jump,            &&dsp_op_jr,
+		&&dsp_op_mmult,           &&dsp_op_mtoi,
+		&&dsp_op_normi,           &&dsp_op_nop,
+		&&dsp_op_load_r14_ri,     &&dsp_op_load_r15_ri,
+		&&dsp_op_store_r14_ri,    &&dsp_op_store_r15_ri,
+		&&dsp_op_illegal,         &&dsp_op_addqmod
+	};
+
+	goto *dsp_dispatch[index];
+
+	dsp_op_add:             dsp_opcode_add();             return;
+	dsp_op_addc:            dsp_opcode_addc();            return;
+	dsp_op_addq:            dsp_opcode_addq();            return;
+	dsp_op_addqt:           dsp_opcode_addqt();           return;
+	dsp_op_sub:             dsp_opcode_sub();             return;
+	dsp_op_subc:            dsp_opcode_subc();            return;
+	dsp_op_subq:            dsp_opcode_subq();            return;
+	dsp_op_subqt:           dsp_opcode_subqt();           return;
+	dsp_op_neg:             dsp_opcode_neg();             return;
+	dsp_op_and:             dsp_opcode_and();             return;
+	dsp_op_or:              dsp_opcode_or();              return;
+	dsp_op_xor:             dsp_opcode_xor();             return;
+	dsp_op_not:             dsp_opcode_not();             return;
+	dsp_op_btst:            dsp_opcode_btst();            return;
+	dsp_op_bset:            dsp_opcode_bset();            return;
+	dsp_op_bclr:            dsp_opcode_bclr();            return;
+	dsp_op_mult:            dsp_opcode_mult();            return;
+	dsp_op_imult:           dsp_opcode_imult();           return;
+	dsp_op_imultn:          dsp_opcode_imultn();          return;
+	dsp_op_resmac:          dsp_opcode_resmac();          return;
+	dsp_op_imacn:           dsp_opcode_imacn();           return;
+	dsp_op_div:             dsp_opcode_div();             return;
+	dsp_op_abs:             dsp_opcode_abs();             return;
+	dsp_op_sh:              dsp_opcode_sh();              return;
+	dsp_op_shlq:            dsp_opcode_shlq();            return;
+	dsp_op_shrq:            dsp_opcode_shrq();            return;
+	dsp_op_sha:             dsp_opcode_sha();             return;
+	dsp_op_sharq:           dsp_opcode_sharq();           return;
+	dsp_op_ror:             dsp_opcode_ror();             return;
+	dsp_op_rorq:            dsp_opcode_rorq();            return;
+	dsp_op_cmp:             dsp_opcode_cmp();             return;
+	dsp_op_cmpq:            dsp_opcode_cmpq();            return;
+	dsp_op_subqmod:         dsp_opcode_subqmod();         return;
+	dsp_op_sat16s:          dsp_opcode_sat16s();          return;
+	dsp_op_move:            dsp_opcode_move();            return;
+	dsp_op_moveq:           dsp_opcode_moveq();           return;
+	dsp_op_moveta:          dsp_opcode_moveta();          return;
+	dsp_op_movefa:          dsp_opcode_movefa();          return;
+	dsp_op_movei:           dsp_opcode_movei();           return;
+	dsp_op_loadb:           dsp_opcode_loadb();           return;
+	dsp_op_loadw:           dsp_opcode_loadw();           return;
+	dsp_op_load:            dsp_opcode_load();            return;
+	dsp_op_sat32s:          dsp_opcode_sat32s();          return;
+	dsp_op_load_r14_indexed:dsp_opcode_load_r14_indexed();return;
+	dsp_op_load_r15_indexed:dsp_opcode_load_r15_indexed();return;
+	dsp_op_storeb:          dsp_opcode_storeb();          return;
+	dsp_op_storew:          dsp_opcode_storew();          return;
+	dsp_op_store:           dsp_opcode_store();           return;
+	dsp_op_mirror:          dsp_opcode_mirror();          return;
+	dsp_op_store_r14_indexed:dsp_opcode_store_r14_indexed();return;
+	dsp_op_store_r15_indexed:dsp_opcode_store_r15_indexed();return;
+	dsp_op_move_pc:         dsp_opcode_move_pc();         return;
+	dsp_op_jump:            dsp_opcode_jump();            return;
+	dsp_op_jr:              dsp_opcode_jr();              return;
+	dsp_op_mmult:           dsp_opcode_mmult();           return;
+	dsp_op_mtoi:            dsp_opcode_mtoi();            return;
+	dsp_op_normi:           dsp_opcode_normi();           return;
+	dsp_op_nop:             dsp_opcode_nop();             return;
+	dsp_op_load_r14_ri:     dsp_opcode_load_r14_ri();     return;
+	dsp_op_load_r15_ri:     dsp_opcode_load_r15_ri();     return;
+	dsp_op_store_r14_ri:    dsp_opcode_store_r14_ri();    return;
+	dsp_op_store_r15_ri:    dsp_opcode_store_r15_ri();    return;
+	dsp_op_illegal:         dsp_opcode_illegal();         return;
+	dsp_op_addqmod:         dsp_opcode_addqmod();         return;
+#else
+	/* Switch fallback for MSVC and other non-GNU compilers */
 	switch (index)
 	{
-	case 0: dsp_opcode_add(); break;
-	case 1: dsp_opcode_addc(); break;
-	case 2: dsp_opcode_addq(); break;
-	case 3: dsp_opcode_addqt(); break;
-	case 4: dsp_opcode_sub(); break;
-	case 5: dsp_opcode_subc(); break;
-	case 6: dsp_opcode_subq(); break;
-	case 7: dsp_opcode_subqt(); break;
-	case 8: dsp_opcode_neg(); break;
-	case 9: dsp_opcode_and(); break;
+	case 0:  dsp_opcode_add(); break;
+	case 1:  dsp_opcode_addc(); break;
+	case 2:  dsp_opcode_addq(); break;
+	case 3:  dsp_opcode_addqt(); break;
+	case 4:  dsp_opcode_sub(); break;
+	case 5:  dsp_opcode_subc(); break;
+	case 6:  dsp_opcode_subq(); break;
+	case 7:  dsp_opcode_subqt(); break;
+	case 8:  dsp_opcode_neg(); break;
+	case 9:  dsp_opcode_and(); break;
 	case 10: dsp_opcode_or(); break;
 	case 11: dsp_opcode_xor(); break;
 	case 12: dsp_opcode_not(); break;
@@ -932,6 +1042,7 @@ INLINE static void dsp_executeOpcode(uint32_t index)
 	case 63: dsp_opcode_addqmod(); break;
 	default: break;
 	}
+#endif
 }
 
 // DSP opcode handlers

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -867,7 +867,7 @@ INLINE static void executeOpcode(uint32_t index) {
 	gpu_op_store_r14_ri:    gpu_opcode_store_r14_ri();    return;
 	gpu_op_store_r15_ri:    gpu_opcode_store_r15_ri();    return;
 	gpu_op_sat24:           gpu_opcode_sat24();           return;
-	gpu_op_pack:            gpu_opcode_pack();            return;
+	gpu_op_pack:            gpu_opcode_pack();            return; /* NOLINT(readability-redundant-control-flow) -- goto target */
 #else
 	/* Switch fallback for MSVC and other non-GNU compilers */
 	switch (index) {

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -760,203 +760,184 @@ void GPUExec(int32_t cycles)
 }
 
 INLINE static void executeOpcode(uint32_t index) {
-    switch (index) {
-        case 0:
-            gpu_opcode_add();
-            break;
-        case 1:
-            gpu_opcode_addc();
-            break;
-        case 2:
-            gpu_opcode_addq();
-            break;
-        case 3:
-            gpu_opcode_addqt();
-            break;
-        case 4:
-            gpu_opcode_sub();
-            break;
-        case 5:
-            gpu_opcode_subc();
-            break;
-        case 6:
-            gpu_opcode_subq();
-            break;
-        case 7:
-            gpu_opcode_subqt();
-            break;
-        case 8:
-            gpu_opcode_neg();
-            break;
-        case 9:
-            gpu_opcode_and();
-            break;
-        case 10:
-            gpu_opcode_or();
-            break;
-        case 11:
-            gpu_opcode_xor();
-            break;
-        case 12:
-            gpu_opcode_not();
-            break;
-        case 13:
-            gpu_opcode_btst();
-            break;
-        case 14:
-            gpu_opcode_bset();
-            break;
-        case 15:
-            gpu_opcode_bclr();
-            break;
-        case 16:
-            gpu_opcode_mult();
-            break;
-        case 17:
-            gpu_opcode_imult();
-            break;
-        case 18:
-            gpu_opcode_imultn();
-            break;
-        case 19:
-            gpu_opcode_resmac();
-            break;
-        case 20:
-            gpu_opcode_imacn();
-            break;
-        case 21:
-            gpu_opcode_div();
-            break;
-        case 22:
-            gpu_opcode_abs();
-            break;
-        case 23:
-            gpu_opcode_sh();
-            break;
-        case 24:
-            gpu_opcode_shlq();
-            break;
-        case 25:
-            gpu_opcode_shrq();
-            break;
-        case 26:
-            gpu_opcode_sha();
-            break;
-        case 27:
-            gpu_opcode_sharq();
-            break;
-        case 28:
-            gpu_opcode_ror();
-            break;
-        case 29:
-            gpu_opcode_rorq();
-            break;
-        case 30:
-            gpu_opcode_cmp();
-            break;
-        case 31:
-            gpu_opcode_cmpq();
-            break;
-        case 32:
-            gpu_opcode_sat8();
-            break;
-        case 33:
-            gpu_opcode_sat16();
-            break;
-        case 34:
-            gpu_opcode_move();
-            break;
-        case 35:
-            gpu_opcode_moveq();
-            break;
-        case 36:
-            gpu_opcode_moveta();
-            break;
-        case 37:
-            gpu_opcode_movefa();
-            break;
-        case 38:
-            gpu_opcode_movei();
-            break;
-        case 39:
-            gpu_opcode_loadb();
-            break;
-        case 40:
-            gpu_opcode_loadw();
-            break;
-        case 41:
-            gpu_opcode_load();
-            break;
-        case 42:
-            gpu_opcode_loadp();
-            break;
-        case 43:
-            gpu_opcode_load_r14_indexed();
-            break;
-        case 44:
-            gpu_opcode_load_r15_indexed();
-            break;
-        case 45:
-            gpu_opcode_storeb();
-            break;
-        case 46:
-            gpu_opcode_storew();
-            break;
-        case 47:
-            gpu_opcode_store();
-            break;
-        case 48:
-            gpu_opcode_storep();
-            break;
-        case 49:
-            gpu_opcode_store_r14_indexed();
-            break;
-        case 50:
-            gpu_opcode_store_r15_indexed();
-            break;
-        case 51:
-            gpu_opcode_move_pc();
-            break;
-        case 52:
-            gpu_opcode_jump();
-            break;
-        case 53:
-            gpu_opcode_jr();
-            break;
-        case 54:
-            gpu_opcode_mmult();
-            break;
-        case 55:
-            gpu_opcode_mtoi();
-            break;
-        case 56:
-            gpu_opcode_normi();
-            break;
-        case 57:
-            gpu_opcode_nop();
-            break;
-        case 58:
-            gpu_opcode_load_r14_ri();
-            break;
-        case 59:
-            gpu_opcode_load_r15_ri();
-            break;
-        case 60:
-            gpu_opcode_store_r14_ri();
-            break;
-        case 61:
-            gpu_opcode_store_r15_ri();
-            break;
-        case 62:
-            gpu_opcode_sat24();
-            break;
-        case 63:
-            gpu_opcode_pack();
-            break;
-        default:
-            // WriteLog("\nUnknown opcode %i\n", index);
-            break;
-    }
+#ifdef __GNUC__
+	/* Computed-goto dispatch table -- one label per RISC opcode.
+	 * GCC/Clang extension: &&label yields the address of a label;
+	 * goto *ptr jumps through an arbitrary code address.  This
+	 * eliminates the single indirect-branch bottleneck of switch
+	 * dispatch and lets the branch predictor track each opcode
+	 * independently. */
+	static const void *gpu_dispatch[64] = {
+		&&gpu_op_add,             &&gpu_op_addc,
+		&&gpu_op_addq,            &&gpu_op_addqt,
+		&&gpu_op_sub,             &&gpu_op_subc,
+		&&gpu_op_subq,            &&gpu_op_subqt,
+		&&gpu_op_neg,             &&gpu_op_and,
+		&&gpu_op_or,              &&gpu_op_xor,
+		&&gpu_op_not,             &&gpu_op_btst,
+		&&gpu_op_bset,            &&gpu_op_bclr,
+		&&gpu_op_mult,            &&gpu_op_imult,
+		&&gpu_op_imultn,          &&gpu_op_resmac,
+		&&gpu_op_imacn,           &&gpu_op_div,
+		&&gpu_op_abs,             &&gpu_op_sh,
+		&&gpu_op_shlq,            &&gpu_op_shrq,
+		&&gpu_op_sha,             &&gpu_op_sharq,
+		&&gpu_op_ror,             &&gpu_op_rorq,
+		&&gpu_op_cmp,             &&gpu_op_cmpq,
+		&&gpu_op_sat8,            &&gpu_op_sat16,
+		&&gpu_op_move,            &&gpu_op_moveq,
+		&&gpu_op_moveta,          &&gpu_op_movefa,
+		&&gpu_op_movei,           &&gpu_op_loadb,
+		&&gpu_op_loadw,           &&gpu_op_load,
+		&&gpu_op_loadp,           &&gpu_op_load_r14_indexed,
+		&&gpu_op_load_r15_indexed,&&gpu_op_storeb,
+		&&gpu_op_storew,          &&gpu_op_store,
+		&&gpu_op_storep,          &&gpu_op_store_r14_indexed,
+		&&gpu_op_store_r15_indexed,&&gpu_op_move_pc,
+		&&gpu_op_jump,            &&gpu_op_jr,
+		&&gpu_op_mmult,           &&gpu_op_mtoi,
+		&&gpu_op_normi,           &&gpu_op_nop,
+		&&gpu_op_load_r14_ri,     &&gpu_op_load_r15_ri,
+		&&gpu_op_store_r14_ri,    &&gpu_op_store_r15_ri,
+		&&gpu_op_sat24,           &&gpu_op_pack
+	};
+
+	goto *gpu_dispatch[index];
+
+	gpu_op_add:             gpu_opcode_add();             return;
+	gpu_op_addc:            gpu_opcode_addc();            return;
+	gpu_op_addq:            gpu_opcode_addq();            return;
+	gpu_op_addqt:           gpu_opcode_addqt();           return;
+	gpu_op_sub:             gpu_opcode_sub();             return;
+	gpu_op_subc:            gpu_opcode_subc();            return;
+	gpu_op_subq:            gpu_opcode_subq();            return;
+	gpu_op_subqt:           gpu_opcode_subqt();           return;
+	gpu_op_neg:             gpu_opcode_neg();             return;
+	gpu_op_and:             gpu_opcode_and();             return;
+	gpu_op_or:              gpu_opcode_or();              return;
+	gpu_op_xor:             gpu_opcode_xor();             return;
+	gpu_op_not:             gpu_opcode_not();             return;
+	gpu_op_btst:            gpu_opcode_btst();            return;
+	gpu_op_bset:            gpu_opcode_bset();            return;
+	gpu_op_bclr:            gpu_opcode_bclr();            return;
+	gpu_op_mult:            gpu_opcode_mult();            return;
+	gpu_op_imult:           gpu_opcode_imult();           return;
+	gpu_op_imultn:          gpu_opcode_imultn();          return;
+	gpu_op_resmac:          gpu_opcode_resmac();          return;
+	gpu_op_imacn:           gpu_opcode_imacn();           return;
+	gpu_op_div:             gpu_opcode_div();             return;
+	gpu_op_abs:             gpu_opcode_abs();             return;
+	gpu_op_sh:              gpu_opcode_sh();              return;
+	gpu_op_shlq:            gpu_opcode_shlq();            return;
+	gpu_op_shrq:            gpu_opcode_shrq();            return;
+	gpu_op_sha:             gpu_opcode_sha();             return;
+	gpu_op_sharq:           gpu_opcode_sharq();           return;
+	gpu_op_ror:             gpu_opcode_ror();             return;
+	gpu_op_rorq:            gpu_opcode_rorq();            return;
+	gpu_op_cmp:             gpu_opcode_cmp();             return;
+	gpu_op_cmpq:            gpu_opcode_cmpq();            return;
+	gpu_op_sat8:            gpu_opcode_sat8();            return;
+	gpu_op_sat16:           gpu_opcode_sat16();           return;
+	gpu_op_move:            gpu_opcode_move();            return;
+	gpu_op_moveq:           gpu_opcode_moveq();           return;
+	gpu_op_moveta:          gpu_opcode_moveta();          return;
+	gpu_op_movefa:          gpu_opcode_movefa();          return;
+	gpu_op_movei:           gpu_opcode_movei();           return;
+	gpu_op_loadb:           gpu_opcode_loadb();           return;
+	gpu_op_loadw:           gpu_opcode_loadw();           return;
+	gpu_op_load:            gpu_opcode_load();            return;
+	gpu_op_loadp:           gpu_opcode_loadp();           return;
+	gpu_op_load_r14_indexed:gpu_opcode_load_r14_indexed();return;
+	gpu_op_load_r15_indexed:gpu_opcode_load_r15_indexed();return;
+	gpu_op_storeb:          gpu_opcode_storeb();          return;
+	gpu_op_storew:          gpu_opcode_storew();          return;
+	gpu_op_store:           gpu_opcode_store();           return;
+	gpu_op_storep:          gpu_opcode_storep();          return;
+	gpu_op_store_r14_indexed:gpu_opcode_store_r14_indexed();return;
+	gpu_op_store_r15_indexed:gpu_opcode_store_r15_indexed();return;
+	gpu_op_move_pc:         gpu_opcode_move_pc();         return;
+	gpu_op_jump:            gpu_opcode_jump();            return;
+	gpu_op_jr:              gpu_opcode_jr();              return;
+	gpu_op_mmult:           gpu_opcode_mmult();           return;
+	gpu_op_mtoi:            gpu_opcode_mtoi();            return;
+	gpu_op_normi:           gpu_opcode_normi();           return;
+	gpu_op_nop:             gpu_opcode_nop();             return;
+	gpu_op_load_r14_ri:     gpu_opcode_load_r14_ri();     return;
+	gpu_op_load_r15_ri:     gpu_opcode_load_r15_ri();     return;
+	gpu_op_store_r14_ri:    gpu_opcode_store_r14_ri();    return;
+	gpu_op_store_r15_ri:    gpu_opcode_store_r15_ri();    return;
+	gpu_op_sat24:           gpu_opcode_sat24();           return;
+	gpu_op_pack:            gpu_opcode_pack();            return;
+#else
+	/* Switch fallback for MSVC and other non-GNU compilers */
+	switch (index) {
+	case 0:  gpu_opcode_add();             break;
+	case 1:  gpu_opcode_addc();            break;
+	case 2:  gpu_opcode_addq();            break;
+	case 3:  gpu_opcode_addqt();           break;
+	case 4:  gpu_opcode_sub();             break;
+	case 5:  gpu_opcode_subc();            break;
+	case 6:  gpu_opcode_subq();            break;
+	case 7:  gpu_opcode_subqt();           break;
+	case 8:  gpu_opcode_neg();             break;
+	case 9:  gpu_opcode_and();             break;
+	case 10: gpu_opcode_or();              break;
+	case 11: gpu_opcode_xor();             break;
+	case 12: gpu_opcode_not();             break;
+	case 13: gpu_opcode_btst();            break;
+	case 14: gpu_opcode_bset();            break;
+	case 15: gpu_opcode_bclr();            break;
+	case 16: gpu_opcode_mult();            break;
+	case 17: gpu_opcode_imult();           break;
+	case 18: gpu_opcode_imultn();          break;
+	case 19: gpu_opcode_resmac();          break;
+	case 20: gpu_opcode_imacn();           break;
+	case 21: gpu_opcode_div();             break;
+	case 22: gpu_opcode_abs();             break;
+	case 23: gpu_opcode_sh();              break;
+	case 24: gpu_opcode_shlq();            break;
+	case 25: gpu_opcode_shrq();            break;
+	case 26: gpu_opcode_sha();             break;
+	case 27: gpu_opcode_sharq();           break;
+	case 28: gpu_opcode_ror();             break;
+	case 29: gpu_opcode_rorq();            break;
+	case 30: gpu_opcode_cmp();             break;
+	case 31: gpu_opcode_cmpq();            break;
+	case 32: gpu_opcode_sat8();            break;
+	case 33: gpu_opcode_sat16();           break;
+	case 34: gpu_opcode_move();            break;
+	case 35: gpu_opcode_moveq();           break;
+	case 36: gpu_opcode_moveta();          break;
+	case 37: gpu_opcode_movefa();          break;
+	case 38: gpu_opcode_movei();           break;
+	case 39: gpu_opcode_loadb();           break;
+	case 40: gpu_opcode_loadw();           break;
+	case 41: gpu_opcode_load();            break;
+	case 42: gpu_opcode_loadp();           break;
+	case 43: gpu_opcode_load_r14_indexed(); break;
+	case 44: gpu_opcode_load_r15_indexed(); break;
+	case 45: gpu_opcode_storeb();          break;
+	case 46: gpu_opcode_storew();          break;
+	case 47: gpu_opcode_store();           break;
+	case 48: gpu_opcode_storep();          break;
+	case 49: gpu_opcode_store_r14_indexed(); break;
+	case 50: gpu_opcode_store_r15_indexed(); break;
+	case 51: gpu_opcode_move_pc();         break;
+	case 52: gpu_opcode_jump();            break;
+	case 53: gpu_opcode_jr();              break;
+	case 54: gpu_opcode_mmult();           break;
+	case 55: gpu_opcode_mtoi();            break;
+	case 56: gpu_opcode_normi();           break;
+	case 57: gpu_opcode_nop();             break;
+	case 58: gpu_opcode_load_r14_ri();     break;
+	case 59: gpu_opcode_load_r15_ri();     break;
+	case 60: gpu_opcode_store_r14_ri();    break;
+	case 61: gpu_opcode_store_r15_ri();    break;
+	case 62: gpu_opcode_sat24();           break;
+	case 63: gpu_opcode_pack();            break;
+	default: break;
+	}
+#endif
 }
 
 // GPU opcodes


### PR DESCRIPTION
## Summary
- Replaces the `switch(index)` dispatch in both `executeOpcode()` (GPU) and `dsp_executeOpcode()` (DSP) with computed-goto (`&&label` / `goto *ptr`) under `#ifdef __GNUC__`
- Each opcode gets its own branch-target entry in the CPU branch predictor, eliminating the single-indirect-branch bottleneck of switch dispatch
- MSVC fallback retains the existing switch — computed-goto is a GNU extension
- All 64 opcodes verified against `gpu_opcode[]` / `dsp_opcode[]` tables; GPU and DSP differ at opcodes 32/33/42/48/62/63

## Test plan
- [x] `make -j12` — clean build, zero warnings
- [x] `bash scripts/c89-lint.sh src/tom/gpu.c src/jerry/dsp.c` — passed
- [x] `make test` — all tests pass
- [ ] `make benchmark` — compare FPS before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)