### PR TITLE
acid(blitter): promote 1/2/4bpp phrase-mode tests to real blits

### DIFF
--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -1,6 +1,6 @@
-[FAIL tests/blitter/copy_pix1_phrase.jag
-[FAIL tests/blitter/copy_pix2_phrase.jag
-[FAIL tests/blitter/copy_pix4_phrase.jag
+[PASS tests/blitter/copy_pix1_phrase.jag
+[PASS tests/blitter/copy_pix2_phrase.jag
+[PASS tests/blitter/copy_pix4_phrase.jag
 [FAIL tests/blitter/pattern_fill.jag
 [FAIL tests/bus/bus_blitter_starves_cpu.jag
 [FAIL tests/bus/bus_cpu_starves_blitter.jag

--- a/test/acid/tests/blitter/copy_pix1_phrase.s
+++ b/test/acid/tests/blitter/copy_pix1_phrase.s
@@ -1,23 +1,69 @@
 ;
 ; tests/blitter/copy_pix1_phrase.s - 1bpp phrase-mode copy.
 ;
-; **DELIBERATE FAIL PLACEHOLDER**: any actual 1bpp blit (pixsize=0)
-; on the accurate blitter hangs forever inside BlitterMidsummer2.
-; Same root cause as copy_pix2_phrase -- low pixsizes wedge the
-; state machine.  Documented as a real emulator bug.
+; 2 phrases (16 bytes = 128 px @ 1bpp).
 ;
-; To turn this into a real test once the blitter bug is fixed,
-; replace the ACID_FAIL with the SRC fill / blit / verify pattern
-; from copy_pix4_phrase.s (which works correctly for 4bpp).
+; FLAGS:
+;   pixsize=0 (1bpp):  bits 3..5 = 000 -> $00000000
+;   width 128 (m=0,e=4): bits 11..14 = 0100 -> $00002000
+;   xadd=PHR (0):      bits 16..17 = 00  -> $00000000
+;   pitch=0 (1):       bits 0..1 = 00
+;   ----------------------------- $00002000
 ;
 ; Detail codes:
-;   99 = placeholder, real test pending blitter fix
+;   N (1..4) = first mismatched longword index
 ;
                 include "include/jaguar_header.s"
                 include "include/acid_test.s"
                 include "include/jaguar_regs.s"
 
+SRC             equ     $00080000
+DST             equ     $00090000
+N_LONGS         equ     4               ; 16 bytes = 2 phrases = 128 px @ 1bpp
+
+FLAGS           equ     $00002000
+COUNT_VAL       equ     $00010080       ; outer=1, inner=128
+
                 org     $802000
 entry:
                 ACID_INIT
-                ACID_FAIL #99,#0,#0
+
+                ;; Pre-fill SRC with a known recognizable pattern.
+                lea     SRC.l,a0
+                move.l  #N_LONGS-1,d0
+                move.l  #$F0F0A5A5,d1
+.fill:          move.l  d1,(a0)+
+                ror.l   #8,d1
+                dbra    d0,.fill
+
+                ;; Pre-fill DST with sentinel.
+                lea     DST.l,a0
+                move.l  #N_LONGS-1,d0
+.sent:          move.l  #$00000000,(a0)+
+                dbra    d0,.sent
+
+                ;; Configure blitter: SRC->DST 1bpp phrase mode.
+                move.l  #DST,B_A1_BASE
+                move.l  #FLAGS,B_A1_FLAGS
+                move.l  #0,B_A1_PIXEL
+                move.l  #SRC,B_A2_BASE
+                move.l  #FLAGS,B_A2_FLAGS
+                move.l  #0,B_A2_PIXEL
+                move.l  #COUNT_VAL,B_PIXLINECOUNTER
+                move.l  #SRCEN|LFU_FN_C,B_COMMAND
+
+                ;; Compare SRC vs DST longword-by-longword.
+                lea     SRC.l,a0
+                lea     DST.l,a1
+                move.l  #N_LONGS-1,d2
+                moveq   #1,d3
+.cmp:           move.l  (a0)+,d4
+                move.l  (a1)+,d5
+                cmp.l   d4,d5
+                bne     .bad
+                addq.l  #1,d3
+                dbra    d2,.cmp
+
+                ACID_PASS
+
+.bad:           ACID_FAIL d3,d5,d4

--- a/test/acid/tests/blitter/copy_pix2_phrase.s
+++ b/test/acid/tests/blitter/copy_pix2_phrase.s
@@ -1,25 +1,69 @@
 ;
 ; tests/blitter/copy_pix2_phrase.s - 2bpp phrase-mode copy.
 ;
-; **DELIBERATE FAIL PLACEHOLDER**: any actual 2bpp blit (pixsize=1)
-; on the accurate blitter hangs forever inside BlitterMidsummer2 --
-; tested with inner counts of 4, 16, 64, and 256 pixels; all hang
-; the runner indefinitely.  This is a real emulator bug surfaced by
-; the acid suite.  Until it's fixed, this test reports FAIL
-; immediately so the rest of the suite can complete without hanging.
+; 4 phrases (32 bytes = 128 px @ 2bpp).
 ;
-; To turn this into a real test once the blitter bug is fixed:
-; replace the ACID_FAIL with the SRC fill / blit / verify pattern
-; from copy_pix4_phrase.s (which works correctly for 4bpp).
+; FLAGS:
+;   pixsize=1 (2bpp):  bits 3..5 = 001 -> $00000008
+;   width 128 (m=0,e=4): bits 11..14 = 0100 -> $00002000
+;   xadd=PHR (0):      bits 16..17 = 00  -> $00000000
+;   pitch=0 (1):       bits 0..1 = 00
+;   ----------------------------- $00002008
 ;
 ; Detail codes:
-;   99 = placeholder, real test pending blitter fix
+;   N (1..8) = first mismatched longword index
 ;
                 include "include/jaguar_header.s"
                 include "include/acid_test.s"
                 include "include/jaguar_regs.s"
 
+SRC             equ     $00080000
+DST             equ     $00090000
+N_LONGS         equ     8               ; 32 bytes = 4 phrases = 128 px @ 2bpp
+
+FLAGS           equ     $00002008
+COUNT_VAL       equ     $00010080       ; outer=1, inner=128
+
                 org     $802000
 entry:
                 ACID_INIT
-                ACID_FAIL #99,#0,#0
+
+                ;; Pre-fill SRC with a known recognizable pattern.
+                lea     SRC.l,a0
+                move.l  #N_LONGS-1,d0
+                move.l  #$AABBCCDD,d1
+.fill:          move.l  d1,(a0)+
+                add.l   #$01010101,d1
+                dbra    d0,.fill
+
+                ;; Pre-fill DST with sentinel.
+                lea     DST.l,a0
+                move.l  #N_LONGS-1,d0
+.sent:          move.l  #$55555555,(a0)+
+                dbra    d0,.sent
+
+                ;; Configure blitter: SRC->DST 2bpp phrase mode.
+                move.l  #DST,B_A1_BASE
+                move.l  #FLAGS,B_A1_FLAGS
+                move.l  #0,B_A1_PIXEL
+                move.l  #SRC,B_A2_BASE
+                move.l  #FLAGS,B_A2_FLAGS
+                move.l  #0,B_A2_PIXEL
+                move.l  #COUNT_VAL,B_PIXLINECOUNTER
+                move.l  #SRCEN|LFU_FN_C,B_COMMAND
+
+                ;; Compare SRC vs DST longword-by-longword.
+                lea     SRC.l,a0
+                lea     DST.l,a1
+                move.l  #N_LONGS-1,d2
+                moveq   #1,d3
+.cmp:           move.l  (a0)+,d4
+                move.l  (a1)+,d5
+                cmp.l   d4,d5
+                bne     .bad
+                addq.l  #1,d3
+                dbra    d2,.cmp
+
+                ACID_PASS
+
+.bad:           ACID_FAIL d3,d5,d4

--- a/test/acid/tests/blitter/copy_pix4_phrase.s
+++ b/test/acid/tests/blitter/copy_pix4_phrase.s
@@ -1,22 +1,69 @@
 ;
 ; tests/blitter/copy_pix4_phrase.s - 4bpp phrase-mode copy.
 ;
-; **DELIBERATE FAIL PLACEHOLDER**: 4bpp phrase blits with the full
-; 128-pixel inner count hang BlitterMidsummer2.  Same root cause as
-; copy_pix1_phrase / copy_pix2_phrase -- low-pixsize phrase blits
-; wedge the state machine.  Test deferred until the blitter loop is
-; fixed.  copy_pix8_phrase / copy_pix16_phrase / copy_pix32_phrase
-; all PASS, so the issue is specifically with pixsize <= 2 (= 4bpp,
-; 2bpp, 1bpp).
+; 8 phrases (64 bytes = 128 px @ 4bpp).
+;
+; FLAGS:
+;   pixsize=2 (4bpp):  bits 3..5 = 010 -> $00000010
+;   width 128 (m=0,e=4): bits 11..14 = 0100 -> $00002000
+;   xadd=PHR (0):      bits 16..17 = 00  -> $00000000
+;   pitch=0 (1):       bits 0..1 = 00
+;   ----------------------------- $00002010
 ;
 ; Detail codes:
-;   99 = placeholder, real test pending blitter fix
+;   N (1..16) = first mismatched longword index
 ;
                 include "include/jaguar_header.s"
                 include "include/acid_test.s"
                 include "include/jaguar_regs.s"
 
+SRC             equ     $00080000
+DST             equ     $00090000
+N_LONGS         equ     16              ; 64 bytes = 8 phrases = 128 px @ 4bpp
+
+FLAGS           equ     $00002010
+COUNT_VAL       equ     $00010080       ; outer=1, inner=128
+
                 org     $802000
 entry:
                 ACID_INIT
-                ACID_FAIL #99,#0,#0
+
+                ;; Pre-fill SRC with a known recognizable pattern.
+                lea     SRC.l,a0
+                move.l  #N_LONGS-1,d0
+                move.l  #$12345678,d1
+.fill:          move.l  d1,(a0)+
+                add.l   #$11111111,d1
+                dbra    d0,.fill
+
+                ;; Pre-fill DST with sentinel so a partial copy is visible.
+                lea     DST.l,a0
+                move.l  #N_LONGS-1,d0
+.sent:          move.l  #$A5A55A5A,(a0)+
+                dbra    d0,.sent
+
+                ;; Configure blitter: SRC->DST 4bpp phrase mode.
+                move.l  #DST,B_A1_BASE
+                move.l  #FLAGS,B_A1_FLAGS
+                move.l  #0,B_A1_PIXEL
+                move.l  #SRC,B_A2_BASE
+                move.l  #FLAGS,B_A2_FLAGS
+                move.l  #0,B_A2_PIXEL
+                move.l  #COUNT_VAL,B_PIXLINECOUNTER
+                move.l  #SRCEN|LFU_FN_C,B_COMMAND
+
+                ;; Compare SRC vs DST longword-by-longword.
+                lea     SRC.l,a0
+                lea     DST.l,a1
+                move.l  #N_LONGS-1,d2
+                moveq   #1,d3
+.cmp:           move.l  (a0)+,d4
+                move.l  (a1)+,d5
+                cmp.l   d4,d5
+                bne     .bad
+                addq.l  #1,d3
+                dbra    d2,.cmp
+
+                ACID_PASS
+
+.bad:           ACID_FAIL d3,d5,d4


### PR DESCRIPTION
## Summary
- Replace three ACID_FAIL #99 placeholders with real SRC→DST copy-and-verify tests
- `copy_pix1_phrase`: 1bpp, 2 phrases (128 pixels)
- `copy_pix2_phrase`: 2bpp, 4 phrases (128 pixels)
- `copy_pix4_phrase`: 4bpp, 8 phrases (128 pixels)
- BASELINE.txt updated: 3 tests promoted FAIL→PASS

These tests were placeholders because the accurate blitter (`BlitterMidsummer2`) used to hang forever for pixsize ≤ 2 in phrase mode. PR #142's generalized formula (`ppp = 64 >> pixsize`) fixed the root cause. This PR validates the fix with real blit-and-verify tests.

## Test plan
- [x] C89 lint passes
- [x] `make test` — all tests pass
- [x] Acid suite: 3 tests promoted from FAIL to PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)