### PR TITLE
feat(options): clearer Blitter and BIOS option wording (#184)

### DIFF
--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -29,4 +29,4 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 
-description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM), and a Fast Blitter core option is available that trades some accuracy for additional speed on lower-end hardware. Supports a high-level BIOS that lets most commercial titles boot without a real BIOS image, plus save states, SRAM, cheat codes, and RetroAchievements."
+description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM), and the Blitter core option can be set to 'Fast' to trade some accuracy for additional speed on lower-end hardware. Supports a high-level BIOS that lets most commercial titles boot without a real BIOS image, plus save states, SRAM, cheat codes, and RetroAchievements."

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -93,14 +93,14 @@ struct retro_core_option_v2_category option_cats_us[] = {
 struct retro_core_option_v2_definition option_defs_us[] = {
    {
       "virtualjaguar_usefastblitter",
-      "Fast Blitter",
+      "Blitter",
       NULL,
-      "Use the faster blitter, it is older and less compatible, it will break some games.",
+      "Choose which blitter implementation to use. 'Accurate' is SIMD-accelerated (SSE2 on x86, NEON on ARM) and is the most compatible. 'Fast' is the older blitter; it trades accuracy for extra speed on low-end hardware and breaks some games.",
       NULL,
       NULL,
       {
-         { "disabled", NULL },
-         { "enabled",  NULL },
+         { "disabled", "Accurate" },
+         { "enabled",  "Fast" },
          { NULL, NULL },
       },
       "disabled"
@@ -124,12 +124,12 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_bios",
       "BIOS",
       NULL,
-      "Use the Jaguar BIOS, required for some games.",
+      "Choose which BIOS the core boots with. 'HLE' has the core emulate the BIOS setup and services itself, which lets most commercial titles boot without the real Jaguar BIOS ROM. 'Real' boots the built-in Jaguar BIOS ROM, which some games require. Neither setting needs an external BIOS file.",
       NULL,
       NULL,
       {
-         { "disabled", NULL },
-         { "enabled",  NULL },
+         { "disabled", "HLE" },
+         { "enabled",  "Real" },
          { NULL, NULL },
       },
       "disabled"


### PR DESCRIPTION
Closes #184.

Presents the two toggles as what they actually choose between, using the labeled-value form that `virtualjaguar_crash_detect` already uses in the same array:

| Option | Before | After |
|---|---|---|
| `virtualjaguar_usefastblitter` | "Fast Blitter" — `disabled` / `enabled` | **"Blitter"** — `Accurate` / `Fast` |
| `virtualjaguar_bios` | "BIOS" — `disabled` / `enabled` | **"BIOS"** — `HLE` / `Real` |

Descriptions rewritten to say what each choice does. `dist/info/virtualjaguar_libretro.info` updated where it referred to the option by its old name.

## Config compatibility — keys and stored values are unchanged

Only display labels and descriptions changed. `virtualjaguar_usefastblitter`/`virtualjaguar_bios` and the `"disabled"`/`"enabled"` value strings are untouched, so existing user configs keep working and nothing resets.

Verified by inspection and at runtime:
- `libretro.c:291-327` is the only production consumer — all `strcmp` calls compare **values**, never labels.
- The 40+ `test/` references are env-callback stubs answering `GET_VARIABLE` with hardcoded value strings.
- Two throwaway probes dlopened the built dylib and dumped the descriptors: v2 reports `value[0]="disabled" label="Accurate"`, `value[1]="enabled" label="Fast"` (and `HLE`/`Real`), defaults still `"disabled"`.
- `libretro_core_options_intl.h` has no `option_defs_*` array at all (all 25 language sections are bare comments), so there is nothing to keep in sync.

## Known trade-off, flagged for reviewer judgement

The **v0** core-options fallback drops labels by design and renders `desc` plus raw value strings, so a pre-v1 frontend now shows "Blitter: disabled", which reads as "blitter off" where "Fast Blitter: disabled" was unambiguous. There is no way to keep the v2 presentation the issue asks for and also fix v0, short of patching the shared upstream conversion boilerplate. Any current RetroArch uses v1/v2 and is unaffected. Happy to revert to "Fast Blitter" as the label if maintainers weigh v0 frontends more heavily.

## Testing

- `scripts/c89-lint.sh libretro_core_options.h` → passed. All-ASCII for the MSVC buildbot.
- `make clean && make -j` → clean, no warnings (clean build deliberately, since a header-only change can otherwise relink a stale `libretro.o`).
- `make TEST_EXPORTS=1 test` → **exit 0**, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)