### PR TITLE
perf(risc): inline delay-slot execution in GPU and DSP

### DIFF
--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -936,22 +936,35 @@ INLINE static void dsp_executeOpcode(uint32_t index)
 
 // DSP opcode handlers
 
-// There is a problem here with interrupt handlers the JUMP and JR instructions that
-// can cause trouble because an interrupt can occur *before* the instruction following the
-// jump can execute... !!! FIX !!!
+/* There is a problem here with interrupt handlers the JUMP and JR instructions that
+ * can cause trouble because an interrupt can occur *before* the instruction following the
+ * jump can execute... !!! FIX !!! */
 INLINE static void dsp_opcode_jump(void)
 {
-	// normalize flags
-/*	dsp_flag_c=dsp_flag_c?1:0;
-	dsp_flag_z=dsp_flag_z?1:0;
-	dsp_flag_n=dsp_flag_n?1:0;*/
-	// KLUDGE: Used by BRANCH_CONDITION
+	/* KLUDGE: Used by BRANCH_CONDITION */
 	uint32_t jaguar_flags = (dsp_flag_n << 2) | (dsp_flag_c << 1) | dsp_flag_z;
 
 	if (BRANCH_CONDITION(IMM_2))
 	{
 		uint32_t delayed_pc = RM;
-		DSPExec(1);
+		uint16_t ds_opcode;
+		uint32_t ds_index;
+		/* Inline delay-slot: fetch-decode-execute one instruction at current
+		 * PC before applying the branch target.  This replaces the old
+		 * recursive DSPExec(1) call, avoiding full function-call overhead,
+		 * redundant IRQ checks, and pipeline-state save/restore. */
+		if (dsp_pc >= DSP_WORK_RAM_BASE && dsp_pc < DSP_WORK_RAM_BASE + 0x2000)
+		{
+			uint32_t off = dsp_pc - DSP_WORK_RAM_BASE;
+			ds_opcode = ((uint16_t)dsp_ram_8[off] << 8) | (uint16_t)dsp_ram_8[off + 1];
+		}
+		else
+			ds_opcode = DSPReadWord(dsp_pc, DSP);
+		ds_index = ds_opcode >> 10;
+		dsp_opcode_first_parameter  = (ds_opcode >> 5) & 0x1F;
+		dsp_opcode_second_parameter = ds_opcode & 0x1F;
+		dsp_pc += 2;
+		dsp_executeOpcode(ds_index);
 		dsp_pc = delayed_pc;
 	}
 }
@@ -959,18 +972,30 @@ INLINE static void dsp_opcode_jump(void)
 
 INLINE static void dsp_opcode_jr(void)
 {
-	// normalize flags
-/*	dsp_flag_c=dsp_flag_c?1:0;
-	dsp_flag_z=dsp_flag_z?1:0;
-	dsp_flag_n=dsp_flag_n?1:0;*/
-	// KLUDGE: Used by BRANCH_CONDITION
+	/* KLUDGE: Used by BRANCH_CONDITION */
 	uint32_t jaguar_flags = (dsp_flag_n << 2) | (dsp_flag_c << 1) | dsp_flag_z;
 
 	if (BRANCH_CONDITION(IMM_2))
 	{
-		int32_t offset = ((IMM_1 & 0x10) ? 0xFFFFFFF0 | IMM_1 : IMM_1);		// Sign extend IMM_1
+		int32_t offset = ((IMM_1 & 0x10) ? 0xFFFFFFF0 | IMM_1 : IMM_1);		/* Sign extend IMM_1 */
 		int32_t delayed_pc = dsp_pc + (offset * 2);
-		DSPExec(1);
+		uint16_t ds_opcode;
+		uint32_t ds_index;
+		/* Inline delay-slot: fetch-decode-execute one instruction at current
+		 * PC before applying the branch target.  Same rationale as in
+		 * dsp_opcode_jump above. */
+		if (dsp_pc >= DSP_WORK_RAM_BASE && dsp_pc < DSP_WORK_RAM_BASE + 0x2000)
+		{
+			uint32_t off = dsp_pc - DSP_WORK_RAM_BASE;
+			ds_opcode = ((uint16_t)dsp_ram_8[off] << 8) | (uint16_t)dsp_ram_8[off + 1];
+		}
+		else
+			ds_opcode = DSPReadWord(dsp_pc, DSP);
+		ds_index = ds_opcode >> 10;
+		dsp_opcode_first_parameter  = (ds_opcode >> 5) & 0x1F;
+		dsp_opcode_second_parameter = ds_opcode & 0x1F;
+		dsp_pc += 2;
+		dsp_executeOpcode(ds_index);
 		dsp_pc = delayed_pc;
 	}
 }

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -999,17 +999,31 @@ INLINE static void executeOpcode(uint32_t index) {
 
 INLINE static void gpu_opcode_jump(void)
 {
-   // normalize flags
-   /*	gpu_flag_c = (gpu_flag_c ? 1 : 0);
-      gpu_flag_z = (gpu_flag_z ? 1 : 0);
-      gpu_flag_n = (gpu_flag_n ? 1 : 0);*/
-   // KLUDGE: Used by BRANCH_CONDITION
+   /* normalize flags */
+   /* KLUDGE: Used by BRANCH_CONDITION */
    uint32_t jaguar_flags = (gpu_flag_n << 2) | (gpu_flag_c << 1) | gpu_flag_z;
 
    if (BRANCH_CONDITION(IMM_2))
    {
       uint32_t delayed_pc = RM;
-      GPUExec(1);
+      uint16_t ds_opcode;
+      uint32_t ds_index;
+      /* Inline delay-slot: fetch-decode-execute one instruction at current
+       * PC before applying the branch target.  This replaces the old
+       * recursive GPUExec(1) call, avoiding full function-call overhead,
+       * redundant IRQ checks, and pipeline-state save/restore. */
+      if (gpu_pc >= GPU_WORK_RAM_BASE && gpu_pc < GPU_WORK_RAM_BASE + 0x1000)
+      {
+         uint32_t off = gpu_pc - GPU_WORK_RAM_BASE;
+         ds_opcode = ((uint16_t)gpu_ram_8[off] << 8) | (uint16_t)gpu_ram_8[off + 1];
+      }
+      else
+         ds_opcode = GPUReadWord(gpu_pc, GPU);
+      ds_index = ds_opcode >> 10;
+      gpu_opcode_first_parameter  = (ds_opcode >> 5) & 0x1F;
+      gpu_opcode_second_parameter = ds_opcode & 0x1F;
+      gpu_pc += 2;
+      executeOpcode(ds_index);
       gpu_pc = delayed_pc;
    }
 }
@@ -1021,9 +1035,25 @@ INLINE static void gpu_opcode_jr(void)
 
    if (BRANCH_CONDITION(IMM_2))
    {
-      int32_t offset     = ((IMM_1 & 0x10) ? 0xFFFFFFF0 | IMM_1 : IMM_1);		// Sign extend IMM_1
+      int32_t offset     = ((IMM_1 & 0x10) ? 0xFFFFFFF0 | IMM_1 : IMM_1);		/* Sign extend IMM_1 */
       int32_t delayed_pc = gpu_pc + (offset * 2);
-      GPUExec(1);
+      uint16_t ds_opcode;
+      uint32_t ds_index;
+      /* Inline delay-slot: fetch-decode-execute one instruction at current
+       * PC before applying the branch target.  Same rationale as in
+       * gpu_opcode_jump above. */
+      if (gpu_pc >= GPU_WORK_RAM_BASE && gpu_pc < GPU_WORK_RAM_BASE + 0x1000)
+      {
+         uint32_t off = gpu_pc - GPU_WORK_RAM_BASE;
+         ds_opcode = ((uint16_t)gpu_ram_8[off] << 8) | (uint16_t)gpu_ram_8[off + 1];
+      }
+      else
+         ds_opcode = GPUReadWord(gpu_pc, GPU);
+      ds_index = ds_opcode >> 10;
+      gpu_opcode_first_parameter  = (ds_opcode >> 5) & 0x1F;
+      gpu_opcode_second_parameter = ds_opcode & 0x1F;
+      gpu_pc += 2;
+      executeOpcode(ds_index);
       gpu_pc = delayed_pc;
    }
 }


### PR DESCRIPTION
## Summary
- Replaces recursive `GPUExec(1)` / `DSPExec(1)` calls in branch delay slots with inline fetch-decode-execute
- Eliminates per-delay-slot overhead: function call, redundant IRQ checks, `gpu_in_exec` increment/decrement, `releaseTimeSlice_flag` reset, `GPU_RUNNING` loop check
- Delay-slot code inlines in `gpu_opcode_jump()`, `gpu_opcode_jr()`, `dsp_opcode_jump()`, `dsp_opcode_jr()` — 4 sites total
- Fast path reads directly from local RAM array; fallback uses `GPUReadWord`/`DSPReadWord`

## Test plan
- [x] `make -j12` — clean build, zero warnings
- [x] `bash scripts/c89-lint.sh src/tom/gpu.c src/jerry/dsp.c` — passed
- [x] `make test` — all tests pass
- [ ] `make benchmark` — compare FPS before/after
- [ ] Test branch-heavy games (AvP, Doom, Tempest 2000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)