### PR TITLE
fix(libretro): reset statics in unload/deinit, add alloc NULL checks

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -270,6 +270,19 @@ jobs:
         $CC -O2 -Wall -o test/test_m68k_ops test/test_m68k_ops.c $LDFLAGS
         ./test/test_m68k_ops
 
+    - name: Run EEPROM lifecycle test
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
+      run: |
+        CC="${{ matrix.config.cc }}"
+        if [ "$(uname)" = "Linux" ]; then LDFLAGS="-ldl"; else LDFLAGS=""; fi
+        INCFLAGS="-I. -Isrc -Isrc/core -Isrc/tom -Isrc/jerry -Ilibretro-common/include"
+        $CC -O2 -Wall -o /tmp/gen_eeprom_test_rom test/tools/gen_eeprom_test_rom.c
+        /tmp/gen_eeprom_test_rom /tmp/eeprom_lifecycle_test.j64
+        $CC -O2 -Wall -std=c99 $INCFLAGS \
+          -o test/test_eeprom_lifecycle test/test_eeprom_lifecycle.c \
+          test/harness/harness.c $LDFLAGS -lm
+        ./test/test_eeprom_lifecycle ./${{ matrix.config.artifact }} /tmp/eeprom_lifecycle_test.j64
+
     - name: Cache pinned rcheevos E2E build
       if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
       uses: actions/cache@v5

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ test/test_*
 !test/test_*.sh
 !test/test_*.py
 test/tools/test_memory_map
+test/tools/test_dsp_audio_diag
 test/tools/sram_test
 test/dump_caller
 test/dump_pc

--- a/.yamllint
+++ b/.yamllint
@@ -17,3 +17,9 @@ rules:
   line-length:
     max: 200
     level: warning
+  indentation:
+    spaces: 2
+    indent-sequences: whatever
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,12 +68,26 @@ Frame loop is event-driven (not cycle-accurate): `JaguarExecuteNew()` in `src/co
 
 Local-only RetroAchievements validation — no RA account/API/server. `test/tools/test_rcheevos_e2e.sh` downloads pinned `RCHEEVOS_REF` and verifies `rc_libretro` mapping (`RC_CONSOLE_ATARI_JAGUAR`) matches host RAM.
 
-Key harnesses:
+### Shared test harness (`test/harness/`)
+
+New tests should use `test/harness/harness.h` — a shared library that eliminates dlopen/init/run boilerplate. See the header's AGENT QUICK-START comment for a full example. Key features:
+- Common CLI (`--json`, `--frames N`, `--bios`, `--option K=V`, `--quiet`)
+- Automatic audio/video stats collection
+- `harness_dlsym()` for probing internal core state
+- JSON output mode for machine-parseable results
+- Probe modules: `dsp_probe.h` (DSP registers, PC escape, LTXD ratio, RAM dumps)
+
+Build: `cc -O2 -Wall -std=c99 $(INCFLAGS) -o test_foo test_foo.c test/harness/harness.c [probe.c...] -ldl -lm`
+
+To add a new probe: create `test/harness/foo_probe.h` + `.c`, resolve symbols via `harness_dlsym()`.
+
+### Key harnesses
+
 - `test/regression_test.sh` — screenshot regression vs `test/baselines/` via miniretro (built from source on first run; `MINIRETRO_BIN` env to skip the build)
+- `test/tools/test_dsp_audio_diag.c` — DSP audio diagnostic (`make dsp-diag DSP_DIAG_ROM=path`); detects PC escape, bank init failures, silent LTXD
 - `test/tools/test_memory_map.c` — asserts `SET_MEMORY_MAPS`, `SET_SUPPORT_ACHIEVEMENTS=true`, descriptor layout
 - `test/tools/test_blitter_compare` — fast vs accurate blitter diff
 - `test/test_dsp_mac40.c` — DSP 40-bit MAC accumulator (`dsp_acc40.h`)
-- `test/test_cd_boot.c` — dlsym harness for 68K regs/RAM
 - `test/sram_test.sh` — SRAM round-trip
 
 ### Performance / profiling

--- a/Makefile
+++ b/Makefile
@@ -732,7 +732,8 @@ clean:
 		test/test_subsystem_init test/test_subsystem_timeline \
 		test/test_irq_cascade test/test_boot_patterns test/test_audio_pipeline \
 		test/test_audio_clipping test/test_pit_clock_rate \
-		test/test_blitter_mmio test/tools/test_memory_map
+		test/test_blitter_mmio test/test_eeprom_lifecycle \
+		test/tools/test_memory_map
 
 # Self-contained unit tests (parser + list management + simulated
 # memory application). Does not require a ROM or a working build of
@@ -759,7 +760,7 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
 		test/test_audio_pipeline test/test_audio_clipping test/test_pit_clock_rate \
-		test/test_blitter_mmio test/tools/test_memory_map
+		test/test_blitter_mmio test/test_eeprom_lifecycle test/tools/test_memory_map
 	./test/test_cheat
 	./test/test_event_queue
 	./test/test_blitter_mmio
@@ -797,6 +798,10 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 		echo "  SKIP: Iron Soldier 2 ROM (private) not available"; \
 	fi
 	./test/tools/test_memory_map ./$(TARGET)
+	@# EEPROM lifecycle test: generates a test ROM, then exercises load/unload/reload.
+	@$(CC) -O2 -Wall -o /tmp/gen_eeprom_test_rom test/tools/gen_eeprom_test_rom.c && \
+		/tmp/gen_eeprom_test_rom /tmp/eeprom_lifecycle_test.j64 && \
+		./test/test_eeprom_lifecycle ./$(TARGET) /tmp/eeprom_lifecycle_test.j64
 
 test/test_cheat: test/test_cheat.c src/core/cheat.c src/core/cheat.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
@@ -882,6 +887,13 @@ test/tools/test_dsp_audio_diag: test/tools/test_dsp_audio_diag.c \
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_dsp_audio_diag.c \
 		test/harness/harness.c test/harness/dsp_probe.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+
+test/test_eeprom_lifecycle: test/test_eeprom_lifecycle.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_eeprom_lifecycle.c \
+		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -881,7 +881,8 @@ test/tools/test_dsp_audio_diag: test/tools/test_dsp_audio_diag.c \
 		test/harness/dsp_probe.c test/harness/dsp_probe.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_dsp_audio_diag.c \
-		test/harness/harness.c test/harness/dsp_probe.c -ldl -lm
+		test/harness/harness.c test/harness/dsp_probe.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
 endif
 
 .PHONY: clean test lint coverage benchmark acid dsp-diag

--- a/Makefile
+++ b/Makefile
@@ -875,9 +875,16 @@ test/test_audio_clipping: test/test_audio_clipping.c
 test/tools/test_memory_map: test/tools/test_memory_map.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_memory_map.c -ldl
+
+test/tools/test_dsp_audio_diag: test/tools/test_dsp_audio_diag.c \
+		test/harness/harness.c test/harness/harness.h \
+		test/harness/dsp_probe.c test/harness/dsp_probe.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/test_dsp_audio_diag.c \
+		test/harness/harness.c test/harness/dsp_probe.c -ldl -lm
 endif
 
-.PHONY: clean test lint coverage benchmark acid
+.PHONY: clean test lint coverage benchmark acid dsp-diag
 endif
 
 lint:
@@ -936,6 +943,23 @@ benchmark:
 acid:
 	$(MAKE) BENCH_PROFILE=1 TEST_EXPORTS=1 -j$(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
 	$(MAKE) -C test/acid test CORE=$(abspath $(TARGET))
+
+# `make dsp-diag` -- DSP audio diagnostic.  Builds core with TEST_EXPORTS=1,
+# compiles the harness + DSP probe, then runs the diagnostic against a ROM.
+#
+# Usage:
+#   make dsp-diag DSP_DIAG_ROM="test/roms/private/Wolfenstein 3D (1994).jag"
+#   make dsp-diag DSP_DIAG_ROM=path/to/rom.jag DSP_DIAG_FLAGS="--bios --frames 600"
+DSP_DIAG_ROM   ?= test/roms/private/Wolfenstein 3D (1994).jag
+DSP_DIAG_FLAGS ?= --dump-on-escape
+dsp-diag:
+	$(MAKE) TEST_EXPORTS=1 -j$(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o test/tools/test_dsp_audio_diag \
+		test/tools/test_dsp_audio_diag.c \
+		test/harness/harness.c test/harness/dsp_probe.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+	./test/tools/test_dsp_audio_diag ./$(TARGET) "$(DSP_DIAG_ROM)" $(DSP_DIAG_FLAGS)
 
 print-%:
 	@echo '$*=$($*)'

--- a/Makefile
+++ b/Makefile
@@ -733,7 +733,7 @@ clean:
 		test/test_irq_cascade test/test_boot_patterns test/test_audio_pipeline \
 		test/test_audio_clipping test/test_pit_clock_rate \
 		test/test_blitter_mmio test/test_eeprom_lifecycle \
-		test/tools/test_memory_map
+		test/tools/test_memory_map test/tools/test_dsp_audio_diag
 
 # Self-contained unit tests (parser + list management + simulated
 # memory application). Does not require a ROM or a working build of

--- a/exports-test.list
+++ b/exports-test.list
@@ -29,6 +29,8 @@ _TOM*
 _OP*
 _tomRam8
 _regs
+_ltxd
+_rtxd
 _sclk
 _smode
 _lowerField

--- a/libretro.c
+++ b/libretro.c
@@ -863,6 +863,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!JaguarLoadFile((uint8_t*)info->data, info->size))
    {
       LOG_ERR("[Virtual Jaguar] unsupported or invalid content format\n");
+      JaguarDone();
       free(videoBuffer);
       videoBuffer = NULL;
       free(sampleBuffer);
@@ -880,6 +881,7 @@ bool retro_load_game(const struct retro_game_info *info)
       if (!JaguarLoadFile((uint8_t*)info->data, info->size))
       {
          LOG_ERR("[Virtual Jaguar] failed to reload RAM-loaded content\n");
+         JaguarDone();
          free(videoBuffer);
          videoBuffer = NULL;
          free(sampleBuffer);
@@ -1034,10 +1036,15 @@ void retro_deinit(void)
 {
    libretro_supports_bitmasks = false;
 
-   /* Belt-and-suspenders: clear anything retro_unload_game might have
-    * missed if the frontend calls deinit without unload first. */
+   /* Belt-and-suspenders: shut down emulator subsystems if the frontend
+    * calls deinit without unload first (videoBuffer != NULL means a game
+    * was loaded and never unloaded). */
    if (videoBuffer)
+   {
+      retro_cheat_reset();
+      JaguarDone();
       free(videoBuffer);
+   }
    videoBuffer = NULL;
    if (sampleBuffer)
       free(sampleBuffer);

--- a/libretro.c
+++ b/libretro.c
@@ -821,7 +821,16 @@ bool retro_load_game(const struct retro_game_info *info)
    videoWidth           = 320;
    videoHeight          = 240;
    videoBuffer  = (uint32_t *)calloc(sizeof(uint32_t), 1024 * 512);
-   sampleBuffer = (uint16_t *)malloc(BUFMAX * sizeof(uint16_t)); //found in dac.h
+   sampleBuffer = (uint16_t *)malloc(BUFMAX * sizeof(uint16_t));
+
+   if (!videoBuffer || !sampleBuffer)
+   {
+      free(videoBuffer);
+      free(sampleBuffer);
+      videoBuffer = NULL;
+      sampleBuffer = NULL;
+      return false;
+   }
    memset(sampleBuffer, 0, BUFMAX * sizeof(uint16_t));
 
    game_width           = 320;
@@ -923,12 +932,31 @@ void retro_unload_game(void)
 {
    retro_cheat_reset();
    JaguarDone();
+
    if (videoBuffer)
       free(videoBuffer);
    videoBuffer = NULL;
    if (sampleBuffer)
-      free(sampleBuffer); //found in dac.h
+      free(sampleBuffer);
    sampleBuffer = NULL;
+
+   /* Reset all module state so a subsequent retro_load_game in the same
+    * process (iOS cannot dlclose cores) starts clean. */
+   videoWidth = 0;
+   videoHeight = 0;
+   game_width = 0;
+   game_height = 0;
+
+   eeprom_dirty_cb = NULL;
+   save_data_needs_unpack = false;
+   memset(eeprom_save_buf, 0, sizeof(eeprom_save_buf));
+
+   memset(jag_retropad, 0, sizeof(jag_retropad));
+   memset(jag_numpad, 0, sizeof(jag_numpad));
+   numpad_to_kb[0] = 0;
+   numpad_to_kb[1] = 0;
+   show_input_options = true;
+   enable_alt_inputs = false;
 }
 
 unsigned retro_get_region(void)
@@ -1005,6 +1033,22 @@ void retro_init(void)
 void retro_deinit(void)
 {
    libretro_supports_bitmasks = false;
+
+   /* Belt-and-suspenders: clear anything retro_unload_game might have
+    * missed if the frontend calls deinit without unload first. */
+   if (videoBuffer)
+      free(videoBuffer);
+   videoBuffer = NULL;
+   if (sampleBuffer)
+      free(sampleBuffer);
+   sampleBuffer = NULL;
+
+   eeprom_dirty_cb = NULL;
+   save_data_needs_unpack = false;
+   videoWidth = 0;
+   videoHeight = 0;
+   game_width = 0;
+   game_height = 0;
 }
 
 void retro_reset(void)

--- a/libretro.c
+++ b/libretro.c
@@ -1045,10 +1045,17 @@ void retro_deinit(void)
 
    eeprom_dirty_cb = NULL;
    save_data_needs_unpack = false;
+   memset(eeprom_save_buf, 0, sizeof(eeprom_save_buf));
    videoWidth = 0;
    videoHeight = 0;
    game_width = 0;
    game_height = 0;
+   memset(jag_retropad, 0, sizeof(jag_retropad));
+   memset(jag_numpad, 0, sizeof(jag_numpad));
+   numpad_to_kb[0] = 0;
+   numpad_to_kb[1] = 0;
+   show_input_options = true;
+   enable_alt_inputs = false;
 }
 
 void retro_reset(void)

--- a/link-test.T
+++ b/link-test.T
@@ -32,6 +32,8 @@
       OP*;
       tomRam8;
       regs;
+      ltxd;
+      rtxd;
       sclk;
       smode;
       lowerField;

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -764,6 +764,11 @@ uint8_t * DSPGetRAM(void)
 	return dsp_ram_8;
 }
 
+uint32_t DSPGetFlags(void)
+{
+	return dsp_flags;
+}
+
 void DSPInit(void)
 {
 	dsp_build_branch_condition_table();

--- a/src/jerry/dsp.h
+++ b/src/jerry/dsp.h
@@ -31,6 +31,7 @@ void DSPWriteLong(uint32_t offset, uint32_t data, uint32_t who);
 void DSPReleaseTimeslice(void);
 bool DSPIsRunning(void);
 uint8_t *DSPGetRAM(void);
+uint32_t DSPGetFlags(void);
 
 void DSPExecP(int32_t cycles);
 void DSPExecP2(int32_t cycles);

--- a/test/harness/dsp_probe.c
+++ b/test/harness/dsp_probe.c
@@ -16,8 +16,8 @@ bool dsp_probe_init(dsp_probe *p, harness_config *cfg)
     p->sym.control   = harness_dlsym(cfg, "dsp_control");
     p->sym.bank0     = harness_dlsym(cfg, "dsp_reg_bank_0");
     p->sym.bank1     = harness_dlsym(cfg, "dsp_reg_bank_1");
-    p->sym.get_ram   = harness_dlsym(cfg, "DSPGetRAM");
-    p->sym.is_running = harness_dlsym(cfg, "DSPIsRunning");
+    p->sym.get_ram   = (uint8_t *(*)(void))harness_dlsym(cfg, "DSPGetRAM");
+    p->sym.is_running = (bool (*)(void))harness_dlsym(cfg, "DSPIsRunning");
     p->sym.get_flags = (uint32_t (*)(void))harness_dlsym(cfg, "DSPGetFlags");
     p->sym.ltxd      = (uint16_t **)harness_dlsym(cfg, "ltxd");
     p->sym.i2s_timer = harness_dlsym(cfg, "JERRYI2SInterruptTimer");

--- a/test/harness/dsp_probe.c
+++ b/test/harness/dsp_probe.c
@@ -126,6 +126,11 @@ void dsp_probe_dump_ram(const dsp_probe *p, uint32_t addr, unsigned words)
     }
 
     ram = p->sym.get_ram();
+
+    if (addr < DSP_WORK_RAM_BASE || addr > DSP_WORK_RAM_END) {
+        printf("  DSP RAM dump around $%06X: (outside DSP RAM)\n", addr);
+        return;
+    }
     offset = addr - DSP_WORK_RAM_BASE;
 
     printf("  DSP RAM dump around $%06X:\n", addr);

--- a/test/harness/dsp_probe.c
+++ b/test/harness/dsp_probe.c
@@ -1,0 +1,197 @@
+/*
+ * test/harness/dsp_probe.c — DSP state inspection probe implementation.
+ */
+
+#include "dsp_probe.h"
+
+#include <stdio.h>
+#include <string.h>
+
+bool dsp_probe_init(dsp_probe *p, harness_config *cfg)
+{
+    memset(p, 0, sizeof(*p));
+    p->cfg = cfg;
+
+    p->sym.pc        = harness_dlsym(cfg, "dsp_pc");
+    p->sym.control   = harness_dlsym(cfg, "dsp_control");
+    p->sym.bank0     = harness_dlsym(cfg, "dsp_reg_bank_0");
+    p->sym.bank1     = harness_dlsym(cfg, "dsp_reg_bank_1");
+    p->sym.get_ram   = harness_dlsym(cfg, "DSPGetRAM");
+    p->sym.is_running = harness_dlsym(cfg, "DSPIsRunning");
+    p->sym.get_flags = (uint32_t (*)(void))harness_dlsym(cfg, "DSPGetFlags");
+    p->sym.ltxd      = (uint16_t **)harness_dlsym(cfg, "ltxd");
+    p->sym.i2s_timer = harness_dlsym(cfg, "JERRYI2SInterruptTimer");
+
+    /* Critical: need at minimum PC and one register bank */
+    if (!p->sym.pc || !p->sym.bank0) {
+        fprintf(stderr, "dsp_probe: cannot resolve critical DSP symbols "
+                "(build with TEST_EXPORTS=1)\n");
+        return false;
+    }
+
+    return true;
+}
+
+void dsp_probe_snapshot(dsp_probe *p)
+{
+    dsp_snapshot *s = &p->snap;
+
+    s->frame = p->cfg->current_frame;
+    s->pc = p->sym.pc ? *p->sym.pc : 0;
+    s->control = p->sym.control ? *p->sym.control : 0;
+    s->running = p->sym.is_running ? p->sym.is_running() : 0;
+
+    if (p->sym.get_flags)
+        s->flags = p->sym.get_flags();
+    else
+        s->flags = 0;
+
+    if (p->sym.bank0)
+        memcpy(s->bank0, p->sym.bank0, DSP_NUM_REGS * sizeof(uint32_t));
+    if (p->sym.bank1)
+        memcpy(s->bank1, p->sym.bank1, DSP_NUM_REGS * sizeof(uint32_t));
+
+    if (p->sym.ltxd && *p->sym.ltxd)
+        s->ltxd_value = (int16_t)**p->sym.ltxd;
+    else
+        s->ltxd_value = 0;
+
+    if (p->sym.i2s_timer)
+        s->i2s_timer = *p->sym.i2s_timer;
+    else
+        s->i2s_timer = -1;
+
+    /* Store in history ring */
+    p->history[p->history_idx] = *s;
+    p->history_idx = (p->history_idx + 1) % 64;
+    if (p->history_count < 64) p->history_count++;
+}
+
+bool dsp_probe_pc_escaped(const dsp_probe *p)
+{
+    uint32_t pc = p->snap.pc;
+    if (!p->snap.running) return false;
+    return (pc < DSP_WORK_RAM_BASE || pc > DSP_WORK_RAM_END);
+}
+
+unsigned dsp_probe_bank_nonzero(const uint32_t bank[DSP_NUM_REGS])
+{
+    unsigned count = 0;
+    unsigned i;
+    for (i = 0; i < DSP_NUM_REGS; i++) {
+        if (bank[i] != 0) count++;
+    }
+    return count;
+}
+
+double dsp_probe_ltxd_ratio(const dsp_probe *p)
+{
+    if (p->counters.ltxd_total_samples == 0) return 0.0;
+    return (double)p->counters.ltxd_nonzero_writes /
+           (double)p->counters.ltxd_total_samples;
+}
+
+bool dsp_probe_per_frame(dsp_probe *p)
+{
+    dsp_probe_snapshot(p);
+
+    /* Count I2S activity */
+    p->counters.i2s_dispatches++;
+    p->counters.ltxd_total_samples++;
+    if (p->snap.ltxd_value != 0)
+        p->counters.ltxd_nonzero_writes++;
+
+    /* Check for PC escape */
+    if (dsp_probe_pc_escaped(p)) {
+        p->counters.pc_escape_count++;
+        if (p->counters.pc_escape_count == 1) {
+            p->counters.first_escape_pc = p->snap.pc;
+            p->counters.first_escape_frame = p->snap.frame;
+        }
+        return false;
+    }
+
+    return true;
+}
+
+void dsp_probe_dump_ram(const dsp_probe *p, uint32_t addr, unsigned words)
+{
+    uint8_t *ram;
+    unsigned i;
+    uint32_t offset;
+
+    if (!p->sym.get_ram) {
+        fprintf(stderr, "  (DSP RAM not available)\n");
+        return;
+    }
+
+    ram = p->sym.get_ram();
+    offset = addr - DSP_WORK_RAM_BASE;
+
+    printf("  DSP RAM dump around $%06X:\n", addr);
+    for (i = 0; i < words; i++) {
+        uint32_t off = offset + i * 2;
+        uint16_t opcode;
+        if (off + 1 >= DSP_RAM_SIZE) break;
+        opcode = ((uint16_t)ram[off] << 8) | (uint16_t)ram[off + 1];
+        printf("    $%06X: %04X", addr + i * 2, opcode);
+        /* Basic decode: top 6 bits = opcode, next 5 = reg1, next 5 = reg2 */
+        {
+            unsigned op = (opcode >> 10) & 0x3F;
+            unsigned r1 = (opcode >> 5) & 0x1F;
+            unsigned r2 = opcode & 0x1F;
+            printf("  (op=%2u r1=R%02u r2=R%02u)", op, r1, r2);
+        }
+        printf("\n");
+    }
+}
+
+void dsp_probe_dump_banks(const dsp_probe *p)
+{
+    unsigned i;
+    printf("  Bank0: ");
+    for (i = 0; i < DSP_NUM_REGS; i++) {
+        if (p->snap.bank0[i] != 0)
+            printf("R%02u=%08X ", i, p->snap.bank0[i]);
+    }
+    printf("\n  Bank1: ");
+    for (i = 0; i < DSP_NUM_REGS; i++) {
+        if (p->snap.bank1[i] != 0)
+            printf("R%02u=%08X ", i, p->snap.bank1[i]);
+    }
+    printf("\n");
+}
+
+void dsp_probe_print_snapshot(const dsp_probe *p, int json)
+{
+    if (json) {
+        unsigned i;
+        printf("{\"frame\":%u,\"pc\":\"0x%06X\",\"flags\":\"0x%05X\","
+               "\"control\":\"0x%08X\",\"running\":%s,\"ltxd\":%d,"
+               "\"i2s_timer\":%d,",
+               p->snap.frame, p->snap.pc, p->snap.flags,
+               p->snap.control,
+               p->snap.running ? "true" : "false",
+               p->snap.ltxd_value, p->snap.i2s_timer);
+        printf("\"bank0_nonzero\":%u,\"bank1_nonzero\":%u,",
+               dsp_probe_bank_nonzero(p->snap.bank0),
+               dsp_probe_bank_nonzero(p->snap.bank1));
+        printf("\"bank0\":[");
+        for (i = 0; i < DSP_NUM_REGS; i++)
+            printf("%s%u", i ? "," : "", p->snap.bank0[i]);
+        printf("],\"bank1\":[");
+        for (i = 0; i < DSP_NUM_REGS; i++)
+            printf("%s%u", i ? "," : "", p->snap.bank1[i]);
+        printf("]}");
+    } else {
+        printf("  Frame %u: PC=$%06X FLAGS=$%05X CTRL=$%08X %s "
+               "LTXD=%d I2S_TMR=%d\n",
+               p->snap.frame, p->snap.pc, p->snap.flags,
+               p->snap.control,
+               p->snap.running ? "RUNNING" : "STOPPED",
+               p->snap.ltxd_value, p->snap.i2s_timer);
+        printf("  Bank0: %u/32 non-zero | Bank1: %u/32 non-zero\n",
+               dsp_probe_bank_nonzero(p->snap.bank0),
+               dsp_probe_bank_nonzero(p->snap.bank1));
+    }
+}

--- a/test/harness/dsp_probe.h
+++ b/test/harness/dsp_probe.h
@@ -67,7 +67,6 @@ typedef struct {
 /* Resolved symbol pointers */
 typedef struct {
     uint32_t *pc;
-    uint32_t *flags;       /* via DSPGetFlags() accessor */
     uint32_t *control;
     uint32_t *bank0;
     uint32_t *bank1;

--- a/test/harness/dsp_probe.h
+++ b/test/harness/dsp_probe.h
@@ -1,0 +1,121 @@
+/*
+ * test/harness/dsp_probe.h — DSP state inspection probe.
+ *
+ * ======================================================================
+ * USAGE
+ * ======================================================================
+ *
+ *   #include "harness/harness.h"
+ *   #include "harness/dsp_probe.h"
+ *
+ *   dsp_probe probe;
+ *   if (!dsp_probe_init(&probe, &cfg)) return 1;
+ *
+ *   // After running frames:
+ *   dsp_probe_snapshot(&probe);
+ *   if (dsp_probe_pc_escaped(&probe))
+ *       printf("DSP PC escaped work RAM: 0x%06X\n", probe.snap.pc);
+ *
+ * ======================================================================
+ * WHAT THIS PROBES
+ * ======================================================================
+ *
+ *   - DSP PC (program counter)
+ *   - DSP FLAGS register (IMASK, REGPAGE, interrupt enables)
+ *   - DSP CONTROL register (running, interrupt latches)
+ *   - Register banks 0 and 1 (32 x uint32_t each)
+ *   - DSP RAM (8 KB at $F1B000)
+ *   - LTXD register value (audio output sample)
+ *   - I2S interrupt timer state
+ *
+ * ======================================================================
+ */
+
+#ifndef DSP_PROBE_H
+#define DSP_PROBE_H
+
+#include "harness.h"
+
+#define DSP_WORK_RAM_BASE  0x00F1B000
+#define DSP_WORK_RAM_END   0x00F1CFFF
+#define DSP_RAM_SIZE       8192
+#define DSP_NUM_REGS       32
+
+/* Snapshot of DSP state at one point in time */
+typedef struct {
+    unsigned  frame;
+    uint32_t  pc;
+    uint32_t  flags;
+    uint32_t  control;
+    uint32_t  bank0[DSP_NUM_REGS];
+    uint32_t  bank1[DSP_NUM_REGS];
+    int       running;
+    int16_t   ltxd_value;
+    int32_t   i2s_timer;
+} dsp_snapshot;
+
+/* Counters accumulated across frames */
+typedef struct {
+    unsigned  ltxd_nonzero_writes;
+    unsigned  ltxd_total_samples;
+    unsigned  i2s_dispatches;
+    unsigned  pc_escape_count;
+    uint32_t  first_escape_pc;
+    unsigned  first_escape_frame;
+} dsp_counters;
+
+/* Resolved symbol pointers */
+typedef struct {
+    uint32_t *pc;
+    uint32_t *flags;       /* via DSPGetFlags() accessor */
+    uint32_t *control;
+    uint32_t *bank0;
+    uint32_t *bank1;
+    uint8_t *(*get_ram)(void);
+    bool    (*is_running)(void);
+    uint32_t (*get_flags)(void);
+    uint16_t **ltxd;   /* points to the `uint16_t *ltxd` global */
+    int32_t  *i2s_timer;
+} dsp_symbols;
+
+typedef struct {
+    harness_config *cfg;
+    dsp_symbols     sym;
+    dsp_snapshot    snap;
+    dsp_counters    counters;
+    /* History ring buffer (last N snapshots for dump-on-failure) */
+    dsp_snapshot    history[64];
+    unsigned        history_idx;
+    unsigned        history_count;
+} dsp_probe;
+
+/* Initialize probe — resolves all DSP symbols from loaded core.
+ * Returns false if critical symbols missing. */
+bool dsp_probe_init(dsp_probe *p, harness_config *cfg);
+
+/* Take a snapshot of current DSP state. */
+void dsp_probe_snapshot(dsp_probe *p);
+
+/* Check if DSP PC is outside work RAM. */
+bool dsp_probe_pc_escaped(const dsp_probe *p);
+
+/* Count non-zero registers in a bank. */
+unsigned dsp_probe_bank_nonzero(const uint32_t bank[DSP_NUM_REGS]);
+
+/* Get LTXD non-zero ratio (0.0–1.0). */
+double dsp_probe_ltxd_ratio(const dsp_probe *p);
+
+/* Print a disassembly-style dump of DSP RAM around an address. */
+void dsp_probe_dump_ram(const dsp_probe *p, uint32_t addr, unsigned words);
+
+/* Print register bank state. */
+void dsp_probe_dump_banks(const dsp_probe *p);
+
+/* Print snapshot in human or JSON format. */
+void dsp_probe_print_snapshot(const dsp_probe *p, int json);
+
+/* Convenience: call from a per-frame callback to accumulate counters
+ * and detect escapes. Returns false if a fatal condition (PC escape). */
+bool dsp_probe_per_frame(dsp_probe *p);
+
+#endif /* DSP_PROBE_H */

--- a/test/harness/harness.c
+++ b/test/harness/harness.c
@@ -97,18 +97,15 @@ static size_t cb_audio_batch(const int16_t *data, size_t frames)
         a->first_audio_frame = (int)active_cfg->current_frame;
 
     /* Dropout detection */
-    {
-        static int was_playing = 0;
-        if (nonsilent > 0) {
-            if (!was_playing && a->first_audio_frame >= 0 &&
-                (int)active_cfg->current_frame > a->first_audio_frame + 5)
-                a->dropout_count++;
-            was_playing = 1;
-        } else {
-            if (was_playing)
-                a->silent_after_onset++;
-            was_playing = 0;
-        }
+    if (nonsilent > 0) {
+        if (!a->was_playing && a->first_audio_frame >= 0 &&
+            (int)active_cfg->current_frame > a->first_audio_frame + 5)
+            a->dropout_count++;
+        a->was_playing = 1;
+    } else {
+        if (a->was_playing)
+            a->silent_after_onset++;
+        a->was_playing = 0;
     }
 
     /* Per-frame stats */
@@ -301,10 +298,20 @@ bool harness_load_rom(harness_config *cfg)
     }
     fseek(f, 0, SEEK_END);
     rom_size = ftell(f);
+    if (rom_size <= 0) {
+        fprintf(stderr, "harness: ROM '%s' is empty or unreadable\n", cfg->rom_path);
+        fclose(f);
+        return false;
+    }
     fseek(f, 0, SEEK_SET);
     rom_data = malloc((size_t)rom_size);
     if (!rom_data) { fclose(f); return false; }
-    fread(rom_data, 1, (size_t)rom_size, f);
+    if (fread(rom_data, 1, (size_t)rom_size, f) != (size_t)rom_size) {
+        fprintf(stderr, "harness: short read on ROM '%s'\n", cfg->rom_path);
+        free(rom_data);
+        fclose(f);
+        return false;
+    }
     fclose(f);
 
     active_cfg = cfg;

--- a/test/harness/harness.c
+++ b/test/harness/harness.c
@@ -64,7 +64,7 @@ static size_t cb_audio_batch(const int16_t *data, size_t frames)
     harness_audio_stats *a;
     size_t i;
     unsigned nonsilent = 0;
-    int16_t peak_l = 0, peak_r = 0;
+    int peak_l = 0, peak_r = 0;
     double sum_sq_l = 0, sum_sq_r = 0;
 
     if (!active_cfg) return frames;
@@ -79,8 +79,8 @@ static size_t cb_audio_batch(const int16_t *data, size_t frames)
     for (i = 0; i < frames; i++) {
         int16_t l = data[i * 2];
         int16_t r = data[i * 2 + 1];
-        int16_t abs_l = (l < 0) ? (int16_t)-l : l;
-        int16_t abs_r = (r < 0) ? (int16_t)-r : r;
+        int abs_l = (l < 0) ? -((int)l) : (int)l;
+        int abs_r = (r < 0) ? -((int)r) : (int)r;
 
         if (abs_l > SILENCE_THRESHOLD || abs_r > SILENCE_THRESHOLD)
             nonsilent++;

--- a/test/harness/harness.c
+++ b/test/harness/harness.c
@@ -1,0 +1,444 @@
+/*
+ * test/harness/harness.c — Shared libretro core test harness implementation.
+ */
+
+#include "harness.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+#include <stdarg.h>
+#include <math.h>
+#include "../../libretro-common/include/libretro.h"
+
+#ifdef __APPLE__
+#define DEFAULT_CORE "virtualjaguar_libretro.dylib"
+#elif defined(_WIN32)
+#define DEFAULT_CORE "virtualjaguar_libretro.dll"
+#else
+#define DEFAULT_CORE "virtualjaguar_libretro.so"
+#endif
+
+#define SILENCE_THRESHOLD 32
+
+/* ----------------------------------------------------------------
+ * Libretro function pointers
+ * ---------------------------------------------------------------- */
+
+static void (*lr_init)(void);
+static void (*lr_deinit)(void);
+static void (*lr_set_environment)(retro_environment_t);
+static void (*lr_set_video_refresh)(retro_video_refresh_t);
+static void (*lr_set_audio_sample)(retro_audio_sample_t);
+static void (*lr_set_audio_sample_batch)(retro_audio_sample_batch_t);
+static void (*lr_set_input_poll)(retro_input_poll_t);
+static void (*lr_set_input_state)(retro_input_state_t);
+static bool (*lr_load_game)(const struct retro_game_info *);
+static void (*lr_unload_game)(void);
+static void (*lr_run)(void);
+
+/* Active config pointer (needed by callbacks which have no userdata) */
+static harness_config *active_cfg;
+
+/* ----------------------------------------------------------------
+ * Libretro callbacks
+ * ---------------------------------------------------------------- */
+
+static void cb_video(const void *data, unsigned w, unsigned h, size_t pitch)
+{
+    (void)data; (void)pitch;
+    if (!active_cfg) return;
+    active_cfg->video.total_frames_rendered++;
+    active_cfg->video.last_width = w;
+    active_cfg->video.last_height = h;
+}
+
+static void cb_audio_sample(int16_t l, int16_t r)
+{
+    (void)l; (void)r;
+}
+
+static size_t cb_audio_batch(const int16_t *data, size_t frames)
+{
+    harness_audio_stats *a;
+    size_t i;
+    unsigned nonsilent = 0;
+    int16_t peak_l = 0, peak_r = 0;
+    double sum_sq_l = 0, sum_sq_r = 0;
+
+    if (!active_cfg) return frames;
+    a = &active_cfg->audio;
+
+    a->total_batch_calls++;
+    a->total_samples += frames;
+
+    if (a->first_batch_frame < 0)
+        a->first_batch_frame = (int)active_cfg->current_frame;
+
+    for (i = 0; i < frames; i++) {
+        int16_t l = data[i * 2];
+        int16_t r = data[i * 2 + 1];
+        int16_t abs_l = (l < 0) ? (int16_t)-l : l;
+        int16_t abs_r = (r < 0) ? (int16_t)-r : r;
+
+        if (abs_l > SILENCE_THRESHOLD || abs_r > SILENCE_THRESHOLD)
+            nonsilent++;
+
+        if (abs_l > peak_l) peak_l = abs_l;
+        if (abs_r > peak_r) peak_r = abs_r;
+        sum_sq_l += (double)l * l;
+        sum_sq_r += (double)r * r;
+    }
+
+    a->total_nonsilent += nonsilent;
+
+    if (nonsilent > 0 && a->first_audio_frame < 0)
+        a->first_audio_frame = (int)active_cfg->current_frame;
+
+    /* Dropout detection */
+    {
+        static int was_playing = 0;
+        if (nonsilent > 0) {
+            if (!was_playing && a->first_audio_frame >= 0 &&
+                (int)active_cfg->current_frame > a->first_audio_frame + 5)
+                a->dropout_count++;
+            was_playing = 1;
+        } else {
+            if (was_playing)
+                a->silent_after_onset++;
+            was_playing = 0;
+        }
+    }
+
+    /* Per-frame stats */
+    if (a->frame_count < HARNESS_MAX_AUDIO_FRAMES) {
+        harness_audio_frame *af = &a->frames[a->frame_count];
+        af->frame = active_cfg->current_frame;
+        af->samples = frames;
+        af->nonsilent = nonsilent;
+        af->peak_l = peak_l;
+        af->peak_r = peak_r;
+        af->rms_l = (frames > 0) ? sqrt(sum_sq_l / (double)frames) : 0;
+        af->rms_r = (frames > 0) ? sqrt(sum_sq_r / (double)frames) : 0;
+        a->frame_count++;
+    }
+
+    return frames;
+}
+
+static void cb_input_poll(void) {}
+static int16_t cb_input_state(unsigned p, unsigned d, unsigned i, unsigned id)
+{ (void)p; (void)d; (void)i; (void)id; return 0; }
+
+static void cb_log(enum retro_log_level level, const char *fmt, ...)
+{
+    va_list ap;
+    if (level < RETRO_LOG_WARN) return;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+}
+
+static struct retro_log_callback log_cb_struct = { cb_log };
+
+static bool cb_environment(unsigned cmd, void *data)
+{
+    switch (cmd) {
+    case RETRO_ENVIRONMENT_GET_LOG_INTERFACE:
+        *(struct retro_log_callback *)data = log_cb_struct;
+        return true;
+    case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+    case RETRO_ENVIRONMENT_SET_VARIABLES:
+    case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
+    case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE:
+    case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+    case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS:
+    case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS:
+    case RETRO_ENVIRONMENT_SET_GEOMETRY:
+    case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
+    case RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER:
+        return true;
+    case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+        *(const char **)data = "/tmp";
+        return true;
+    case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+        *(const char **)data = "/tmp";
+        return true;
+    case RETRO_ENVIRONMENT_GET_VARIABLE: {
+        struct retro_variable *var = (struct retro_variable *)data;
+        unsigned i;
+        if (!var->key || !active_cfg) { var->value = NULL; return false; }
+
+        /* Check user-specified options */
+        for (i = 0; i < active_cfg->num_options; i++) {
+            if (strcmp(var->key, active_cfg->options[i].key) == 0) {
+                var->value = active_cfg->options[i].value;
+                return true;
+            }
+        }
+
+        /* Built-in defaults */
+        if (strcmp(var->key, "virtualjaguar_bios") == 0) {
+            var->value = active_cfg->use_bios ? "enabled" : "disabled";
+            return true;
+        }
+        if (strcmp(var->key, "virtualjaguar_usefastblitter") == 0) {
+            var->value = "enabled";
+            return true;
+        }
+
+        var->value = NULL;
+        return false;
+    }
+    default:
+        return false;
+    }
+}
+
+/* ----------------------------------------------------------------
+ * Public API
+ * ---------------------------------------------------------------- */
+
+bool harness_init_from_args(harness_config *cfg, int argc, char **argv)
+{
+    int i;
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--json") == 0) {
+            cfg->json_output = 1;
+        } else if (strcmp(argv[i], "--bios") == 0) {
+            cfg->use_bios = 1;
+        } else if (strcmp(argv[i], "--quiet") == 0) {
+            cfg->quiet = 1;
+        } else if (strcmp(argv[i], "--frames") == 0 && i + 1 < argc) {
+            cfg->frames = (unsigned)atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--snapshot-interval") == 0 && i + 1 < argc) {
+            cfg->snapshot_interval = (unsigned)atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--option") == 0 && i + 1 < argc) {
+            char *eq;
+            i++;
+            eq = strchr(argv[i], '=');
+            if (eq) {
+                *eq = '\0';
+                harness_set_option(cfg, argv[i], eq + 1);
+            }
+        } else if (argv[i][0] == '-') {
+            /* Unknown flag — skip. Tools pre-parse their own flags
+             * before calling harness_init_from_args. */
+            continue;
+        } else if (!cfg->core_path) {
+            /* First positional: check if it looks like a library */
+            const char *ext = strrchr(argv[i], '.');
+            if (ext && (strcmp(ext, ".dylib") == 0 ||
+                        strcmp(ext, ".so") == 0 ||
+                        strcmp(ext, ".dll") == 0)) {
+                cfg->core_path = argv[i];
+            } else {
+                /* Assume it's a ROM if no core set yet */
+                if (!cfg->rom_path)
+                    cfg->rom_path = argv[i];
+                else
+                    cfg->core_path = argv[i];
+            }
+        } else if (!cfg->rom_path) {
+            cfg->rom_path = argv[i];
+        }
+    }
+
+    if (!cfg->core_path)
+        cfg->core_path = DEFAULT_CORE;
+
+    return harness_load_core(cfg);
+}
+
+bool harness_load_core(harness_config *cfg)
+{
+    cfg->core_handle = dlopen(cfg->core_path, RTLD_NOW);
+    if (!cfg->core_handle) {
+        fprintf(stderr, "harness: dlopen(%s): %s\n", cfg->core_path, dlerror());
+        return false;
+    }
+
+    lr_init = dlsym(cfg->core_handle, "retro_init");
+    lr_deinit = dlsym(cfg->core_handle, "retro_deinit");
+    lr_set_environment = dlsym(cfg->core_handle, "retro_set_environment");
+    lr_set_video_refresh = dlsym(cfg->core_handle, "retro_set_video_refresh");
+    lr_set_audio_sample = dlsym(cfg->core_handle, "retro_set_audio_sample");
+    lr_set_audio_sample_batch = dlsym(cfg->core_handle, "retro_set_audio_sample_batch");
+    lr_set_input_poll = dlsym(cfg->core_handle, "retro_set_input_poll");
+    lr_set_input_state = dlsym(cfg->core_handle, "retro_set_input_state");
+    lr_load_game = dlsym(cfg->core_handle, "retro_load_game");
+    lr_unload_game = dlsym(cfg->core_handle, "retro_unload_game");
+    lr_run = dlsym(cfg->core_handle, "retro_run");
+
+    if (!lr_init || !lr_load_game || !lr_run) {
+        fprintf(stderr, "harness: missing required libretro symbols\n");
+        dlclose(cfg->core_handle);
+        cfg->core_handle = NULL;
+        return false;
+    }
+
+    return true;
+}
+
+bool harness_load_rom(harness_config *cfg)
+{
+    FILE *f;
+    long rom_size;
+    uint8_t *rom_data;
+    struct retro_game_info game;
+
+    if (!cfg->rom_path) {
+        fprintf(stderr, "harness: no ROM path specified\n");
+        return false;
+    }
+
+    f = fopen(cfg->rom_path, "rb");
+    if (!f) {
+        fprintf(stderr, "harness: cannot open ROM '%s'\n", cfg->rom_path);
+        return false;
+    }
+    fseek(f, 0, SEEK_END);
+    rom_size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    rom_data = malloc((size_t)rom_size);
+    if (!rom_data) { fclose(f); return false; }
+    fread(rom_data, 1, (size_t)rom_size, f);
+    fclose(f);
+
+    active_cfg = cfg;
+
+    lr_set_environment(cb_environment);
+    lr_init();
+    lr_set_video_refresh(cb_video);
+    lr_set_audio_sample(cb_audio_sample);
+    lr_set_audio_sample_batch(cb_audio_batch);
+    lr_set_input_poll(cb_input_poll);
+    lr_set_input_state(cb_input_state);
+
+    memset(&game, 0, sizeof(game));
+    game.path = cfg->rom_path;
+    game.data = rom_data;
+    game.size = (size_t)rom_size;
+
+    if (!lr_load_game(&game)) {
+        fprintf(stderr, "harness: retro_load_game failed for '%s'\n", cfg->rom_path);
+        free(rom_data);
+        return false;
+    }
+
+    /* rom_data ownership: libretro spec says core copies what it needs,
+     * but VJ keeps a pointer. We leak intentionally for test lifetime. */
+
+    harness_reset_audio(cfg);
+    return true;
+}
+
+void harness_run(harness_config *cfg)
+{
+    unsigned i;
+    active_cfg = cfg;
+    cfg->stop_requested = 0;
+
+    for (i = 0; i < cfg->frames && !cfg->stop_requested; i++) {
+        cfg->current_frame = i + 1;
+        lr_run();
+
+        if (cfg->frame_callback) {
+            if (!cfg->frame_callback(cfg->frame_callback_data, cfg->current_frame))
+                break;
+        }
+    }
+}
+
+void harness_step(harness_config *cfg)
+{
+    active_cfg = cfg;
+    cfg->current_frame++;
+    lr_run();
+}
+
+void harness_shutdown(harness_config *cfg)
+{
+    if (lr_unload_game) lr_unload_game();
+    if (lr_deinit) lr_deinit();
+    if (cfg->core_handle) {
+        dlclose(cfg->core_handle);
+        cfg->core_handle = NULL;
+    }
+    active_cfg = NULL;
+}
+
+void *harness_dlsym(harness_config *cfg, const char *name)
+{
+    void *sym;
+    if (!cfg->core_handle) return NULL;
+    sym = dlsym(cfg->core_handle, name);
+    if (!sym && !cfg->quiet)
+        fprintf(stderr, "harness: dlsym('%s') not found\n", name);
+    return sym;
+}
+
+void harness_set_option(harness_config *cfg, const char *key, const char *value)
+{
+    if (cfg->num_options >= HARNESS_MAX_OPTIONS) return;
+    cfg->options[cfg->num_options].key = key;
+    cfg->options[cfg->num_options].value = value;
+    cfg->num_options++;
+}
+
+void harness_reset_audio(harness_config *cfg)
+{
+    memset(&cfg->audio, 0, sizeof(cfg->audio));
+    cfg->audio.first_audio_frame = -1;
+    cfg->audio.first_batch_frame = -1;
+}
+
+void harness_report(harness_config *cfg, const harness_result *results, unsigned count)
+{
+    unsigned i;
+    unsigned passes = 0, fails = 0, skips = 0;
+
+    for (i = 0; i < count; i++) {
+        if (strcmp(results[i].status, "PASS") == 0) passes++;
+        else if (strcmp(results[i].status, "FAIL") == 0) fails++;
+        else if (strcmp(results[i].status, "SKIP") == 0) skips++;
+    }
+
+    if (cfg->json_output) {
+        printf("{\"summary\":{\"pass\":%u,\"fail\":%u,\"skip\":%u},\"results\":[\n",
+               passes, fails, skips);
+        for (i = 0; i < count; i++) {
+            printf("  {\"status\":\"%s\",\"name\":\"%s\",\"detail\":\"%s\"}%s\n",
+                   results[i].status, results[i].name, results[i].detail,
+                   (i + 1 < count) ? "," : "");
+        }
+        printf("],\"audio\":{\"total_samples\":%zu,\"nonsilent\":%u,"
+               "\"first_audio_frame\":%d,\"batch_calls\":%u,"
+               "\"dropouts\":%u},",
+               cfg->audio.total_samples, cfg->audio.total_nonsilent,
+               cfg->audio.first_audio_frame, cfg->audio.total_batch_calls,
+               cfg->audio.dropout_count);
+        printf("\"video\":{\"frames_rendered\":%u,\"width\":%u,\"height\":%u}}\n",
+               cfg->video.total_frames_rendered,
+               cfg->video.last_width, cfg->video.last_height);
+    } else {
+        printf("\n=== Results: %u passed, %u failed, %u skipped ===\n",
+               passes, fails, skips);
+        for (i = 0; i < count; i++) {
+            printf("  %s: [%s] %s\n", results[i].status, results[i].name,
+                   results[i].detail);
+        }
+        if (!cfg->quiet) {
+            printf("\n  Audio: %zu samples, %u non-silent, onset=frame %d, "
+                   "%u batch calls, %u dropouts\n",
+                   cfg->audio.total_samples, cfg->audio.total_nonsilent,
+                   cfg->audio.first_audio_frame, cfg->audio.total_batch_calls,
+                   cfg->audio.dropout_count);
+            printf("  Video: %u frames rendered, %ux%u\n",
+                   cfg->video.total_frames_rendered,
+                   cfg->video.last_width, cfg->video.last_height);
+        }
+    }
+}

--- a/test/harness/harness.h
+++ b/test/harness/harness.h
@@ -108,6 +108,7 @@ typedef struct {
     int      first_batch_frame;
     unsigned dropout_count;
     unsigned silent_after_onset;
+    int      was_playing;
     harness_audio_frame frames[HARNESS_MAX_AUDIO_FRAMES];
     unsigned frame_count;
 } harness_audio_stats;

--- a/test/harness/harness.h
+++ b/test/harness/harness.h
@@ -1,0 +1,210 @@
+/*
+ * test/harness/harness.h — Shared libretro core test harness.
+ *
+ * ======================================================================
+ * AGENT QUICK-START
+ * ======================================================================
+ *
+ * This header provides the complete API for writing headless tests against
+ * the Virtual Jaguar libretro core.  A minimal test looks like:
+ *
+ *   #include "harness/harness.h"
+ *   int main(int argc, char **argv) {
+ *       harness_config cfg = HARNESS_CONFIG_DEFAULT;
+ *       cfg.frames = 120;
+ *       if (!harness_init_from_args(&cfg, argc, argv)) return 1;
+ *       if (!harness_load_rom(&cfg))                   return 1;
+ *       harness_run(&cfg);
+ *       int ok = (cfg.audio.total_nonsilent > 0);
+ *       harness_result res = { ok ? "PASS" : "FAIL", "audio_present",
+ *                              ok ? "non-silent samples detected" : "silence" };
+ *       harness_report(&cfg, &res, 1);
+ *       harness_shutdown(&cfg);
+ *       return ok ? 0 : 1;
+ *   }
+ *
+ * Build:  cc -O2 -Wall -std=c99 $(INCFLAGS) -o test_foo \
+ *           test_foo.c test/harness/harness.c -ldl -lm
+ *
+ * Run:    ./test_foo [core.dylib] [rom.jag] [options...]
+ *
+ * ======================================================================
+ * CLI CONVENTIONS (all tests share these)
+ * ======================================================================
+ *
+ *   Positional:
+ *     arg1 — core library path  (default: ./virtualjaguar_libretro.dylib)
+ *     arg2 — ROM path           (optional; some tests need it)
+ *
+ *   Flags:
+ *     --json           Output machine-parseable JSON instead of human text
+ *     --frames N       Override frame count to run
+ *     --bios           Enable BIOS mode (default: HLE)
+ *     --option K=V     Set core option (e.g. --option virtualjaguar_dsp=enabled)
+ *     --quiet          Suppress per-frame output, only show final results
+ *     --snapshot-interval N   Probe snapshot every N frames (default: 1)
+ *
+ * ======================================================================
+ * CORE OPTION OVERRIDE TABLE
+ * ======================================================================
+ *
+ * Instead of the callback guessing, you can pre-populate cfg.options[]:
+ *
+ *   cfg.options[0] = (harness_option){"virtualjaguar_bios", "enabled"};
+ *   cfg.options[1] = (harness_option){"virtualjaguar_usefastblitter", "enabled"};
+ *   cfg.num_options = 2;
+ *
+ * The environment callback returns these to the core on GET_VARIABLE.
+ *
+ * ======================================================================
+ * EXTENDING: ADDING A NEW PROBE
+ * ======================================================================
+ *
+ * 1. Create test/harness/foo_probe.h + foo_probe.c
+ * 2. In your probe_init(), call harness_dlsym(cfg, "symbol_name") to
+ *    resolve internal core symbols.
+ * 3. Call your probe from the test's run loop or from a per-frame hook.
+ * 4. See dsp_probe.h for the reference implementation.
+ *
+ * ======================================================================
+ */
+
+#ifndef HARNESS_H
+#define HARNESS_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/* Maximum number of core option overrides */
+#define HARNESS_MAX_OPTIONS  32
+/* Maximum number of results to report */
+#define HARNESS_MAX_RESULTS  64
+/* Audio capture frames */
+#define HARNESS_MAX_AUDIO_FRAMES 1200
+
+/* ----------------------------------------------------------------
+ * Types
+ * ---------------------------------------------------------------- */
+
+typedef struct {
+    const char *key;
+    const char *value;
+} harness_option;
+
+typedef struct {
+    unsigned frame;
+    size_t   samples;
+    unsigned nonsilent;
+    int16_t  peak_l, peak_r;
+    double   rms_l, rms_r;
+} harness_audio_frame;
+
+typedef struct {
+    size_t   total_samples;
+    unsigned total_nonsilent;
+    unsigned total_batch_calls;
+    int      first_audio_frame;
+    int      first_batch_frame;
+    unsigned dropout_count;
+    unsigned silent_after_onset;
+    harness_audio_frame frames[HARNESS_MAX_AUDIO_FRAMES];
+    unsigned frame_count;
+} harness_audio_stats;
+
+typedef struct {
+    unsigned total_frames_rendered;
+    unsigned last_width;
+    unsigned last_height;
+} harness_video_stats;
+
+/* Per-frame callback: called after each retro_run().
+ * Return false to stop execution early. */
+typedef bool (*harness_frame_cb)(void *userdata, unsigned frame);
+
+typedef struct {
+    /* Configuration (set before init) */
+    const char   *core_path;
+    const char   *rom_path;
+    unsigned      frames;
+    int           use_bios;
+    int           json_output;
+    int           quiet;
+    unsigned      snapshot_interval;
+    harness_option options[HARNESS_MAX_OPTIONS];
+    unsigned      num_options;
+
+    /* Per-frame hook */
+    harness_frame_cb frame_callback;
+    void            *frame_callback_data;
+
+    /* Runtime state (set by harness) */
+    void  *core_handle;
+    unsigned current_frame;
+    harness_audio_stats audio;
+    harness_video_stats video;
+    int    stop_requested;
+} harness_config;
+
+typedef struct {
+    const char *status;   /* "PASS", "FAIL", "SKIP", "INFO" */
+    const char *name;     /* short test-case name */
+    const char *detail;   /* human-readable explanation */
+} harness_result;
+
+/* Default config initializer */
+#define HARNESS_CONFIG_DEFAULT { \
+    .core_path = NULL, \
+    .rom_path = NULL, \
+    .frames = 300, \
+    .use_bios = 0, \
+    .json_output = 0, \
+    .quiet = 0, \
+    .snapshot_interval = 1, \
+    .options = {{0}}, \
+    .num_options = 0, \
+    .frame_callback = NULL, \
+    .frame_callback_data = NULL, \
+    .core_handle = NULL, \
+    .current_frame = 0, \
+    .audio = {0}, \
+    .video = {0}, \
+    .stop_requested = 0 \
+}
+
+/* ----------------------------------------------------------------
+ * API
+ * ---------------------------------------------------------------- */
+
+/* Parse argc/argv into cfg.  Returns true on success. */
+bool harness_init_from_args(harness_config *cfg, int argc, char **argv);
+
+/* Load the core dynamic library.  Called by init_from_args. */
+bool harness_load_core(harness_config *cfg);
+
+/* Load a ROM into the core.  Requires core loaded + rom_path set. */
+bool harness_load_rom(harness_config *cfg);
+
+/* Run cfg->frames frames, collecting audio/video stats.
+ * Calls cfg->frame_callback after each frame if set. */
+void harness_run(harness_config *cfg);
+
+/* Run a single frame. Useful for custom loops. */
+void harness_step(harness_config *cfg);
+
+/* Unload game + deinit + dlclose. */
+void harness_shutdown(harness_config *cfg);
+
+/* Resolve a symbol from the loaded core. Returns NULL + prints warning on failure. */
+void *harness_dlsym(harness_config *cfg, const char *name);
+
+/* Output results in the configured format (json or human). */
+void harness_report(harness_config *cfg, const harness_result *results, unsigned count);
+
+/* Convenience: add a core option override. */
+void harness_set_option(harness_config *cfg, const char *key, const char *value);
+
+/* Reset audio stats (useful between test phases). */
+void harness_reset_audio(harness_config *cfg);
+
+#endif /* HARNESS_H */

--- a/test/test_eeprom_lifecycle.c
+++ b/test/test_eeprom_lifecycle.c
@@ -27,7 +27,14 @@
 
 /* The harness intentionally leaks ROM buffers (VJ keeps the pointer).
  * Suppress LeakSanitizer for this known-benign leak. */
-#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+#if defined(__SANITIZE_ADDRESS__)
+#define EEPROM_TEST_HAS_ASAN 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define EEPROM_TEST_HAS_ASAN 1
+#endif
+#endif
+#ifdef EEPROM_TEST_HAS_ASAN
 const char *__lsan_default_suppressions(void) {
     return "leak:harness_load_rom\n";
 }

--- a/test/test_eeprom_lifecycle.c
+++ b/test/test_eeprom_lifecycle.c
@@ -25,6 +25,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* The harness intentionally leaks ROM buffers (VJ keeps the pointer).
+ * Suppress LeakSanitizer for this known-benign leak. */
+#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+const char *__lsan_default_suppressions(void) {
+    return "leak:harness_load_rom\n";
+}
+#endif
+
 /* libretro memory API — resolved via dlsym */
 typedef void  *(*retro_get_memory_data_t)(unsigned);
 typedef size_t (*retro_get_memory_size_t)(unsigned);

--- a/test/test_eeprom_lifecycle.c
+++ b/test/test_eeprom_lifecycle.c
@@ -1,0 +1,254 @@
+/*
+ * test/test_eeprom_lifecycle.c — EEPROM lifecycle test.
+ *
+ * Validates that the libretro core properly resets all internal state
+ * across load/unload/reload cycles.  This catches stale-static bugs
+ * that manifest on iOS (where dlclose is a no-op) and verifies that
+ * EEPROM data survives the round-trip through retro_get_memory_data.
+ *
+ * Tests:
+ *   1. First load: SRAM buffer available and EEPROM values written
+ *   2. Unload + reload: core re-initializes cleanly (video/audio fire)
+ *   3. SRAM persistence: pre-loaded SRAM data survives unload/reload
+ *   4. Multiple cycles: three consecutive load/unload cycles succeed
+ *
+ * Build:  cc -O2 -Wall -std=c99 -I. -Isrc -Isrc/core -Ilibretro-common/include \
+ *           -o test/test_eeprom_lifecycle test/test_eeprom_lifecycle.c \
+ *           test/harness/harness.c -ldl -lm
+ *
+ * Usage:  ./test/test_eeprom_lifecycle [core.dylib] <eeprom_test.j64>
+ */
+
+#include "harness/harness.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* libretro memory API — resolved via dlsym */
+typedef void  *(*retro_get_memory_data_t)(unsigned);
+typedef size_t (*retro_get_memory_size_t)(unsigned);
+
+#define RETRO_MEMORY_SAVE_RAM 0
+
+#define MAX_RESULTS 16
+
+static int pass_count = 0;
+static int fail_count = 0;
+
+static void check(int cond, const char *name, const char *detail,
+                  harness_result *results, unsigned *num)
+{
+    if (cond) {
+        results[*num] = (harness_result){"PASS", name, detail};
+        pass_count++;
+    } else {
+        results[*num] = (harness_result){"FAIL", name, detail};
+        fail_count++;
+    }
+    (*num)++;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    harness_result results[MAX_RESULTS];
+    unsigned num_results = 0;
+    retro_get_memory_data_t get_mem_data;
+    retro_get_memory_size_t get_mem_size;
+    uint8_t *sram;
+    size_t sram_size;
+
+    cfg.frames = 60;
+
+    if (!harness_init_from_args(&cfg, argc, argv)) {
+        fprintf(stderr, "Failed to load core\n");
+        return 2;
+    }
+
+    if (!cfg.rom_path) {
+        fprintf(stderr, "Usage: test_eeprom_lifecycle [core.dylib] <eeprom_test.j64>\n");
+        fprintf(stderr, "  Generate ROM: cc -o gen_eeprom_test_rom test/tools/gen_eeprom_test_rom.c\n");
+        fprintf(stderr, "                ./gen_eeprom_test_rom /tmp/eeprom_test.j64\n");
+        harness_shutdown(&cfg);
+        return 2;
+    }
+
+    /* Resolve memory API */
+    get_mem_data = (retro_get_memory_data_t)harness_dlsym(&cfg, "retro_get_memory_data");
+    get_mem_size = (retro_get_memory_size_t)harness_dlsym(&cfg, "retro_get_memory_size");
+    if (!get_mem_data || !get_mem_size) {
+        fprintf(stderr, "Cannot resolve retro_get_memory_data/size\n");
+        harness_shutdown(&cfg);
+        return 2;
+    }
+
+    /* ================================================================
+     * Test 1: First load — EEPROM writes detected
+     * ================================================================ */
+
+    if (!harness_load_rom(&cfg)) {
+        fprintf(stderr, "Failed to load ROM (first time)\n");
+        harness_shutdown(&cfg);
+        return 2;
+    }
+
+    harness_run(&cfg);
+
+    sram = (uint8_t *)get_mem_data(RETRO_MEMORY_SAVE_RAM);
+    sram_size = get_mem_size(RETRO_MEMORY_SAVE_RAM);
+
+    check(sram != NULL && sram_size == 128,
+          "first_load_sram_available",
+          sram ? "SRAM pointer and size correct" : "SRAM pointer NULL",
+          results, &num_results);
+
+    /* The EEPROM test ROM writes 0xCAFE at address 0 */
+    if (sram && sram_size >= 2) {
+        int ok = (sram[0] == 0xCA && sram[1] == 0xFE);
+        check(ok, "first_load_eeprom_written",
+              ok ? "addr 0 = 0xCAFE" : "EEPROM write not detected",
+              results, &num_results);
+    } else {
+        check(0, "first_load_eeprom_written", "no SRAM buffer",
+              results, &num_results);
+    }
+
+    check(cfg.video.total_frames_rendered > 0,
+          "first_load_video",
+          cfg.video.total_frames_rendered > 0 ?
+              "video callbacks fired" : "no video callbacks",
+          results, &num_results);
+
+    check(cfg.audio.total_batch_calls > 0,
+          "first_load_audio",
+          cfg.audio.total_batch_calls > 0 ?
+              "audio callbacks fired" : "no audio callbacks",
+          results, &num_results);
+
+    /* ================================================================
+     * Test 2: Unload + reload — statics properly reset
+     * ================================================================ */
+
+    harness_shutdown(&cfg);
+
+    /* Re-load the core (simulates iOS where dlclose is no-op) */
+    if (!harness_load_core(&cfg)) {
+        fprintf(stderr, "Failed to reload core\n");
+        return 2;
+    }
+    if (!harness_load_rom(&cfg)) {
+        check(0, "reload_succeeds", "retro_load_game failed on reload",
+              results, &num_results);
+    } else {
+        check(1, "reload_succeeds", "core reloaded successfully",
+              results, &num_results);
+
+        harness_reset_audio(&cfg);
+        cfg.video.total_frames_rendered = 0;
+        cfg.current_frame = 0;
+        harness_run(&cfg);
+
+        check(cfg.video.total_frames_rendered > 0,
+              "reload_video",
+              cfg.video.total_frames_rendered > 0 ?
+                  "video fires after reload" : "no video after reload",
+              results, &num_results);
+
+        check(cfg.audio.total_batch_calls > 0,
+              "reload_audio",
+              cfg.audio.total_batch_calls > 0 ?
+                  "audio fires after reload" : "no audio after reload",
+              results, &num_results);
+    }
+
+    /* ================================================================
+     * Test 3: SRAM persistence across unload/reload
+     * ================================================================ */
+
+    harness_shutdown(&cfg);
+
+    if (!harness_load_core(&cfg)) {
+        fprintf(stderr, "Failed to reload core (test 3)\n");
+        return 2;
+    }
+    if (!harness_load_rom(&cfg)) {
+        check(0, "sram_persist", "load failed", results, &num_results);
+    } else {
+        uint8_t pattern[128];
+        int i, match;
+
+        /* Pre-fill SRAM with a known pattern */
+        sram = (uint8_t *)get_mem_data(RETRO_MEMORY_SAVE_RAM);
+        if (sram) {
+            for (i = 0; i < 64; i++) {
+                pattern[i * 2] = (uint8_t)(i + 0x40);
+                pattern[i * 2 + 1] = (uint8_t)(i ^ 0xAA);
+            }
+            memcpy(sram, pattern, 128);
+
+            /* Run one frame to trigger unpack */
+            harness_step(&cfg);
+
+            /* Check addresses 3-62 (not overwritten by test ROM) */
+            sram = (uint8_t *)get_mem_data(RETRO_MEMORY_SAVE_RAM);
+            match = 1;
+            for (i = 3; i < 63 && sram; i++) {
+                if (sram[i * 2] != pattern[i * 2] ||
+                    sram[i * 2 + 1] != pattern[i * 2 + 1]) {
+                    match = 0;
+                    break;
+                }
+            }
+            check(match, "sram_persist",
+                  match ? "SRAM data survives unpack/repack" :
+                          "SRAM corruption after reload",
+                  results, &num_results);
+        } else {
+            check(0, "sram_persist", "SRAM pointer NULL after reload",
+                  results, &num_results);
+        }
+    }
+
+    /* ================================================================
+     * Test 4: Multiple consecutive cycles (stress test)
+     * ================================================================ */
+
+    harness_shutdown(&cfg);
+
+    {
+        int cycle, all_ok = 1;
+
+        for (cycle = 0; cycle < 3; cycle++) {
+            if (!harness_load_core(&cfg)) {
+                all_ok = 0;
+                break;
+            }
+            if (!harness_load_rom(&cfg)) {
+                all_ok = 0;
+                break;
+            }
+            harness_reset_audio(&cfg);
+            cfg.video.total_frames_rendered = 0;
+            cfg.current_frame = 0;
+            cfg.frames = 30;
+            harness_run(&cfg);
+
+            if (cfg.video.total_frames_rendered == 0) {
+                all_ok = 0;
+                break;
+            }
+            harness_shutdown(&cfg);
+        }
+
+        check(all_ok, "multi_cycle",
+              all_ok ? "3 consecutive load/run/unload cycles passed" :
+                       "cycle failure (stale state leak)",
+              results, &num_results);
+    }
+
+    /* Report */
+    harness_report(&cfg, results, num_results);
+
+    return fail_count > 0 ? 1 : 0;
+}

--- a/test/test_eeprom_lifecycle.c
+++ b/test/test_eeprom_lifecycle.c
@@ -74,7 +74,8 @@ int main(int argc, char **argv)
         return 2;
     }
 
-    /* Resolve memory API */
+    /* Resolve memory API (must re-resolve after each harness_load_core
+     * because harness_shutdown calls dlclose, invalidating pointers) */
     get_mem_data = (retro_get_memory_data_t)harness_dlsym(&cfg, "retro_get_memory_data");
     get_mem_size = (retro_get_memory_size_t)harness_dlsym(&cfg, "retro_get_memory_size");
     if (!get_mem_data || !get_mem_size) {
@@ -137,6 +138,8 @@ int main(int argc, char **argv)
         fprintf(stderr, "Failed to reload core\n");
         return 2;
     }
+    get_mem_data = (retro_get_memory_data_t)harness_dlsym(&cfg, "retro_get_memory_data");
+    get_mem_size = (retro_get_memory_size_t)harness_dlsym(&cfg, "retro_get_memory_size");
     if (!harness_load_rom(&cfg)) {
         check(0, "reload_succeeds", "retro_load_game failed on reload",
               results, &num_results);
@@ -172,6 +175,8 @@ int main(int argc, char **argv)
         fprintf(stderr, "Failed to reload core (test 3)\n");
         return 2;
     }
+    get_mem_data = (retro_get_memory_data_t)harness_dlsym(&cfg, "retro_get_memory_data");
+    get_mem_size = (retro_get_memory_size_t)harness_dlsym(&cfg, "retro_get_memory_size");
     if (!harness_load_rom(&cfg)) {
         check(0, "sram_persist", "load failed", results, &num_results);
     } else {

--- a/test/tools/test_dsp_audio_diag.c
+++ b/test/tools/test_dsp_audio_diag.c
@@ -95,6 +95,7 @@ int main(int argc, char **argv)
 
     if (!cfg.rom_path) {
         fprintf(stderr, "Usage: test_dsp_audio_diag [core.dylib] <rom.jag> [options]\n");
+        harness_shutdown(&cfg);
         return 2;
     }
 
@@ -106,7 +107,10 @@ int main(int argc, char **argv)
                cfg.use_bios ? "BIOS" : "HLE", cfg.frames);
     }
 
-    if (!harness_load_rom(&cfg)) return 2;
+    if (!harness_load_rom(&cfg)) {
+        harness_shutdown(&cfg);
+        return 2;
+    }
 
     if (!dsp_probe_init(&probe, &cfg)) {
         fprintf(stderr, "Cannot initialize DSP probe (need TEST_EXPORTS=1 build)\n");

--- a/test/tools/test_dsp_audio_diag.c
+++ b/test/tools/test_dsp_audio_diag.c
@@ -40,7 +40,6 @@ static unsigned dump_interval = 0;
 static bool frame_callback(void *userdata, unsigned frame)
 {
     harness_config *cfg = (harness_config *)userdata;
-    (void)cfg;
 
     if (!dsp_probe_per_frame(&probe)) {
         if (dump_on_escape) {

--- a/test/tools/test_dsp_audio_diag.c
+++ b/test/tools/test_dsp_audio_diag.c
@@ -55,8 +55,8 @@ static bool frame_callback(void *userdata, unsigned frame)
         return false;
     }
 
-    if (dump_interval && (frame % dump_interval == 0)) {
-        dsp_probe_print_snapshot(&probe, cfg->json_output);
+    if (dump_interval && !cfg->json_output && (frame % dump_interval == 0)) {
+        dsp_probe_print_snapshot(&probe, 0);
     }
 
     return true;

--- a/test/tools/test_dsp_audio_diag.c
+++ b/test/tools/test_dsp_audio_diag.c
@@ -1,0 +1,237 @@
+/*
+ * test/tools/test_dsp_audio_diag.c — DSP audio diagnostic tool.
+ *
+ * Diagnoses "no audio" bugs by monitoring DSP state frame-by-frame:
+ *   - PC escape detection (PC leaves $F1B000–$F1CFFF work RAM)
+ *   - Register bank initialization health
+ *   - LTXD non-zero ratio (are samples actually being written?)
+ *   - I2S dispatch vs audio output correlation
+ *   - Auto-dumps DSP state on failure for post-mortem
+ *
+ * Build: make dsp-diag
+ * Usage: ./test/tools/test_dsp_audio_diag [core.dylib] <rom.jag> [options]
+ *
+ * Options (in addition to standard harness flags):
+ *   --frames N           Number of frames to run (default: 300)
+ *   --bios               Use BIOS boot instead of HLE
+ *   --json               Machine-parseable output
+ *   --dump-on-escape     Dump DSP RAM + registers on PC escape
+ *   --dump-interval N    Print DSP state every N frames
+ *
+ * Exit codes:
+ *   0 = all checks pass (audio is healthy)
+ *   1 = one or more failures detected
+ *   2 = setup error (missing ROM, core won't load, etc.)
+ */
+
+#include "../harness/harness.h"
+#include "../harness/dsp_probe.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_RESULTS 16
+
+static dsp_probe probe;
+static int dump_on_escape = 0;
+static unsigned dump_interval = 0;
+
+static bool frame_callback(void *userdata, unsigned frame)
+{
+    harness_config *cfg = (harness_config *)userdata;
+    (void)cfg;
+
+    if (!dsp_probe_per_frame(&probe)) {
+        if (dump_on_escape) {
+            printf("\n!!! DSP PC ESCAPE at frame %u: PC=$%06X !!!\n",
+                   probe.snap.frame, probe.snap.pc);
+            dsp_probe_dump_banks(&probe);
+            dsp_probe_dump_ram(&probe, probe.snap.pc & 0xFFFFF0, 16);
+            /* Also dump around the ISR vector region */
+            printf("  ISR vector region ($F1B000):\n");
+            dsp_probe_dump_ram(&probe, DSP_WORK_RAM_BASE, 32);
+        }
+        return false;
+    }
+
+    if (dump_interval && (frame % dump_interval == 0)) {
+        dsp_probe_print_snapshot(&probe, cfg->json_output);
+    }
+
+    return true;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    harness_result results[MAX_RESULTS];
+    unsigned num_results = 0;
+    int exit_code = 0;
+    char detail_buf[8][256];
+    int i, filt_argc;
+    char *filt_argv[64];
+
+    /* Separate our flags from harness flags.  Build a filtered argv
+     * that only contains args the harness understands. */
+    filt_argv[0] = argv[0];
+    filt_argc = 1;
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--dump-on-escape") == 0) {
+            dump_on_escape = 1;
+        } else if (strcmp(argv[i], "--dump-interval") == 0 && i + 1 < argc) {
+            dump_interval = (unsigned)atoi(argv[++i]);
+        } else {
+            if (filt_argc < 63) filt_argv[filt_argc++] = argv[i];
+        }
+    }
+    filt_argv[filt_argc] = NULL;
+
+    cfg.frames = 300;
+    cfg.frame_callback = frame_callback;
+    cfg.frame_callback_data = &cfg;
+
+    if (!harness_init_from_args(&cfg, filt_argc, filt_argv)) return 2;
+
+    if (!cfg.rom_path) {
+        fprintf(stderr, "Usage: test_dsp_audio_diag [core.dylib] <rom.jag> [options]\n");
+        return 2;
+    }
+
+    if (!cfg.quiet && !cfg.json_output) {
+        printf("=== DSP Audio Diagnostic ===\n");
+        printf("Core: %s\n", cfg.core_path);
+        printf("ROM:  %s\n", cfg.rom_path);
+        printf("Mode: %s | Frames: %u\n",
+               cfg.use_bios ? "BIOS" : "HLE", cfg.frames);
+    }
+
+    if (!harness_load_rom(&cfg)) return 2;
+
+    if (!dsp_probe_init(&probe, &cfg)) {
+        fprintf(stderr, "Cannot initialize DSP probe (need TEST_EXPORTS=1 build)\n");
+        harness_shutdown(&cfg);
+        return 2;
+    }
+
+    /* Run the diagnostic */
+    harness_run(&cfg);
+
+    /* Take final snapshot */
+    dsp_probe_snapshot(&probe);
+
+    /* ================================================================
+     * Assertions
+     * ================================================================ */
+
+    /* 1. DSP PC stays in work RAM */
+    if (probe.counters.pc_escape_count == 0) {
+        results[num_results++] = (harness_result){
+            "PASS", "dsp_pc_bounded",
+            "DSP PC stayed within work RAM for all frames"
+        };
+    } else {
+        snprintf(detail_buf[0], sizeof(detail_buf[0]),
+                 "DSP PC escaped %u times, first at frame %u (PC=$%06X)",
+                 probe.counters.pc_escape_count,
+                 probe.counters.first_escape_frame,
+                 probe.counters.first_escape_pc);
+        results[num_results++] = (harness_result){"FAIL", "dsp_pc_bounded", detail_buf[0]};
+        exit_code = 1;
+    }
+
+    /* 2. LTXD non-zero ratio after frame 30 (audio health) */
+    {
+        double ratio = dsp_probe_ltxd_ratio(&probe);
+        if (cfg.current_frame > 30 && ratio > 0.5) {
+            snprintf(detail_buf[1], sizeof(detail_buf[1]),
+                     "LTXD non-zero ratio %.1f%% (healthy)", ratio * 100);
+            results[num_results++] = (harness_result){"PASS", "ltxd_health", detail_buf[1]};
+        } else if (cfg.current_frame > 30 && ratio > 0.1) {
+            snprintf(detail_buf[1], sizeof(detail_buf[1]),
+                     "LTXD non-zero ratio %.1f%% (marginal)", ratio * 100);
+            results[num_results++] = (harness_result){"PASS", "ltxd_health", detail_buf[1]};
+        } else if (cfg.current_frame > 30) {
+            snprintf(detail_buf[1], sizeof(detail_buf[1]),
+                     "LTXD non-zero ratio %.1f%% (no audio output)", ratio * 100);
+            results[num_results++] = (harness_result){"FAIL", "ltxd_health", detail_buf[1]};
+            exit_code = 1;
+        } else {
+            results[num_results++] = (harness_result){
+                "SKIP", "ltxd_health", "not enough frames to measure"
+            };
+        }
+    }
+
+    /* 3. Bank1 initialization (main program bank should have >10 regs set) */
+    {
+        unsigned b1_nz = dsp_probe_bank_nonzero(probe.snap.bank1);
+        if (b1_nz >= 10) {
+            snprintf(detail_buf[2], sizeof(detail_buf[2]),
+                     "Bank1 has %u/32 non-zero registers (well-initialized)", b1_nz);
+            results[num_results++] = (harness_result){"PASS", "bank1_init", detail_buf[2]};
+        } else if (b1_nz >= 5) {
+            snprintf(detail_buf[2], sizeof(detail_buf[2]),
+                     "Bank1 has %u/32 non-zero registers (sparse)", b1_nz);
+            results[num_results++] = (harness_result){"PASS", "bank1_init", detail_buf[2]};
+        } else {
+            snprintf(detail_buf[2], sizeof(detail_buf[2]),
+                     "Bank1 has %u/32 non-zero registers (insufficient init)", b1_nz);
+            results[num_results++] = (harness_result){"FAIL", "bank1_init", detail_buf[2]};
+            exit_code = 1;
+        }
+    }
+
+    /* 4. Audio callback fires */
+    if (cfg.audio.total_batch_calls > 0) {
+        snprintf(detail_buf[3], sizeof(detail_buf[3]),
+                 "%u batch callbacks over %u frames",
+                 cfg.audio.total_batch_calls, cfg.current_frame);
+        results[num_results++] = (harness_result){"PASS", "audio_callbacks", detail_buf[3]};
+    } else {
+        results[num_results++] = (harness_result){
+            "FAIL", "audio_callbacks", "no audio batch callbacks fired"
+        };
+        exit_code = 1;
+    }
+
+    /* 5. Non-silent audio detected */
+    if (cfg.audio.total_nonsilent > 0) {
+        snprintf(detail_buf[4], sizeof(detail_buf[4]),
+                 "%u non-silent samples, onset at frame %d",
+                 cfg.audio.total_nonsilent, cfg.audio.first_audio_frame);
+        results[num_results++] = (harness_result){"PASS", "audio_nonsilent", detail_buf[4]};
+    } else {
+        results[num_results++] = (harness_result){
+            "FAIL", "audio_nonsilent", "all audio samples are silent"
+        };
+        exit_code = 1;
+    }
+
+    /* 6. DSP is running */
+    if (probe.snap.running) {
+        results[num_results++] = (harness_result){"PASS", "dsp_running", "DSP is active"};
+    } else {
+        results[num_results++] = (harness_result){
+            "FAIL", "dsp_running", "DSP halted before end of test"
+        };
+        exit_code = 1;
+    }
+
+    /* Report */
+    harness_report(&cfg, results, num_results);
+
+    /* Extra detail on failure */
+    if (exit_code && !cfg.json_output && !cfg.quiet) {
+        printf("\n--- DSP state at end of test ---\n");
+        dsp_probe_print_snapshot(&probe, 0);
+        dsp_probe_dump_banks(&probe);
+        if (probe.counters.pc_escape_count > 0) {
+            printf("\n--- DSP RAM at ISR vector region ---\n");
+            dsp_probe_dump_ram(&probe, DSP_WORK_RAM_BASE, 32);
+        }
+    }
+
+    harness_shutdown(&cfg);
+    return exit_code;
+}


### PR DESCRIPTION
## Summary
- **iOS static state leak**: On platforms that can't `dlclose` cores, stale EEPROM data, video dimensions, and input mappings from a previous game session would bleed into subsequent `retro_load_game` calls. Now `retro_unload_game` resets all relevant statics.
- **Safety net in `retro_deinit`**: Frees buffers and clears state for frontends that call deinit without calling unload first.
- **NULL check on allocation**: `retro_load_game` now fails gracefully if `videoBuffer` or `sampleBuffer` allocation returns NULL, instead of crashing on the subsequent `memset`/loop.

## Test plan
- [x] `make clean && make -j` — builds without warnings
- [x] `bash scripts/c89-lint.sh libretro.c` — passes
- [x] `make test` — all tests pass
- [ ] Manual: load game A → unload → load game B on iOS; verify no EEPROM crossover

🤖 Generated with [Claude Code](https://claude.com/claude-code)