### PR TITLE
fix(pit): use half-system-clock rate (13.3 MHz) for PIT timers

### DIFF
--- a/src/jerry/jerry.c
+++ b/src/jerry/jerry.c
@@ -223,9 +223,14 @@ void JERRYResetPIT1(void)
 
    if (JERRYPIT1Prescaler | JERRYPIT1Divider)
    {
-      /* Period = (prescaler+1)*(divider+1) * RISC_CYCLE_{NTSC,PAL}. */
+      /*
+       * The JTRM Software Reference says PIT divides the "processor
+       * clock" (26.59 MHz), but games like Doom were programmed
+       * assuming the half-rate (13.3 MHz).  Using M68K_CYCLE matches
+       * observed game behavior and other emulators.
+       */
       double usecs = (double)(JERRYPIT1Prescaler + 1) * (double)(JERRYPIT1Divider + 1)
-         * (vjs.hardwareTypeNTSC ? RISC_CYCLE_IN_USEC : RISC_CYCLE_PAL_IN_USEC);
+         * (vjs.hardwareTypeNTSC ? M68K_CYCLE_IN_USEC : M68K_CYCLE_PAL_IN_USEC);
       SetCallbackTime(JERRYPIT1Callback, usecs, EVENT_JERRY);
    }
 }
@@ -237,8 +242,14 @@ void JERRYResetPIT2(void)
 
    if (JERRYPIT2Prescaler | JERRYPIT2Divider)
    {
+      /*
+       * The JTRM Software Reference says PIT divides the "processor
+       * clock" (26.59 MHz), but games like Doom were programmed
+       * assuming the half-rate (13.3 MHz).  Using M68K_CYCLE matches
+       * observed game behavior and other emulators.
+       */
       double usecs = (double)(JERRYPIT2Prescaler + 1) * (double)(JERRYPIT2Divider + 1)
-         * (vjs.hardwareTypeNTSC ? RISC_CYCLE_IN_USEC : RISC_CYCLE_PAL_IN_USEC);
+         * (vjs.hardwareTypeNTSC ? M68K_CYCLE_IN_USEC : M68K_CYCLE_PAL_IN_USEC);
       SetCallbackTime(JERRYPIT2Callback, usecs, EVENT_JERRY);
    }
 }

--- a/src/jerry/jerry.c
+++ b/src/jerry/jerry.c
@@ -217,18 +217,22 @@ void JERRYResetI2S(void)
 }
 
 
+/*
+ * PIT clock rate: The JTRM Software Reference says PIT divides the
+ * "processor clock" (26.59 MHz), but games like Doom were programmed
+ * assuming the half-rate (13.3 MHz).  Using M68K_CYCLE_IN_USEC for
+ * scheduling and M68K_CLOCK_RATE for frequency helpers matches observed
+ * game behavior and other emulators.  TOMResetPIT() in tom.c uses the
+ * same convention.
+ */
+
 void JERRYResetPIT1(void)
 {
    RemoveCallback(JERRYPIT1Callback);
 
    if (JERRYPIT1Prescaler | JERRYPIT1Divider)
    {
-      /*
-       * The JTRM Software Reference says PIT divides the "processor
-       * clock" (26.59 MHz), but games like Doom were programmed
-       * assuming the half-rate (13.3 MHz).  Using M68K_CYCLE matches
-       * observed game behavior and other emulators.
-       */
+      /* See PIT clock rate note above. */
       double usecs = (double)(JERRYPIT1Prescaler + 1) * (double)(JERRYPIT1Divider + 1)
          * (vjs.hardwareTypeNTSC ? M68K_CYCLE_IN_USEC : M68K_CYCLE_PAL_IN_USEC);
       SetCallbackTime(JERRYPIT1Callback, usecs, EVENT_JERRY);
@@ -242,12 +246,7 @@ void JERRYResetPIT2(void)
 
    if (JERRYPIT2Prescaler | JERRYPIT2Divider)
    {
-      /*
-       * The JTRM Software Reference says PIT divides the "processor
-       * clock" (26.59 MHz), but games like Doom were programmed
-       * assuming the half-rate (13.3 MHz).  Using M68K_CYCLE matches
-       * observed game behavior and other emulators.
-       */
+      /* See PIT clock rate note above. */
       double usecs = (double)(JERRYPIT2Prescaler + 1) * (double)(JERRYPIT2Divider + 1)
          * (vjs.hardwareTypeNTSC ? M68K_CYCLE_IN_USEC : M68K_CYCLE_PAL_IN_USEC);
       SetCallbackTime(JERRYPIT2Callback, usecs, EVENT_JERRY);
@@ -649,14 +648,16 @@ void JERRYWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
 
 int JERRYGetPIT1Frequency(void)
 {
-   int systemClockFrequency = (vjs.hardwareTypeNTSC ? RISC_CLOCK_RATE_NTSC : RISC_CLOCK_RATE_PAL);
+   /* Use M68K_CLOCK_RATE to match M68K_CYCLE_IN_USEC scheduling; see PIT clock rate note. */
+   int systemClockFrequency = (vjs.hardwareTypeNTSC ? M68K_CLOCK_RATE_NTSC : M68K_CLOCK_RATE_PAL);
    return systemClockFrequency / ((JERRYPIT1Prescaler + 1) * (JERRYPIT1Divider + 1));
 }
 
 
 int JERRYGetPIT2Frequency(void)
 {
-   int systemClockFrequency = (vjs.hardwareTypeNTSC ? RISC_CLOCK_RATE_NTSC : RISC_CLOCK_RATE_PAL);
+   /* Use M68K_CLOCK_RATE to match M68K_CYCLE_IN_USEC scheduling; see PIT clock rate note. */
+   int systemClockFrequency = (vjs.hardwareTypeNTSC ? M68K_CLOCK_RATE_NTSC : M68K_CLOCK_RATE_PAL);
    return systemClockFrequency / ((JERRYPIT2Prescaler + 1) * (JERRYPIT2Divider + 1));
 }
 

--- a/src/jerry/jerry.c
+++ b/src/jerry/jerry.c
@@ -650,7 +650,10 @@ int JERRYGetPIT1Frequency(void)
 {
    /* Use M68K_CLOCK_RATE to match M68K_CYCLE_IN_USEC scheduling; see PIT clock rate note. */
    int systemClockFrequency = (vjs.hardwareTypeNTSC ? M68K_CLOCK_RATE_NTSC : M68K_CLOCK_RATE_PAL);
-   return systemClockFrequency / ((JERRYPIT1Prescaler + 1) * (JERRYPIT1Divider + 1));
+   int64_t divisor = (int64_t)(JERRYPIT1Prescaler + 1) * (int64_t)(JERRYPIT1Divider + 1);
+   if (divisor == 0)
+      return 0;
+   return (int)(systemClockFrequency / divisor);
 }
 
 
@@ -658,7 +661,10 @@ int JERRYGetPIT2Frequency(void)
 {
    /* Use M68K_CLOCK_RATE to match M68K_CYCLE_IN_USEC scheduling; see PIT clock rate note. */
    int systemClockFrequency = (vjs.hardwareTypeNTSC ? M68K_CLOCK_RATE_NTSC : M68K_CLOCK_RATE_PAL);
-   return systemClockFrequency / ((JERRYPIT2Prescaler + 1) * (JERRYPIT2Divider + 1));
+   int64_t divisor = (int64_t)(JERRYPIT2Prescaler + 1) * (int64_t)(JERRYPIT2Divider + 1);
+   if (divisor == 0)
+      return 0;
+   return (int)(systemClockFrequency / divisor);
 }
 
 #include "state.h"

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -1281,7 +1281,6 @@ void TOMSetIRQLatch(int irq, int enabled)
  * observed game behavior and other emulators.  See also jerry.c.
  */
 
-/* NEW: */
 /* TOM Programmable Interrupt Timer handler */
 /* NOTE: TOM's PIT is only enabled if the prescaler is != 0 */
 /*       The PIT only generates an interrupt when it counts down to zero, not when loaded! */

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -1296,9 +1296,14 @@ void TOMResetPIT(void)
 
    if (tomTimerPrescaler)
    {
-      /* Period = (prescaler+1)*(divider+1) * RISC_CYCLE_{NTSC,PAL}. */
+      /*
+       * The JTRM Software Reference says PIT divides the "processor
+       * clock" (26.59 MHz), but games like Doom were programmed
+       * assuming the half-rate (13.3 MHz).  Using M68K_CYCLE matches
+       * observed game behavior and other emulators.
+       */
       double usecs = (double)(tomTimerPrescaler + 1) * (double)(tomTimerDivider + 1)
-         * (vjs.hardwareTypeNTSC ? RISC_CYCLE_IN_USEC : RISC_CYCLE_PAL_IN_USEC);
+         * (vjs.hardwareTypeNTSC ? M68K_CYCLE_IN_USEC : M68K_CYCLE_PAL_IN_USEC);
       SetCallbackTime(TOMPITCallback, usecs, EVENT_MAIN);
    }
 #endif

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -1274,10 +1274,17 @@ void TOMSetIRQLatch(int irq, int enabled)
 }
 
 
-// NEW:
-// TOM Programmable Interrupt Timer handler
-// NOTE: TOM's PIT is only enabled if the prescaler is != 0
-//       The PIT only generates an interrupt when it counts down to zero, not when loaded!
+/*
+ * PIT clock rate: The JTRM Software Reference says PIT divides the
+ * "processor clock" (26.59 MHz), but games like Doom were programmed
+ * assuming the half-rate (13.3 MHz).  Using M68K_CYCLE_IN_USEC matches
+ * observed game behavior and other emulators.  See also jerry.c.
+ */
+
+/* NEW: */
+/* TOM Programmable Interrupt Timer handler */
+/* NOTE: TOM's PIT is only enabled if the prescaler is != 0 */
+/*       The PIT only generates an interrupt when it counts down to zero, not when loaded! */
 
 void TOMPITCallback(void);
 
@@ -1285,23 +1292,18 @@ void TOMPITCallback(void);
 void TOMResetPIT(void)
 {
 #ifndef NEW_TIMER_SYSTEM
-   // Add the next period to the counter; +1 is specified by the JTRM.
-   //There is a small problem with this approach: If both the prescaler and the divider are equal
-   //to $FFFF then the counter won't be large enough to handle it. !!! FIX !!!
+   /* Add the next period to the counter; +1 is specified by the JTRM. */
+   /* There is a small problem with this approach: If both the prescaler and the divider are
+      equal to $FFFF then the counter won't be large enough to handle it. !!! FIX !!! */
    if (tom_timer_prescaler)
       tom_timer_counter += (1 + tom_timer_prescaler) * (1 + tom_timer_divider);
 #else
-   // Need to remove previous timer from the queue, if it exists...
+   /* Need to remove previous timer from the queue, if it exists... */
    RemoveCallback(TOMPITCallback);
 
    if (tomTimerPrescaler)
    {
-      /*
-       * The JTRM Software Reference says PIT divides the "processor
-       * clock" (26.59 MHz), but games like Doom were programmed
-       * assuming the half-rate (13.3 MHz).  Using M68K_CYCLE matches
-       * observed game behavior and other emulators.
-       */
+      /* See PIT clock rate note above. */
       double usecs = (double)(tomTimerPrescaler + 1) * (double)(tomTimerDivider + 1)
          * (vjs.hardwareTypeNTSC ? M68K_CYCLE_IN_USEC : M68K_CYCLE_PAL_IN_USEC);
       SetCallbackTime(TOMPITCallback, usecs, EVENT_MAIN);

--- a/test/acid/tests/timing/pit_countdown_rate.s
+++ b/test/acid/tests/timing/pit_countdown_rate.s
@@ -3,25 +3,25 @@
 ; at the rate determined by its prescaler/divider, within +/- 5%.
 ;
 ; Per src/jerry/jerry.c:
-;     usecs = (prescaler+1) * (divider+1) * RISC_CYCLE_IN_USEC
-; with RISC_CYCLE_IN_USEC = 1 / 26.590906 MHz ~= 0.0376 us/cycle.
+;     usecs = (prescaler+1) * (divider+1) * M68K_CYCLE_IN_USEC
+; with M68K_CYCLE_IN_USEC = 1 / 13.295453 MHz ~= 0.0752 us/cycle.
 ;
 ; We arm with prescaler=255, divider=255:
-;     period = 256 * 256 / 26.590906e6 = ~2464.6 us per IRQ
-;     rate   = 1e6 / 2464.6 = ~405.7 Hz
+;     period = 256 * 256 / 13.295453e6 = ~4929.2 us per IRQ
+;     rate   = 1e6 / 4929.2 = ~202.9 Hz
 ;
 ; Run a calibrated 68K busy-loop window (~1 second wall clock at
 ; 13.295 MHz NTSC, same loop sizing as vblank_60hz_exact.s -- the
 ; `subq.l #1,Dn / bne.s` taken pair = 18 cycles, so 739_130 iters
 ; ~= 13.3 M cycles ~= 1.001 sec) and count IRQs.
 ;
-; Expected = BUSY_ITERS * 36 / 65536 = 739130 * 36 / 65536 = ~406.
-; At this low rate (~406 IRQs), handler overhead is negligible
-; (~0.004 sec), so a +/-5% tolerance is comfortable.
+; Expected = BUSY_ITERS * 18 / 65536 = 739130 * 18 / 65536 = ~203.
+; At this low rate (~203 IRQs), handler overhead is negligible
+; (~0.002 sec), so a +/-5% tolerance is comfortable.
 ;
 ; Detail codes:
-;   1 = IRQ count outside [386, 426] (+/-5%)
-;       observed = counter, expected = 406
+;   1 = IRQ count outside [193, 213] (+/-5%)
+;       observed = counter, expected = 203
 ;   2 = counter zero -- IRQ never delivered (wiring regression)
 ;
                 include "include/jaguar_header.s"
@@ -44,12 +44,12 @@ HW_IRQ_VECTOR   equ     $00000100
 ;; Busy loop sized to ~1 second wall (matches vblank_60hz_exact).
 BUSY_ITERS      equ     739130
 
-;; Expected IRQ count for prescaler=255, divider=255 at the RISC-rate
-;; PIT clock.  At ~406 IRQs/sec the handler overhead is negligible
-;; (~0.4% of the measurement window), so +/-5% is reliable.
-EXPECT_IRQS     equ     406
-LO_IRQS         equ     386                     ; -5%
-HI_IRQS         equ     426                     ; +5%
+;; Expected IRQ count for prescaler=255, divider=255 at the M68K-rate
+;; PIT clock.  At ~203 IRQs/sec the handler overhead is negligible
+;; (~0.2% of the measurement window), so +/-5% is reliable.
+EXPECT_IRQS     equ     203
+LO_IRQS         equ     193                     ; -5%
+HI_IRQS         equ     213                     ; +5%
 
 PIT_PRESCALER   equ     255
 PIT_DIVIDER     equ     255


### PR DESCRIPTION
## Summary
- Reverts JERRY PIT1/PIT2 and TOM PIT to use M68K_CYCLE_IN_USEC (13.3 MHz) instead of RISC_CYCLE_IN_USEC (26.59 MHz)
- Fixes Doom running ~2x too fast, and likely fixes music timing for games that use PIT for tempo
- Recalibrates acid test `pit_countdown_rate` from ~406 to ~203 expected IRQs

## Context
The JTRM Software Reference says PIT divides the "processor clock" (26.59 MHz), but games like Doom were programmed assuming the half-rate (13.3 MHz). Using M68K_CYCLE matches observed game behavior. PR #145 restored the full rate per JTRM but this broke game speed for PIT-dependent games.

## Test plan
- [ ] Verify Doom runs at correct speed in RetroArch
- [ ] Verify Doom music works (PIT2 drives music tempo)
- [ ] Verify Rayman timing
- [ ] Acid test pit_countdown_rate passes
- [ ] No regressions in yarc/jagniccc screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)