### PR TITLE
Update bug_report.yml BIOS info

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,7 +47,7 @@ body:
       description: Set in RetroArch core options as `virtualjaguar_bios`.
       options:
         - "HLE BIOS (default; no real BIOS file)"
-        - "Real BIOS (jagboot.rom in system/)"
+        - "Real BIOS (real BIOS file is included in Virtual Jaguar core)"
         - "Not sure"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,8 +46,8 @@ body:
       label: BIOS mode
       description: Set in RetroArch core options as `virtualjaguar_bios`.
       options:
-        - "HLE BIOS (default; no real BIOS file)"
-        - "Real BIOS (real BIOS file is included in Virtual Jaguar core)"
+        - "HLE BIOS (default; faked post-boot state, faster)"
+        - "Real BIOS (built into the core; runs the actual boot sequence)"
         - "Not sure"
     validations:
       required: true


### PR DESCRIPTION
<!--
Thanks for the PR!  This repo uses a GitFlow-style integration
branch: please target `develop` (the default for new feature work).
Use `master` only for hotfixes from `hotfix/*` or release branches
from `release/*`.
-->

## Summary

Changed the issue template to specify that the real BIOS is hosted as part of the core. The core does not check for `jagboot.rom`

Real BIOS `.c` files:
https://github.com/libretro/virtualjaguar-libretro/tree/master/src/bios

