### PR TITLE
fix(blitter): cache a1 at sread for CLIP_A1 in accurate state machine

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -1948,6 +1948,18 @@ void BlitterMidsummer2(void)
          uint64_t srcz = 0;
          bool winhibit;
          uint32_t a1_ya_cached, a2_ya_cached;
+         /* CLIP_A1 must check the a1 position THAT WAS USED for the
+          * sread that loaded srcd, not the post-step a1.  The state
+          * machine steps a1 (via srca_addi) during the same cycle as
+          * sread but BEFORE the dwrite that consumes srcd, so by the
+          * time we evaluate the clip check at dwrite, a1 is one step
+          * ahead.  Cache a1_x/a1_y at sread time and use the cached
+          * values for the clip test below.  Matches fast, which checks
+          * CLIP_A1 against pre-step a1.  Fixes BSG cmd=0x09800F41
+          * family per-pixel divergence at row-edge positions where the
+          * fractional source X drifts across 0 mid-row. */
+         int16_t a1_x_at_sread = a1_x;
+         int16_t a1_y_at_sread = a1_y;
 
          indone = false;
 
@@ -2792,6 +2804,10 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
+               /* Snapshot pre-step a1 for the CLIP_A1 check at dwrite
+                * time -- see a1_x_at_sread declaration. */
+               a1_x_at_sread = a1_x;
+               a1_y_at_sread = a1_y;
                //uint32_t srcAddr, pixAddr;
                //ADDRGEN(srcAddr, pixAddr, gena2i, zaddr,
                //	a1_x, a1_y, a1_base, a1_pitch, a1_pixsize, a1_width, a1_zoffset,
@@ -2830,6 +2846,10 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
+               /* Snapshot pre-step a1 for the CLIP_A1 check at dwrite
+                * time -- see a1_x_at_sread declaration. */
+               a1_x_at_sread = a1_x;
+               a1_y_at_sread = a1_y;
                srcd2 = srcd1;
                srcd1 = ((uint64_t)blitter_read_long(address) << 32) | (uint64_t)blitter_read_long(address + 4);
                //Kludge to take pixel size into account...
@@ -3113,10 +3133,13 @@ A1_xcomp	:= MAG_15 (a1xgr, a1xeq, a1xlt, a1_x{0..14}, a1_win_x{0..14});
 A1_ycomp	:= MAG_15 (a1ygr, a1yeq, a1ylt, a1_y{0..14}, a1_win_y{0..14});
 A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
 */
-               //NOTE: There seems to be an off-by-one bug here in the clip_a1 section... !!! FIX !!!
-               //      Actually, seems to be related to phrase mode writes...
-               //      Or is it? Could be related to non-15-bit compares as above?
-               if (clip_a1 && ((a1_x & 0x8000) || (a1_y & 0x8000) || (a1_x >= a1_win_x) || (a1_y >= a1_win_y)))
+               /* Check CLIP_A1 against the pre-step a1 position (the one
+                * used for the sread that loaded srcd), not the post-step
+                * a1.  See a1_x_at_sread declaration above for the
+                * rationale.  This matches fast's CLIP_A1 timing. */
+               if (clip_a1 && ((a1_x_at_sread & 0x8000) || (a1_y_at_sread & 0x8000)
+                            || (a1_x_at_sread >= (int16_t)a1_win_x)
+                            || (a1_y_at_sread >= (int16_t)a1_win_y)))
                   winhibit = true;
 
 

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -3136,7 +3136,18 @@ A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
                /* Check CLIP_A1 against the pre-step a1 position (the one
                 * used for the sread that loaded srcd), not the post-step
                 * a1.  See a1_x_at_sread declaration above for the
-                * rationale.  This matches fast's CLIP_A1 timing. */
+                * rationale.  This matches fast's CLIP_A1 timing.
+                *
+                * When srcen/srcenx are both clear, no sread/sreadx ever
+                * fires to refresh the cache, but a1 can still step each
+                * iteration via dsta_addi (when !dsta2).  Refresh from
+                * live a1_x/a1_y at the top of dwrite -- the step for
+                * this cycle hasn't fired yet, so live a1 == pre-step. */
+               if (!srcen && !srcenx)
+               {
+                  a1_x_at_sread = a1_x;
+                  a1_y_at_sread = a1_y;
+               }
                if (clip_a1 && ((a1_x_at_sread & 0x8000) || (a1_y_at_sread & 0x8000)
                             || (a1_x_at_sread >= (int16_t)a1_win_x)
                             || (a1_y_at_sread >= (int16_t)a1_win_y)))


### PR DESCRIPTION
## Summary

Accurate blitter checked **CLIP_A1 against the post-step a1**; fast checks it against the pre-step a1 (the one that read srcd). For rotated/scaled blits where fractional X drifts source X across 0 mid-row, accurate spuriously inhibits one write per scanline.

## Root cause

The accurate state machine steps a1 via \`srca_addi\` during the **same cycle** as \`sread\` but **before** the later \`dwrite\` cycle consumes srcd. So at dwrite, the live \`a1_x\` already reflects the next iteration's position, while srcd came from the previous one. Fast checks CLIP_A1 against the same a1 that did the read, so the two paths diverge whenever source X crosses 0 mid-row.

For BSG \`cmd=0x09800F41\` (sprite with \`A1_INC = 0xFFFFFFFF\`, \`A1_FINC\` fractional Y/X step) source X drifts by ≈ −0.13 per pixel. Roughly every 7 pixels the integer X transitions from 0 to −1; at that pixel, accurate's post-step \`a1_x = −1\` fails the \`(a1_x & 0x8000)\` negative-sign clip check and inhibits the write that fast emits.

## Fix

Cache \`a1_x\` and \`a1_y\` at \`sread\` and \`sreadx\` time into locals \`a1_x_at_sread\` / \`a1_y_at_sread\`. Use the cached values in the CLIP_A1 check at dwrite. The check now matches fast's pre-step semantics.

Clears the prior \`/* off-by-one bug here */\` FIXME on the same lines.

## Measured impact

Battle Sphere Gold state1, 30 frames, 1574 blits, with PR #190 (writeback) + #191 (lane-2) + #195 (DCOMPEN source-zero) all applied locally:

| Stage | Per-blit fast-vs-accurate divergence | Remaining families |
|---|---|---|
| develop (no other PRs) | ~21 % | many |
| + PR #191 (lane-2) | 3.76 % | \`cmd=0x49802609\` + \`cmd=0x09800F41\` |
| + PR #195 (DCOMPEN source-zero) | 1.91 % | \`cmd=0x09800F41\` only |
| + this PR (CLIP_A1 timing) | **0.00 %** | none — IDENTICAL |

## Diagnosis

The bug was tracked down with a per-pixel trace facility (\`[BLT-TRACE-FAST]\` / \`[BLT-TRACE-ACC]\` stderr emitters in both blitter paths, behind a one-shot counter armed from the test tool). The trace cleanly aligned the two paths on \`dst\` position and showed the first divergence at a position where both fast and acc **read the same srcd value**, but only acc inhibited — pointing straight at the CLIP_A1 check. The trace lives on the investigation branch and isn't bundled here so this PR stays a minimal one-file fix.

## Test plan

- [x] \`make -j$(getconf _NPROCESSORS_ONLN)\` clean build
- [x] \`bash scripts/c89-lint.sh src/tom/blitter.c\` — passes
- [x] Full \`make test\` suite — 0 failures
- [x] BSG state1 30-frame run confirms 0.00 % divergence
- [ ] **Verify visually in RetroArch on a real BSG run** (accurate mode) — needed before merge; headless comparator can't catch presentation-layer regressions

## Notes

- Independent of #190 / #191 / #195. Stack in any merge order.
- Only touches the dwrite-path CLIP_A1 check. The other two CLIP_A1 sites (lines 2270 and 2596) are in the patfill / fast-copy specializations and don't have the same state-machine timing issue; leaving them alone keeps the diff minimal.
- The cached values are evaluated as \`int16_t\` to match the original semantics (\`a1_x & 0x8000\` is the negative-sign test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)