### PR TITLE
fix(blitter): skip dstd memory read when bkgwren is set (AvP alpha noise)

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -2977,17 +2977,13 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
                //byte_merge must see the existing dest byte in the low 8 bits of
                //dstd or the unmodified pixel slots in that byte get zeroed
                //(matches WRITE_PIXEL_1/2/4 RMW in the fast blitter).
-               /* Phrase writes merge via byte_merge(mask): inhibited bytes come
-                * from dstd.  When bkgwren is set, hardware uses the DSTDATA
-                * register value as background (typically zero), NOT live
-                * framebuffer data — reading memory here would inject existing
-                * pixels as noise (the AvP red-artifact bug).
-                *
-                * When bkgwren is NOT set and !DSTEN, dstd would stay at
-                * DSTDATA (often 0) and keyed/HUD pixels show black boxes
-                * (Battle Sphere cockpit reticle).  Read the framebuffer in
-                * that case so byte_merge has the live pixels.
-                * See commit 54ca486. */
+               /* Phrase writes merge via byte_merge(mask): inhibited bytes
+                * come from dstd.  When bkgwren is set, hardware uses the
+                * DSTDATA register value as background — reading memory
+                * would inject stale pixels as noise (AvP red-artifact bug).
+                * When bkgwren is NOT set, always read the framebuffer so
+                * byte_merge has the live pixels for uninhibited positions
+                * (Battle Sphere cockpit reticle fix, commit 54ca486). */
                if (phrase_mode && !bkgwren)
                   dstd = ((uint64_t)blitter_read_long(address) << 32) | (uint64_t)blitter_read_long(address + 4);
                else if (!phrase_mode && pixsize < 3 && !dsten && !bkgwren)

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -2978,13 +2978,17 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
                //dstd or the unmodified pixel slots in that byte get zeroed
                //(matches WRITE_PIXEL_1/2/4 RMW in the fast blitter).
                /* Phrase writes merge via byte_merge(mask): inhibited bytes come
-                * from dstd. With !DSTEN the dread path never runs (all dread
-                * strobes need dsten), so dstd would stay at DSTDATA — often 0
-                * — and keyed/HUD pixels show black boxes (Battle Sphere
-                * cockpit reticle / targeting squares).  Always read the
-                * framebuffer in phrase mode so byte_merge has the live pixels.
-                * See commit 54ca486 (which was lost in a later merge). */
-               if (phrase_mode)
+                * from dstd.  When bkgwren is set, hardware uses the DSTDATA
+                * register value as background (typically zero), NOT live
+                * framebuffer data — reading memory here would inject existing
+                * pixels as noise (the AvP red-artifact bug).
+                *
+                * When bkgwren is NOT set and !DSTEN, dstd would stay at
+                * DSTDATA (often 0) and keyed/HUD pixels show black boxes
+                * (Battle Sphere cockpit reticle).  Read the framebuffer in
+                * that case so byte_merge has the live pixels.
+                * See commit 54ca486. */
+               if (phrase_mode && !bkgwren)
                   dstd = ((uint64_t)blitter_read_long(address) << 32) | (uint64_t)blitter_read_long(address + 4);
                else if (!phrase_mode && pixsize < 3 && !dsten && !bkgwren)
                   dstd = (uint64_t)blitter_read_byte(address);


### PR DESCRIPTION
Fixes the red alpha noise on AvP map screen in accurate blitter mode.

## Summary
- Root cause: Midsummer blitter dwrite state unconditionally read destination memory in phrase mode, injecting stale framebuffer pixels into inhibited byte positions via byte_merge
- When bkgwren is set, hardware uses the DSTDATA register value (typically zero) as background, NOT live framebuffer data
- Fix: add && !bkgwren to the phrase-mode dstd read condition (matching the collapsed pattern-fill path that already had this guard)

## Test plan
- [x] AvP: map screen in accurate blitter mode shows clean pixels
- [ ] Battle Sphere: cockpit HUD reticle still renders correctly
- [x] test/test_blitter_mmio passes
- [x] Build passes on GCC + Clang

Generated with Claude Code