### PR TITLE
fix(hle): gate DSPGO auto-clear on non-zero samples — fixes #181 Battle Sphere Gold

### DIFF
--- a/src/core/state.h
+++ b/src/core/state.h
@@ -19,7 +19,7 @@ extern "C" {
 
 /* Save state format identifier and version */
 #define STATE_MAGIC     0x564A5353  /* "VJSS" */
-#define STATE_VERSION   2
+#define STATE_VERSION   3
 
 /* Header flags */
 #define STATE_FLAG_MEMTRACK  0x01

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -318,6 +318,7 @@ size_t DACStateSave(uint8_t *buf)
 	STATE_SAVE_VAR(buf, bufferDone);
 	STATE_SAVE_VAR(buf, i2sWritePos);
 	STATE_SAVE_VAR(buf, i2sWriteCount);
+	STATE_SAVE_VAR(buf, i2sNonZeroCount);
 	STATE_SAVE_VAR(buf, i2sPhase);
 	STATE_SAVE_VAR(buf, i2sRateRatio);
 
@@ -333,6 +334,7 @@ size_t DACStateLoad(const uint8_t *buf)
 	STATE_LOAD_VAR(buf, bufferDone);
 	STATE_LOAD_VAR(buf, i2sWritePos);
 	STATE_LOAD_VAR(buf, i2sWriteCount);
+	STATE_LOAD_VAR(buf, i2sNonZeroCount);
 	STATE_LOAD_VAR(buf, i2sPhase);
 	STATE_LOAD_VAR(buf, i2sRateRatio);
 

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -66,6 +66,7 @@ static int16_t i2sRingL[I2S_RING_SIZE];
 static int16_t i2sRingR[I2S_RING_SIZE];
 static uint32_t i2sWritePos = 0;	/* next write position in ring */
 static uint32_t i2sWriteCount = 0;	/* total samples captured this frame */
+static uint32_t i2sNonZeroCount = 0;	/* samples with non-zero amplitude this frame */
 static double i2sPhase = 0.0;		/* fractional read position */
 static double i2sRateRatio = 1.0;	/* i2s_rate / 48000.0 */
 
@@ -92,6 +93,7 @@ void DACReset(void)
 
    i2sWritePos = 0;
    i2sWriteCount = 0;
+   i2sNonZeroCount = 0;
    i2sPhase = 0.0;
    i2sRateRatio = 1.0;
    memset(i2sRingL, 0, sizeof(i2sRingL));
@@ -105,6 +107,11 @@ void DACDone(void)
 uint32_t DACGetI2SWriteCount(void)
 {
    return i2sWriteCount;
+}
+
+uint32_t DACGetI2SNonZeroCount(void)
+{
+   return i2sNonZeroCount;
 }
 
 /* Update the rate ratio when SCLK changes */
@@ -137,6 +144,8 @@ static void DACCaptureSample(int16_t left, int16_t right)
    i2sRingR[i2sWritePos & I2S_RING_MASK] = right;
    i2sWritePos++;
    i2sWriteCount++;
+   if (left != 0 || right != 0)
+      i2sNonZeroCount++;
 }
 
 void DSPSampleCallback(void)
@@ -208,6 +217,7 @@ void DACPrepareFrame(int length)
    i2sRingR[1] = (int16_t)(*rtxd);
    i2sWritePos = 2;
    i2sWriteCount = 2;
+   i2sNonZeroCount = 0;
    i2sPhase = i2sPhase - (double)(uint32_t)i2sPhase;
 
    /* Refresh rate ratio in case SCLK was written between frames */

--- a/src/jerry/dac.h
+++ b/src/jerry/dac.h
@@ -18,6 +18,7 @@ void DACReset(void);
 void DACDone(void);
 void DACPrepareFrame(int length);
 uint32_t DACGetI2SWriteCount(void);
+uint32_t DACGetI2SNonZeroCount(void);
 
 // DAC memory access
 

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -492,12 +492,23 @@ uint32_t DSPReadLong(uint32_t offset, uint32_t who/*=UNKNOWN*/)
              * ignoring normal gameplay status checks (~1-10/frame).
              *
              * Exception: if the DSP is actively producing audio
-             * (i2sWriteCount > 2, beyond the DACPrepareFrame seed),
-             * it is running a legitimate audio mixer (e.g. Doom) and
-             * must not be killed. */
+             * (non-zero LTXD/RTXD samples beyond the DACPrepareFrame
+             * seed), it is running a legitimate audio mixer (e.g.
+             * Doom) and must not be killed.  Issue #181 (Battle
+             * Sphere): the silenced/escaped DSP still issues STORE
+             * 0,RTXD per loop iteration, so we gate on non-zero
+             * sample count, not raw write count. */
             if (who == M68K && DSP_RUNNING && !vjs.useJaguarBIOS)
             {
-               if (DACGetI2SWriteCount() > 2)
+               /* "Real audio" gate: a DSP that's mixing for the user
+                * writes non-zero LTXD/RTXD pairs.  A DSP that wrote
+                * silence (Battle Sphere with an escaped DSP that still
+                * issues STORE 0,RTXD per loop iteration) racks up
+                * thousands of i2sWriteCount per frame but produces no
+                * audio.  Counting that as "real audio" wedges the
+                * cart's DSPGO poll forever.  Require non-zero samples
+                * before declaring the engine alive. */
+               if (DACGetI2SNonZeroCount() > 2)
                   dspgo_poll_count = 0;
                else
                {

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -501,14 +501,16 @@ uint32_t DSPReadLong(uint32_t offset, uint32_t who/*=UNKNOWN*/)
             if (who == M68K && DSP_RUNNING && !vjs.useJaguarBIOS)
             {
                /* "Real audio" gate: a DSP that's mixing for the user
-                * writes non-zero LTXD/RTXD pairs.  A DSP that wrote
-                * silence (Battle Sphere with an escaped DSP that still
-                * issues STORE 0,RTXD per loop iteration) racks up
-                * thousands of i2sWriteCount per frame but produces no
-                * audio.  Counting that as "real audio" wedges the
-                * cart's DSPGO poll forever.  Require non-zero samples
-                * before declaring the engine alive. */
-               if (DACGetI2SNonZeroCount() > 2)
+                * writes non-zero LTXD/RTXD samples.  The non-zero
+                * counter is reset to 0 at every DACPrepareFrame
+                * (unlike i2sWriteCount which is seeded to 2 for the
+                * resampler), so any non-zero sample this frame is
+                * enough to declare the engine alive.  A DSP that
+                * wrote only silence -- Battle Sphere with an escaped
+                * DSP still issuing STORE 0,RTXD per loop iteration --
+                * stays at 0 and the auto-clear correctly fires.
+                * Counter ticks when either channel is non-zero. */
+               if (DACGetI2SNonZeroCount() > 0)
                   dspgo_poll_count = 0;
                else
                {


### PR DESCRIPTION
## Summary

Fixes [#181](https://github.com/libretro/virtualjaguar-libretro/issues/181) — Battle Sphere Gold (and possibly other carts in the same family) doesn't launch with HLE BIOS.

## Root cause

\`DSPReadLong\` has an HLE-only auto-clear that resets DSPGO when an M68K read of \`D_CTRL\` racks up suspiciously many polls (a cart waiting on its DSP code to finish a frame). The gate \"is the DSP actually mixing audio?\" was previously \`DACGetI2SWriteCount() > 2\` — i.e., \"more than the seed samples in DACPrepareFrame.\"

Battle Sphere's HLE failure mode: its DSP escapes RAM at frame 16 (\`[CRASH-DETECT] dsp_pc_escape pc=\$1190F238\`), then keeps issuing \`STORE 0,RTXD\` per loop iteration — racking up thousands of *silent* sample writes per frame. The gate sees those, treats it as a real mixer, and refuses to auto-clear. M68K wedges in a tight DSPGO poll at \`\$8141EA\` forever.

## Fix

Track non-zero-amplitude sample writes separately (\`i2sNonZeroCount\`) and gate on that. A real mixer (Doom) writes non-zero samples; a silenced/escaped DSP gets correctly classified as \"not actually mixing\" and the auto-clear fires.

No change in BIOS mode (still gated on \`!vjs.useJaguarBIOS\`).

## Validation

- **Battle Sphere HLE**: was hung at \`\$8141EA\` with \`video_stall@frame 302\`; now executes through to title screen, framebuffer non-zero pixels stable at 18,845, audio presence \`RMS=1453\`.
- **Iron Soldier 1 HLE** (regression check): \`test_audio_presence\` PASS, \`RMS=1377.7\` in \`[200, 25000]\` envelope.
- **Doom HLE** (real-mixer-protection check): \`test_audio_presence\` PASS, \`RMS=2610.0\` — auto-clear still correctly refuses to fire on actual audio.
- **\`make TEST_EXPORTS=1 test\`**: exits 0, only documented Skyhammer / IS2 EXPECTED-FAIL clipping entries.
- C89 lint passes.

## Open caveat

Battle Sphere's underlying DSP escape at frame 16 is the same family of HLE bug as Wolf3D / Skyhammer / IS2 (untracked DSP register-bank state at boot). With this fix, BSG reaches the title screen *despite* the escape; properly fixing the escape itself is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)