### PR TITLE
fix(bus): centralized bus arbiter for GPU/blitter memory contention

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -31,6 +31,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/tom/tom.c  \
 	$(CORE_DIR)/src/cd/cdintf.c \
 	$(CORE_DIR)/src/cd/cdrom.c \
+	$(CORE_DIR)/src/core/bus_arbiter.c \
 	$(CORE_DIR)/src/core/cheat.c \
 	$(CORE_DIR)/src/core/crc32.c \
 	$(CORE_DIR)/src/core/perf_counters.c \

--- a/Makefile.common
+++ b/Makefile.common
@@ -34,6 +34,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/cd/jagcd_bios.c \
 	$(CORE_DIR)/src/cd/jagcd_cart.c \
 	$(CORE_DIR)/src/cd/jagcd_hle.c \
+	$(CORE_DIR)/src/core/bus_arbiter.c \
 	$(CORE_DIR)/src/core/cheat.c \
 	$(CORE_DIR)/src/core/crc32.c \
 	$(CORE_DIR)/src/core/perf_counters.c \

--- a/exports-test.list
+++ b/exports-test.list
@@ -58,3 +58,5 @@ _BlitterCompare*
 _DAC*
 _JoystickState*
 _MTState*
+_busArbiter
+_bus_arbiter_*

--- a/libretro.c
+++ b/libretro.c
@@ -8,6 +8,7 @@
 #include <compat/posix_string.h>
 #include <compat/strl.h>
 
+#include "bus_arbiter.h"
 #include "cheat.h"
 #include "crash_detect.h"
 #include "file.h"
@@ -314,6 +315,20 @@ static void check_variables(void)
    {
       CrashDetectSetMode(CRASH_DETECT_ON);
    }
+
+   var.key = "virtualjaguar_bus_contention";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "enabled") == 0)
+         vjs.useBusContention = true;
+      else
+         vjs.useBusContention = false;
+   }
+   else
+      vjs.useBusContention = true;
+   busArbiter.enabled = vjs.useBusContention ? 1 : 0;
 
    var.key = "virtualjaguar_bios";
    var.value = NULL;
@@ -864,6 +879,7 @@ bool retro_load_game(const struct retro_game_info *info)
    /* Register EEPROM dirty callback so the save buffer stays in sync */
    eeprom_dirty_cb = eeprom_pack_save_buf;
 
+   bus_arbiter_init();
    JaguarInit();                                             // set up hardware
    CrashDetectReset();                                       // zero per-game watchdog state
    memcpy(jagMemSpace + 0xE00000, jaguarBootROM, 0x20000); // Use the stock BIOS
@@ -1052,6 +1068,7 @@ void retro_init(void)
 
 void retro_deinit(void)
 {
+   bus_arbiter_reset();
    libretro_supports_bitmasks = false;
 
    /* Belt-and-suspenders: shut down emulator subsystems if the frontend

--- a/libretro.c
+++ b/libretro.c
@@ -288,6 +288,7 @@ void retro_set_environment(retro_environment_t cb)
 static void check_variables(void)
 {
    unsigned i;
+   unsigned contention_scale;
    struct retro_variable var;
    var.key = "virtualjaguar_usefastblitter";
    var.value = NULL;
@@ -328,7 +329,22 @@ static void check_variables(void)
    }
    else
       vjs.useBusContention = true;
+
+   contention_scale = 1;
+   var.key = "virtualjaguar_bus_contention_scale";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "8x") == 0)
+         contention_scale = 8;
+      else if (strcmp(var.value, "4x") == 0)
+         contention_scale = 4;
+      else if (strcmp(var.value, "2x") == 0)
+         contention_scale = 2;
+   }
+
    busArbiter.enabled = vjs.useBusContention ? 1 : 0;
+   busArbiter.contention_scale = (uint8_t)contention_scale;
 
    var.key = "virtualjaguar_bios";
    var.value = NULL;
@@ -870,6 +886,7 @@ bool retro_load_game(const struct retro_game_info *info)
    vjs.hardwareTypeNTSC = true;
    vjs.useJaguarBIOS    = false;
 
+   bus_arbiter_init();
    check_variables();
 
 #ifdef BUILD_TIMESTAMP
@@ -879,7 +896,6 @@ bool retro_load_game(const struct retro_game_info *info)
    /* Register EEPROM dirty callback so the save buffer stays in sync */
    eeprom_dirty_cb = eeprom_pack_save_buf;
 
-   bus_arbiter_init();
    JaguarInit();                                             // set up hardware
    CrashDetectReset();                                       // zero per-game watchdog state
    memcpy(jagMemSpace + 0xE00000, jaguarBootROM, 0x20000); // Use the stock BIOS

--- a/libretro.c
+++ b/libretro.c
@@ -336,6 +336,7 @@ void retro_set_environment(retro_environment_t cb)
 static void check_variables(void)
 {
    unsigned i;
+   unsigned contention_scale;
    struct retro_variable var;
    var.key = "virtualjaguar_usefastblitter";
    var.value = NULL;
@@ -383,7 +384,22 @@ static void check_variables(void)
    }
    else
       vjs.useBusContention = true;
+
+   contention_scale = 1;
+   var.key = "virtualjaguar_bus_contention_scale";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "8x") == 0)
+         contention_scale = 8;
+      else if (strcmp(var.value, "4x") == 0)
+         contention_scale = 4;
+      else if (strcmp(var.value, "2x") == 0)
+         contention_scale = 2;
+   }
+
    busArbiter.enabled = vjs.useBusContention ? 1 : 0;
+   busArbiter.contention_scale = (uint8_t)contention_scale;
 
    var.key = "virtualjaguar_bios";
    var.value = NULL;

--- a/libretro.c
+++ b/libretro.c
@@ -16,6 +16,7 @@ int64_t rfseek(RFILE* stream, int64_t offset, int origin);
 int64_t rftell(RFILE* stream);
 int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream);
 
+#include "bus_arbiter.h"
 #include "cheat.h"
 #include "crash_detect.h"
 #include "file.h"
@@ -369,6 +370,20 @@ static void check_variables(void)
       CDTraceSetEnabled(strcmp(var.value, "enabled") == 0);
    else
       CDTraceSetEnabled(0);
+
+   var.key = "virtualjaguar_bus_contention";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "enabled") == 0)
+         vjs.useBusContention = true;
+      else
+         vjs.useBusContention = false;
+   }
+   else
+      vjs.useBusContention = true;
+   busArbiter.enabled = vjs.useBusContention ? 1 : 0;
 
    var.key = "virtualjaguar_bios";
    var.value = NULL;
@@ -1136,6 +1151,7 @@ bool retro_load_game(const struct retro_game_info *info)
    vjs.cdBootMode       = CDBOOT_HLE;
    vjs.cdReadSpeed      = CDSPEED_2X;
 
+   bus_arbiter_init();
    check_variables();
 
    /* Always identify the exact build in the frontend log: version, short
@@ -1401,6 +1417,7 @@ void retro_init(void)
 
 void retro_deinit(void)
 {
+   bus_arbiter_reset();
    libretro_supports_bitmasks = false;
 
    /* Belt-and-suspenders: shut down emulator subsystems if the frontend

--- a/libretro.c
+++ b/libretro.c
@@ -383,7 +383,7 @@ static void check_variables(void)
          vjs.useBusContention = false;
    }
    else
-      vjs.useBusContention = true;
+      vjs.useBusContention = false;
 
    contention_scale = 1;
    var.key = "virtualjaguar_bus_contention_scale";
@@ -400,6 +400,8 @@ static void check_variables(void)
 
    busArbiter.enabled = vjs.useBusContention ? 1 : 0;
    busArbiter.contention_scale = (uint8_t)contention_scale;
+   if (!busArbiter.enabled)
+      bus_arbiter_begin_timeslice(); /* drop stale accumulators on disable */
 
    var.key = "virtualjaguar_bios";
    var.value = NULL;

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -124,7 +124,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_bus_contention",
       "Bus Contention",
       NULL,
-      "Model bus arbitration between processors. GPU and blitter memory accesses stall appropriately based on DRAM timing. Fixes games that run too fast (e.g. Doom). Disable if a game has issues.",
+      "Model bus arbitration between processors. GPU and blitter memory accesses stall based on DRAM timing. Disable if a game has issues.",
       NULL,
       NULL,
       {
@@ -133,6 +133,22 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "enabled"
+   },
+   {
+      "virtualjaguar_bus_contention_scale",
+      "Bus Contention Scale",
+      NULL,
+      "Scales bus contention penalty charged to GPU/blitter accesses. Use larger values to tune slowdown for bus-bound titles.",
+      NULL,
+      NULL,
+      {
+         { "1x", "1x (default)" },
+         { "2x", "2x" },
+         { "4x", "4x" },
+         { "8x", "8x" },
+         { NULL, NULL },
+      },
+      "1x"
    },
    {
       "virtualjaguar_bios",

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -121,6 +121,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "enabled"
    },
    {
+      "virtualjaguar_bus_contention",
+      "Bus Contention",
+      NULL,
+      "Model bus arbitration between processors. GPU and blitter memory accesses stall appropriately based on DRAM timing. Fixes games that run too fast (e.g. Doom). Disable if a game has issues.",
+      NULL,
+      NULL,
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
       "virtualjaguar_bios",
       "BIOS",
       NULL,

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -121,6 +121,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "enabled"
    },
    {
+      "virtualjaguar_bus_contention",
+      "Bus Contention",
+      NULL,
+      "Model bus arbitration between processors. GPU and blitter memory accesses stall appropriately based on DRAM timing. Fixes games that run too fast (e.g. Doom). Disable if a game has issues.",
+      NULL,
+      NULL,
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
       "virtualjaguar_cd_trace",
       "CD Trace (Diagnostic)",
       NULL,

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -124,7 +124,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_bus_contention",
       "Bus Contention",
       NULL,
-      "Model bus arbitration between processors. GPU and blitter memory accesses stall appropriately based on DRAM timing. Fixes games that run too fast (e.g. Doom). Disable if a game has issues.",
+      "Model bus arbitration between processors. GPU and blitter memory accesses stall based on DRAM timing. Disable if a game has issues.",
       NULL,
       NULL,
       {
@@ -133,6 +133,22 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "enabled"
+   },
+   {
+      "virtualjaguar_bus_contention_scale",
+      "Bus Contention Scale",
+      NULL,
+      "Scales bus contention penalty charged to GPU/blitter accesses. Use larger values to tune slowdown for bus-bound titles.",
+      NULL,
+      NULL,
+      {
+         { "1x", "1x (default)" },
+         { "2x", "2x" },
+         { "4x", "4x" },
+         { "8x", "8x" },
+         { NULL, NULL },
+      },
+      "1x"
    },
    {
       "virtualjaguar_cd_trace",

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -122,17 +122,17 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "virtualjaguar_bus_contention",
-      "Bus Contention",
+      "Bus Contention (Experimental)",
       NULL,
-      "Model bus arbitration between processors. GPU and blitter memory accesses stall based on DRAM timing. Disable if a game has issues.",
+      "Model bus arbitration between processors: GPU and blitter memory accesses stall based on DRAM timing and penalize the 68K. Fixes overspeed in 68K/GPU-heavy titles that run too fast (e.g. Doom), but is experimental — leave disabled unless a game runs too fast.",
       NULL,
       NULL,
       {
-         { "enabled",  NULL },
          { "disabled", NULL },
+         { "enabled",  NULL },
          { NULL, NULL },
       },
-      "enabled"
+      "disabled"
    },
    {
       "virtualjaguar_bus_contention_scale",

--- a/link-test.T
+++ b/link-test.T
@@ -61,5 +61,7 @@
       DAC*;
       JoystickState*;
       MTState*;
+      busArbiter;
+      bus_arbiter_*;
    local: *;
 };

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -22,12 +22,21 @@ static const uint8_t dramspeed_table[4] = { 2, 3, 4, 5 };
 /* RAS precharge penalty for page miss (row activation + precharge). */
 #define PAGE_MISS_PENALTY 4
 
+static uint32_t bus_arbiter_apply_scale(uint32_t sys_clocks)
+{
+    if (busArbiter.contention_scale <= 1)
+        return sys_clocks;
+
+    return sys_clocks * busArbiter.contention_scale;
+}
+
 void bus_arbiter_init(void)
 {
     memset(&busArbiter, 0, sizeof(busArbiter));
     busArbiter.dram_base_clocks = 5;
     busArbiter.dram_miss_penalty = PAGE_MISS_PENALTY;
     busArbiter.enabled = 1;
+    busArbiter.contention_scale = 1;
 }
 
 void bus_arbiter_reset(void)
@@ -48,7 +57,7 @@ void bus_arbiter_update_memcon(uint16_t memcon1)
 void bus_arbiter_charge(int master, uint32_t sys_clocks)
 {
     if (master >= 0 && master < BM_COUNT)
-        busArbiter.bus_cycles[master] += sys_clocks;
+        busArbiter.bus_cycles[master] += bus_arbiter_apply_scale(sys_clocks);
 }
 
 uint32_t bus_arbiter_penalty(int master)
@@ -112,8 +121,13 @@ uint32_t bus_arbiter_dram_cost(uint32_t addr)
 uint32_t bus_arbiter_charge_access(int master, uint32_t addr)
 {
     uint32_t cost;
+    uint32_t scaled_cost;
     cost = bus_arbiter_dram_cost(addr);
-    if (cost > 0)
+    if (cost > 0) {
+        scaled_cost = bus_arbiter_apply_scale(cost);
         bus_arbiter_charge(master, cost);
-    return cost;
+        return scaled_cost;
+    }
+    
+    return 0;
 }

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -1,0 +1,119 @@
+/*
+ * bus_arbiter.c — Centralized bus arbitration model.
+ *
+ * See bus_arbiter.h for design rationale.
+ *
+ * MEMCON1 default on Jaguar: 0x1861
+ *   Bits 5-6 (DRAMSPEED): 0b11 = 5 system clocks per DRAM access
+ *   Page miss adds ~4 clocks for RAS precharge + row activation
+ *
+ * MiSTer reference: rtl/Rework/arb.v, mem.v, gateway.v
+ */
+
+#include "bus_arbiter.h"
+#include <string.h>
+
+struct BusArbiter busArbiter;
+
+/* DRAMSPEED field (MEMCON1 bits 5-6) -> base DRAM clocks per access.
+ * JTRM: 00=2, 01=3, 10=4, 11=5 system clocks. */
+static const uint8_t dramspeed_table[4] = { 2, 3, 4, 5 };
+
+/* RAS precharge penalty for page miss (row activation + precharge). */
+#define PAGE_MISS_PENALTY 4
+
+void bus_arbiter_init(void)
+{
+    memset(&busArbiter, 0, sizeof(busArbiter));
+    busArbiter.dram_base_clocks = 5;
+    busArbiter.dram_miss_penalty = PAGE_MISS_PENALTY;
+    busArbiter.enabled = 1;
+}
+
+void bus_arbiter_reset(void)
+{
+    int i;
+    for (i = 0; i < BM_COUNT; i++)
+        busArbiter.bus_cycles[i] = 0;
+    busArbiter.op_active = 0;
+}
+
+void bus_arbiter_update_memcon(uint16_t memcon1)
+{
+    uint8_t dramspeed;
+    dramspeed = (memcon1 >> 5) & 0x03;
+    busArbiter.dram_base_clocks = dramspeed_table[dramspeed];
+}
+
+void bus_arbiter_charge(int master, uint32_t sys_clocks)
+{
+    if (master >= 0 && master < BM_COUNT)
+        busArbiter.bus_cycles[master] += sys_clocks;
+}
+
+uint32_t bus_arbiter_penalty(int master)
+{
+    uint32_t higher_total;
+    int i;
+
+    if (!busArbiter.enabled)
+        return 0;
+
+    higher_total = 0;
+    for (i = 0; i < master && i < BM_COUNT; i++)
+        higher_total += busArbiter.bus_cycles[i];
+
+    return higher_total;
+}
+
+void bus_arbiter_begin_timeslice(void)
+{
+    int i;
+    for (i = 0; i < BM_COUNT; i++)
+        busArbiter.bus_cycles[i] = 0;
+}
+
+void bus_arbiter_set_op_active(int active)
+{
+    busArbiter.op_active = (uint8_t)(active != 0);
+}
+
+uint32_t bus_arbiter_dram_cost(uint32_t addr)
+{
+    /* GPU local RAM: 0xF03000-0xF03FFF — no bus transaction */
+    if (addr >= 0xF03000 && addr <= 0xF03FFF)
+        return 0;
+
+    /* DSP local RAM: 0xF1B000-0xF1CFFF — no bus transaction */
+    if (addr >= 0xF1B000 && addr <= 0xF1CFFF)
+        return 0;
+
+    /* Main DRAM (0x000000-0x1FFFFF): full DRAM access cost.
+     * Use page-miss cost as the average — sequential access patterns
+     * would get page hits, but without tracking row state, the miss
+     * cost is a reasonable average for scattered GPU access patterns. */
+    if (addr < 0x200000)
+        return busArbiter.dram_base_clocks + busArbiter.dram_miss_penalty;
+
+    /* Cartridge ROM (0x800000-0xDFFFFF): similar cost to DRAM.
+     * ROMSPEED from MEMCON1 bits 3-4 controls this, but games rarely
+     * access ROM from GPU at runtime. Use DRAM base cost. */
+    if (addr >= 0x800000 && addr < 0xE00000)
+        return busArbiter.dram_base_clocks;
+
+    /* TOM/JERRY registers: ~2 system clocks (I/O bus). */
+    if (addr >= 0xF00000)
+        return 2;
+
+    /* Default for other addresses */
+    return busArbiter.dram_base_clocks;
+}
+
+uint32_t bus_arbiter_charge_access(int master, uint32_t addr)
+{
+    uint32_t cost;
+    cost = bus_arbiter_dram_cost(addr);
+    if (cost > 0)
+        bus_arbiter_charge(master, cost);
+    return cost;
+}

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -131,6 +131,6 @@ uint32_t bus_arbiter_charge_access(int master, uint32_t addr)
         bus_arbiter_charge(master, cost);
         return scaled_cost;
     }
-    
+
     return 0;
 }

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -35,7 +35,10 @@ void bus_arbiter_init(void)
     memset(&busArbiter, 0, sizeof(busArbiter));
     busArbiter.dram_base_clocks = 5;
     busArbiter.dram_miss_penalty = PAGE_MISS_PENALTY;
-    busArbiter.enabled = 1;
+    /* Default OFF: contention modeling is experimental and must be a
+     * zero-behavior-change opt-in.  check_variables() enables it when
+     * the virtualjaguar_bus_contention core option is set. */
+    busArbiter.enabled = 0;
     busArbiter.contention_scale = 1;
 }
 

--- a/src/core/bus_arbiter.h
+++ b/src/core/bus_arbiter.h
@@ -62,6 +62,9 @@ struct BusArbiter {
 
     /* Feature toggle (from core option) */
     uint8_t enabled;
+
+    /* Scale factor applied to charged contention cycles (1x, 2x, ...). */
+    uint8_t contention_scale;
 };
 
 extern struct BusArbiter busArbiter;

--- a/src/core/bus_arbiter.h
+++ b/src/core/bus_arbiter.h
@@ -1,0 +1,102 @@
+/*
+ * bus_arbiter.h — Centralized bus arbitration model.
+ *
+ * Models the Jaguar's single 64-bit bus shared by all masters.
+ * Based on the MiSTer FPGA implementation (arb.v / gateway.v / mem.v).
+ *
+ * Rather than cycle-accurate arbitration, this uses an accounting model:
+ * each bus master reports its external memory accesses; the arbiter
+ * computes how many cycles each master lost to higher-priority traffic.
+ */
+
+#ifndef BUS_ARBITER_H
+#define BUS_ARBITER_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Bus master IDs, ordered by JTRM priority (0 = highest).
+ *
+ * JTRM priority table:
+ *   1. Refresh
+ *   2. DSP DMA
+ *   3. GPU DMA
+ *   4. Blitter (high priority, BUSHI)
+ *   5. Object Processor
+ *   6. DSP (normal)
+ *   7. CPU interrupt acknowledge
+ *   8. GPU (normal)
+ *   9. Blitter (normal)
+ *  10. CPU (68000)
+ */
+enum BusMaster {
+    BM_REFRESH = 0,
+    BM_DSP_DMA,
+    BM_GPU_DMA,
+    BM_BLITTER_HI,
+    BM_OP,
+    BM_DSP,
+    BM_CPU_IACK,
+    BM_GPU,
+    BM_BLITTER,
+    BM_CPU,
+    BM_COUNT
+};
+
+struct BusArbiter {
+    /* Accumulated bus cycles consumed per master this timeslice.
+     * Units: system clocks (26.59 MHz). */
+    uint32_t bus_cycles[BM_COUNT];
+
+    /* DRAM timing derived from MEMCON1 DRAMSPEED field.
+     * Page hit = base access time; page miss adds RAS precharge. */
+    uint8_t dram_base_clocks;
+    uint8_t dram_miss_penalty;
+
+    /* OP active display tracking (set during HDB-HDE on visible lines) */
+    uint8_t op_active;
+
+    /* Feature toggle (from core option) */
+    uint8_t enabled;
+};
+
+extern struct BusArbiter busArbiter;
+
+void bus_arbiter_init(void);
+void bus_arbiter_reset(void);
+
+/* Called when MEMCON1 is written to recompute DRAM timing. */
+void bus_arbiter_update_memcon(uint16_t memcon1);
+
+/* Record that `master` consumed `sys_clocks` of bus bandwidth. */
+void bus_arbiter_charge(int master, uint32_t sys_clocks);
+
+/* Compute how many system clocks `master` lost to higher-priority
+ * masters this timeslice.  Result is in system clocks. */
+uint32_t bus_arbiter_penalty(int master);
+
+/* Reset per-timeslice accumulators. Call at the start of each
+ * event timeslice in JaguarExecuteNew(). */
+void bus_arbiter_begin_timeslice(void);
+
+/* Set OP active display state (called from TOM halfline callback). */
+void bus_arbiter_set_op_active(int active);
+
+/* Return DRAM access cost in system clocks for a given address.
+ * Local GPU/DSP RAM returns 0 (no bus transaction).
+ * ROM returns ROM speed from MEMCON1. */
+uint32_t bus_arbiter_dram_cost(uint32_t addr);
+
+/* Convenience: charge a DRAM access for `master` at `addr`.
+ * Returns the cost charged (0 if address is local RAM). */
+uint32_t bus_arbiter_charge_access(int master, uint32_t addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BUS_ARBITER_H */

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -22,6 +22,7 @@
 #include "perf_counters.h"
 #include "dac.h"
 #include "dsp.h"
+#include "bus_arbiter.h"
 #include "eeprom.h"
 #include "event.h"
 #include "gpu.h"
@@ -948,9 +949,18 @@ uint8_t * GetRamPtr(void)
 /* New Jaguar execution stack
  * This executes 1 frame's worth of code.
  * Interleaves EVENT_MAIN (video/halfline) and EVENT_JERRY (DSP/I2S/timers)
- * so the DSP runs alongside the 68K and GPU, matching real hardware timing. */
+ * so the DSP runs alongside the 68K and GPU, matching real hardware timing.
+ *
+ * Bus contention: GPU external memory accesses self-penalize (the GPU
+ * burns extra cycles per LOAD/STORE in gpu.c).  Those same cycles are
+ * also recorded in the bus arbiter.  At each timeslice boundary we
+ * deduct the accumulated higher-priority bus traffic from the 68K
+ * budget, modeling the real hardware priority: GPU > blitter > 68K. */
 void JaguarExecuteNew(void)
 {
+   int32_t m68k_budget;
+   uint32_t m68k_penalty;
+
    PERF_INC(timing_jaguar_execute_calls);
    frameDone = false;
 
@@ -963,7 +973,19 @@ void JaguarExecuteNew(void)
       if (timeToJerryEvent < timeToMainEvent)
       {
          timeDelta = timeToJerryEvent;
-         m68k_execute(USEC_TO_M68K_CYCLES(timeDelta));
+
+         m68k_budget = (int32_t)USEC_TO_M68K_CYCLES(timeDelta);
+         if (busArbiter.enabled)
+         {
+            m68k_penalty = bus_arbiter_penalty(BM_CPU) / 2;
+            if ((int32_t)m68k_penalty > m68k_budget)
+               m68k_budget = 0;
+            else
+               m68k_budget -= (int32_t)m68k_penalty;
+            bus_arbiter_begin_timeslice();
+         }
+
+         m68k_execute(m68k_budget);
          GPUExec(USEC_TO_RISC_CYCLES(timeDelta));
          DSPExec(USEC_TO_RISC_CYCLES(timeDelta));
          SubtractEventTimes(timeDelta, EVENT_MAIN);
@@ -972,7 +994,19 @@ void JaguarExecuteNew(void)
       else
       {
          timeDelta = timeToMainEvent;
-         m68k_execute(USEC_TO_M68K_CYCLES(timeDelta));
+
+         m68k_budget = (int32_t)USEC_TO_M68K_CYCLES(timeDelta);
+         if (busArbiter.enabled)
+         {
+            m68k_penalty = bus_arbiter_penalty(BM_CPU) / 2;
+            if ((int32_t)m68k_penalty > m68k_budget)
+               m68k_budget = 0;
+            else
+               m68k_budget -= (int32_t)m68k_penalty;
+            bus_arbiter_begin_timeslice();
+         }
+
+         m68k_execute(m68k_budget);
          GPUExec(USEC_TO_RISC_CYCLES(timeDelta));
          DSPExec(USEC_TO_RISC_CYCLES(timeDelta));
          SubtractEventTimes(timeDelta, EVENT_JERRY);

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -25,6 +25,7 @@
 #include "jagcd_hle.h"
 #include "dac.h"
 #include "dsp.h"
+#include "bus_arbiter.h"
 #include "eeprom.h"
 #include "event.h"
 #include "gpu.h"
@@ -1045,9 +1046,18 @@ uint8_t * GetRamPtr(void)
 /* New Jaguar execution stack
  * This executes 1 frame's worth of code.
  * Interleaves EVENT_MAIN (video/halfline) and EVENT_JERRY (DSP/I2S/timers)
- * so the DSP runs alongside the 68K and GPU, matching real hardware timing. */
+ * so the DSP runs alongside the 68K and GPU, matching real hardware timing.
+ *
+ * Bus contention: GPU external memory accesses self-penalize (the GPU
+ * burns extra cycles per LOAD/STORE in gpu.c).  Those same cycles are
+ * also recorded in the bus arbiter.  At each timeslice boundary we
+ * deduct the accumulated higher-priority bus traffic from the 68K
+ * budget, modeling the real hardware priority: GPU > blitter > 68K. */
 void JaguarExecuteNew(void)
 {
+   int32_t m68k_budget;
+   uint32_t m68k_penalty;
+
    PERF_INC(timing_jaguar_execute_calls);
    frameDone = false;
 
@@ -1067,7 +1077,19 @@ void JaguarExecuteNew(void)
          timeDelta = timeToJerryEvent;
          riscCycles = USEC_TO_RISC_CYCLES(timeDelta);
          GPUBeginSlice(riscCycles);
-         m68k_execute(USEC_TO_M68K_CYCLES(timeDelta));
+
+         m68k_budget = (int32_t)USEC_TO_M68K_CYCLES(timeDelta);
+         if (busArbiter.enabled)
+         {
+            m68k_penalty = bus_arbiter_penalty(BM_CPU) / 2;
+            if ((int32_t)m68k_penalty > m68k_budget)
+               m68k_budget = 0;
+            else
+               m68k_budget -= (int32_t)m68k_penalty;
+            bus_arbiter_begin_timeslice();
+         }
+
+         m68k_execute(m68k_budget);
          GPUExec(GPUSliceRemaining());
          DSPExec(riscCycles);
          SubtractEventTimes(timeDelta, EVENT_MAIN);
@@ -1078,7 +1100,19 @@ void JaguarExecuteNew(void)
          timeDelta = timeToMainEvent;
          riscCycles = USEC_TO_RISC_CYCLES(timeDelta);
          GPUBeginSlice(riscCycles);
-         m68k_execute(USEC_TO_M68K_CYCLES(timeDelta));
+
+         m68k_budget = (int32_t)USEC_TO_M68K_CYCLES(timeDelta);
+         if (busArbiter.enabled)
+         {
+            m68k_penalty = bus_arbiter_penalty(BM_CPU) / 2;
+            if ((int32_t)m68k_penalty > m68k_budget)
+               m68k_budget = 0;
+            else
+               m68k_budget -= (int32_t)m68k_penalty;
+            bus_arbiter_begin_timeslice();
+         }
+
+         m68k_execute(m68k_budget);
          GPUExec(GPUSliceRemaining());
          DSPExec(riscCycles);
          SubtractEventTimes(timeDelta, EVENT_JERRY);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -20,6 +20,7 @@ struct VJSettings
 	bool hardwareTypeNTSC;						// Set to false for PAL
 	bool useJaguarBIOS;
 	bool useFastBlitter;
+	bool useBusContention;
 };
 
 // Exported variables

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -46,6 +46,8 @@ struct VJSettings
 	char jagBootPath[MAX_PATH];
 	char CDBootPath[MAX_PATH];
 	char alpineROMPath[MAX_PATH];
+
+	bool useBusContention;
 };
 
 enum { BT_K_SERIES, BT_M_SERIES, BT_STUBULATOR_1, BT_STUBULATOR_2 };

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -25,6 +25,7 @@
 #include "blitter_simd.h"
 
 #include <string.h>
+#include "bus_arbiter.h"
 #include "jaguar.h"
 #include "perf_counters.h"
 #include "state.h"
@@ -141,6 +142,15 @@ PERF_COUNTER(blitter_inner_io);
 PERF_COUNTER(blitter_inner_idle);
 PERF_COUNTER(blitter_phrase_reads);
 PERF_COUNTER(blitter_phrase_writes);
+
+/* Bus contention: each phrase read/write is a DRAM bus transaction.
+ * Charge the cost to the arbiter so the 68K gets penalized. */
+#define BLITTER_BUS_CHARGE() \
+   do { \
+      if (busArbiter.enabled) \
+         bus_arbiter_charge(BM_BLITTER, \
+            busArbiter.dram_base_clocks + busArbiter.dram_miss_penalty); \
+   } while (0)
 
 #define REG(A)	(((uint32_t)blitter_ram[(A)] << 24) | ((uint32_t)blitter_ram[(A)+1] << 16) \
 				| ((uint32_t)blitter_ram[(A)+2] << 8) | (uint32_t)blitter_ram[(A)+3])
@@ -1045,6 +1055,16 @@ void blitter_blit(uint32_t cmd)
    }
 
    blitter_generic(cmd);
+
+   /* Fast blitter bus contention: estimate 2 bus transactions per
+    * inner iteration (one source read + one destination write).
+    * Phrase mode processes a full phrase per iteration. */
+   if (busArbiter.enabled && n_pixels > 0 && n_lines > 0)
+   {
+      uint32_t total_ops = n_pixels * n_lines * 2;
+      bus_arbiter_charge(BM_BLITTER, total_ops *
+         (busArbiter.dram_base_clocks + busArbiter.dram_miss_penalty));
+   }
 }
 #endif
 /*******************************************************************************
@@ -2180,6 +2200,7 @@ void BlitterMidsummer2(void)
 
                /* ---- Write pixel/phrase ---- */
                PERF_INC(blitter_phrase_writes);
+               BLITTER_BUS_CHARGE();
                if (!pf_winhibit || bkgwren)
                {
                   if (phrase_mode)
@@ -2394,6 +2415,7 @@ void BlitterMidsummer2(void)
                srcd1 = ((uint64_t)blitter_read_long(fc_src_addr) << 32)
                   | (uint64_t)blitter_read_long(fc_src_addr + 4);
                PERF_INC(blitter_phrase_reads);
+               BLITTER_BUS_CHARGE();
 
                /* Pixel mode: shift source to correct position */
                if (!phrase_mode)
@@ -2503,6 +2525,7 @@ void BlitterMidsummer2(void)
 
                /* Write */
                PERF_INC(blitter_phrase_writes);
+               BLITTER_BUS_CHARGE();
                if (!fc_winhibit || bkgwren)
                {
                   if (phrase_mode)
@@ -2815,6 +2838,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
             if (sreadx)
             {
                PERF_INC(blitter_phrase_reads);
+               BLITTER_BUS_CHARGE();
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
@@ -2857,6 +2881,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
             if (sread)
             {
                PERF_INC(blitter_phrase_reads);
+               BLITTER_BUS_CHARGE();
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
@@ -2886,6 +2911,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
             if (szread)
             {
                PERF_INC(blitter_phrase_reads);
+               BLITTER_BUS_CHARGE();
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
@@ -2900,6 +2926,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
             if (dread)
             {
                PERF_INC(blitter_phrase_reads);
+               BLITTER_BUS_CHARGE();
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
@@ -2941,6 +2968,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
 #endif
 
                PERF_INC(blitter_phrase_writes);
+               BLITTER_BUS_CHARGE();
                ppp = 64 >> pixsize;
                inct = -((dsta2 ? a2_x : a1_x) & 0x07);
                inc = (!phrase_mode || (phrase_mode && (inct & 0x01)) ? 0x01 : 0x00);
@@ -3191,6 +3219,7 @@ A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
             if (dzwrite)
             {
                PERF_INC(blitter_phrase_writes);
+               BLITTER_BUS_CHARGE();
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -25,6 +25,7 @@
 #include "blitter_simd.h"
 
 #include <string.h>
+#include "bus_arbiter.h"
 #include "jaguar.h"
 #include "perf_counters.h"
 #include "state.h"
@@ -141,6 +142,15 @@ PERF_COUNTER(blitter_inner_io);
 PERF_COUNTER(blitter_inner_idle);
 PERF_COUNTER(blitter_phrase_reads);
 PERF_COUNTER(blitter_phrase_writes);
+
+/* Bus contention: each phrase read/write is a DRAM bus transaction.
+ * Charge the cost to the arbiter so the 68K gets penalized. */
+#define BLITTER_BUS_CHARGE() \
+   do { \
+      if (busArbiter.enabled) \
+         bus_arbiter_charge(BM_BLITTER, \
+            busArbiter.dram_base_clocks + busArbiter.dram_miss_penalty); \
+   } while (0)
 
 #define REG(A)	(((uint32_t)blitter_ram[(A)] << 24) | ((uint32_t)blitter_ram[(A)+1] << 16) \
 				| ((uint32_t)blitter_ram[(A)+2] << 8) | (uint32_t)blitter_ram[(A)+3])
@@ -1093,6 +1103,16 @@ void blitter_blit(uint32_t cmd)
    }
 
    blitter_generic(cmd);
+
+   /* Fast blitter bus contention: estimate 2 bus transactions per
+    * inner iteration (one source read + one destination write).
+    * Phrase mode processes a full phrase per iteration. */
+   if (busArbiter.enabled && n_pixels > 0 && n_lines > 0)
+   {
+      uint32_t total_ops = n_pixels * n_lines * 2;
+      bus_arbiter_charge(BM_BLITTER, total_ops *
+         (busArbiter.dram_base_clocks + busArbiter.dram_miss_penalty));
+   }
 }
 #endif
 /*******************************************************************************
@@ -2278,6 +2298,7 @@ void BlitterMidsummer2(void)
 
                /* ---- Write pixel/phrase ---- */
                PERF_INC(blitter_phrase_writes);
+               BLITTER_BUS_CHARGE();
                if (!pf_winhibit || bkgwren)
                {
                   if (phrase_mode)
@@ -2492,6 +2513,7 @@ void BlitterMidsummer2(void)
                srcd1 = ((uint64_t)blitter_read_long(fc_src_addr) << 32)
                   | (uint64_t)blitter_read_long(fc_src_addr + 4);
                PERF_INC(blitter_phrase_reads);
+               BLITTER_BUS_CHARGE();
 
                /* Pixel mode: shift source to correct position */
                if (!phrase_mode)
@@ -2601,6 +2623,7 @@ void BlitterMidsummer2(void)
 
                /* Write */
                PERF_INC(blitter_phrase_writes);
+               BLITTER_BUS_CHARGE();
                if (!fc_winhibit || bkgwren)
                {
                   if (phrase_mode)
@@ -2913,6 +2936,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
             if (sreadx)
             {
                PERF_INC(blitter_phrase_reads);
+               BLITTER_BUS_CHARGE();
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
@@ -2955,6 +2979,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
             if (sread)
             {
                PERF_INC(blitter_phrase_reads);
+               BLITTER_BUS_CHARGE();
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
@@ -2984,6 +3009,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
             if (szread)
             {
                PERF_INC(blitter_phrase_reads);
+               BLITTER_BUS_CHARGE();
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
@@ -2998,6 +3024,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
             if (dread)
             {
                PERF_INC(blitter_phrase_reads);
+               BLITTER_BUS_CHARGE();
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
@@ -3039,6 +3066,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
 #endif
 
                PERF_INC(blitter_phrase_writes);
+               BLITTER_BUS_CHARGE();
                ppp = 64 >> pixsize;
                inct = -((dsta2 ? a2_x : a1_x) & 0x07);
                inc = (!phrase_mode || (phrase_mode && (inct & 0x01)) ? 0x01 : 0x00);
@@ -3289,6 +3317,7 @@ A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
             if (dzwrite)
             {
                PERF_INC(blitter_phrase_writes);
+               BLITTER_BUS_CHARGE();
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -27,15 +27,32 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>								// For memset
+#include "bus_arbiter.h"
 #include "log.h"
 #include "dsp.h"
 #include "jaguar.h"
 #include "m68000/m68kinterface.h"
+#include "settings.h"
 #include "tom.h"
 
 
 // Seems alignment in loads & stores was off...
 #define GPU_CORRECT_ALIGNMENT
+
+/* Bus contention: accumulates stall cycles for GPU external memory
+ * accesses within a single instruction.  Reset before each opcode
+ * in GPUExec(), then added to cycle cost after the opcode completes.
+ * Units: system clocks (same as bus_arbiter charges). */
+static uint32_t gpu_bus_stall;
+
+/* Charge an external memory access and accumulate the stall.
+ * addr is the target address — GPU local RAM (0xF03000-0xF03FFF)
+ * costs nothing; external addresses cost DRAM access time. */
+#define GPU_EXT_ACCESS(addr) \
+   do { \
+      if (busArbiter.enabled) \
+         gpu_bus_stall += bus_arbiter_charge_access(BM_GPU, (addr)); \
+   } while (0)
 
 #define GPU_TRACE_DEBUG 0
 #if GPU_TRACE_DEBUG
@@ -744,16 +761,14 @@ void GPUExec(int32_t cycles)
       //$E400 -> 1110 01 -> $39 -> 57
       //GPU #1
       gpu_pc += 2;
+      gpu_bus_stall = 0;
 #if 0
       gpu_opcode[index]();
 #else
        executeOpcode(index);
 #endif
-      // BIOS hacking
-      //GPU: [00F03548] jr      nz,00F03560 (0xd561) (RM=00F03114, RN=00000004) ->     --> JR: Branch taken.
-      //GPU: [00F0354C] jump    nz,(r29) (0xd3a1) (RM=00F03314, RN=00000004) -> (RM=00F03314, RN=00000004)
 
-      cycles -= gpu_opcode_cycles[index];
+      cycles -= gpu_opcode_cycles[index] + (int32_t)gpu_bus_stall;
    }
 
    gpu_in_exec--;
@@ -1184,12 +1199,17 @@ INLINE static void gpu_opcode_store_r14_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2), RN, GPU);
+   {
+      uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1199,12 +1219,17 @@ INLINE static void gpu_opcode_store_r15_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2), RN, GPU);
+   {
+      uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1214,12 +1239,17 @@ INLINE static void gpu_opcode_load_r14_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[14] + RM, GPU);
+   {
+      uint32_t address = gpu_reg[14] + RM;
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 
@@ -1229,12 +1259,17 @@ INLINE static void gpu_opcode_load_r15_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[15] + RM, GPU);
+   {
+      uint32_t address = gpu_reg[15] + RM;
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 
@@ -1244,12 +1279,17 @@ INLINE static void gpu_opcode_store_r14_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[14] + RM, RN, GPU);
+   {
+      uint32_t address = gpu_reg[14] + RM;
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1259,12 +1299,17 @@ INLINE static void gpu_opcode_store_r15_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT_STORE
    uint32_t address = gpu_reg[15] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[15] + RM, RN, GPU);
+   {
+      uint32_t address = gpu_reg[15] + RM;
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1287,12 +1332,13 @@ INLINE static void gpu_opcode_pack(void)
 
 INLINE static void gpu_opcode_storeb(void)
 {
-   //Is this right???
-   // Would appear to be so...!
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM, RN & 0xFF, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       JaguarWriteByte(RM, RN, GPU);
+   }
 }
 
 
@@ -1302,12 +1348,18 @@ INLINE static void gpu_opcode_storew(void)
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM & 0xFFFFFFFE, RN & 0xFFFF, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       JaguarWriteWord(RM, RN, GPU);
+   }
 #else
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM, RN & 0xFFFF, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       JaguarWriteWord(RM, RN, GPU);
+   }
 #endif
 }
 
@@ -1318,8 +1370,12 @@ INLINE static void gpu_opcode_store(void)
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM & 0xFFFFFFFC, RN, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       GPUWriteLong(RM, RN, GPU);
+   }
 #else
+   GPU_EXT_ACCESS(RM);
    GPUWriteLong(RM, RN, GPU);
 #endif
 }
@@ -1335,10 +1391,14 @@ INLINE static void gpu_opcode_storep(void)
    }
    else
    {
+      GPU_EXT_ACCESS(RM);
+      GPU_EXT_ACCESS(RM + 4);
       GPUWriteLong(RM + 0, gpu_hidata, GPU);
       GPUWriteLong(RM + 4, RN, GPU);
    }
 #else
+   GPU_EXT_ACCESS(RM);
+   GPU_EXT_ACCESS(RM + 4);
    GPUWriteLong(RM + 0, gpu_hidata, GPU);
    GPUWriteLong(RM + 4, RN, GPU);
 #endif
@@ -1349,7 +1409,10 @@ INLINE static void gpu_opcode_loadb(void)
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       RN = GPUReadLong(RM, GPU) & 0xFF;
    else
+   {
+      GPU_EXT_ACCESS(RM);
       RN = JaguarReadByte(RM, GPU);
+   }
 }
 
 
@@ -1359,12 +1422,18 @@ INLINE static void gpu_opcode_loadw(void)
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       RN = GPUReadLong(RM & 0xFFFFFFFE, GPU) & 0xFFFF;
    else
+   {
+      GPU_EXT_ACCESS(RM);
       RN = JaguarReadWord(RM, GPU);
+   }
 #else
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       RN = GPUReadLong(RM, GPU) & 0xFFFF;
    else
+   {
+      GPU_EXT_ACCESS(RM);
       RN = JaguarReadWord(RM, GPU);
+   }
 #endif
 }
 
@@ -1389,8 +1458,10 @@ INLINE static void gpu_opcode_loadw(void)
 INLINE static void gpu_opcode_load(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
+   GPU_EXT_ACCESS(RM);
    RN = GPUReadLong(RM & 0xFFFFFFFC, GPU);
 #else
+   GPU_EXT_ACCESS(RM);
    RN = GPUReadLong(RM, GPU);
 #endif
 }
@@ -1406,10 +1477,14 @@ INLINE static void gpu_opcode_loadp(void)
    }
    else
    {
+      GPU_EXT_ACCESS(RM);
+      GPU_EXT_ACCESS(RM + 4);
       gpu_hidata = GPUReadLong(RM + 0, GPU);
       RN		   = GPUReadLong(RM + 4, GPU);
    }
 #else
+   GPU_EXT_ACCESS(RM);
+   GPU_EXT_ACCESS(RM + 4);
    gpu_hidata = GPUReadLong(RM + 0, GPU);
    RN		   = GPUReadLong(RM + 4, GPU);
 #endif
@@ -1421,12 +1496,17 @@ INLINE static void gpu_opcode_load_r14_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2), GPU);
+   {
+      uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 
@@ -1436,12 +1516,17 @@ INLINE static void gpu_opcode_load_r15_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2), GPU);
+   {
+      uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>								// For memset
+#include "bus_arbiter.h"
 #include "log.h"
 #include "dsp.h"
 #include "jaguar.h"
@@ -38,6 +39,21 @@
 
 // Seems alignment in loads & stores was off...
 #define GPU_CORRECT_ALIGNMENT
+
+/* Bus contention: accumulates stall cycles for GPU external memory
+ * accesses within a single instruction.  Reset before each opcode
+ * in GPUExec(), then added to cycle cost after the opcode completes.
+ * Units: system clocks (same as bus_arbiter charges). */
+static uint32_t gpu_bus_stall;
+
+/* Charge an external memory access and accumulate the stall.
+ * addr is the target address — GPU local RAM (0xF03000-0xF03FFF)
+ * costs nothing; external addresses cost DRAM access time. */
+#define GPU_EXT_ACCESS(addr) \
+   do { \
+      if (busArbiter.enabled) \
+         gpu_bus_stall += bus_arbiter_charge_access(BM_GPU, (addr)); \
+   } while (0)
 
 #define GPU_TRACE_DEBUG 0
 #if GPU_TRACE_DEBUG
@@ -1006,16 +1022,14 @@ void GPUExec(int32_t cycles)
       //$E400 -> 1110 01 -> $39 -> 57
       //GPU #1
       gpu_pc += 2;
+      gpu_bus_stall = 0;
 #if 0
       gpu_opcode[index]();
 #else
        executeOpcode(index);
 #endif
-      // BIOS hacking
-      //GPU: [00F03548] jr      nz,00F03560 (0xd561) (RM=00F03114, RN=00000004) ->     --> JR: Branch taken.
-      //GPU: [00F0354C] jump    nz,(r29) (0xd3a1) (RM=00F03314, RN=00000004) -> (RM=00F03314, RN=00000004)
 
-      cycles -= gpu_opcode_cycles[index];
+      cycles -= gpu_opcode_cycles[index] + (int32_t)gpu_bus_stall;
 
       /* Single-step barrier (G_CTRL SINGLE_STEP, bit 3): a running RISC core
        * that has just set SINGLE_STEP has entered single-step mode and stops
@@ -1476,12 +1490,17 @@ INLINE static void gpu_opcode_store_r14_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2), RN, GPU);
+   {
+      uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1491,12 +1510,17 @@ INLINE static void gpu_opcode_store_r15_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2), RN, GPU);
+   {
+      uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1506,12 +1530,17 @@ INLINE static void gpu_opcode_load_r14_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[14] + RM, GPU);
+   {
+      uint32_t address = gpu_reg[14] + RM;
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 
@@ -1521,12 +1550,17 @@ INLINE static void gpu_opcode_load_r15_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[15] + RM, GPU);
+   {
+      uint32_t address = gpu_reg[15] + RM;
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 
@@ -1536,12 +1570,17 @@ INLINE static void gpu_opcode_store_r14_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[14] + RM, RN, GPU);
+   {
+      uint32_t address = gpu_reg[14] + RM;
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1551,12 +1590,17 @@ INLINE static void gpu_opcode_store_r15_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT_STORE
    uint32_t address = gpu_reg[15] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[15] + RM, RN, GPU);
+   {
+      uint32_t address = gpu_reg[15] + RM;
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1579,12 +1623,13 @@ INLINE static void gpu_opcode_pack(void)
 
 INLINE static void gpu_opcode_storeb(void)
 {
-   //Is this right???
-   // Would appear to be so...!
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM, RN & 0xFF, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       JaguarWriteByte(RM, RN, GPU);
+   }
 }
 
 
@@ -1594,12 +1639,18 @@ INLINE static void gpu_opcode_storew(void)
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM & 0xFFFFFFFE, RN & 0xFFFF, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       JaguarWriteWord(RM, RN, GPU);
+   }
 #else
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM, RN & 0xFFFF, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       JaguarWriteWord(RM, RN, GPU);
+   }
 #endif
 }
 
@@ -1610,8 +1661,12 @@ INLINE static void gpu_opcode_store(void)
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM & 0xFFFFFFFC, RN, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       GPUWriteLong(RM, RN, GPU);
+   }
 #else
+   GPU_EXT_ACCESS(RM);
    GPUWriteLong(RM, RN, GPU);
 #endif
 }
@@ -1640,6 +1695,8 @@ INLINE static void gpu_opcode_store(void)
  * which needs its own before/after evidence rather than riding along here. */
 INLINE static void gpu_opcode_storep(void)
 {
+   GPU_EXT_ACCESS(RM);
+   GPU_EXT_ACCESS(RM + 4);
    GPUWriteLong((RM & 0xFFFFFFF8) + 0, gpu_hidata, GPU);
    GPUWriteLong((RM & 0xFFFFFFF8) + 4, RN, GPU);
 }
@@ -1663,7 +1720,10 @@ INLINE static void gpu_opcode_loadb(void)
       RN = GPUReadLong(RM & 0xFFFFFFFC, GPU);
    }
    else
+   {
+      GPU_EXT_ACCESS(RM);
       RN = JaguarReadByte(RM, GPU);
+   }
 }
 
 
@@ -1676,7 +1736,10 @@ INLINE static void gpu_opcode_loadw(void)
       RN = GPUReadLong(RM & 0xFFFFFFFC, GPU);
    }
    else
+   {
+      GPU_EXT_ACCESS(RM);
       RN = JaguarReadWord(RM, GPU);
+   }
 }
 
 
@@ -1700,8 +1763,10 @@ INLINE static void gpu_opcode_loadw(void)
 INLINE static void gpu_opcode_load(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
+   GPU_EXT_ACCESS(RM);
    RN = GPUReadLong(RM & 0xFFFFFFFC, GPU);
 #else
+   GPU_EXT_ACCESS(RM);
    RN = GPUReadLong(RM, GPU);
 #endif
 }
@@ -1717,10 +1782,14 @@ INLINE static void gpu_opcode_loadp(void)
    }
    else
    {
+      GPU_EXT_ACCESS(RM);
+      GPU_EXT_ACCESS(RM + 4);
       gpu_hidata = GPUReadLong(RM + 0, GPU);
       RN		   = GPUReadLong(RM + 4, GPU);
    }
 #else
+   GPU_EXT_ACCESS(RM);
+   GPU_EXT_ACCESS(RM + 4);
    gpu_hidata = GPUReadLong(RM + 0, GPU);
    RN		   = GPUReadLong(RM + 4, GPU);
 #endif
@@ -1732,12 +1801,17 @@ INLINE static void gpu_opcode_load_r14_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2), GPU);
+   {
+      uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 
@@ -1747,12 +1821,17 @@ INLINE static void gpu_opcode_load_r15_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2), GPU);
+   {
+      uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -257,6 +257,7 @@
 
 #include <string.h>								// For memset()
 #include "blitter.h"
+#include "bus_arbiter.h"
 #include "event.h"
 #include "gpu.h"
 #include "jaguar.h"
@@ -1040,6 +1041,7 @@ void TOMReset(void)
    {
       SET16(tomRam8, MEMCON1, 0x1861);
       SET16(tomRam8, MEMCON2, 0x35CC);
+      bus_arbiter_update_memcon(0x1861);
       SET16(tomRam8, HP, 844);			// Horizontal Period (1-based; HP=845)
       SET16(tomRam8, HBB, 1713);		// Horizontal Blank Begin
       SET16(tomRam8, HBE, 125);			// Horizontal Blank End
@@ -1066,6 +1068,7 @@ void TOMReset(void)
    {
       SET16(tomRam8, MEMCON1, 0x1861);
       SET16(tomRam8, MEMCON2, 0x35CC);
+      bus_arbiter_update_memcon(0x1861);
       SET16(tomRam8, HP, 850);			// Horizontal Period
       SET16(tomRam8, HBB, 1711);		// Horizontal Blank Begin
       SET16(tomRam8, HBE, 158);			// Horizontal Blank End
@@ -1321,6 +1324,9 @@ void TOMWriteWord(uint32_t offset, uint16_t data, uint32_t who)
    // Fix a lockup bug... :-P
    TOMWriteByte(0xF00000 | offset, data >> 8, who);
    TOMWriteByte(0xF00000 | (offset+1), data & 0xFF, who);
+
+   if (offset == MEMCON1)
+      bus_arbiter_update_memcon(data);
 
    // detect screen resolution changes
    //This may go away in the future, if we do the virtualized screen thing...

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -257,6 +257,7 @@
 
 #include <string.h>								// For memset()
 #include "blitter.h"
+#include "bus_arbiter.h"
 #include "event.h"
 #include "gpu.h"
 #include "jaguar.h"
@@ -1140,6 +1141,7 @@ void TOMReset(void)
    {
       SET16(tomRam8, MEMCON1, 0x1861);
       SET16(tomRam8, MEMCON2, 0x35CC);
+      bus_arbiter_update_memcon(0x1861);
       SET16(tomRam8, HP, 844);			// Horizontal Period (1-based; HP=845)
       SET16(tomRam8, HBB, 1713);		// Horizontal Blank Begin
       SET16(tomRam8, HBE, 125);			// Horizontal Blank End
@@ -1166,6 +1168,7 @@ void TOMReset(void)
    {
       SET16(tomRam8, MEMCON1, 0x1861);
       SET16(tomRam8, MEMCON2, 0x35CC);
+      bus_arbiter_update_memcon(0x1861);
       SET16(tomRam8, HP, 850);			// Horizontal Period
       SET16(tomRam8, HBB, 1711);		// Horizontal Blank Begin
       SET16(tomRam8, HBE, 158);			// Horizontal Blank End
@@ -1460,6 +1463,9 @@ void TOMWriteWord(uint32_t offset, uint16_t data, uint32_t who)
    // Fix a lockup bug... :-P
    TOMWriteByte(0xF00000 | offset, data >> 8, who);
    TOMWriteByte(0xF00000 | (offset+1), data & 0xFF, who);
+
+   if (offset == MEMCON1)
+      bus_arbiter_update_memcon(data);
 
    // detect screen resolution changes
    //This may go away in the future, if we do the virtualized screen thing...

--- a/test/test_cd_bios_boot.c
+++ b/test/test_cd_bios_boot.c
@@ -83,6 +83,14 @@ static bool cd_environment(unsigned cmd, void *data)
             return true;
         }
         if (strcmp(var->key, "virtualjaguar_cd_boot_mode") == 0)    { var->value = "bios"; return true; }
+        if (strcmp(var->key, "virtualjaguar_bus_contention") == 0)  {
+            /* Opt-in experimental bus-contention sweeps (data runs):
+             * VJ_TEST_CD_BUS_CONTENTION=enabled.  Unset -> core default. */
+            const char *bc = getenv("VJ_TEST_CD_BUS_CONTENTION");
+            if (bc && *bc) { var->value = bc; return true; }
+            var->value = NULL;
+            return false;
+        }
         var->value = NULL;
         return false;
     }

--- a/test/test_cd_hle_boot.c
+++ b/test/test_cd_hle_boot.c
@@ -72,6 +72,14 @@ static bool cd_environment(unsigned cmd, void *data)
         if (strcmp(var->key, "virtualjaguar_usefastblitter") == 0)  { var->value = "enabled";  return true; }
         if (strcmp(var->key, "virtualjaguar_cd_bios_type") == 0)    { var->value = "retail";   return true; }
         if (strcmp(var->key, "virtualjaguar_cd_boot_mode") == 0)    { var->value = "hle";      return true; }
+        if (strcmp(var->key, "virtualjaguar_bus_contention") == 0)  {
+            /* Opt-in experimental bus-contention sweeps (data runs):
+             * VJ_TEST_CD_BUS_CONTENTION=enabled.  Unset -> core default. */
+            const char *bc = getenv("VJ_TEST_CD_BUS_CONTENTION");
+            if (bc && *bc) { var->value = bc; return true; }
+            var->value = NULL;
+            return false;
+        }
         var->value = NULL;
         return false;
     }


### PR DESCRIPTION
## Summary

- Adds a centralized bus arbiter (`bus_arbiter.c/h`) modeled after the MiSTer FPGA implementation (`arb.v` / `gateway.v` / `mem.v`)
- GPU LOAD/STORE to external memory charges DRAM access costs, slowing GPU-rendered games (Doom, Wolf3D, AvP) toward realistic speeds
- Blitter phrase reads/writes charge bus cycles that penalize the 68K at the next timeslice boundary
- DRAM timing derived from MEMCON1 DRAMSPEED register (5 sys clocks base + 4 page-miss penalty default)
- New core option **"Bus Contention (Experimental)" — default: `disabled`**, plus **"Bus Contention Scale"** (`1x` default / `2x` / `4x` / `8x`) to tune the charge

This ships opt-in on purpose: the model is experimental, so the shipped default must be a zero-behaviour-change no-op. Every charge and penalty site short-circuits on `busArbiter.enabled`, and `bus_arbiter_init()` starts with `enabled = 0`.

## Hardware reference

JTRM bus priority: GPU > blitter > OP > 68K. Each bus transaction costs 5-9 system clocks depending on DRAM page hit/miss. MiSTer models this with a centralized FSM arbiter; we use an accounting model that accumulates costs and distributes penalties at timeslice boundaries.

## What this fixes (when enabled)

GPU-rendered games (Doom being the poster child) currently run ~2x too fast because the GPU completes rendering in ~2 VBlanks instead of 4-8. The bus arbiter charges realistic DRAM access costs that consume GPU cycles, matching the hardware behaviour where external memory accesses stall the GPU pipeline.

Measured against Doom's own game-tick counter in main RAM (`$04082C` / `$1062C4`, sampled once per emulated second over a 32-second window):

| Configuration | Doom game ticks/s |
|---|---|
| contention disabled (shipped default) | 24.90 |
| contention enabled, scale `1x` | 24.42 |
| contention enabled, scale `8x` | 14.48 / 14.52 |

Scale `8x` lands Doom inside the real hardware's 10-15 fps range. The arithmetic is consistent with the earlier flat-penalty tuning work: 8 x the model's 9-cycle access cost = 72 ≈ the penalty-60 figure from PR #168.

## What's NOT in this PR

- OP bus stealing during active display (Phase 3 of the plan)
- Correct GPU opcode cycle counts (all are still 1)
- DSP bus contention (low priority — DSP mainly uses local RAM)
- Enabling the option by default, or per-title defaults. Those need the per-title validation sweep below to land first.

## Test plan

With the option **disabled** (the shipped default):

- [x] Full build passes (`make -j`, `make TEST_EXPORTS=1`)
- [x] C89 lint passes on all modified files
- [x] `make TEST_EXPORTS=1 test` exits 0 (16 harnesses green, 0 failed)
- [x] Runtime proof that disabled means inert: the exported `busArbiter` sampled every frame over 900 frames of Doom shows `enabled=0` and every `bus_cycles[]` accumulator at 0. The same probe with the option enabled shows GPU/BLITTER charging (max 126 / 1710, 74768 total), so the all-zero reading is a real discriminator and not just a per-timeslice reset artefact.
- [x] Benchmark parity vs pristine `develop` on the same host, interleaved A/B over 8 pairs to cancel drift: median p50 6.452 ms (develop) vs 6.399 ms (this branch); best-of-8 p50 5.980 vs 5.771. Within run-to-run noise (host was at load average 17-26).
- [x] CD boot matrix, 3000 frames, all 20 title x mode rows: stage column bit-identical to `docs/cd-boot-matrix.md`.

With the option **enabled** (informational, not a merge gate):

- [x] Doom game-tick rate measured at every scale (table above)
- [x] Battle Morph HLE runs clean under `cd_wedge_probe` (3000 frames, `--arm 600 --freeze-frames 900`) at both scale `1x` and `8x`
- [ ] Device checks: AvP, Atari Karts, Iron Soldier, Super Burnout, Wolf3D non-regression in RetroArch
- [ ] Per-title validation sweep before flipping the default to enabled

## Note on the disabled path

"Disabled" is *behaviourally* identical to pre-arbiter behaviour, not literally instruction-identical: `gpu_bus_stall = 0` is assigned per opcode and added to the cycle cost unconditionally (it is always 0 when the option is off), and a few `#else` branches gained a block scope plus a temporary for the address. The evidence for no behaviour change is the all-zero accumulator run plus the benchmark parity above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
