### PR TITLE
fix(blitter): apply final outer-loop step in accurate writeback

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -3384,6 +3384,39 @@ fc_inner_done:
       }
    }
 
+   /* Per JTRM: "the X pointer will be left pointing at the start of the
+    * first phrase not written by the blit."  The fast blitter applies its
+    * outer-loop step unconditionally on every iteration including the
+    * last, leaving the pointer past the last write.  The Midsummer state
+    * machine here only applies the step between inner iterations (a1update
+    * fires when transitioning from one inner to the next), so after
+    * n_lines inner passes it has performed only n_lines-1 steps.  Mirror
+    * fast's "one closing step" so the writeback values match between
+    * modes and chained-blit games (e.g. Battle Sphere Gold sprite
+    * pipeline) see consistent A1_PIXEL/A2_PIXEL between blits. */
+   {
+      uint16_t fcx_carry = 0, fcy_carry = 0;
+      if (upda1f)
+      {
+         uint32_t fxt = (uint32_t)a1_frac_x + (uint32_t)a1_stepf_x;
+         uint32_t fyt = (uint32_t)a1_frac_y + (uint32_t)a1_stepf_y;
+         fcx_carry = (uint16_t)(fxt >> 16);
+         fcy_carry = (uint16_t)(fyt >> 16);
+         a1_frac_x = (uint16_t)(fxt & 0xFFFF);
+         a1_frac_y = (uint16_t)(fyt & 0xFFFF);
+      }
+      if (upda1)
+      {
+         a1_x += a1_step_x + (int16_t)fcx_carry;
+         a1_y += a1_step_y + (int16_t)fcy_carry;
+      }
+      if (upda2)
+      {
+         a2_x += a2_step_x;
+         a2_y += a2_step_y;
+      }
+   }
+
    // Write values back to registers (in real blitter, these are continuously updated)
    SET16(blitter_ram, A1_PIXEL + 2, a1_x);
    SET16(blitter_ram, A1_PIXEL + 0, a1_y);

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -3405,7 +3405,12 @@ fc_inner_done:
          a1_frac_x = (uint16_t)(fxt & 0xFFFF);
          a1_frac_y = (uint16_t)(fyt & 0xFFFF);
       }
-      if (upda1)
+      /* Match the in-loop a1update gate at line 1862-1864: the integer
+       * step fires whenever a1fupdate fires OR (upda1 && !upda1f), i.e.,
+       * whenever (upda1 || upda1f).  Gating only on upda1 would diverge
+       * by one a1_step on every iteration in the UPDA1F=1, UPDA1=0 case
+       * (rotated/scaled blits without integer-pixel writeback). */
+      if (upda1 || upda1f)
       {
          a1_x += a1_step_x + (int16_t)fcx_carry;
          a1_y += a1_step_y + (int16_t)fcy_carry;


### PR DESCRIPTION
## Summary

Closes a documented divergence between fast and accurate blitter A1_PIXEL/A1_FPIXEL/A2_PIXEL writeback values. Per JTRM (Software Reference Manual, blitter chapter):

> *"the X pointer will be left pointing at the start of the first phrase not written by the blit."*

Fast achieves this by stepping A1/A2 unconditionally at the end of every outer iteration, including the last. The accurate (Midsummer) state machine only fires \`a1fupdate\`/\`a1update\`/\`a2update\` on transitions *between* inner iterations, so after \`n_lines\` inner passes it has performed only \`n_lines-1\` steps — one short of JTRM/fast.

Fix: mirror fast's "one closing step" on exit from the outer loop, gated on the same \`UPDA1F\`/\`UPDA1\`/\`UPDA2\` cmd flags that drove the in-loop signals.

## Verification

Trace tooling on [\`debug/bsg-blit76-trace\`](https://github.com/libretro/virtualjaguar-libretro/tree/debug/bsg-blit76-trace) (separate diagnostic branch) reveals the divergence directly. BSG savestate, blit #76:

\`\`\`
pre (both paths):  A1_PIX=FFFA000E A1_FPIX=2AA6103C A2_PIX=001100A2
                   A1_STEP=FFF0FFF5 A1_FSTEP=D920A920 A2_STEP=0001FFFC

post fast:               A1_PIX=0000FFFD A1_FPIX=56265F3C A2_PIX=001500A2
post acc (before fix):   A1_PIX=000F0007 A1_FPIX=7D06B61C A2_PIX=001400A6
post acc (after fix):    A1_PIX=0000FFFD A1_FPIX=56265F3C A2_PIX=001500A2   ← match
\`\`\`

Before this fix, \`test_blitter_compare\` emits dozens of "REG DIFF" lines per 60-frame BSG run as the writeback diverges on every chained sprite blit. After: zero.

## Scope

This commit closes the writeback discrepancy only. The 21% per-blit pixel-output diff that \`test_blitter_compare\` reports for BSG is a *separate* per-blit logic divergence (z-comparator lane selection in COMP_CTRL, fast's DSTENZ register-vs-memory read) and is NOT addressed here; that investigation continues under #189 / #180.

## Test plan

- [x] Full \`test/regression_test.sh\` passes (8/8): jagniccc + yarc, determinism + frameskip + save-state + rewind.
- [x] \`scripts/c89-lint.sh src/tom/blitter.c\` passes.
- [x] \`test_blitter_compare\` on BSG savestate: \`REG DIFF\` count drops from dozens to zero.
- [x] No visible regression in BSG headless screenshot at frames 60/300/600/900 vs develop (0-byte diff).

## Refs

- Issue #189 — full writeback-divergence root-cause writeup
- Issue #180 — BIOS cube edges (same bug family)
- \`docs/jtrm-blitter.md:224\` — documented A1_PIXEL writeback divergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)