### PR TITLE
refactor(headers): move libretro externs into proper headers

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -17,6 +17,9 @@
 #include "joystick.h"
 #include "settings.h"
 #include "tom.h"
+#include "eeprom.h"
+#include "memtrack.h"
+#include "vjag_memory.h"
 #include "state.h"
 #include "log.h"
 #include "version.h" /* generated; defines CORE_VERSION */
@@ -44,11 +47,6 @@ int videoHeight              = 0;
 uint32_t *videoBuffer        = NULL;
 int game_width               = 0;
 int game_height              = 0;
-
-extern uint16_t eeprom_ram[64];
-extern uint8_t mtMem[0x20000];
-extern uint32_t jaguarMainROMCRC32;
-extern void (*eeprom_dirty_cb)(void);
 
 /* Save buffer for RETRO_MEMORY_SAVE_RAM.
  * Regular carts: 128 bytes (64 x 16-bit EEPROM words, big-endian packed).
@@ -1071,8 +1069,6 @@ void retro_reset(void)
 }
 
 #ifdef DEBUG_PRESENTATION
-extern uint16_t *ltxd, *rtxd;
-extern uint32_t screenPitch;
 static unsigned dbg_frame_counter = 0;
 
 static void dbg_dump_frame(void)

--- a/src/core/memtrack.h
+++ b/src/core/memtrack.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+extern uint8_t mtMem[0x20000];
+
 void MTInit(void);
 void MTReset(void);
 void MTDone(void);

--- a/src/core/memtrack.h
+++ b/src/core/memtrack.h
@@ -7,7 +7,9 @@
 
 #include <stdint.h>
 
-extern uint8_t mtMem[0x20000];
+#define MT_MEM_SIZE 0x20000
+
+extern uint8_t mtMem[MT_MEM_SIZE];
 
 void MTInit(void);
 void MTReset(void);

--- a/src/jerry/eeprom.h
+++ b/src/jerry/eeprom.h
@@ -11,6 +11,9 @@
 extern "C" {
 #endif
 
+extern uint16_t eeprom_ram[64];
+extern void (*eeprom_dirty_cb)(void);
+
 void EepromInit(void);
 void EepromReset(void);
 void EepromDone(void);


### PR DESCRIPTION
## Summary
- Move bare `extern` declarations from `libretro.c` into their proper headers (`eeprom.h`, `memtrack.h`)
- Add `#include "eeprom.h"`, `#include "memtrack.h"`, `#include "vjag_memory.h"` to `libretro.c`
- Remove redundant `extern` declarations (including DEBUG_PRESENTATION block)
- `jaguarMainROMCRC32` was already in `jaguar.h` — just remove the duplicate extern

Reduces coupling and makes the interface between libretro.c and core modules explicit.

## Test plan
- [x] `make clean && make -j` — builds without warnings
- [x] `bash scripts/c89-lint.sh libretro.c` — passes
- [x] `make test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)