### PR TITLE
chore(test): export BlitterCompare* + strip RA wrapper in compare tool

### DIFF
--- a/exports-test.list
+++ b/exports-test.list
@@ -42,3 +42,4 @@ _perf_counters_dump
 _perf_counters_reset
 _perf_counters_register
 _perf_counters_find
+_BlitterCompare*

--- a/link-test.T
+++ b/link-test.T
@@ -45,5 +45,6 @@
       perf_counters_reset;
       perf_counters_register;
       perf_counters_find;
+      BlitterCompare*;
    local: *;
 };

--- a/test/tools/test_blitter_compare.c
+++ b/test/tools/test_blitter_compare.c
@@ -357,8 +357,18 @@ int main(int argc, char **argv)
       state_buf = malloc(sz);
       if (fread(state_buf, 1, sz, sf) == sz)
       {
-         if (pretro_unserialize(state_buf, sz))
-            fprintf(stderr, "--- Loaded save state from %s (%zu bytes) ---\n", state_load_path, sz);
+         /* RetroArch wraps savestates with a 16-byte "RASTATE\x01MEM "
+          * header.  Strip it so the core's retro_unserialize sees just
+          * its own VJSS payload. */
+         void *unser_buf = state_buf;
+         size_t unser_sz = sz;
+         if (sz > 16 && memcmp(state_buf, "RASTATE", 7) == 0)
+         {
+            unser_buf = (uint8_t *)state_buf + 16;
+            unser_sz  = sz - 16;
+         }
+         if (pretro_unserialize(unser_buf, unser_sz))
+            fprintf(stderr, "--- Loaded save state from %s (%zu bytes) ---\n", state_load_path, unser_sz);
          else
             fprintf(stderr, "WARNING: retro_unserialize failed for %s\n", state_load_path);
       }


### PR DESCRIPTION
## Summary

Two small infrastructure fixes that make \`test/tools/test_blitter_compare\` actually usable. Both came up while investigating Battle Sphere Gold's accurate-blitter transparency divergence (issue #181 follow-up; the actual blitter bug is *not* in this PR — see below).

1. **Export \`BlitterCompare*\` symbols** in \`exports-test.list\` and \`link-test.T\`. The tool was bailing with \`Core does not export BlitterCompare symbols. Rebuild core.\` because the four symbols it dlsym's (\`Enable\`, \`GetStats\`, \`IsEnabled\`, \`DumpCmdStats\`) were never in the test-ABI exports. One \`BlitterCompare*\` wildcard fixes both files. Production exports unchanged (these only apply under \`TEST_EXPORTS=1\`).

2. **Strip RA savestate wrapper** in \`test_blitter_compare.c\` \`--load-state\` path. RetroArch wraps the core payload with a 16-byte \`RASTATE\\x01MEM \` header. \`test_screenshot\` already handles this; \`test_blitter_compare\` did not, so any RA-generated state file would fail \`retro_unserialize\` and the tool silently fell back to comparing the cold-boot title screen — useless for any in-game scene investigation.

## Sanity

- \`nm -gU virtualjaguar_libretro.dylib | grep BlitterCompare\` shows all four symbols exported under TEST_EXPORTS=1.
- \`make TEST_EXPORTS=1 test\` passes (only the documented Skyhammer / IS2 EXPECTED-FAIL clipping entries).
- With a BSG in-game savestate, \`test_blitter_compare\` now reports **676 of 3190 blits differ (21%)** between fast and accurate paths in a single in-game frame — vs the previous 0 / cold-boot output. The bug being measured is real; the *fix* for it is a separate investigation.

## What's NOT here

The Battle Sphere Gold "black square where the transparent crosshair should be" bug (accurate blitter only) is a real divergence in the cmd=0x09900F71 / 0x09800F41 / 0x49802609 paths (all SRCEN+DCOMPEN), but I couldn't pin it to a clean root cause tonight. \`COMP_CTRL\` produces correct \`winhibit\` values for both transparent (srcd=0) and opaque (srcd≠0) iterations, and \`wdata\` matches \`srcd\` as expected. The divergence is somewhere deeper — likely in address generation or per-pixel iteration count for non-phrase 16bpp blits. Not pushing a speculative fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)