### PR TITLE
Release v2.3.1 — polish + triage infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,8 +46,8 @@ body:
       label: BIOS mode
       description: Set in RetroArch core options as `virtualjaguar_bios`.
       options:
-        - "HLE BIOS (default; no real BIOS file)"
-        - "Real BIOS (jagboot.rom in system/)"
+        - "HLE BIOS (default; faked post-boot state, faster)"
+        - "Real BIOS (built into the core; runs the actual boot sequence)"
         - "Not sure"
     validations:
       required: true

--- a/.github/workflows/acid-test.yml
+++ b/.github/workflows/acid-test.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Cache vasm
         id: vasm-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /usr/local/bin/vasmm68k_mot
           # Bust the cache if anyone bumps prb28/vasm SHA.

--- a/.github/workflows/acid-test.yml
+++ b/.github/workflows/acid-test.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload artefacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: acid-results
           path: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -418,7 +418,7 @@ jobs:
           bash scripts/gen-version-h.sh
           make coverage CC="gcc" CXX="g++"
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -299,7 +299,7 @@ jobs:
       run: bash test/tools/test_rcheevos_e2e.sh ./${{ matrix.config.artifact }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.config.displayTargetName }}
         path: ${{ matrix.config.artifact }}
@@ -356,7 +356,7 @@ jobs:
       run: make -j4 platform=vita
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: PS Vita
         path: virtualjaguar_libretro_vita.a
@@ -376,7 +376,7 @@ jobs:
         DEVKITPRO: /opt/devkitpro
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: Nintendo Switch
         path: virtualjaguar_libretro_libnx.a

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,7 +16,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -15,6 +15,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.4
+        uses: cirrus-actions/rebase@1.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -87,7 +87,7 @@ jobs:
 
     - name: Upload diff artifacts
       if: failure()
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: regression-diffs-${{ matrix.config.platform }}
         path: regression-diffs/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,7 +273,7 @@ jobs:
           rm "dist/${DBG}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: virtualjaguar_libretro-${{ matrix.config.platform }}
           path: dist/
@@ -310,7 +310,7 @@ jobs:
           rm "dist/${OUT}.debug"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: virtualjaguar_libretro-vita
           path: dist/
@@ -346,7 +346,7 @@ jobs:
           rm "dist/${OUT}.debug"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: virtualjaguar_libretro-switch
           path: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ test/tools/build/
 # Acid-test build outputs
 test/acid/acid_run
 test/acid/tests/**/*.jag
+/test/tools/test_frame_timing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,8 @@ To add a new probe: create `test/harness/foo_probe.h` + `.c`, resolve symbols vi
 
 `src/core/crash_detect.c` runs once per frame from `retro_run` and logs to the RetroArch log on these signatures:
 
-- `gpu_pc_escape` — GPU running with PC outside `[$F03000,$F03FFF]` ∪ `[$0,$1FFFFF]`
-- `dsp_pc_escape` — DSP running with PC outside `[$F1B000,$F1CFFF]` ∪ `[$0,$1FFFFF]`
+- `gpu_pc_escape` — GPU running with PC outside `[$F03000,$F03FFF]` ∪ `[$0,$E3FFFF]` (matches the JaguarReadX address decoding: main RAM mirrors at the bottom 8MB, cart ROM, boot ROM)
+- `dsp_pc_escape` — DSP running with PC outside `[$F1B000,$F1CFFF]` ∪ `[$0,$E3FFFF]`
 - `gpu_wedge` / `dsp_wedge` — same PC for ≥180 / 600 frames while still flagged running
 - `video_stall` — framebuffer hash unchanged for 300 frames while a processor is running
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ To add a new probe: create `test/harness/foo_probe.h` + `.c`, resolve symbols vi
 - `test/regression_test.sh` — screenshot regression vs `test/baselines/` via miniretro (built from source on first run; `MINIRETRO_BIN` env to skip the build)
 - `test/tools/test_dsp_audio_diag.c` — DSP audio diagnostic (`make dsp-diag DSP_DIAG_ROM=path`); detects PC escape, bank init failures, silent LTXD
 - `test/tools/test_frame_timing.c` — per-frame timing diagnostic (`make frame-timing FRAME_TIMING_ROM=path`); reports halflines/cycles/VBlanks per frame, wall-clock speed ratio, anomaly detection. Use `--csv` for per-frame data, `--json` for machine output
+- `test/test_audio_clipping.c` — detects loud-broken audio (saturation density, run length, sustained loud RMS). Catches the Skyhammer / IS2 "saturated square wave" failure mode.
+- `test/test_audio_presence.c` — counterpart to clipping: asserts audio is present in a known-good envelope (RMS within `[floor, ceiling]`, onset reached, no long zero runs). **Required to catch the silencing-regression class** where a "fix" drops RMS to zero — clipping passes but the game has no audio. Iron Soldier 1 baseline: RMS ~1175 on develop.
 - `test/tools/test_memory_map.c` — asserts `SET_MEMORY_MAPS`, `SET_SUPPORT_ACHIEVEMENTS=true`, descriptor layout
 - `test/tools/test_blitter_compare` — fast vs accurate blitter diff
 - `test/test_dsp_mac40.c` — DSP 40-bit MAC accumulator (`dsp_acc40.h`)
@@ -94,6 +96,18 @@ To add a new probe: create `test/harness/foo_probe.h` + `.c`, resolve symbols vi
 ### Performance / profiling
 
 `make benchmark` runs `test/tools/test_benchmark` headlessly against a fixed ROM (default `test/roms/yarc.j64`, 600 frames) and prints FPS / ms-per-frame. Use as a same-host commit-to-commit delta — don't compare across machines. Full guide: [`docs/profiling.md`](docs/profiling.md) covers Instruments / `perf` / flame graphs and the SIMD A/B knob.
+
+### Audio / DSP work — required tests
+
+**Any change to `src/jerry/dac.c`, `src/jerry/dsp.c`, the HLE BIOS DSP/audio engine path in `src/core/jaguar.c`, or the DSP IRQ return-address logic MUST be validated against both audio tests, not just one.** A clipping check alone is insufficient: PR #170 (closed) shipped a "fix" that took Iron Soldier 2 from 17% saturated samples to RMS=521 (silent), and the clipping test passed because silence has 0% saturation.
+
+Required runs before declaring an audio change done:
+
+1. `make TEST_EXPORTS=1 test` — must exit 0. Both `test_audio_clipping` and `test_audio_presence` are part of the suite. The presence check on Iron Soldier 1 uses develop's measured envelope (`--rms-floor 200 --rms-ceiling 25000`). If your change moves IS1's RMS outside that band, you've changed audio behavior — verify it's intentional.
+2. Sanity-check that previously-clipping titles (Skyhammer, IS2) didn't go from "loud broken" to "silent broken". Skyhammer should still fail clipping until it's actually fixed; if it suddenly passes clipping but presence drops to silence, that's the masked-failure pattern.
+3. **Verify in RetroArch on a real game.** Headless tests cannot tell "music plays" from "structured noise at the right RMS" or catch BIOS-mode crashes. Memory: PR #170's BIOS crash + HLE silence in Skyhammer were both invisible to the test suite.
+
+Do not relax thresholds in `test_audio_clipping.c` or `test_audio_presence.c` to make a PR pass. If a real fix makes a known-broken title legitimately quieter, that's a separate, deliberate baseline update — call it out in the commit, not as a side effect.
 
 ### Headless framebuffer caveat
 
@@ -118,7 +132,7 @@ When spawning agents for work in this repo, include these rules:
 1. **C89 strict.** No mid-block declarations, no `for(int i…)`, no C99. All vars at top of block. Run `bash scripts/c89-lint.sh src/YOURFILE.c` before declaring done.
 2. **Branch from develop.** Use `git worktree` or branch off develop. Never target main.
 3. **Hardware reference.** For any emulation-accuracy work, read `docs/jtrm-*.md` first. Do NOT trust source-code comments for clock rates or register behavior.
-4. **Test after changes.** Run `make -j$(getconf _NPROCESSORS_ONLN)` to verify build. Run `make test` for the full suite. For blitter changes, also run `test/tools/test_blitter_compare` if available.
+4. **Test after changes.** Run `make -j$(getconf _NPROCESSORS_ONLN)` to verify build. Run `make test` for the full suite. For blitter changes, also run `test/tools/test_blitter_compare` if available. **For audio / DSP / HLE-engine changes**, both `test_audio_clipping` and `test_audio_presence` must pass; running only one masks the silencing-regression class (see "Audio / DSP work — required tests" above). Verify in RetroArch on a real game before declaring done — headless tests cannot tell music from structured noise, and they don't catch BIOS-mode crashes.
 5. **No unnecessary changes.** Don't refactor surrounding code, add abstractions, or clean up unrelated files. Surgical changes only.
 6. **Commit message style.** Use conventional commits: `fix(component):`, `perf(component):`, `test(component):`, `docs:`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,19 @@ To add a new probe: create `test/harness/foo_probe.h` + `.c`, resolve symbols vi
 
 `make benchmark` runs `test/tools/test_benchmark` headlessly against a fixed ROM (default `test/roms/yarc.j64`, 600 frames) and prints FPS / ms-per-frame. Use as a same-host commit-to-commit delta — don't compare across machines. Full guide: [`docs/profiling.md`](docs/profiling.md) covers Instruments / `perf` / flame graphs and the SIMD A/B knob.
 
+### Runtime crash watchdog
+
+`src/core/crash_detect.c` runs once per frame from `retro_run` and logs to the RetroArch log on these signatures:
+
+- `gpu_pc_escape` — GPU running with PC outside `[$F03000,$F03FFF]` ∪ `[$0,$1FFFFF]`
+- `dsp_pc_escape` — DSP running with PC outside `[$F1B000,$F1CFFF]` ∪ `[$0,$1FFFFF]`
+- `gpu_wedge` / `dsp_wedge` — same PC for ≥180 / 600 frames while still flagged running
+- `video_stall` — framebuffer hash unchanged for 300 frames while a processor is running
+
+Toggled via core option `virtualjaguar_crash_detect = enabled` (default) / `disabled` / `verbose`. Verbose mode adds a state heartbeat every 600 frames. Cost when enabled: one indirect call + ~256-pixel hash per frame; off-mode short-circuits at the first instruction.
+
+When triaging "X crashes / hangs / goes to a black screen" reports, the user's RetroArch log should show the signature. No save state, no input recording needed — the log line at the moment-of-crash points at which subsystem broke. **Add new signatures here when you find a recurring failure mode that isn't already covered**; don't sprinkle one-off `LOG_ERR` calls across the subsystem files.
+
 ### Audio / DSP work — required tests
 
 **Any change to `src/jerry/dac.c`, `src/jerry/dsp.c`, the HLE BIOS DSP/audio engine path in `src/core/jaguar.c`, or the DSP IRQ return-address logic MUST be validated against both audio tests, not just one.** A clipping check alone is insufficient: PR #170 (closed) shipped a "fix" that took Iron Soldier 2 from 17% saturated samples to RMS=521 (silent), and the clipping test passed because silence has 0% saturation.

--- a/Makefile
+++ b/Makefile
@@ -731,7 +731,7 @@ clean:
 		test/test_dsp_ops test/test_dsp_unit test/test_hle_bios \
 		test/test_subsystem_init test/test_subsystem_timeline \
 		test/test_irq_cascade test/test_boot_patterns test/test_audio_pipeline \
-		test/test_audio_clipping test/test_pit_clock_rate \
+		test/test_audio_clipping test/test_audio_presence test/test_pit_clock_rate \
 		test/test_blitter_mmio test/test_eeprom_lifecycle \
 		test/test_tom_visible_window test/test_framebuffer_integrity \
 		test/tools/test_memory_map test/tools/test_dsp_audio_diag \
@@ -761,7 +761,7 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 		$(TARGET) test/test_m68k_ops test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
-		test/test_audio_pipeline test/test_audio_clipping test/test_pit_clock_rate \
+		test/test_audio_pipeline test/test_audio_clipping test/test_audio_presence test/test_pit_clock_rate \
 		test/test_blitter_mmio test/test_eeprom_lifecycle test/test_tom_visible_window \
 		test/test_framebuffer_integrity test/tools/test_memory_map
 	./test/test_cheat
@@ -800,6 +800,17 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 		./test/test_audio_clipping ./$(TARGET) "test/roms/private/Iron Soldier 2 (World).j64" --label "Iron Soldier 2" --expect-clipping --quiet; \
 	else \
 		echo "  SKIP: Iron Soldier 2 ROM (private) not available"; \
+	fi
+	@# Presence check: counterpart to the clipping check.  A "fix" that
+	@# silences the game (e.g. PR #170 closed without merge) drops RMS
+	@# to zero — clipping passes but the game has no audio.  Iron
+	@# Soldier 1 boots straight to a music-on title; envelope was
+	@# measured on develop (RMS ~1175).  Floor 200 catches silence
+	@# regressions; ceiling 25000 catches loud-broken regressions.
+	@if [ -f "test/roms/private/Iron Soldier (1994).jag" ]; then \
+		./test/test_audio_presence ./$(TARGET) "test/roms/private/Iron Soldier (1994).jag" --label "Iron Soldier 1" --rms-floor 200 --rms-ceiling 25000 --quiet; \
+	else \
+		echo "  SKIP: Iron Soldier 1 ROM (private) not available (audio presence)"; \
 	fi
 	./test/tools/test_memory_map ./$(TARGET)
 	@# Framebuffer integrity: alpha corruption + screen position shift detection.
@@ -891,6 +902,10 @@ test/test_audio_pipeline: test/test_audio_pipeline.c
 test/test_audio_clipping: test/test_audio_clipping.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_audio_clipping.c -ldl -lm
+
+test/test_audio_presence: test/test_audio_presence.c
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_audio_presence.c -ldl -lm
 
 test/tools/test_memory_map: test/tools/test_memory_map.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ TARGET_NAME := virtualjaguar
 # Single source-of-truth for the human-readable version string.
 # Bumped by .github/workflows/version-bump.yml (greps this line).
 # Composed into CORE_VERSION in src/core/version.h, generated below.
-CORE_BASE_VERSION := v2.3.0
+CORE_BASE_VERSION := v2.3.1
 
 ifeq ($(DEBUG),1)
    CFLAGS += -DBUILD_TIMESTAMP="\"debug $(shell date -u +%Y-%m-%dT%H:%M:%SZ)\""

--- a/Makefile.common
+++ b/Makefile.common
@@ -34,6 +34,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/core/cheat.c \
 	$(CORE_DIR)/src/core/crc32.c \
 	$(CORE_DIR)/src/core/perf_counters.c \
+	$(CORE_DIR)/src/core/crash_detect.c \
 	$(CORE_DIR)/src/core/event.c \
 	$(CORE_DIR)/src/jerry/eeprom.c \
 	$(CORE_DIR)/src/core/filedb.c \

--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -5,7 +5,7 @@ supported_extensions = "j64|jag|rom|abs|cof|bin|prg"
 corename = "Virtual Jaguar"
 license = "GPLv3"
 permissions = ""
-display_version = "v2.3.0"
+display_version = "v2.3.1"
 categories = "Emulator"
 
 # Hardware Information

--- a/docs/RELEASE_NOTES_v2.3.1.md
+++ b/docs/RELEASE_NOTES_v2.3.1.md
@@ -77,10 +77,13 @@ bug reports about them have a real chance of being actionable.
 - **Doom**: runs at ~2x speed, music silent.  Bus arbitration / cycle
   accuracy modeling not implemented; PR #169 (draft) is in design
   limbo.
-- **Wolfenstein 3D**: no audio (DSP escapes to $0006EE around frame
-  48).  Long-standing — present in v2.2.0 too, not a v2.3.x
-  regression.  Watchdog now logs the escape signature cleanly when
-  it happens.
+- **Wolfenstein 3D**: no audio.  The dsp-diag tool shows the DSP
+  PC drifting to $0006EE in main RAM around frame 48 (Bank1
+  registers never finish initializing); the runtime watchdog
+  subsequently logs `dsp_pc_escape pc=$00FFF004E8` once the
+  drift hits unmapped register space, and the new wedge bail-out
+  (this release) prevents the headless harness from hanging on it.
+  Long-standing — present in v2.2.0 too, not a v2.3.x regression.
 - **Skyhammer / Iron Soldier 2**: saturated square-wave audio in HLE
   (DSP engine state not fully replicated).  Both tests deliberately
   flag these as `EXPECTED-FAIL` in the suite manifest until a real

--- a/docs/RELEASE_NOTES_v2.3.1.md
+++ b/docs/RELEASE_NOTES_v2.3.1.md
@@ -1,0 +1,115 @@
+# Virtual Jaguar libretro v2.3.1
+
+Polish release — 17 commits since v2.3.0.  No new emulation features;
+this is an infrastructure / triage / safety pass that was on develop
+between v2.3.0 (April 2026) and now.  None of the long-standing audio
+or game-compatibility issues changed; the difference is that future
+bug reports about them have a real chance of being actionable.
+
+## Highlights
+
+- **Runtime crash watchdog** — a new opt-out core option,
+  `Crash Detect`, logs `gpu_pc_escape` / `dsp_pc_escape` / `gpu_wedge`
+  / `dsp_wedge` / `video_stall` events to the RetroArch log when a
+  game hangs or goes black.  Bug reports about freezes can now be
+  triaged from the log alone, without save states or replays.
+- **DSP wedge fix** — when the DSP PC escapes into unmapped memory,
+  the inner exec loop now drains the timeslice instead of busy-looping
+  for minutes.  This was a v2.3.0 regression that made the headless
+  test harness hang on Wolfenstein 3D for 12+ minutes per session.
+- **Audio presence test** (`test/test_audio_presence.c`) — counterpart
+  to the existing clipping check.  Catches the silencing-regression
+  class where a "fix" drops a game's RMS to zero (clipping check
+  passes silence as PASS).  Iron Soldier 1 is the in-tree baseline
+  (RMS ~1175 on develop).  Both audio tests now run in `make test`
+  and CLAUDE.md documents that audio / DSP changes must clear both
+  before being declared done.
+- **Bug-report template** clarified — the BIOS-mode dropdown
+  previously implied users needed to supply `jagboot.rom` in
+  `system/`, which has never been the case for this libretro core
+  (the BIOS is bundled in the dylib).  The template now distinguishes
+  the boot **path** users had selected, which is what bug triage
+  actually cares about.
+
+## What's new
+
+### Bug fixes
+
+- **DSP**: bail out of the exec loop when the DSP PC is in unmapped
+  memory.  Avoids a busy-loop that burned the entire timeslice
+  emulating opcodes fetched from bus-default 0xFFFF.  Wolf3D headless
+  test now completes in <30 seconds, matching v2.2.0 wall-clock.
+
+### Tooling
+
+- **`src/core/crash_detect.c`** — opt-out runtime watchdog.  Once-per-
+  frame hook with cheap PC-range checks and a 256-pixel rolling
+  framebuffer hash; off-mode short-circuits at the first instruction.
+  Modes: `enabled` (default) / `disabled` / `verbose` (heartbeat
+  every 600 frames).
+- **`test/test_audio_presence.c`** — asserts the audio onset is
+  reached and the window RMS lies in `[floor, ceiling]`, with no
+  long zero runs.  Per-ROM thresholds via CLI args.  Wired into
+  `make test` against Iron Soldier 1.
+- **`test/tools/test_video_dim_log.c`** — diagnostic harness that
+  prints every video resolution change and black-frame streak.
+  Useful for correlating "crash after N seconds" reports against
+  actual hardware events.
+
+### CI / infrastructure
+
+- Dependabot bumps for GitHub Actions (codecov-action 5→6,
+  actions/cache 4→5, actions/labeler 5→6, actions/upload-artifact
+  4→7, cirrus-actions/rebase 1.4→1.8).
+- `test/tools/test_frame_timing` added to `.gitignore`.
+
+### Documentation
+
+- **CLAUDE.md** — new "Runtime crash watchdog" and "Audio / DSP work
+  — required tests" sections.  Pins the rule that DSP/audio PRs must
+  clear both `test_audio_clipping` AND `test_audio_presence`, with
+  PR #170 cited as the precedent (clipping passed on a "fix" that
+  silenced Iron Soldier 2).
+- **Bug-report template** — clarified HLE vs Real BIOS distinction.
+
+## Known issues (unchanged from v2.3.0)
+
+- **Doom**: runs at ~2x speed, music silent.  Bus arbitration / cycle
+  accuracy modeling not implemented; PR #169 (draft) is in design
+  limbo.
+- **Wolfenstein 3D**: no audio (DSP escapes to $0006EE around frame
+  48).  Long-standing — present in v2.2.0 too, not a v2.3.x
+  regression.  Watchdog now logs the escape signature cleanly when
+  it happens.
+- **Skyhammer / Iron Soldier 2**: saturated square-wave audio in HLE
+  (DSP engine state not fully replicated).  Both tests deliberately
+  flag these as `EXPECTED-FAIL` in the suite manifest until a real
+  fix lands.
+- **Battle Sphere**: menu navigation issues.
+- **Jaguar CD**: PR #120 is rebased and builds, but multi-track CD
+  games still break mid-game; not in this release.
+
+## Compared to v2.3.0
+
+18 files changed, +1,004 / -17 lines across 17 commits.
+
+## Downloads
+
+Pre-built libretro cores for 16 platforms:
+
+- Linux: x86_64, aarch64, i686
+- macOS: arm64, x86_64
+- Windows: x86_64, i686 (MSYS2/MinGW)
+- iOS: arm64; tvOS: arm64
+- Android: arm64-v8a, armeabi-v7a, x86_64, x86
+- Web: Emscripten WASM
+- Consoles: PS Vita, Nintendo Switch
+
+Each binary has a matching `*-debug.tar.gz` with split debug symbols.
+SHA256 checksums in `SHA256SUMS.txt`.
+
+## Maintainers
+
+libretro/Provenance fork: Joseph Mattiello (@JoeMatt, Provenance-Emu).
+
+Thanks to @checktext00 for the bug-report template fix (#179).

--- a/libretro.c
+++ b/libretro.c
@@ -9,6 +9,7 @@
 #include <compat/strl.h>
 
 #include "cheat.h"
+#include "crash_detect.h"
 #include "file.h"
 #include "jagbios.h"
 #include "jaguar.h"
@@ -296,6 +297,22 @@ static void check_variables(void)
          vjs.useFastBlitter = true;
       else
          vjs.useFastBlitter = false;
+   }
+
+   var.key = "virtualjaguar_crash_detect";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "verbose") == 0)
+         CrashDetectSetMode(CRASH_DETECT_VERBOSE);
+      else if (strcmp(var.value, "disabled") == 0)
+         CrashDetectSetMode(CRASH_DETECT_OFF);
+      else
+         CrashDetectSetMode(CRASH_DETECT_ON);
+   }
+   else
+   {
+      CrashDetectSetMode(CRASH_DETECT_ON);
    }
 
    var.key = "virtualjaguar_bios";
@@ -848,6 +865,7 @@ bool retro_load_game(const struct retro_game_info *info)
    eeprom_dirty_cb = eeprom_pack_save_buf;
 
    JaguarInit();                                             // set up hardware
+   CrashDetectReset();                                       // zero per-game watchdog state
    memcpy(jagMemSpace + 0xE00000, jaguarBootROM, 0x20000); // Use the stock BIOS
 
    JaguarSetScreenPitch(videoWidth);
@@ -1028,6 +1046,8 @@ void retro_init(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_INPUT_BITMASKS, NULL))
       libretro_supports_bitmasks = true;
+
+   CrashDetectInit();
 }
 
 void retro_deinit(void)
@@ -1145,6 +1165,13 @@ void retro_run(void)
    JaguarExecuteNew();
    cheat_apply_all();
    SoundCallback(NULL, sampleBuffer, vjs.hardwareTypeNTSC == 1 ? BUFNTSC : BUFPAL);
+
+   /* Runtime watchdog: looks for GPU/DSP PC escape, GPU/DSP wedge,
+    * and video stall. Fires LOG_WRN/LOG_ERR via vj_log_cb so the
+    * signature shows up in the RetroArch log without extra wiring.
+    * Off-mode short-circuits in CrashDetectFrameTick, so the cost
+    * when disabled is one indirect function call per frame. */
+   CrashDetectFrameTick(videoBuffer, (unsigned)game_width, (unsigned)game_height);
 
    video_cb(videoBuffer, game_width, game_height, game_width << 2);
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -106,6 +106,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "virtualjaguar_crash_detect",
+      "Crash Detect",
+      NULL,
+      "Lightweight runtime watchdog that logs GPU/DSP PC escape, GPU/DSP wedge, and video stall events to the RetroArch log. Helpful when filing bug reports about games that hang or go to a black screen mid-play. Verbose mode also dumps a state heartbeat every 10 seconds.",
+      NULL,
+      NULL,
+      {
+         { "enabled",  "Enabled" },
+         { "disabled", "Disabled" },
+         { "verbose",  "Enabled (verbose / heartbeat)" },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
       "virtualjaguar_bios",
       "BIOS",
       NULL,

--- a/src/core/crash_detect.c
+++ b/src/core/crash_detect.c
@@ -4,7 +4,7 @@
 #include "log.h"
 #include "../jerry/dsp.h"   /* DSPIsRunning() returns bool -- match the canonical decl */
 #include "../tom/gpu.h"     /* GPUIsRunning() */
-#include <stdbool.h>
+#include <boolean.h>        /* MSVC 2005/2010-compat shim for <stdbool.h> */
 #include <stdint.h>
 #include <stddef.h>
 

--- a/src/core/crash_detect.c
+++ b/src/core/crash_detect.c
@@ -2,27 +2,38 @@
 
 #include "crash_detect.h"
 #include "log.h"
+#include "../jerry/dsp.h"   /* DSPIsRunning() returns bool -- match the canonical decl */
+#include "../tom/gpu.h"     /* GPUIsRunning() */
+#include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
 
 /* External state we sample (see src/tom/gpu.c, src/jerry/dsp.c).
- * We declare the symbols we need directly rather than pulling the
- * full subsystem headers, to keep this TU light and avoid include
- * coupling to the rest of the core. */
+ * The IsRunning() functions come from the headers above; only the PC
+ * statics need explicit extern decls here. */
 extern uint32_t gpu_pc;
 extern uint32_t dsp_pc;
-int  GPUIsRunning(void);
-int  DSPIsRunning(void);  /* declared as bool in dsp.h, ABI-compatible with int */
 
 /* ---------- tunables ---------- */
 
-/* Valid PC ranges per processor.  Outside these = "PC escape". */
+/* Valid PC ranges per processor.  Outside these = "PC escape".
+ *
+ * Match the address decoding in JaguarReadX/WriteX (src/core/jaguar.c):
+ * any address < $E40000 lands in main RAM (mirrored 4x for the bottom
+ * 8 MB), cart ROM, or the boot ROM region -- all of which can host
+ * legitimate executable code.  Above $E40000 is register space and
+ * unmapped territory; only the processor's own local SRAM is valid
+ * for execution there.
+ *
+ * Earlier versions of this watchdog used `pc <= 0x1FFFFF` and
+ * false-positively flagged any DSP/GPU code that ran from a RAM mirror
+ * at $200000-$7FFFFF or from cart ROM at $800000+.  Caught by Copilot
+ * review on PR #182. */
 #define GPU_LOCAL_LO   0x00F03000u
 #define GPU_LOCAL_HI   0x00F03FFFu
 #define DSP_LOCAL_LO   0x00F1B000u
 #define DSP_LOCAL_HI   0x00F1CFFFu
-#define MAIN_RAM_LO    0x00000000u
-#define MAIN_RAM_HI    0x001FFFFFu
+#define MAPPED_CODE_HI 0x00E3FFFFu  /* RAM mirrors + cart + boot ROM */
 
 /* Wedge thresholds.  We sample once per frame, so 600 frames @ 60Hz =
  * 10 seconds of the same PC while still flagged "running". */
@@ -66,15 +77,15 @@ static unsigned last_log_fb_stall;
 
 static int gpu_pc_valid(uint32_t pc)
 {
+   if (pc <= MAPPED_CODE_HI) return 1;
    if (pc >= GPU_LOCAL_LO && pc <= GPU_LOCAL_HI) return 1;
-   if (pc >= MAIN_RAM_LO && pc <= MAIN_RAM_HI) return 1;
    return 0;
 }
 
 static int dsp_pc_valid(uint32_t pc)
 {
+   if (pc <= MAPPED_CODE_HI) return 1;
    if (pc >= DSP_LOCAL_LO && pc <= DSP_LOCAL_HI) return 1;
-   if (pc >= MAIN_RAM_LO && pc <= MAIN_RAM_HI) return 1;
    return 0;
 }
 
@@ -162,7 +173,7 @@ void CrashDetectFrameTick(const uint32_t *fb, unsigned w, unsigned h)
    if (gpu_running && !gpu_pc_valid(cur_gpu_pc))
    {
       if (may_log(&last_log_gpu_escape))
-         LOG_ERR("[CRASH-DETECT] gpu_pc_escape frame=%u pc=$%08X (valid: F03000-F03FFF or main RAM)\n",
+         LOG_ERR("[CRASH-DETECT] gpu_pc_escape frame=%u pc=$%08X (valid: $0-$E3FFFF or $F03000-$F03FFF)\n",
                  frame_no, cur_gpu_pc);
    }
 
@@ -170,7 +181,7 @@ void CrashDetectFrameTick(const uint32_t *fb, unsigned w, unsigned h)
    if (dsp_running && !dsp_pc_valid(cur_dsp_pc))
    {
       if (may_log(&last_log_dsp_escape))
-         LOG_ERR("[CRASH-DETECT] dsp_pc_escape frame=%u pc=$%08X (valid: F1B000-F1CFFF or main RAM)\n",
+         LOG_ERR("[CRASH-DETECT] dsp_pc_escape frame=%u pc=$%08X (valid: $0-$E3FFFF or $F1B000-$F1CFFF)\n",
                  frame_no, cur_dsp_pc);
    }
 

--- a/src/core/crash_detect.c
+++ b/src/core/crash_detect.c
@@ -1,0 +1,235 @@
+/* crash_detect.c -- See crash_detect.h.  Cheap per-frame watchdog. */
+
+#include "crash_detect.h"
+#include "log.h"
+#include <stdint.h>
+#include <stddef.h>
+
+/* External state we sample (see src/tom/gpu.c, src/jerry/dsp.c).
+ * We declare the symbols we need directly rather than pulling the
+ * full subsystem headers, to keep this TU light and avoid include
+ * coupling to the rest of the core. */
+extern uint32_t gpu_pc;
+extern uint32_t dsp_pc;
+int  GPUIsRunning(void);
+int  DSPIsRunning(void);  /* declared as bool in dsp.h, ABI-compatible with int */
+
+/* ---------- tunables ---------- */
+
+/* Valid PC ranges per processor.  Outside these = "PC escape". */
+#define GPU_LOCAL_LO   0x00F03000u
+#define GPU_LOCAL_HI   0x00F03FFFu
+#define DSP_LOCAL_LO   0x00F1B000u
+#define DSP_LOCAL_HI   0x00F1CFFFu
+#define MAIN_RAM_LO    0x00000000u
+#define MAIN_RAM_HI    0x001FFFFFu
+
+/* Wedge thresholds.  We sample once per frame, so 600 frames @ 60Hz =
+ * 10 seconds of the same PC while still flagged "running". */
+#define WEDGE_FRAMES_GPU   180   /* 3 sec of GPU stuck at one PC */
+#define WEDGE_FRAMES_DSP   600   /* 10 sec for DSP -- many engines idle on a JR loop */
+#define STALL_FRAMES_FB    300   /* 5 sec of identical framebuffer hash */
+
+/* Halfline expectation per frame: 524 NTSC, 624 PAL.  Anomaly band is +/- 4. */
+
+/* Verbose-mode heartbeat: dump current state every N frames. */
+#define HEARTBEAT_FRAMES   600
+
+/* Throttle each anomaly class so a wedged title doesn't spam the log. */
+#define LOG_REPEAT_FRAMES  600   /* re-fire same signature at most every 10s */
+
+/* ---------- state ---------- */
+
+static int  cd_mode = CRASH_DETECT_ON;
+static int  cd_initialized = 0;
+
+static unsigned frame_no;
+
+static uint32_t last_gpu_pc;
+static unsigned gpu_same_pc_frames;
+static uint32_t last_dsp_pc;
+static unsigned dsp_same_pc_frames;
+
+static uint32_t fb_hash_prev;
+static unsigned fb_same_hash_frames;
+
+static unsigned next_heartbeat_frame;
+
+/* Last frame at which each signature fired -- prevents log spam. */
+static unsigned last_log_gpu_escape;
+static unsigned last_log_dsp_escape;
+static unsigned last_log_gpu_wedge;
+static unsigned last_log_dsp_wedge;
+static unsigned last_log_fb_stall;
+
+/* ---------- helpers ---------- */
+
+static int gpu_pc_valid(uint32_t pc)
+{
+   if (pc >= GPU_LOCAL_LO && pc <= GPU_LOCAL_HI) return 1;
+   if (pc >= MAIN_RAM_LO && pc <= MAIN_RAM_HI) return 1;
+   return 0;
+}
+
+static int dsp_pc_valid(uint32_t pc)
+{
+   if (pc >= DSP_LOCAL_LO && pc <= DSP_LOCAL_HI) return 1;
+   if (pc >= MAIN_RAM_LO && pc <= MAIN_RAM_HI) return 1;
+   return 0;
+}
+
+/* Cheap rolling framebuffer hash.  Sample 256 evenly-spaced pixels --
+ * enough entropy to detect a frozen frame, costs 256 ops per frame.
+ * We deliberately skip alpha (top byte) so XRGB padding noise doesn't
+ * inflate the hash. */
+static uint32_t fb_hash(const uint32_t *fb, unsigned w, unsigned h)
+{
+   uint32_t h32 = 0x9E3779B9u;
+   uint32_t total;
+   uint32_t step;
+   uint32_t i;
+
+   if (!fb || w == 0 || h == 0) return 0;
+   total = w * h;
+   step  = (total > 256) ? (total / 256) : 1;
+   for (i = 0; i < total; i += step)
+   {
+      uint32_t v = fb[i] & 0x00FFFFFFu;
+      h32 ^= v + 0x9E3779B9u + (h32 << 6) + (h32 >> 2);
+   }
+   return h32;
+}
+
+static int may_log(unsigned *last_frame)
+{
+   if (frame_no - *last_frame < LOG_REPEAT_FRAMES && *last_frame != 0)
+      return 0;
+   *last_frame = (frame_no == 0) ? 1 : frame_no;
+   return 1;
+}
+
+/* ---------- public API ---------- */
+
+void CrashDetectInit(void)
+{
+   cd_initialized = 1;
+   CrashDetectReset();
+}
+
+void CrashDetectReset(void)
+{
+   frame_no = 0;
+   last_gpu_pc = 0;
+   gpu_same_pc_frames = 0;
+   last_dsp_pc = 0;
+   dsp_same_pc_frames = 0;
+   fb_hash_prev = 0;
+   fb_same_hash_frames = 0;
+   next_heartbeat_frame = HEARTBEAT_FRAMES;
+   last_log_gpu_escape = 0;
+   last_log_dsp_escape = 0;
+   last_log_gpu_wedge = 0;
+   last_log_dsp_wedge = 0;
+   last_log_fb_stall = 0;
+}
+
+void CrashDetectSetMode(int mode)
+{
+   if (mode < CRASH_DETECT_OFF || mode > CRASH_DETECT_VERBOSE) mode = CRASH_DETECT_ON;
+   cd_mode = mode;
+}
+
+void CrashDetectFrameTick(const uint32_t *fb, unsigned w, unsigned h)
+{
+   uint32_t cur_gpu_pc;
+   uint32_t cur_dsp_pc;
+   int      gpu_running;
+   int      dsp_running;
+   uint32_t cur_fb_hash;
+
+   if (!cd_initialized) return;
+   if (cd_mode == CRASH_DETECT_OFF) return;
+
+   frame_no++;
+
+   cur_gpu_pc = gpu_pc;
+   cur_dsp_pc = dsp_pc;
+   gpu_running = GPUIsRunning();
+   dsp_running = DSPIsRunning();
+   cur_fb_hash = fb_hash(fb, w, h);
+
+   /* ---- GPU PC escape ---- */
+   if (gpu_running && !gpu_pc_valid(cur_gpu_pc))
+   {
+      if (may_log(&last_log_gpu_escape))
+         LOG_ERR("[CRASH-DETECT] gpu_pc_escape frame=%u pc=$%08X (valid: F03000-F03FFF or main RAM)\n",
+                 frame_no, cur_gpu_pc);
+   }
+
+   /* ---- DSP PC escape ---- */
+   if (dsp_running && !dsp_pc_valid(cur_dsp_pc))
+   {
+      if (may_log(&last_log_dsp_escape))
+         LOG_ERR("[CRASH-DETECT] dsp_pc_escape frame=%u pc=$%08X (valid: F1B000-F1CFFF or main RAM)\n",
+                 frame_no, cur_dsp_pc);
+   }
+
+   /* ---- GPU wedge: same PC, still running ---- */
+   if (gpu_running && cur_gpu_pc == last_gpu_pc)
+   {
+      gpu_same_pc_frames++;
+      if (gpu_same_pc_frames == WEDGE_FRAMES_GPU
+          && may_log(&last_log_gpu_wedge))
+         LOG_WRN("[CRASH-DETECT] gpu_wedge frame=%u pc=$%08X stuck for %u frames\n",
+                 frame_no, cur_gpu_pc, WEDGE_FRAMES_GPU);
+   }
+   else
+   {
+      gpu_same_pc_frames = 0;
+   }
+
+   /* ---- DSP wedge: same PC, still running ---- */
+   if (dsp_running && cur_dsp_pc == last_dsp_pc)
+   {
+      dsp_same_pc_frames++;
+      if (dsp_same_pc_frames == WEDGE_FRAMES_DSP
+          && may_log(&last_log_dsp_wedge))
+         LOG_WRN("[CRASH-DETECT] dsp_wedge frame=%u pc=$%08X stuck for %u frames\n",
+                 frame_no, cur_dsp_pc, WEDGE_FRAMES_DSP);
+   }
+   else
+   {
+      dsp_same_pc_frames = 0;
+   }
+
+   /* ---- Video stall: framebuffer hash unchanged while either
+    * processor still running. */
+   if (fb && cur_fb_hash == fb_hash_prev && (gpu_running || dsp_running))
+   {
+      fb_same_hash_frames++;
+      if (fb_same_hash_frames == STALL_FRAMES_FB
+          && may_log(&last_log_fb_stall))
+         LOG_WRN("[CRASH-DETECT] video_stall frame=%u fb_hash=$%08X unchanged for %u frames "
+                 "gpu_pc=$%08X gpu_run=%d dsp_pc=$%08X dsp_run=%d\n",
+                 frame_no, cur_fb_hash, STALL_FRAMES_FB,
+                 cur_gpu_pc, gpu_running, cur_dsp_pc, dsp_running);
+   }
+   else
+   {
+      fb_same_hash_frames = 0;
+   }
+
+   /* ---- Verbose heartbeat ---- */
+   if (cd_mode == CRASH_DETECT_VERBOSE && frame_no >= next_heartbeat_frame)
+   {
+      LOG_INF("[CRASH-DETECT] heartbeat frame=%u gpu_pc=$%08X gpu_run=%d "
+              "dsp_pc=$%08X dsp_run=%d fb_hash=$%08X\n",
+              frame_no, cur_gpu_pc, gpu_running,
+              cur_dsp_pc, dsp_running, cur_fb_hash);
+      next_heartbeat_frame = frame_no + HEARTBEAT_FRAMES;
+   }
+
+   last_gpu_pc = cur_gpu_pc;
+   last_dsp_pc = cur_dsp_pc;
+   fb_hash_prev = cur_fb_hash;
+}

--- a/src/core/crash_detect.c
+++ b/src/core/crash_detect.c
@@ -4,7 +4,7 @@
 #include "log.h"
 #include "../jerry/dsp.h"   /* DSPIsRunning() returns bool -- match the canonical decl */
 #include "../tom/gpu.h"     /* GPUIsRunning() */
-#include <boolean.h>        /* MSVC 2005/2010-compat shim for <stdbool.h> */
+#include <boolean.h>        /* project shim; bool / true / false */
 #include <stdint.h>
 #include <stddef.h>
 

--- a/src/core/crash_detect.h
+++ b/src/core/crash_detect.h
@@ -1,0 +1,43 @@
+/* crash_detect.h -- Lightweight runtime watchdog for Jaguar emulation
+ * anomalies that look like a "crash" to the user (GPU/DSP PC escape,
+ * GPU/DSP wedge, video stall).  Hooks once per frame; cost is a few
+ * comparisons + a tiny rolling framebuffer hash, so it's enabled by
+ * default in production builds.
+ *
+ * On detect, fires LOG_WRN/LOG_ERR via vj_log_cb so the signature
+ * shows up in any RetroArch log without extra plumbing.  Does not
+ * abort -- the core keeps running so users get the full event trace
+ * of their session, not just the first trip.
+ *
+ * Tuning lives at the top of crash_detect.c.
+ */
+
+#ifndef CRASH_DETECT_H
+#define CRASH_DETECT_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Watchdog modes. Set via core option `virtualjaguar_crash_detect`. */
+#define CRASH_DETECT_OFF      0
+#define CRASH_DETECT_ON       1   /* default -- log on anomaly only */
+#define CRASH_DETECT_VERBOSE  2   /* also log periodic heartbeat snapshots */
+
+/* Lifecycle */
+void CrashDetectInit(void);
+void CrashDetectReset(void);   /* called on retro_load_game / JaguarReset */
+void CrashDetectSetMode(int mode);
+
+/* Per-frame hook -- call once at the END of JaguarExecuteNew so all
+ * subsystems have been advanced.  fb may be NULL if no framebuffer
+ * is available this frame; the stall detector skips that frame. */
+void CrashDetectFrameTick(const uint32_t *fb, unsigned w, unsigned h);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CRASH_DETECT_H */

--- a/src/core/crash_detect.h
+++ b/src/core/crash_detect.h
@@ -28,7 +28,7 @@ extern "C" {
 
 /* Lifecycle */
 void CrashDetectInit(void);
-void CrashDetectReset(void);   /* called on retro_load_game / JaguarReset */
+void CrashDetectReset(void);   /* called from retro_load_game */
 void CrashDetectSetMode(int mode);
 
 /* Per-frame hook -- call once at the END of JaguarExecuteNew so all

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -859,6 +859,25 @@ void DSPExec(int32_t cycles)
 			IMASKCleared = false;
 		}
 
+		/* PC escape bail-out.  When the DSP PC has wandered into a
+		 * region that doesn't contain executable code (between main
+		 * RAM and DSP local SRAM, or above the cart space), every
+		 * "fetched opcode" is bus-default 0xFFFF garbage that decodes
+		 * to a near-zero-cost opcode -- the inner loop then burns the
+		 * entire timeslice without making progress, hanging the
+		 * frontend.  See Wolf3D / issue #38: PC escapes to $0006EE
+		 * area and the headless harness wedged for 12+ minutes per
+		 * frame.  Drain cycles instead and let the runtime watchdog
+		 * (src/core/crash_detect.c) log the dsp_pc_escape signature.
+		 * DSP_RUNNING is left alone so games that legitimately stop
+		 * the DSP via DSPGO=0 are unaffected. */
+		if (!((dsp_pc <= 0x001FFFFF) ||
+		      (dsp_pc >= DSP_WORK_RAM_BASE && dsp_pc < DSP_WORK_RAM_BASE + 0x2000)))
+		{
+			cycles = 0;
+			break;
+		}
+
 		if (dsp_pc >= DSP_WORK_RAM_BASE && dsp_pc < DSP_WORK_RAM_BASE + 0x2000)
 		{
 			uint32_t off = dsp_pc - DSP_WORK_RAM_BASE;

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -860,18 +860,26 @@ void DSPExec(int32_t cycles)
 		}
 
 		/* PC escape bail-out.  When the DSP PC has wandered into a
-		 * region that doesn't contain executable code (between main
-		 * RAM and DSP local SRAM, or above the cart space), every
-		 * "fetched opcode" is bus-default 0xFFFF garbage that decodes
-		 * to a near-zero-cost opcode -- the inner loop then burns the
-		 * entire timeslice without making progress, hanging the
-		 * frontend.  See Wolf3D / issue #38: PC escapes to $0006EE
-		 * area and the headless harness wedged for 12+ minutes per
-		 * frame.  Drain cycles instead and let the runtime watchdog
+		 * region that doesn't contain executable code (register space
+		 * above $E40000 outside DSP local SRAM), every "fetched opcode"
+		 * is bus-default 0xFFFF garbage that decodes to a near-zero-
+		 * cost opcode -- the inner loop then burns the entire timeslice
+		 * without making progress, hanging the frontend.  See Wolf3D /
+		 * issue #38: PC escapes to $0006EE area and the headless
+		 * harness wedged for 12+ minutes per frame.  Drain cycles
+		 * instead and let the runtime watchdog
 		 * (src/core/crash_detect.c) log the dsp_pc_escape signature.
 		 * DSP_RUNNING is left alone so games that legitimately stop
-		 * the DSP via DSPGO=0 are unaffected. */
-		if (!((dsp_pc <= 0x001FFFFF) ||
+		 * the DSP via DSPGO=0 are unaffected.
+		 *
+		 * Valid execution regions match JaguarReadX address decoding
+		 * (src/core/jaguar.c): anything <= $E3FFFF (main RAM mirrored
+		 * 4x for the bottom 8MB, cart ROM, boot ROM) plus DSP local
+		 * SRAM.  Earlier versions of this check used `<= 0x1FFFFF`
+		 * and would have false-flagged DSP code running from a RAM
+		 * mirror at $200000-$7FFFFF or from cart ROM at $800000+.
+		 * Caught by Copilot review on PR #182. */
+		if (!((dsp_pc <= 0x00E3FFFF) ||
 		      (dsp_pc >= DSP_WORK_RAM_BASE && dsp_pc < DSP_WORK_RAM_BASE + 0x2000)))
 		{
 			cycles = 0;

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -860,17 +860,24 @@ void DSPExec(int32_t cycles)
 		}
 
 		/* PC escape bail-out.  When the DSP PC has wandered into a
-		 * region that doesn't contain executable code (register space
-		 * above $E40000 outside DSP local SRAM), every "fetched opcode"
+		 * region that doesn't contain executable code -- register
+		 * space at $F00000-$F1FFFF outside DSP local SRAM, or the
+		 * unmapped territory above $E40000 -- every "fetched opcode"
 		 * is bus-default 0xFFFF garbage that decodes to a near-zero-
-		 * cost opcode -- the inner loop then burns the entire timeslice
-		 * without making progress, hanging the frontend.  See Wolf3D /
-		 * issue #38: PC escapes to $0006EE area and the headless
-		 * harness wedged for 12+ minutes per frame.  Drain cycles
-		 * instead and let the runtime watchdog
-		 * (src/core/crash_detect.c) log the dsp_pc_escape signature.
-		 * DSP_RUNNING is left alone so games that legitimately stop
-		 * the DSP via DSPGO=0 are unaffected.
+		 * cost opcode.  The inner loop then burns the entire
+		 * timeslice without making progress, hanging the frontend.
+		 *
+		 * Wolf3D headless triage caught this in v2.3.0: the runtime
+		 * watchdog logged `dsp_pc_escape pc=$00FFF004E8` (PC top-byte
+		 * corrupted) and the harness wedged for 12+ minutes per
+		 * frame.  An earlier dsp-diag snapshot showed PC=$0006EE in
+		 * RAM at frame 48 -- that's the upstream bug (separate from
+		 * this bail-out: $0006EE is *valid* RAM and decodes to real
+		 * opcodes; it's where the DSP eventually drifts INTO bad
+		 * territory that triggers the wedge).  Drain cycles here and
+		 * let the runtime watchdog (src/core/crash_detect.c) log the
+		 * actual escape PC.  DSP_RUNNING is left alone so games that
+		 * legitimately stop the DSP via DSPGO=0 are unaffected.
 		 *
 		 * Valid execution regions match JaguarReadX address decoding
 		 * (src/core/jaguar.c): anything <= $E3FFFF (main RAM mirrored

--- a/test/test_audio_presence.c
+++ b/test/test_audio_presence.c
@@ -181,7 +181,12 @@ static bool load_core(const char *path)
       return false;
    }
 #define LOAD(sym) do { p_##sym = dlsym(core_handle, #sym); \
-   if (!p_##sym) { fprintf(stderr, "Missing symbol: %s\n", #sym); return false; } } while (0)
+   if (!p_##sym) { \
+      fprintf(stderr, "Missing symbol: %s\n", #sym); \
+      dlclose(core_handle); core_handle = NULL; \
+      return false; \
+   } \
+} while (0)
    LOAD(retro_init);
    LOAD(retro_deinit);
    LOAD(retro_set_environment);
@@ -321,6 +326,8 @@ int main(int argc, char **argv)
    if (!p_retro_load_game(&game))
    {
       fprintf(stderr, "FAIL: retro_load_game failed\n");
+      p_retro_deinit();
+      dlclose(core_handle); core_handle = NULL;
       free(rom_buf);
       return 1;
    }
@@ -330,6 +337,7 @@ int main(int argc, char **argv)
 
    p_retro_unload_game();
    p_retro_deinit();
+   dlclose(core_handle); core_handle = NULL;
    free(rom_buf);
 
    /* ---------- Report ---------- */

--- a/test/test_audio_presence.c
+++ b/test/test_audio_presence.c
@@ -1,0 +1,379 @@
+/* test_audio_presence.c -- Detect missing or stuck audio (silence / DC).
+ *
+ * Counterpart to test_audio_clipping.c.  That test detects loud-broken
+ * audio (saturation/clipping).  This test detects the OTHER failure
+ * mode: a "fix" that silences the game instead of fixing it, or a
+ * regression where the DSP audio engine never starts emitting samples
+ * at all.  Closing PR #170 was the prompt for this — the clipping
+ * test passed on PR #170 because Iron Soldier 2 went from
+ * "RMS=28587 (loud broken)" to "RMS=521 (effectively silent)".
+ *
+ * The test runs N frames and asserts:
+ *   - first_audio_frame is reached (some non-trivial sample seen)
+ *   - window RMS lies inside [floor, ceiling] for the chosen ROM
+ *   - longest run of near-zero stereo frames < max_zero_run_pct of window
+ *
+ * Tunable per-ROM via --rms-floor / --rms-ceiling / --max-zero-run-pct.
+ *
+ * Build: see Makefile target test/test_audio_presence
+ * Usage: ./test/test_audio_presence <core> <rom> [opts]
+ *
+ * Exit:  0 PASS, 1 FAIL, 2 SKIP (ROM missing)
+ *
+ * If <rom> is omitted or missing, exits 2 (skip) so CI without private
+ * ROMs reports a clean skip instead of a failure.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <math.h>
+#include <dlfcn.h>
+#include "../libretro-common/include/libretro.h"
+
+#define WINDOW_START_FRAME 60     /* skip first 1s — boot silence/whoosh */
+#define DEFAULT_TOTAL_FRAMES 300  /* 5s at 60fps */
+#define ONSET_THRESHOLD 32        /* |s| > this => audio onset */
+#define ZERO_THRESHOLD 32         /* both channels |s| <= this => "near-zero" frame */
+
+/* ---------- libretro symbols ---------- */
+static void *core_handle;
+static void (*p_retro_init)(void);
+static void (*p_retro_deinit)(void);
+static void (*p_retro_set_environment)(retro_environment_t);
+static void (*p_retro_set_video_refresh)(retro_video_refresh_t);
+static void (*p_retro_set_audio_sample)(retro_audio_sample_t);
+static void (*p_retro_set_audio_sample_batch)(retro_audio_sample_batch_t);
+static void (*p_retro_set_input_poll)(retro_input_poll_t);
+static void (*p_retro_set_input_state)(retro_input_state_t);
+static bool (*p_retro_load_game)(const struct retro_game_info *);
+static void (*p_retro_unload_game)(void);
+static void (*p_retro_run)(void);
+
+/* ---------- capture state ---------- */
+static unsigned current_frame = 0;
+static int first_audio_frame = -1;
+static double window_sum_sq = 0;
+static uint64_t window_sample_count = 0;       /* counts mono samples */
+static unsigned longest_zero_run = 0;
+static unsigned current_zero_run = 0;
+static unsigned active_window_frames = 0;
+
+/* ---------- core libretro callback shims ---------- */
+static void video_refresh(const void *d, unsigned w, unsigned h, size_t p)
+{ (void)d; (void)w; (void)h; (void)p; }
+
+static void audio_sample(int16_t l, int16_t r) { (void)l; (void)r; }
+
+static size_t audio_batch(const int16_t *data, size_t frames)
+{
+   size_t i;
+   bool in_window = (current_frame >= WINDOW_START_FRAME);
+   double frame_sum_sq = 0;
+
+   for (i = 0; i < frames; i++)
+   {
+      int16_t l = data[i * 2];
+      int16_t r = data[i * 2 + 1];
+      int16_t abs_l = (l < 0) ? -l : l;
+      int16_t abs_r = (r < 0) ? -r : r;
+      bool near_zero = (abs_l <= ZERO_THRESHOLD) && (abs_r <= ZERO_THRESHOLD);
+
+      if (first_audio_frame < 0 && (abs_l > ONSET_THRESHOLD || abs_r > ONSET_THRESHOLD))
+         first_audio_frame = (int)current_frame;
+
+      if (in_window)
+      {
+         frame_sum_sq += (double)l * l + (double)r * r;
+
+         if (near_zero)
+         {
+            current_zero_run++;
+            if (current_zero_run > longest_zero_run)
+               longest_zero_run = current_zero_run;
+         }
+         else
+         {
+            current_zero_run = 0;
+         }
+      }
+   }
+
+   if (in_window && frames > 0)
+   {
+      window_sum_sq += frame_sum_sq;
+      window_sample_count += frames * 2;
+      active_window_frames++;
+   }
+
+   return frames;
+}
+
+static void input_poll(void) {}
+static int16_t input_state(unsigned p, unsigned d, unsigned i, unsigned id)
+{ (void)p; (void)d; (void)i; (void)id; return 0; }
+
+static int use_bios = 0;
+static int log_quiet = 0;
+
+static void log_printf(enum retro_log_level level, const char *fmt, ...)
+{
+   va_list ap;
+   if (log_quiet || level < RETRO_LOG_WARN) return;
+   va_start(ap, fmt);
+   vfprintf(stderr, fmt, ap);
+   va_end(ap);
+}
+
+static struct retro_log_callback log_cb = { log_printf };
+
+static bool environment(unsigned cmd, void *data)
+{
+   switch (cmd)
+   {
+   case RETRO_ENVIRONMENT_GET_LOG_INTERFACE:
+      *(struct retro_log_callback *)data = log_cb;
+      return true;
+   case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+   case RETRO_ENVIRONMENT_SET_VARIABLES:
+   case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
+   case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE:
+   case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+   case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS:
+   case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS:
+   case RETRO_ENVIRONMENT_SET_GEOMETRY:
+   case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
+   case RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER:
+      return true;
+   case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+   case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+      *(const char **)data = "/tmp";
+      return true;
+   case RETRO_ENVIRONMENT_GET_VARIABLE:
+   {
+      struct retro_variable *var = (struct retro_variable *)data;
+      if (var->key && strcmp(var->key, "virtualjaguar_bios") == 0)
+      {
+         var->value = use_bios ? "enabled" : "disabled";
+         return true;
+      }
+      var->value = NULL;
+      return false;
+   }
+   default:
+      return false;
+   }
+}
+
+/* ---------- core load ---------- */
+static bool load_core(const char *path)
+{
+   core_handle = dlopen(path, RTLD_NOW);
+   if (!core_handle)
+   {
+      fprintf(stderr, "dlopen(%s): %s\n", path, dlerror());
+      return false;
+   }
+#define LOAD(sym) do { p_##sym = dlsym(core_handle, #sym); \
+   if (!p_##sym) { fprintf(stderr, "Missing symbol: %s\n", #sym); return false; } } while (0)
+   LOAD(retro_init);
+   LOAD(retro_deinit);
+   LOAD(retro_set_environment);
+   LOAD(retro_set_video_refresh);
+   LOAD(retro_set_audio_sample);
+   LOAD(retro_set_audio_sample_batch);
+   LOAD(retro_set_input_poll);
+   LOAD(retro_set_input_state);
+   LOAD(retro_load_game);
+   LOAD(retro_unload_game);
+   LOAD(retro_run);
+#undef LOAD
+   return true;
+}
+
+static void init_core(void)
+{
+   p_retro_set_environment(environment);
+   p_retro_init();
+   p_retro_set_video_refresh(video_refresh);
+   p_retro_set_audio_sample(audio_sample);
+   p_retro_set_audio_sample_batch(audio_batch);
+   p_retro_set_input_poll(input_poll);
+   p_retro_set_input_state(input_state);
+}
+
+/* ---------- ROM load ---------- */
+static unsigned char *rom_buf = NULL;
+static size_t rom_size = 0;
+
+static int load_rom(const char *path)
+{
+   FILE *fp;
+   long size;
+
+   fp = fopen(path, "rb");
+   if (!fp) return -1;
+   fseek(fp, 0, SEEK_END);
+   size = ftell(fp);
+   fseek(fp, 0, SEEK_SET);
+   if (size <= 0) { fclose(fp); return -1; }
+
+   rom_buf = (unsigned char *)malloc((size_t)size);
+   if (!rom_buf) { fclose(fp); return -1; }
+   if (fread(rom_buf, 1, (size_t)size, fp) != (size_t)size)
+   {
+      free(rom_buf); rom_buf = NULL; fclose(fp); return -1;
+   }
+   fclose(fp);
+   rom_size = (size_t)size;
+   return 0;
+}
+
+int main(int argc, char **argv)
+{
+   const char *core_path = NULL;
+   const char *rom_path = NULL;
+   const char *label = NULL;
+   unsigned total_frames = DEFAULT_TOTAL_FRAMES;
+   double rms_floor = 100.0;
+   double rms_ceiling = 25000.0;
+   double max_zero_run_pct = 50.0;
+   int i;
+   struct retro_game_info game;
+   double window_rms;
+   unsigned zero_run_pct = 0;
+   int fail_count = 0;
+
+   for (i = 1; i < argc; i++)
+   {
+      const char *a = argv[i];
+      if (a[0] != '-')
+      {
+         if (!core_path)      core_path = a;
+         else if (!rom_path)  rom_path = a;
+         continue;
+      }
+      if (!strcmp(a, "--bios"))       use_bios = 1;
+      else if (!strcmp(a, "--quiet")) log_quiet = 1;
+      else if (!strcmp(a, "--frames") && i + 1 < argc) total_frames = (unsigned)atoi(argv[++i]);
+      else if (!strcmp(a, "--rms-floor") && i + 1 < argc) rms_floor = atof(argv[++i]);
+      else if (!strcmp(a, "--rms-ceiling") && i + 1 < argc) rms_ceiling = atof(argv[++i]);
+      else if (!strcmp(a, "--max-zero-run-pct") && i + 1 < argc) max_zero_run_pct = atof(argv[++i]);
+      else if (!strcmp(a, "--label") && i + 1 < argc) label = argv[++i];
+      else
+      {
+         fprintf(stderr, "Unknown arg: %s\n", a);
+         return 2;
+      }
+   }
+
+   if (!core_path)
+   {
+      fprintf(stderr, "Usage: %s <core> <rom> [--bios] [--frames N]\n"
+                      "  [--rms-floor F] [--rms-ceiling C] [--max-zero-run-pct P]\n"
+                      "  [--label NAME] [--quiet]\n", argv[0]);
+      return 2;
+   }
+   if (!rom_path)
+   {
+      fprintf(stderr, "SKIP: no ROM path given\n");
+      return 2;
+   }
+
+   if (load_rom(rom_path) < 0)
+   {
+      fprintf(stderr, "SKIP: ROM not found or unreadable: %s\n", rom_path);
+      return 2;
+   }
+
+   if (!load_core(core_path))
+   {
+      free(rom_buf);
+      return 1;
+   }
+
+   init_core();
+
+   memset(&game, 0, sizeof(game));
+   game.path = rom_path;
+   game.data = rom_buf;
+   game.size = rom_size;
+
+   if (!p_retro_load_game(&game))
+   {
+      fprintf(stderr, "FAIL: retro_load_game failed\n");
+      free(rom_buf);
+      return 1;
+   }
+
+   for (current_frame = 0; current_frame < total_frames; current_frame++)
+      p_retro_run();
+
+   p_retro_unload_game();
+   p_retro_deinit();
+   free(rom_buf);
+
+   /* ---------- Report ---------- */
+   if (window_sample_count > 0)
+      window_rms = sqrt(window_sum_sq / (double)window_sample_count);
+   else
+      window_rms = 0.0;
+
+   if (active_window_frames > 0)
+   {
+      double frames_in_run = (double)longest_zero_run /
+         ((double)window_sample_count / (double)active_window_frames / 2.0);
+      zero_run_pct = (unsigned)(frames_in_run / (double)active_window_frames * 100.0);
+   }
+
+   if (!log_quiet)
+   {
+      printf("\n=== Presence check: %s ===\n", label ? label : rom_path);
+      printf("  ROM:    %s\n", rom_path);
+      printf("  Frames: %u, Window: [%u, %u)\n",
+             total_frames, WINDOW_START_FRAME, total_frames);
+      printf("  BIOS:   %s\n", use_bios ? "enabled" : "disabled (HLE)");
+      printf("  First audio at frame: %d\n", first_audio_frame);
+      printf("  Active window frames: %u / %u\n",
+             active_window_frames, total_frames - WINDOW_START_FRAME);
+      printf("  Window RMS:           %.1f  [floor %.1f, ceiling %.1f]\n",
+             window_rms, rms_floor, rms_ceiling);
+      printf("  Longest zero run:     %u stereo frames (~%u%% of window)\n",
+             longest_zero_run, zero_run_pct);
+   }
+
+   if (first_audio_frame < 0)
+   {
+      printf("  FAIL: no audio onset detected (game silent throughout %u frames)\n",
+             total_frames);
+      fail_count++;
+   }
+   if (window_rms < rms_floor)
+   {
+      printf("  FAIL: window RMS %.1f below floor %.1f (audio missing or muted)\n",
+             window_rms, rms_floor);
+      fail_count++;
+   }
+   if (window_rms > rms_ceiling)
+   {
+      printf("  FAIL: window RMS %.1f above ceiling %.1f (audio possibly broken/saturated)\n",
+             window_rms, rms_ceiling);
+      fail_count++;
+   }
+   if ((double)zero_run_pct > max_zero_run_pct)
+   {
+      printf("  FAIL: longest zero run is ~%u%% of window (>%.0f%%, audio stuck or dropped out)\n",
+             zero_run_pct, max_zero_run_pct);
+      fail_count++;
+   }
+
+   if (fail_count == 0)
+   {
+      printf("  PASS: audio is present and within expected envelope\n");
+      return 0;
+   }
+   return 1;
+}

--- a/test/test_audio_presence.c
+++ b/test/test_audio_presence.c
@@ -78,8 +78,11 @@ static size_t audio_batch(const int16_t *data, size_t frames)
    {
       int16_t l = data[i * 2];
       int16_t r = data[i * 2 + 1];
-      int16_t abs_l = (l < 0) ? -l : l;
-      int16_t abs_r = (r < 0) ? -r : r;
+      /* Promote to int32_t so that negating INT16_MIN doesn't overflow
+       * (-(-32768) is undefined as a 16-bit op).  Caught by Copilot
+       * review on PR #182. */
+      int32_t abs_l = (l < 0) ? -(int32_t)l : (int32_t)l;
+      int32_t abs_r = (r < 0) ? -(int32_t)r : (int32_t)r;
       bool near_zero = (abs_l <= ZERO_THRESHOLD) && (abs_r <= ZERO_THRESHOLD);
 
       if (first_audio_frame < 0 && (abs_l > ONSET_THRESHOLD || abs_r > ONSET_THRESHOLD))
@@ -280,6 +283,19 @@ int main(int argc, char **argv)
    if (!rom_path)
    {
       fprintf(stderr, "SKIP: no ROM path given\n");
+      return 2;
+   }
+
+   /* `--frames` must leave a non-empty measurement window past the
+    * boot-skip prefix; otherwise the report's `total_frames -
+    * WINDOW_START_FRAME` underflows when printed via %u.
+    * Caught by Copilot review on PR #182. */
+   if (total_frames <= WINDOW_START_FRAME)
+   {
+      fprintf(stderr,
+              "ERROR: --frames %u must exceed the %u-frame boot skip "
+              "(WINDOW_START_FRAME).  Pick a value > %u.\n",
+              total_frames, WINDOW_START_FRAME, WINDOW_START_FRAME);
       return 2;
    }
 

--- a/test/tools/test_video_dim_log.c
+++ b/test/tools/test_video_dim_log.c
@@ -155,7 +155,14 @@ static bool load_core(const char *path)
 {
    core_handle = dlopen(path, RTLD_NOW);
    if (!core_handle) { fprintf(stderr, "dlopen: %s\n", dlerror()); return false; }
-#define LOAD(s) do { p_##s = dlsym(core_handle, #s); if (!p_##s) { fprintf(stderr, "missing %s\n", #s); return false; } } while (0)
+#define LOAD(s) do { \
+   p_##s = dlsym(core_handle, #s); \
+   if (!p_##s) { \
+      fprintf(stderr, "missing %s\n", #s); \
+      dlclose(core_handle); core_handle = NULL; \
+      return false; \
+   } \
+} while (0)
    LOAD(retro_init); LOAD(retro_deinit);
    LOAD(retro_set_environment); LOAD(retro_set_video_refresh);
    LOAD(retro_set_audio_sample); LOAD(retro_set_audio_sample_batch);

--- a/test/tools/test_video_dim_log.c
+++ b/test/tools/test_video_dim_log.c
@@ -191,10 +191,16 @@ int main(int argc, char **argv)
    }
    if (!core || !rom) { fprintf(stderr, "Usage: %s <core> <rom> [--frames N] [--bios]\n", argv[0]); return 2; }
 
-   fp = fopen(rom, "rb"); if (!fp) { fprintf(stderr, "open %s: fail\n", rom); return 2; }
-   fseek(fp, 0, SEEK_END); sz = ftell(fp); fseek(fp, 0, SEEK_SET);
+   fp = fopen(rom, "rb");
+   if (!fp) { fprintf(stderr, "open %s: fail\n", rom); return 2; }
+   if (fseek(fp, 0, SEEK_END) != 0) { fclose(fp); fprintf(stderr, "fseek: fail\n"); return 2; }
+   sz = ftell(fp);
+   if (sz <= 0) { fclose(fp); fprintf(stderr, "ftell: bad size %ld\n", sz); return 2; }
+   if (fseek(fp, 0, SEEK_SET) != 0) { fclose(fp); fprintf(stderr, "fseek rewind: fail\n"); return 2; }
    buf = malloc((size_t)sz);
-   if (fread(buf, 1, (size_t)sz, fp) != (size_t)sz) { fclose(fp); free(buf); return 2; }
+   if (!buf) { fclose(fp); fprintf(stderr, "malloc(%ld): fail\n", sz); return 2; }
+   if (fread(buf, 1, (size_t)sz, fp) != (size_t)sz)
+   { fclose(fp); free(buf); fprintf(stderr, "fread: short read\n"); return 2; }
    fclose(fp);
 
    if (!load_core(core)) { free(buf); return 1; }
@@ -208,7 +214,14 @@ int main(int argc, char **argv)
 
    memset(&game, 0, sizeof(game));
    game.path = rom; game.data = buf; game.size = (size_t)sz;
-   if (!p_retro_load_game(&game)) { fprintf(stderr, "load_game failed\n"); free(buf); return 1; }
+   if (!p_retro_load_game(&game))
+   {
+      fprintf(stderr, "load_game failed\n");
+      p_retro_deinit();
+      dlclose(core_handle); core_handle = NULL;
+      free(buf);
+      return 1;
+   }
 
    printf("=== Video dim log: %s, %u frames, BIOS=%s ===\n",
           rom, frames, use_bios ? "on" : "off");
@@ -227,6 +240,7 @@ int main(int argc, char **argv)
 
    p_retro_unload_game();
    p_retro_deinit();
+   dlclose(core_handle); core_handle = NULL;
    free(buf);
    return 0;
 }

--- a/test/tools/test_video_dim_log.c
+++ b/test/tools/test_video_dim_log.c
@@ -1,0 +1,225 @@
+/* test_video_dim_log.c — log every video resolution change.
+ *
+ * Diagnostic for issue #138 (Pitfall crash).  RetroArch log shows
+ * framebuffer churn (320/326/652) for Pitfall — the user reports a
+ * black-screen "crash" after ~45 sec.  Dimension changes are
+ * expensive and may indicate a runtime visible-window problem
+ * introduced by v2.3.0's PR #164 (derive visible window from
+ * VDB/VDE/HDB/HDE).  This tool runs N frames and prints a row each
+ * time width/height changes, so we can see at what frame and how
+ * often the geometry oscillates.
+ *
+ * Build: cc -O2 -Wall -std=c99 -I.. -I../src -I../libretro-common/include \
+ *           -o test_video_dim_log test_video_dim_log.c -ldl
+ * Usage: ./test_video_dim_log <core> <rom> [--frames N] [--bios]
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include "../../libretro-common/include/libretro.h"
+
+static void *core_handle;
+static void (*p_retro_init)(void);
+static void (*p_retro_deinit)(void);
+static void (*p_retro_set_environment)(retro_environment_t);
+static void (*p_retro_set_video_refresh)(retro_video_refresh_t);
+static void (*p_retro_set_audio_sample)(retro_audio_sample_t);
+static void (*p_retro_set_audio_sample_batch)(retro_audio_sample_batch_t);
+static void (*p_retro_set_input_poll)(retro_input_poll_t);
+static void (*p_retro_set_input_state)(retro_input_state_t);
+static bool (*p_retro_load_game)(const struct retro_game_info *);
+static void (*p_retro_unload_game)(void);
+static void (*p_retro_run)(void);
+
+static unsigned current_frame = 0;
+static unsigned last_w = 0, last_h = 0;
+static unsigned change_count = 0;
+static unsigned long long total_pixels = 0;
+static unsigned video_calls = 0;
+static unsigned black_streak = 0;
+static unsigned longest_black_streak = 0;
+static int first_black_streak_frame = -1;
+
+static void video_refresh(const void *data, unsigned w, unsigned h, size_t pitch)
+{
+   const uint32_t *p;
+   uint32_t i, n;
+   uint32_t nonblack = 0;
+
+   video_calls++;
+   if (w != last_w || h != last_h)
+   {
+      printf("  [frame %5u] dim: %ux%u -> %ux%u (change #%u)\n",
+             current_frame, last_w, last_h, w, h, ++change_count);
+      last_w = w; last_h = h;
+   }
+   if (!data) return;
+
+   p = (const uint32_t *)data;
+   n = w * h;
+   if (n > 320*240) n = 320*240; /* cap loop work */
+   for (i = 0; i < n; i++)
+   {
+      uint32_t v = p[i] & 0x00FFFFFF;
+      if (v != 0) { nonblack++; if (nonblack > 4) break; }
+   }
+   total_pixels += w * h;
+
+   if (nonblack <= 4)
+   {
+      if (black_streak == 0 && first_black_streak_frame < 0)
+         first_black_streak_frame = (int)current_frame;
+      black_streak++;
+      if (black_streak > longest_black_streak)
+         longest_black_streak = black_streak;
+   }
+   else
+   {
+      if (black_streak >= 30)
+         printf("  [frame %5u] black streak ended after %u frames (started ~%u)\n",
+                current_frame, black_streak, current_frame - black_streak);
+      black_streak = 0;
+   }
+}
+
+static void audio_sample(int16_t l, int16_t r) { (void)l; (void)r; }
+static size_t audio_batch(const int16_t *d, size_t f) { (void)d; return f; }
+static void input_poll(void) {}
+static int16_t input_state(unsigned a, unsigned b, unsigned c, unsigned d)
+{ (void)a; (void)b; (void)c; (void)d; return 0; }
+
+static int use_bios = 0;
+static struct retro_log_callback log_cb = { 0 };
+static void log_printf(enum retro_log_level lv, const char *fmt, ...)
+{ (void)lv; (void)fmt; }
+
+static bool environment(unsigned cmd, void *data)
+{
+   switch (cmd)
+   {
+   case RETRO_ENVIRONMENT_GET_LOG_INTERFACE:
+      log_cb.log = log_printf;
+      *(struct retro_log_callback *)data = log_cb;
+      return true;
+   case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+   case RETRO_ENVIRONMENT_SET_VARIABLES:
+   case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
+   case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE:
+   case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+   case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS:
+   case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS:
+   case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
+   case RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER:
+      return true;
+   case RETRO_ENVIRONMENT_SET_GEOMETRY:
+   {
+      const struct retro_game_geometry *g = (const struct retro_game_geometry *)data;
+      printf("  [frame %5u] SET_GEOMETRY: %ux%u, aspect %.3f\n",
+             current_frame, g->base_width, g->base_height, g->aspect_ratio);
+      return true;
+   }
+   case RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO:
+   {
+      const struct retro_system_av_info *av = (const struct retro_system_av_info *)data;
+      printf("  [frame %5u] SET_SYSTEM_AV_INFO: %ux%u, aspect %.3f, fps %.2f\n",
+             current_frame, av->geometry.base_width, av->geometry.base_height,
+             av->geometry.aspect_ratio, av->timing.fps);
+      return true;
+   }
+   case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+   case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+      *(const char **)data = "/tmp";
+      return true;
+   case RETRO_ENVIRONMENT_GET_VARIABLE:
+   {
+      struct retro_variable *var = (struct retro_variable *)data;
+      if (var->key && strcmp(var->key, "virtualjaguar_bios") == 0)
+      {
+         var->value = use_bios ? "enabled" : "disabled";
+         return true;
+      }
+      var->value = NULL;
+      return false;
+   }
+   default:
+      return false;
+   }
+}
+
+static bool load_core(const char *path)
+{
+   core_handle = dlopen(path, RTLD_NOW);
+   if (!core_handle) { fprintf(stderr, "dlopen: %s\n", dlerror()); return false; }
+#define LOAD(s) do { p_##s = dlsym(core_handle, #s); if (!p_##s) { fprintf(stderr, "missing %s\n", #s); return false; } } while (0)
+   LOAD(retro_init); LOAD(retro_deinit);
+   LOAD(retro_set_environment); LOAD(retro_set_video_refresh);
+   LOAD(retro_set_audio_sample); LOAD(retro_set_audio_sample_batch);
+   LOAD(retro_set_input_poll); LOAD(retro_set_input_state);
+   LOAD(retro_load_game); LOAD(retro_unload_game); LOAD(retro_run);
+#undef LOAD
+   return true;
+}
+
+int main(int argc, char **argv)
+{
+   const char *core = NULL, *rom = NULL;
+   unsigned frames = 600;
+   FILE *fp;
+   long sz;
+   unsigned char *buf;
+   struct retro_game_info game;
+   int i;
+
+   for (i = 1; i < argc; i++)
+   {
+      const char *a = argv[i];
+      if (a[0] != '-') { if (!core) core = a; else if (!rom) rom = a; continue; }
+      if (!strcmp(a, "--bios")) use_bios = 1;
+      else if (!strcmp(a, "--frames") && i + 1 < argc) frames = (unsigned)atoi(argv[++i]);
+   }
+   if (!core || !rom) { fprintf(stderr, "Usage: %s <core> <rom> [--frames N] [--bios]\n", argv[0]); return 2; }
+
+   fp = fopen(rom, "rb"); if (!fp) { fprintf(stderr, "open %s: fail\n", rom); return 2; }
+   fseek(fp, 0, SEEK_END); sz = ftell(fp); fseek(fp, 0, SEEK_SET);
+   buf = malloc((size_t)sz);
+   if (fread(buf, 1, (size_t)sz, fp) != (size_t)sz) { fclose(fp); free(buf); return 2; }
+   fclose(fp);
+
+   if (!load_core(core)) { free(buf); return 1; }
+   p_retro_set_environment(environment);
+   p_retro_init();
+   p_retro_set_video_refresh(video_refresh);
+   p_retro_set_audio_sample(audio_sample);
+   p_retro_set_audio_sample_batch(audio_batch);
+   p_retro_set_input_poll(input_poll);
+   p_retro_set_input_state(input_state);
+
+   memset(&game, 0, sizeof(game));
+   game.path = rom; game.data = buf; game.size = (size_t)sz;
+   if (!p_retro_load_game(&game)) { fprintf(stderr, "load_game failed\n"); free(buf); return 1; }
+
+   printf("=== Video dim log: %s, %u frames, BIOS=%s ===\n",
+          rom, frames, use_bios ? "on" : "off");
+   for (current_frame = 0; current_frame < frames; current_frame++)
+      p_retro_run();
+
+   printf("\n=== Summary ===\n");
+   printf("  Total dim changes:      %u\n", change_count);
+   printf("  Video callback calls:   %u\n", video_calls);
+   printf("  Final dimensions:       %ux%u\n", last_w, last_h);
+   printf("  Longest black streak:   %u frames", longest_black_streak);
+   if (first_black_streak_frame >= 0)
+      printf(" (first started ~frame %d)\n", first_black_streak_frame);
+   else
+      printf("\n");
+
+   p_retro_unload_game();
+   p_retro_deinit();
+   free(buf);
+   return 0;
+}


### PR DESCRIPTION
## Summary

- Runtime crash watchdog (`src/core/crash_detect.c`) — opt-out core option that logs `gpu_pc_escape` / `dsp_pc_escape` / `gpu_wedge` / `dsp_wedge` / `video_stall` to the RA log when a game hangs.  Means future bug reports become triageable from the log alone.
- DSP wedge defensive bailout — fixes a v2.3.0 regression where Wolf3D's DSP PC escape spun the headless harness for 12+ minutes per frame.
- `test_audio_presence.c` — counterpart to `test_audio_clipping`.  Catches the silencing-regression class (PR #170 lesson).
- Bug-report template clarification (#179, @checktext00) — the BIOS-mode dropdown no longer implies users need an external `jagboot.rom`.

No new emulation features.  None of the long-standing audio / Doom-speed / CD bugs changed.  Full notes in `docs/RELEASE_NOTES_v2.3.1.md`.

## Test plan

- [x] `make clean && make -j` builds clean
- [x] `make test` exits 0 with only documented Skyhammer / IS2 EXPECTED-FAIL clipping entries
- [x] `strings *.dylib | grep v2.3.1` confirms version stamp
- [x] `test_audio_presence` passes on Iron Soldier 1 baseline (RMS ~1175)
- [x] Wolf3D no longer wedges the headless harness (<30 sec, matches v2.2.0 wall-clock)

## Release process

GitFlow per `docs/release-process.md`:
1. Merge this PR to master
2. Tag `v2.3.1` on master, push tag
3. CI (`release.yml`) builds 16 platforms and publishes the GitHub release
4. Back-merge master into develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)