### PR TITLE
chore(test): port build-identity guard to develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ To add a new probe: create `test/harness/foo_probe.h` + `.c`, resolve symbols vi
 
 ### Key harnesses
 
-- `test/regression_test.sh` — screenshot regression vs `test/baselines/` via miniretro (built from source on first run; `MINIRETRO_BIN` env to skip the build)
+- `test/regression_test.sh` — screenshot regression vs `test/baselines/` via miniretro (built from source on first run; `MINIRETRO_BIN` env to skip the build). Baselines are **not committed** — a ROM with no baseline reports `NEW` and prints the `cp` command to create one, so the first run on a fresh clone establishes them locally rather than failing.
 - `test/tools/test_dsp_audio_diag.c` — DSP audio diagnostic (`make dsp-diag DSP_DIAG_ROM=path`); detects PC escape, bank init failures, silent LTXD
 - `test/tools/test_frame_timing.c` — per-frame timing diagnostic (`make frame-timing FRAME_TIMING_ROM=path`); reports halflines/cycles/VBlanks per frame, wall-clock speed ratio, anomaly detection. Use `--csv` for per-frame data, `--json` for machine output
 - `test/test_audio_clipping.c` — detects loud-broken audio (saturation density, run length, sustained loud RMS). Catches the Skyhammer / IS2 "saturated square wave" failure mode.
@@ -94,6 +94,22 @@ To add a new probe: create `test/harness/foo_probe.h` + `.c`, resolve symbols vi
   Usage: `<core.so|.dylib> <rom> [frames] --load-state <file> [--frame-window F L] [--cmd-filter MASK VAL] [--verbose-dump]` (note: `--load-state`, not `--savestate`).
 - `test/test_dsp_mac40.c` — DSP 40-bit MAC accumulator (`dsp_acc40.h`)
 - `test/sram_test.sh` — SRAM round-trip
+
+### Build-identity guard (stale-binary protection)
+
+Every harness that dlopens the core prints the binary's embedded version
+(`vX.Y.Z <gitrev>[-dirty]`). If `VJ_EXPECT_BUILD` is set, a core whose version
+doesn't token-match fails the load loudly instead of silently testing stale code:
+
+```bash
+VJ_EXPECT_BUILD=$(./scripts/build-id.sh) ./test/tools/your_harness ...
+```
+
+`scripts/build-id.sh` prints the short git rev plus `-dirty` when tracked files
+are modified; `scripts/gen-version-h.sh` stamps that same string into the core,
+so the two sides always agree. This exists because `make` can skip a rebuild
+when file mtimes are second-identical — the guard catches that class. Manual
+fallback: `nm -gU <dylib> | grep <newsymbol>`.
 
 ### Performance / profiling
 

--- a/scripts/build-id.sh
+++ b/scripts/build-id.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# Prints the build identity embedded into the core by gen-version-h.sh:
+# the short git rev, with a "-dirty" suffix when tracked files have
+# uncommitted changes.  Test harnesses compare this against the version
+# string reported by a loaded core (VJ_EXPECT_BUILD) so a stale or
+# wrong-branch binary fails loudly instead of silently testing the
+# wrong code.  POSIX sh compatible -- no bashisms.
+
+set -e
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+
+REV=$(cd "$ROOT" && git rev-parse --short HEAD 2>/dev/null || echo unknown)
+if [ "$REV" != "unknown" ]; then
+  if ! (cd "$ROOT" && git diff-index --quiet HEAD -- 2>/dev/null); then
+    REV="${REV}-dirty"
+  fi
+fi
+printf '%s\n' "$REV"

--- a/scripts/gen-version-h.sh
+++ b/scripts/gen-version-h.sh
@@ -25,7 +25,10 @@ if [ -z "$CORE_BASE_VERSION" ]; then
   exit 1
 fi
 
-GIT_REV=$(cd "$ROOT" && git rev-parse --short HEAD 2>/dev/null || echo unknown)
+# Short rev + "-dirty" when tracked files are modified (see build-id.sh).
+# The harness build-identity guard compares VJ_EXPECT_BUILD against this
+# string, so both sides must agree on the dirty suffix.
+GIT_REV=$("$ROOT/scripts/build-id.sh")
 
 mkdir -p "$(dirname "$OUT")"
 TMP="$OUT.tmp"

--- a/test/harness/harness.c
+++ b/test/harness/harness.c
@@ -276,6 +276,42 @@ bool harness_load_core(harness_config *cfg)
         return false;
     }
 
+    /* Build-identity guard: always print which binary is under test; if
+     * VJ_EXPECT_BUILD is set, refuse a core whose version string does not
+     * contain it (stale/wrong-branch binary).  `make` can skip a rebuild
+     * when file mtimes are second-identical, which silently tests old code. */
+    {
+        void (*p_sysinfo)(struct retro_system_info *) =
+            (void (*)(struct retro_system_info *))dlsym(cfg->core_handle,
+                                                        "retro_get_system_info");
+        const char *expect = getenv("VJ_EXPECT_BUILD");
+        struct retro_system_info si;
+        memset(&si, 0, sizeof(si));
+        if (p_sysinfo) {
+            p_sysinfo(&si);
+            if (!cfg->quiet)
+                fprintf(stderr, "harness: core %s %s (%s)\n",
+                        si.library_name ? si.library_name : "?",
+                        si.library_version ? si.library_version : "?",
+                        cfg->core_path);
+        }
+        if (expect && expect[0]) {
+            /* Token-boundary match: "91f0804" must not accept a stale
+             * "91f0804-dirty" build (version format: "vX.Y.Z rev[-dirty]"). */
+            const char *hit = si.library_version ? strstr(si.library_version, expect) : NULL;
+            char tail = hit ? hit[strlen(expect)] : '-';
+            if (!hit || (tail != '\0' && tail != ' ')) {
+                fprintf(stderr,
+                        "harness: FATAL build mismatch -- core reports \"%s\" but "
+                        "VJ_EXPECT_BUILD=\"%s\"; rebuild with `make TEST_EXPORTS=1`.\n",
+                        si.library_version ? si.library_version : "(none)", expect);
+                dlclose(cfg->core_handle);
+                cfg->core_handle = NULL;
+                return false;
+            }
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
## Problem

Harnesses on `develop` could silently test a **stale binary**. `make` skips relinking when file mtimes are second-identical, and nothing verified that the dlopened core was actually the code under test — so a harness could report green against code from before your edit. The Jaguar CD branch grew a guard for this class of bug; this ports the branch-agnostic parts.

## Changes

- **`scripts/build-id.sh`** (new, 18 lines, POSIX sh): prints the short git rev plus `-dirty` when tracked files are modified.
- **`scripts/gen-version-h.sh`**: take `GIT_REV` from `build-id.sh`. This part is load-bearing — without it the version stamped into the core lacks the dirty suffix, so every run from a dirty tree would fail the guard spuriously.
- **`test/harness/harness.c`**: after resolving core symbols, print the core's embedded version; when `VJ_EXPECT_BUILD` is set, refuse a core whose version doesn't token-match. Token-boundary matching so `9e39c1d` does not accept a stale `9e39c1d-dirty` build.
- **`CLAUDE.md`**: document the guard. Also corrects a mildly misleading line — `test/baselines/` is not committed on any branch, and `regression_test.sh` reports missing baselines as `NEW` with the `cp` command to create one, rather than failing.

Usage:
```bash
VJ_EXPECT_BUILD=$(./scripts/build-id.sh) ./test/tools/your_harness ...
```

## Verification

| Check | Result |
|---|---|
| Embedded version string | `v2.3.1 9e39c1d-dirty` (dirty suffix now present) |
| Correct `VJ_EXPECT_BUILD` | loads normally, proceeds past core load |
| Wrong id (`deadbee`) | `FATAL build mismatch`, load refused, exit 1 |
| Clean rev vs dirty binary | `FATAL build mismatch`, load refused, exit 1 |
| `make TEST_EXPORTS=1 test` | **exit 0**, 0 failures across all suites |

Test-only and docs; no emulation behavior changes. C89 lint passed (pre-commit hook).

## Deliberately not ported

`test/tools/cd_visual_verify.c` — it needs harness API fields that don't exist on develop (`video_callback`, `video_callback_data`, `system_dir`). Extending the shared harness API is a larger change than this PR should carry; it can come with the CD branch merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)