### PR TITLE
Fix/blitter a2 wrap and dcompen key

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -2030,7 +2030,7 @@ void BlitterMidsummer2(void)
 
          /* Precompute y*width row offsets (invariant when y unchanged) */
          a1_ya_cached = addrgen_ya((uint16_t)a1_y, a1_width);
-         a2_ya_cached = addrgen_ya((uint16_t)a2_y, a2_width);
+         a2_ya_cached = addrgen_ya((uint16_t)((blitter_ram[A2_FLAGS + 2] & 0x80) ? (a2_y & GET16(blitter_ram, A2_MASK + 0)) : a2_y), a2_width);
 
          /* Precompute address constants (invariant during inner loop) */
          a1_xconst = 6 - a1_pixsize;
@@ -2313,7 +2313,7 @@ void BlitterMidsummer2(void)
                   if (addq_y != a2_y)
                   {
                      a2_y = addq_y;
-                     a2_ya_cached = addrgen_ya((uint16_t)a2_y, a2_width);
+                     a2_ya_cached = addrgen_ya((uint16_t)((blitter_ram[A2_FLAGS + 2] & 0x80) ? (a2_y & GET16(blitter_ram, A2_MASK + 0)) : a2_y), a2_width);
                   }
                }
 
@@ -2600,7 +2600,7 @@ void BlitterMidsummer2(void)
                   if (fc_addq_y != a2_y)
                   {
                      a2_y = fc_addq_y;
-                     a2_ya_cached = addrgen_ya((uint16_t)a2_y, a2_width);
+                     a2_ya_cached = addrgen_ya((uint16_t)((blitter_ram[A2_FLAGS + 2] & 0x80) ? (a2_y & GET16(blitter_ram, A2_MASK + 0)) : a2_y), a2_width);
                   }
                }
 
@@ -2623,7 +2623,7 @@ void BlitterMidsummer2(void)
                   if (fc_addq_y != a2_y)
                   {
                      a2_y = fc_addq_y;
-                     a2_ya_cached = addrgen_ya((uint16_t)a2_y, a2_width);
+                     a2_ya_cached = addrgen_ya((uint16_t)((blitter_ram[A2_FLAGS + 2] & 0x80) ? (a2_y & GET16(blitter_ram, A2_MASK + 0)) : a2_y), a2_width);
                   }
                }
                else
@@ -3332,7 +3332,7 @@ A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
                if (addq_y != a2_y)
                {
                   a2_y = addq_y;
-                  a2_ya_cached = addrgen_ya((uint16_t)a2_y, a2_width);
+                  a2_ya_cached = addrgen_ya((uint16_t)((blitter_ram[A2_FLAGS + 2] & 0x80) ? (a2_y & GET16(blitter_ram, A2_MASK + 0)) : a2_y), a2_width);
                }
             }
 #ifdef BENCH_PROFILE
@@ -3462,7 +3462,18 @@ static void ADDRGEN(uint32_t *address, uint32_t *pixa, bool gena2, bool zaddr,
 	uint16_t a2_x, uint16_t a2_y, uint32_t a2_base, uint8_t a2_pitch, uint8_t a2_pixsize, uint8_t a2_width, uint8_t a2_zoffset,
 	uint32_t a1_ya_pre, uint32_t a2_ya_pre)
 {
-	uint16_t x = (gena2 ? a2_x : a1_x) & 0xFFFF;	/* Actually uses all 16 bits to generate address...! */
+	/* A2 texture-wrap mask: when A2_FLAGS bit 15 is set, the A2 source X
+	 * coordinate is wrapped by the A2_MASK X modulo (low 16 bits) for ADDRESS
+	 * generation only -- the raw accumulator a2_x is never altered.  Matches
+	 * the MiSTer Jaguar core address.v (a2_xm = a2_xr & a2_mask_x,
+	 * https://github.com/MiSTer-devel/Jaguar_MiSTer) and the fast blitter's
+	 * integer-part masking.  Gated on bit 15, so channels that do not enable
+	 * wrapping are bit-for-bit unchanged.  Single ternary keeps it C89-clean. */
+	uint16_t x = (gena2
+		? (uint16_t)((blitter_ram[A2_FLAGS + 2] & 0x80)
+			? (a2_x & GET16(blitter_ram, A2_MASK + 2))
+			: a2_x)
+		: a1_x) & 0xFFFF;	/* Actually uses all 16 bits to generate address...! */
 	uint8_t pixsize = (gena2 ? a2_pixsize : a1_pixsize);
 	uint8_t pitch = (gena2 ? a2_pitch : a1_pitch);
 	uint32_t base = (gena2 ? a2_base : a1_base) >> 3;/*Only upper 21 bits are passed around the bus? Seems like it...*/

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -496,8 +496,22 @@ void blitter_generic(uint32_t cmd)
 
                if (!CMPDST)
                {
-                  if (srcdata == 0)
-                     inhibit = 1;//*/
+                  /* DCOMPEN+!CMPDST source transparency: inhibit where the
+                   * source pixel is 0 (pixel transparency) OR equals PATTERNDATA
+                   * (the DATACOMP colour-key).  The fast path historically
+                   * tested only "== 0"; adding the PATD test matches the
+                   * accurate gate-level comparator (dcomp = patd ^ srcd) and the
+                   * MiSTer Jaguar core comp_ctrl.v
+                   * (https://github.com/MiSTer-devel/Jaguar_MiSTer), so blits
+                   * keying transparency on a non-zero colour render correctly.
+                   * BCOMPEN keeps its single-bit "transparent on 0" test. */
+                  if (BCOMPEN)
+                  {
+                     if (srcdata == 0)
+                        inhibit = 1;
+                  }
+                  else if (srcdata == 0 || srcdata == READ_RDATA(PATTERNDATA, a2, REG(A2_FLAGS), a2_phrase_mode))
+                     inhibit = 1;
                }
                else
                {
@@ -658,7 +672,14 @@ void blitter_generic(uint32_t cmd)
 
                if (!CMPDST)
                {
-                  if (srcdata == 0)
+                  /* DCOMPEN zero-transparency + PATTERNDATA colour-key (see the
+                   * A1<-A2 branch above); source channel here is A1. */
+                  if (BCOMPEN)
+                  {
+                     if (srcdata == 0)
+                        inhibit = 1;
+                  }
+                  else if (srcdata == 0 || srcdata == READ_RDATA(PATTERNDATA, a1, REG(A1_FLAGS), a1_phrase_mode))
                      inhibit = 1;
                }
                else
@@ -1413,11 +1434,10 @@ Zstep		:= JOIN (zstep, zstep[0..31]);*/
 
 	/* Source-pixel transparency for DCOMPEN+!CMPDST.
 	 *
-	 * The fast blitter's DCOMPEN+!CMPDST path inhibits writes whenever
-	 * the source pixel is zero (blitter.c:497-500, "if (srcdata == 0)
-	 * inhibit = 1").  JTRM calls DCOMPEN "pixel-level transparency",
-	 * which matches that behaviour -- the transparent colour is
-	 * hardcoded to zero, regardless of PATD.
+	 * The fast blitter's DCOMPEN+!CMPDST path inhibits writes when the
+	 * source pixel is zero (pixel-level transparency, what JTRM calls
+	 * DCOMPEN) OR when it equals PATTERNDATA (the DATACOMP colour-key) --
+	 * see the two !CMPDST branches earlier in blitter_generic.
 	 *
 	 * The gate-level rewrite of dcomp above (scalar_dcomp & SIMD
 	 * variants) only checks byte-equality against PATD, which is the


### PR DESCRIPTION
fix(blitter): DCOMPEN colour-key against PATTERNDATA in the fast blitter
The fast blitter's DCOMPEN+!CMPDST path inhibited writes only where the
source pixel was zero. The hardware data comparator (DATACOMP) also
inhibits where the source equals PATTERNDATA -- the colour-key the
accurate gate-level path already implements (dcomp = patd ^ srcd, see
MiSTer comp_ctrl.v). Blits keying transparency on a non-zero colour drew
their transparent pixels as a solid colour instead of letting the
background show through.

Add the PATTERNDATA equality test alongside the existing source-zero
test (inhibit on srcdata == 0 || srcdata == PATTERNDATA) in both
data-movement directions. The source-zero test is KEPT, so the
pixel-level transparency the accurate path was augmented to match
(develop's COMP_CTRL zero-mask) is preserved -- no regression for the
source-zero sprite-blit family. BCOMPEN keeps its single-bit
"transparent on 0" test. The COMP_CTRL comment is updated to note the
fast path now keys on both zero and PATD.

Repro: Theme Park's grass tiles key transparency on colour 0x04; with
the fast blitter those pixels were drawn as CLUT[4] instead of being
transparent.


fix(blitter): apply A2 texture-wrap mask in the accurate blitter
BlitterMidsummer2 read the A2 address mask but never applied it (the
reads were #if 0'd), so tiled source blits that enable A2 wrapping read
linearly past the texture instead of wrapping -- producing a black band
and vertical stripes where the texture should repeat.

Apply the mask, gated on A2_FLAGS bit 15, to the source coordinate for
ADDRESS generation only (the raw a2_x/a2_y accumulators are untouched),
matching MiSTer address.v (a2_xm = a2_xr & a2_mask_x) and the fast
blitter's integer-part masking:
  - X: single C89 ternary in ADDRGEN, masking a2_x by A2_MASK low 16.
  - Y: at the five a2_ya_cached sites, masking a2_y by A2_MASK high 16.

Gated on bit 15, so channels that do not enable wrapping are bit-for-bit
unchanged. Repro: Theme Park's isometric grass floor (a 32x32 source
tile, A2_FLAGS=0x0000A418, A2_MASK=0x001F001F) now tiles correctly on
the accurate blitter instead of showing a black band with stripes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>