### PR TITLE
fix(blitter): match fast on z-comparator lane in pixel-mode 16bpp

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -1251,11 +1251,25 @@ void COMP_CTRL(uint8_t *dbinh, bool *nowrite,
    uint8_t inhibit_all;   /* combined per-byte inhibit before mode gating */
    uint8_t gated;          /* after phrase_mode / winhibit gating */
 
-   /* nowrite and winhibit (pixel-mode write inhibit) */
+   /* nowrite and winhibit (pixel-mode write inhibit)
+    *
+    * Z-comparator lane in pixel-mode 16bpp: the fast blitter reads
+    * source/dest Z via `REG(SRCZINT|DSTZ) & 0xFFFF`, which is bytes 2-3
+    * of the 8-byte register (low 16 of the high 32 half).  In the
+    * GET64-shift lane convention here, that is lane 2 -- so
+    * `zcomp & 0x04` matches fast.  Previously accurate used `zcomp & 0x01`
+    * (lane 0 = bytes 6-7), which produced visibly wrong z-inhibit
+    * decisions in BSG sprite blits (cmd=09900F71 / 09800F41 families:
+    * pixel-mode 16bpp DCOMPEN sprites with constant source Z).
+    *
+    * This is a match-fast pragmatic fix; the JTRM-pure behaviour would
+    * select the lane based on the destination pixel's position within a
+    * phrase, which neither path currently does.  See #189 for the full
+    * divergence writeup. */
    winhibit = (bcompen && !bcompbit && !phrase_mode)
       || (dcompen && (dcomp & 0x01) && !phrase_mode && (pixsize == 3))
       || (dcompen && ((dcomp & 0x03) == 0x03) && !phrase_mode && (pixsize == 4))
-      || ((zcomp & 0x01) && !phrase_mode && (pixsize == 4));
+      || ((zcomp & 0x04) && !phrase_mode && (pixsize == 4));
    *nowrite = winhibit && !bkgwren;
 
    /* 16-bit pixel mode flag */


### PR DESCRIPTION
## Summary

Accurate blitter was reading the wrong 16-bit lane of \`SRCZINT\` / \`DSTZ\` for pixel-mode 16bpp z-compare, disagreeing with the fast blitter and producing visibly different output. Closes one large class of per-blit divergence between modes (#180, #189).

## Mechanism

- Fast reads source/dest Z via \`REG(SRCZINT|DSTZ) & 0xFFFF\` → **bytes 2-3** of the 8-byte register (low 16 bits of the high 32-bit half).
- In the \`GET64\` lane convention used in COMP_CTRL, that is **lane 2** → \`zcomp & 0x04\`.
- Accurate previously used \`zcomp & 0x01\` = lane 0 = bytes 6-7 — a different 16-bit slice of the same register.

For pixel-mode 16bpp sprite blits that load \`B_SRCZ1\` with a single Z value in the register's high half — exactly what BSG's hyperdrive-effect crosshair sprite renderer does (\`cmd=09900F71\` / \`09800F41\` families) — the two paths see different Z values for the same source, disagree on \`Z_OP_SUP\`/\`EQU\`/\`INF\` inhibit, and produce different output: accurate writes pixels that fast inhibits.

## Measurement

\`test_blitter_compare\` on BSG savestate (60 frames):

| | Per-blit diff rate |
|---|---|
| develop | 21.19% (676 of 3190 blits) |
| after this fix | **3.76% (120 of 3190)** |

All 120 remaining diffs are \`cmd=49802609\` (60 occurrences in 60 frames — \`SRCEN DSTEN DCOMPEN GOURZ SRCSHADE\` big-phrase blits). Out of scope here; phrase-mode z-compare uses a different code path.

BSG headless screenshots at the hyperdrive-active scene now match fast within ~100 bytes (of 234K) at frame 600.

## Scope and caveat

This is a **match-fast pragmatic fix**. The JTRM-pure behaviour would select the lane based on the destination pixel's position within a phrase (a function of dst-x), which neither path currently implements. After this change:

- Both paths hard-code lane 2.
- Both will be wrong for blits whose destination pixel lands on a different lane.
- But they will *agree*, matching fast's known-good output for the current corpus of games.

Full divergence writeup and follow-up direction (proper per-pixel lane selection) tracked in #189.

## Test plan

- [x] \`test/regression_test.sh\` passes 8/8 (jagniccc + yarc determinism + frameskip + save-state + rewind).
- [x] \`scripts/c89-lint.sh src/tom/blitter.c\` passes.
- [x] \`test_blitter_compare\` per-blit diff rate on BSG: 21.19% → 3.76%.
- [x] BSG accurate headless screenshots at frames 60 / 300 / 600 visually match fast.

## Refs

- #189 — full divergence writeup (writeback + z-lane).
- #180 — BIOS cube edges (same bug family, likely also affected positively by this).
- Companion fix: #190 (final outer-loop step in accurate writeback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)