### PR TITLE
fix(dac): resample I2S output when SCLK changes at runtime

### DIFF
--- a/src/core/jaguar.h
+++ b/src/core/jaguar.h
@@ -55,6 +55,9 @@ extern uint32_t jaguarLoadedRAMStart, jaguarLoadedRAMEnd;
 #define RISC_CLOCK_RATE_PAL		26593900
 #define RISC_CLOCK_RATE_NTSC	26590906
 
+#define SYSTEM_CLOCK_RATE		(vjs.hardwareTypeNTSC ? RISC_CLOCK_RATE_NTSC : RISC_CLOCK_RATE_PAL)
+#define M68K_CLOCK_RATE			(vjs.hardwareTypeNTSC ? M68K_CLOCK_RATE_NTSC : M68K_CLOCK_RATE_PAL)
+
 // Stuff for IRQ handling
 
 #define ASSERT_LINE		1

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -43,7 +43,7 @@ extern retro_audio_sample_batch_t audio_batch_cb;
 #define DAC_AUDIO_RATE		48000	/* Set the audio rate to 48 KHz */
 
 /* Ring buffer for I2S samples produced by the DSP at hardware rate */
-#define I2S_RING_SIZE		8192	/* Power of 2, must be > max samples/frame */
+#define I2S_RING_SIZE		16384	/* Power of 2, must be > max samples/frame (PAL SCLK=0 ~8311) */
 #define I2S_RING_MASK		(I2S_RING_SIZE - 1)
 
 /* Jaguar memory locations */
@@ -117,8 +117,8 @@ void DACUpdateSCLKRate(void)
    /* Clamp to a sane range to avoid division by zero or absurd values.
     * SCLK=0 gives divider=64, i2s_rate~415kHz, ratio~8.66.
     * Upper bound of 16.0 allows all valid SCLK values (0-255). */
-   if (i2sRateRatio < 0.1)
-      i2sRateRatio = 0.1;
+   if (i2sRateRatio < 0.01)
+      i2sRateRatio = 0.01;
    if (i2sRateRatio > 16.0)
       i2sRateRatio = 16.0;
 }
@@ -193,10 +193,10 @@ void DACPrepareFrame(int length)
    numberOfSamples = length;
    bufferDone = false;
 
-   /* Reset ring buffer state for the new frame */
+   /* Preserve fractional phase for interpolation continuity across frames */
    i2sWritePos = 0;
    i2sReadCount = 0;
-   i2sPhase = 0.0;
+   i2sPhase = i2sPhase - (double)(uint32_t)i2sPhase;
 
    /* Refresh rate ratio in case SCLK was written between frames */
    DACUpdateSCLKRate();

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -65,9 +65,11 @@ static bool bufferDone = false;
 static int16_t i2sRingL[I2S_RING_SIZE];
 static int16_t i2sRingR[I2S_RING_SIZE];
 static uint32_t i2sWritePos = 0;	/* next write position in ring */
-static uint32_t i2sReadCount = 0;	/* total samples written this frame */
+static uint32_t i2sWriteCount = 0;	/* total samples captured this frame */
 static double i2sPhase = 0.0;		/* fractional read position */
 static double i2sRateRatio = 1.0;	/* i2s_rate / 48000.0 */
+static int16_t i2sLastL = 0;		/* last sample from previous frame */
+static int16_t i2sLastR = 0;
 
 /* Private function prototypes */
 
@@ -90,9 +92,11 @@ void DACReset(void)
    sstat = 0;
 
    i2sWritePos = 0;
-   i2sReadCount = 0;
+   i2sWriteCount = 0;
    i2sPhase = 0.0;
    i2sRateRatio = 1.0;
+   i2sLastL = 0;
+   i2sLastR = 0;
    memset(i2sRingL, 0, sizeof(i2sRingL));
    memset(i2sRingR, 0, sizeof(i2sRingR));
 }
@@ -130,7 +134,9 @@ static void DACCaptureSample(int16_t left, int16_t right)
    i2sRingL[i2sWritePos & I2S_RING_MASK] = left;
    i2sRingR[i2sWritePos & I2S_RING_MASK] = right;
    i2sWritePos++;
-   i2sReadCount++;
+   i2sWriteCount++;
+   i2sLastL = left;
+   i2sLastR = right;
 }
 
 void DSPSampleCallback(void)
@@ -141,7 +147,7 @@ void DSPSampleCallback(void)
    int32_t s0L, s1L, s0R, s1R;
 
    /* If no I2S samples have been produced yet, output silence / hold last */
-   if (i2sReadCount == 0)
+   if (i2sWriteCount == 0)
    {
       outL = (int16_t)(*ltxd);
       outR = (int16_t)(*rtxd);
@@ -156,10 +162,10 @@ void DSPSampleCallback(void)
       idx1 = idx0 + 1;
 
       /* Clamp indices to available data */
-      if (idx0 >= i2sReadCount)
-         idx0 = i2sReadCount - 1;
-      if (idx1 >= i2sReadCount)
-         idx1 = i2sReadCount - 1;
+      if (idx0 >= i2sWriteCount)
+         idx0 = i2sWriteCount - 1;
+      if (idx1 >= i2sWriteCount)
+         idx1 = i2sWriteCount - 1;
 
       s0L = (int32_t)i2sRingL[idx0 & I2S_RING_MASK];
       s1L = (int32_t)i2sRingL[idx1 & I2S_RING_MASK];
@@ -193,9 +199,12 @@ void DACPrepareFrame(int length)
    numberOfSamples = length;
    bufferDone = false;
 
-   /* Preserve fractional phase for interpolation continuity across frames */
-   i2sWritePos = 0;
-   i2sReadCount = 0;
+   /* Seed ring[0] with the last sample from the previous frame so that
+    * interpolation has a valid left endpoint at the frame boundary. */
+   i2sRingL[0] = i2sLastL;
+   i2sRingR[0] = i2sLastR;
+   i2sWritePos = 1;
+   i2sWriteCount = 1;
    i2sPhase = i2sPhase - (double)(uint32_t)i2sPhase;
 
    /* Refresh rate ratio in case SCLK was written between frames */
@@ -293,7 +302,7 @@ size_t DACStateSave(uint8_t *buf)
 	STATE_SAVE_VAR(buf, numberOfSamples);
 	STATE_SAVE_VAR(buf, bufferDone);
 	STATE_SAVE_VAR(buf, i2sWritePos);
-	STATE_SAVE_VAR(buf, i2sReadCount);
+	STATE_SAVE_VAR(buf, i2sWriteCount);
 	STATE_SAVE_VAR(buf, i2sPhase);
 	STATE_SAVE_VAR(buf, i2sRateRatio);
 
@@ -308,7 +317,7 @@ size_t DACStateLoad(const uint8_t *buf)
 	STATE_LOAD_VAR(buf, numberOfSamples);
 	STATE_LOAD_VAR(buf, bufferDone);
 	STATE_LOAD_VAR(buf, i2sWritePos);
-	STATE_LOAD_VAR(buf, i2sReadCount);
+	STATE_LOAD_VAR(buf, i2sWriteCount);
 	STATE_LOAD_VAR(buf, i2sPhase);
 	STATE_LOAD_VAR(buf, i2sRateRatio);
 

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -109,8 +109,7 @@ void DACUpdateSCLKRate(void)
    double sys_clock;
 
    sclk_val = (uint32_t)(*sclk);
-   sys_clock = vjs.hardwareTypeNTSC
-      ? (double)RISC_CLOCK_RATE_NTSC : (double)RISC_CLOCK_RATE_PAL;
+   sys_clock = (double)SYSTEM_CLOCK_RATE;
    /* sample_rate = system_clock / (64 * (SCLK + 1)) */
    i2s_rate = sys_clock / (64.0 * (sclk_val + 1));
    i2sRateRatio = i2s_rate / (double)DAC_AUDIO_RATE;

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -109,7 +109,8 @@ void DACUpdateSCLKRate(void)
    double sys_clock;
 
    sclk_val = (uint32_t)(*sclk);
-   sys_clock = vjs.hardwareTypeNTSC ? 26590906.0 : 26593900.0;
+   sys_clock = vjs.hardwareTypeNTSC
+      ? (double)RISC_CLOCK_RATE_NTSC : (double)RISC_CLOCK_RATE_PAL;
    /* sample_rate = system_clock / (64 * (SCLK + 1)) */
    i2s_rate = sys_clock / (64.0 * (sclk_val + 1));
    i2sRateRatio = i2s_rate / (double)DAC_AUDIO_RATE;
@@ -232,7 +233,7 @@ void SoundCallback(void * userdata, uint16_t * buffer, int length)
 void DACWriteByte(uint32_t offset, uint8_t data, uint32_t who)
 {
    if (offset == SCLK + 3)
-      DACWriteWord(offset - 3, (uint16_t)data, UNKNOWN);
+      DACWriteWord(SCLK + 2, (uint16_t)data, UNKNOWN);
 }
 
 

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -68,8 +68,6 @@ static uint32_t i2sWritePos = 0;	/* next write position in ring */
 static uint32_t i2sWriteCount = 0;	/* total samples captured this frame */
 static double i2sPhase = 0.0;		/* fractional read position */
 static double i2sRateRatio = 1.0;	/* i2s_rate / 48000.0 */
-static int16_t i2sLastL = 0;		/* last sample from previous frame */
-static int16_t i2sLastR = 0;
 
 /* Private function prototypes */
 
@@ -95,8 +93,6 @@ void DACReset(void)
    i2sWriteCount = 0;
    i2sPhase = 0.0;
    i2sRateRatio = 1.0;
-   i2sLastL = 0;
-   i2sLastR = 0;
    memset(i2sRingL, 0, sizeof(i2sRingL));
    memset(i2sRingR, 0, sizeof(i2sRingR));
 }
@@ -135,8 +131,6 @@ static void DACCaptureSample(int16_t left, int16_t right)
    i2sRingR[i2sWritePos & I2S_RING_MASK] = right;
    i2sWritePos++;
    i2sWriteCount++;
-   i2sLastL = left;
-   i2sLastR = right;
 }
 
 void DSPSampleCallback(void)
@@ -146,8 +140,8 @@ void DSPSampleCallback(void)
    double frac;
    int32_t s0L, s1L, s0R, s1R;
 
-   /* If no I2S samples have been produced yet, output silence / hold last */
-   if (i2sWriteCount == 0)
+   /* Guard: hold current register value if ring is empty (e.g. after reset) */
+   if (i2sWriteCount < 2)
    {
       outL = (int16_t)(*ltxd);
       outR = (int16_t)(*rtxd);
@@ -199,12 +193,15 @@ void DACPrepareFrame(int length)
    numberOfSamples = length;
    bufferDone = false;
 
-   /* Seed ring[0] with the last sample from the previous frame so that
-    * interpolation has a valid left endpoint at the frame boundary. */
-   i2sRingL[0] = i2sLastL;
-   i2sRingR[0] = i2sLastR;
-   i2sWritePos = 1;
-   i2sWriteCount = 1;
+   /* Seed ring with current DAC register values so interpolation has valid
+    * endpoints before the first real DSP write arrives.  Two copies give
+    * both idx0 and idx1 valid data for the interpolator. */
+   i2sRingL[0] = (int16_t)(*ltxd);
+   i2sRingR[0] = (int16_t)(*rtxd);
+   i2sRingL[1] = (int16_t)(*ltxd);
+   i2sRingR[1] = (int16_t)(*rtxd);
+   i2sWritePos = 2;
+   i2sWriteCount = 2;
    i2sPhase = i2sPhase - (double)(uint32_t)i2sPhase;
 
    /* Refresh rate ratio in case SCLK was written between frames */

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -14,26 +14,19 @@
 // JLH  04/30/2012  Changed SDL audio handler to run JERRY
 //
 
-/* The libretro audio path samples LTXD/RTXD at a fixed 48 kHz into
- * sampleBuffer (see SoundCallback below).  JERRYI2SCallback in
- * src/jerry/jerry.c separately models DSP SSI interrupt timing
- * from SCLK/SMODE — these are two coupled clocks, and games that
- * write SCLK at runtime (or use word-strobe modes) effectively
- * change the DSP's I2S rate while the libretro output rate stays
- * at 48 kHz.
+/* The libretro audio path resamples from the I2S rate (determined by
+ * SCLK) to 48 kHz output using linear interpolation.  When SCLK changes
+ * mid-frame (e.g. Skyhammer / Iron Soldier 2 pitch effects), the
+ * resampler adapts to the new rate on the next sample callback.
  *
- * TODO(v2.3): the audio path currently assumes 48 kHz output and
- * does not support games requesting non-48k host rates.  The DSP
- * I2S rate (driven by SCLK) is decoupled from the host output rate
- * by simple sampling; if a future fix wants to support games that
- * vary SCLK at runtime for pitch effects, this layer needs to be
- * either resampled properly or driven from the DSP-side clock.
- * Cross-reference: Skyhammer / Iron Soldier 2 audio clipping family
- * (docs/emulation-bug-hunt-todos.md) is partially related — those
- * carts depend on a specific SCLK/SMODE pair the BIOS leaves. */
+ * I2S samples (written by the DSP to LTXD/RTXD) are captured into a
+ * ring buffer at the hardware I2S rate.  DSPSampleCallback fires at
+ * 48 kHz and linearly interpolates between ring buffer entries to
+ * produce the output stream. */
 
 #include "dac.h"
 
+#include <string.h>
 #include "cdrom.h"
 #include "dsp.h"
 #include "event.h"
@@ -46,10 +39,14 @@
 
 extern retro_audio_sample_batch_t audio_batch_cb;
 
-#define BUFFER_SIZE		0x10000	// Make the DAC buffers 64K x 16 bits
-#define DAC_AUDIO_RATE		48000	// Set the audio rate to 48 KHz
+#define BUFFER_SIZE		0x10000	/* Make the DAC buffers 64K x 16 bits */
+#define DAC_AUDIO_RATE		48000	/* Set the audio rate to 48 KHz */
 
-// Jaguar memory locations
+/* Ring buffer for I2S samples produced by the DSP at hardware rate */
+#define I2S_RING_SIZE		4096	/* Power of 2, must be > max samples/frame */
+#define I2S_RING_MASK		(I2S_RING_SIZE - 1)
+
+/* Jaguar memory locations */
 
 #define LTXD			0xF1A148
 #define RTXD			0xF1A14C
@@ -58,13 +55,21 @@ extern retro_audio_sample_batch_t audio_batch_cb;
 #define SCLK			0xF1A150
 #define SMODE			0xF1A154
 
-// Global variables
+/* Global variables */
 uint16_t * sampleBuffer;
 static int bufferIndex = 0;
 static int numberOfSamples = 0;
 static bool bufferDone = false;
 
-// Private function prototypes
+/* I2S resampling state */
+static int16_t i2sRingL[I2S_RING_SIZE];
+static int16_t i2sRingR[I2S_RING_SIZE];
+static uint32_t i2sWritePos = 0;	/* next write position in ring */
+static uint32_t i2sReadCount = 0;	/* total samples written this frame */
+static double i2sPhase = 0.0;		/* fractional read position */
+static double i2sRateRatio = 1.0;	/* i2s_rate / 48000.0 */
+
+/* Private function prototypes */
 
 void DACInit(void)
 {
@@ -72,26 +77,102 @@ void DACInit(void)
 
    *ltxd = 0;
    lrxd  = 0;
-   *sclk = 19;									// Default is roughly 22 KHz
+   *sclk = 19;									/* Default is roughly 22 KHz */
+   DACUpdateSCLKRate();
 }
 
 
-// Reset the sound buffer FIFOs
+/* Reset the sound buffer FIFOs */
 void DACReset(void)
 {
    *ltxd = 0;
    lrxd  = 0;
    sstat = 0;
+
+   i2sWritePos = 0;
+   i2sReadCount = 0;
+   i2sPhase = 0.0;
+   i2sRateRatio = 1.0;
+   memset(i2sRingL, 0, sizeof(i2sRingL));
+   memset(i2sRingR, 0, sizeof(i2sRingR));
 }
 
 void DACDone(void)
 {
 }
 
+/* Called by JTRM-accurate I2S rate to update the rate ratio when SCLK changes */
+void DACUpdateSCLKRate(void)
+{
+   uint32_t sclk_val;
+   double i2s_rate;
+   double sys_clock;
+
+   sclk_val = (uint32_t)(*sclk);
+   sys_clock = vjs.hardwareTypeNTSC ? 26590906.0 : 26593900.0;
+   /* sample_rate = system_clock / (64 * (SCLK + 1)) */
+   i2s_rate = sys_clock / (64.0 * (sclk_val + 1));
+   i2sRateRatio = i2s_rate / (double)DAC_AUDIO_RATE;
+
+   /* Clamp to a sane range to avoid division by zero or absurd values */
+   if (i2sRateRatio < 0.1)
+      i2sRateRatio = 0.1;
+   if (i2sRateRatio > 4.0)
+      i2sRateRatio = 4.0;
+}
+
+/* Called when the DSP writes a sample pair to LTXD/RTXD.
+ * Stores the sample in the ring buffer for later resampling. */
+static void DACCaptureSample(int16_t left, int16_t right)
+{
+   i2sRingL[i2sWritePos & I2S_RING_MASK] = left;
+   i2sRingR[i2sWritePos & I2S_RING_MASK] = right;
+   i2sWritePos++;
+   i2sReadCount++;
+}
+
 void DSPSampleCallback(void)
 {
-   sampleBuffer[bufferIndex + 0] = *ltxd;
-   sampleBuffer[bufferIndex + 1] = *rtxd;
+   int16_t outL, outR;
+   uint32_t idx0, idx1;
+   double frac;
+   int32_t s0L, s1L, s0R, s1R;
+
+   /* If no I2S samples have been produced yet, output silence / hold last */
+   if (i2sReadCount == 0)
+   {
+      outL = (int16_t)(*ltxd);
+      outR = (int16_t)(*rtxd);
+   }
+   else
+   {
+      /* Linear interpolation between ring buffer samples.
+       * i2sPhase is our fractional position in the I2S sample stream.
+       * We advance by i2sRateRatio for each 48 kHz output sample. */
+      idx0 = (uint32_t)i2sPhase;
+      frac = i2sPhase - (double)idx0;
+      idx1 = idx0 + 1;
+
+      /* Clamp indices to available data */
+      if (idx0 >= i2sReadCount)
+         idx0 = i2sReadCount - 1;
+      if (idx1 >= i2sReadCount)
+         idx1 = i2sReadCount - 1;
+
+      s0L = (int32_t)i2sRingL[idx0 & I2S_RING_MASK];
+      s1L = (int32_t)i2sRingL[idx1 & I2S_RING_MASK];
+      s0R = (int32_t)i2sRingR[idx0 & I2S_RING_MASK];
+      s1R = (int32_t)i2sRingR[idx1 & I2S_RING_MASK];
+
+      outL = (int16_t)(s0L + (int32_t)((double)(s1L - s0L) * frac));
+      outR = (int16_t)(s0R + (int32_t)((double)(s1R - s0R) * frac));
+
+      /* Advance phase by the rate ratio */
+      i2sPhase += i2sRateRatio;
+   }
+
+   sampleBuffer[bufferIndex + 0] = (uint16_t)outL;
+   sampleBuffer[bufferIndex + 1] = (uint16_t)outR;
    bufferIndex += 2;
 
    if (bufferIndex >= numberOfSamples)
@@ -109,6 +190,15 @@ void DACPrepareFrame(int length)
    bufferIndex = 0;
    numberOfSamples = length;
    bufferDone = false;
+
+   /* Reset ring buffer state for the new frame */
+   i2sWritePos = 0;
+   i2sReadCount = 0;
+   i2sPhase = 0.0;
+
+   /* Refresh rate ratio in case SCLK was written between frames */
+   DACUpdateSCLKRate();
+
    SetCallbackTime(DSPSampleCallback, 1000000.0 / (double)DAC_AUDIO_RATE, EVENT_JERRY);
 }
 
@@ -122,15 +212,15 @@ void SoundCallback(void * userdata, uint16_t * buffer, int length)
    {
       for (idx = bufferIndex; idx < length; idx += 2)
       {
-         buffer[idx + 0] = *ltxd;
-         buffer[idx + 1] = *rtxd;
+         buffer[idx + 0] = (uint16_t)((int16_t)(*ltxd));
+         buffer[idx + 1] = (uint16_t)((int16_t)(*rtxd));
       }
    }
 
    audio_batch_cb((int16_t *)buffer, length / 2);
 }
 
-// LTXD/RTXD/SCLK/SMODE ($F1A148/4C/50/54)
+/* LTXD/RTXD/SCLK/SMODE ($F1A148/4C/50/54) */
 void DACWriteByte(uint32_t offset, uint8_t data, uint32_t who)
 {
    if (offset == SCLK + 3)
@@ -143,12 +233,18 @@ void DACWriteWord(uint32_t offset, uint16_t data, uint32_t who)
    if (offset == LTXD + 2)
    {
       *ltxd = data;
+      /* Capture left sample; pair completes when RTXD is written */
    }
    else if (offset == RTXD + 2)
+   {
       *rtxd = data;
-   else if (offset == SCLK + 2)					// Sample rate
+      /* Both channels written — capture the stereo pair */
+      DACCaptureSample((int16_t)(*ltxd), (int16_t)data);
+   }
+   else if (offset == SCLK + 2)					/* Sample rate */
    {
       *sclk = data & 0xFF;
+      DACUpdateSCLKRate();
       JERRYI2SInterruptTimer = -1;
       RemoveCallback(JERRYI2SCallback);
       JERRYI2SCallback();
@@ -194,6 +290,10 @@ size_t DACStateSave(uint8_t *buf)
 	STATE_SAVE_VAR(buf, bufferIndex);
 	STATE_SAVE_VAR(buf, numberOfSamples);
 	STATE_SAVE_VAR(buf, bufferDone);
+	STATE_SAVE_VAR(buf, i2sWritePos);
+	STATE_SAVE_VAR(buf, i2sReadCount);
+	STATE_SAVE_VAR(buf, i2sPhase);
+	STATE_SAVE_VAR(buf, i2sRateRatio);
 
 	return (size_t)(buf - start);
 }
@@ -205,6 +305,10 @@ size_t DACStateLoad(const uint8_t *buf)
 	STATE_LOAD_VAR(buf, bufferIndex);
 	STATE_LOAD_VAR(buf, numberOfSamples);
 	STATE_LOAD_VAR(buf, bufferDone);
+	STATE_LOAD_VAR(buf, i2sWritePos);
+	STATE_LOAD_VAR(buf, i2sReadCount);
+	STATE_LOAD_VAR(buf, i2sPhase);
+	STATE_LOAD_VAR(buf, i2sRateRatio);
 
 	return (size_t)(buf - start);
 }

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -43,7 +43,7 @@ extern retro_audio_sample_batch_t audio_batch_cb;
 #define DAC_AUDIO_RATE		48000	/* Set the audio rate to 48 KHz */
 
 /* Ring buffer for I2S samples produced by the DSP at hardware rate */
-#define I2S_RING_SIZE		4096	/* Power of 2, must be > max samples/frame */
+#define I2S_RING_SIZE		8192	/* Power of 2, must be > max samples/frame */
 #define I2S_RING_MASK		(I2S_RING_SIZE - 1)
 
 /* Jaguar memory locations */
@@ -114,11 +114,13 @@ void DACUpdateSCLKRate(void)
    i2s_rate = sys_clock / (64.0 * (sclk_val + 1));
    i2sRateRatio = i2s_rate / (double)DAC_AUDIO_RATE;
 
-   /* Clamp to a sane range to avoid division by zero or absurd values */
+   /* Clamp to a sane range to avoid division by zero or absurd values.
+    * SCLK=0 gives divider=64, i2s_rate~415kHz, ratio~8.66.
+    * Upper bound of 16.0 allows all valid SCLK values (0-255). */
    if (i2sRateRatio < 0.1)
       i2sRateRatio = 0.1;
-   if (i2sRateRatio > 4.0)
-      i2sRateRatio = 4.0;
+   if (i2sRateRatio > 16.0)
+      i2sRateRatio = 16.0;
 }
 
 /* Called when the DSP writes a sample pair to LTXD/RTXD.

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -70,6 +70,7 @@ static double i2sPhase = 0.0;		/* fractional read position */
 static double i2sRateRatio = 1.0;	/* i2s_rate / 48000.0 */
 
 /* Private function prototypes */
+static void DACUpdateSCLKRate(void);
 
 void DACInit(void)
 {
@@ -101,8 +102,8 @@ void DACDone(void)
 {
 }
 
-/* Called by JTRM-accurate I2S rate to update the rate ratio when SCLK changes */
-void DACUpdateSCLKRate(void)
+/* Update the rate ratio when SCLK changes */
+static void DACUpdateSCLKRate(void)
 {
    uint32_t sclk_val;
    double i2s_rate;
@@ -233,6 +234,8 @@ void DACWriteByte(uint32_t offset, uint8_t data, uint32_t who)
 {
    if (offset == SCLK + 3)
       DACWriteWord(SCLK + 2, (uint16_t)data, UNKNOWN);
+   else if (offset == SMODE + 3)
+      DACWriteWord(SMODE + 2, (uint16_t)data, UNKNOWN);
 }
 
 

--- a/src/jerry/dac.h
+++ b/src/jerry/dac.h
@@ -17,6 +17,7 @@ void DACInit(void);
 void DACReset(void);
 void DACDone(void);
 void DACPrepareFrame(int length);
+void DACUpdateSCLKRate(void);
 
 // DAC memory access
 

--- a/src/jerry/dac.h
+++ b/src/jerry/dac.h
@@ -17,7 +17,6 @@ void DACInit(void);
 void DACReset(void);
 void DACDone(void);
 void DACPrepareFrame(int length);
-void DACUpdateSCLKRate(void);
 
 // DAC memory access
 

--- a/src/jerry/jerry.c
+++ b/src/jerry/jerry.c
@@ -645,7 +645,7 @@ void JERRYWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
 int JERRYGetPIT1Frequency(void)
 {
    /* JERRY PIT uses RISC (full system) clock; see PIT clock rate note. */
-   int systemClockFrequency = (vjs.hardwareTypeNTSC ? RISC_CLOCK_RATE_NTSC : RISC_CLOCK_RATE_PAL);
+   int systemClockFrequency = SYSTEM_CLOCK_RATE;
    int64_t divisor = (int64_t)(JERRYPIT1Prescaler + 1) * (int64_t)(JERRYPIT1Divider + 1);
    if (divisor == 0)
       return 0;
@@ -656,7 +656,7 @@ int JERRYGetPIT1Frequency(void)
 int JERRYGetPIT2Frequency(void)
 {
    /* JERRY PIT uses RISC (full system) clock; see PIT clock rate note. */
-   int systemClockFrequency = (vjs.hardwareTypeNTSC ? RISC_CLOCK_RATE_NTSC : RISC_CLOCK_RATE_PAL);
+   int systemClockFrequency = SYSTEM_CLOCK_RATE;
    int64_t divisor = (int64_t)(JERRYPIT2Prescaler + 1) * (int64_t)(JERRYPIT2Divider + 1);
    if (divisor == 0)
       return 0;

--- a/test/test_pit_clock_rate.c
+++ b/test/test_pit_clock_rate.c
@@ -122,7 +122,8 @@ static void check_func_uses_risc(const char *path, const char *src, const char *
    has_risc = (strstr(snippet, "RISC_CYCLE_IN_USEC") != NULL)
       || (strstr(snippet, "RISC_CYCLE_PAL_IN_USEC") != NULL)
       || (strstr(snippet, "RISC_CLOCK_RATE_NTSC") != NULL)
-      || (strstr(snippet, "RISC_CLOCK_RATE_PAL") != NULL);
+      || (strstr(snippet, "RISC_CLOCK_RATE_PAL") != NULL)
+      || (strstr(snippet, "SYSTEM_CLOCK_RATE") != NULL);
    has_m68k = (strstr(snippet, "M68K_CYCLE_IN_USEC") != NULL)
       || (strstr(snippet, "M68K_CYCLE_PAL_IN_USEC") != NULL)
       || (strstr(snippet, "M68K_CLOCK_RATE_NTSC") != NULL)


### PR DESCRIPTION
## Summary
Games that modify SCLK at runtime (Skyhammer, Iron Soldier 2) were producing clipped/distorted audio because the DAC assumed a fixed relationship between I2S sample rate and the 48 kHz host output.

This adds a proper resampler:
- **Ring buffer capture**: I2S samples written to LTXD/RTXD accumulate in a 16384-entry ring buffer at the actual hardware rate (covers PAL SCLK=0 worst case of ~8311 samples/frame)
- **Rate tracking**: `DACUpdateSCLKRate()` computes the I2S-to-host ratio using JTRM formula `rate = sysclk / (64 * (SCLK + 1))`, referencing `RISC_CLOCK_RATE_NTSC/PAL` constants
- **Linear interpolation**: Host-rate callback reads from ring buffer with fractional phase accumulator, interpolating between adjacent I2S samples
- **Frame continuity**: Ring seeded with current LTXD/RTXD at frame start; fractional phase preserved across boundaries
- **Byte-write fix**: `DACWriteByte` now correctly forwards SCLK byte writes to trigger rate update
- **Savestate**: Resampler position state included in DACStateSave/Load

## Test plan
- [x] `make clean && make -j` — builds clean
- [x] `bash scripts/c89-lint.sh src/jerry/dac.c` — passes
- [x] `make test` — all tests pass
- [ ] Verify Skyhammer/IS2 audio clipping is reduced
- [ ] Verify Atari Karts / Cybermorph audio unchanged (default SCLK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)