### PR TITLE
test(pacing): add frontend-pacing regression test + document fast-forward

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -934,21 +934,21 @@ test/tools/test_dsp_audio_diag: test/tools/test_dsp_audio_diag.c \
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_dsp_audio_diag.c \
 		test/harness/harness.c test/harness/dsp_probe.c \
-		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 
 test/test_eeprom_lifecycle: test/test_eeprom_lifecycle.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_eeprom_lifecycle.c \
 		test/harness/harness.c \
-		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 
 test/test_framebuffer_integrity: test/test_framebuffer_integrity.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_framebuffer_integrity.c \
 		test/harness/harness.c \
-		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 
 # Save-state backwards-compatibility regression guard.  Needs DACStateSave
 # from the wide test symbol set (DAC* in exports-test.list / link-test.T).
@@ -957,14 +957,14 @@ test/test_state_compat: test/test_state_compat.c \
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_state_compat.c \
 		test/harness/harness.c \
-		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 
 test/test_frontend_pacing: test/test_frontend_pacing.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_frontend_pacing.c \
 		test/harness/harness.c \
-		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 endif
 
 .PHONY: clean test lint coverage benchmark acid dsp-diag frame-timing
@@ -1041,7 +1041,7 @@ dsp-diag:
 		-o test/tools/test_dsp_audio_diag \
 		test/tools/test_dsp_audio_diag.c \
 		test/harness/harness.c test/harness/dsp_probe.c \
-		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 	./test/tools/test_dsp_audio_diag ./$(TARGET) "$(DSP_DIAG_ROM)" $(DSP_DIAG_FLAGS)
 
 # `make frame-timing` -- Per-frame timing diagnostic.  Builds core with
@@ -1061,7 +1061,7 @@ frame-timing:
 		-o test/tools/test_frame_timing \
 		test/tools/test_frame_timing.c \
 		test/harness/harness.c test/harness/timing_probe.c \
-		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 	./test/tools/test_frame_timing ./$(TARGET) "$(FRAME_TIMING_ROM)" $(FRAME_TIMING_FLAGS)
 
 print-%:

--- a/Makefile
+++ b/Makefile
@@ -734,7 +734,7 @@ clean:
 		test/test_audio_clipping test/test_audio_presence test/test_pit_clock_rate \
 		test/test_blitter_mmio test/test_eeprom_lifecycle \
 		test/test_tom_visible_window test/test_framebuffer_integrity \
-		test/test_state_compat \
+		test/test_state_compat test/test_frontend_pacing \
 		test/tools/test_memory_map test/tools/test_dsp_audio_diag \
 		test/tools/test_frame_timing
 
@@ -765,6 +765,7 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 		test/test_audio_pipeline test/test_audio_clipping test/test_audio_presence test/test_pit_clock_rate \
 		test/test_blitter_mmio test/test_eeprom_lifecycle test/test_tom_visible_window \
 		test/test_framebuffer_integrity test/test_state_compat \
+		test/test_frontend_pacing \
 		test/tools/test_memory_map
 	./test/test_cheat
 	./test/test_event_queue
@@ -827,6 +828,15 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 	@# committed in-tree, so a missing ROM is a broken checkout and the
 	@# test's exit 77 should stop the suite rather than read as a pass.
 	./test/test_state_compat ./$(TARGET) test/roms/yarc.j64
+	@# Frontend pacing / fast-forward contract: the core must not throttle
+	@# itself, and samples-per-frame must match the advertised fps and
+	@# sample_rate, otherwise the frontend's audio driver becomes the pacing
+	@# bottleneck and fast-forward has nothing to give.
+	@if [ -f "test/roms/yarc.j64" ]; then \
+		./test/test_frontend_pacing ./$(TARGET) test/roms/yarc.j64 --quiet; \
+	else \
+		echo "  SKIP: yarc.j64 ROM not available (frontend pacing)"; \
+	fi
 	@# EEPROM lifecycle test: generates a test ROM, then exercises load/unload/reload.
 	@$(CC) -O2 -Wall -o /tmp/gen_eeprom_test_rom test/tools/gen_eeprom_test_rom.c && \
 		/tmp/gen_eeprom_test_rom /tmp/eeprom_lifecycle_test.j64 && \
@@ -947,6 +957,13 @@ test/test_state_compat: test/test_state_compat.c \
 		test/harness/harness.c test/harness/harness.h src/core/state.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_state_compat.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+
+test/test_frontend_pacing: test/test_frontend_pacing.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_frontend_pacing.c \
 		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
 endif

--- a/Makefile
+++ b/Makefile
@@ -831,12 +831,11 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 	@# Frontend pacing / fast-forward contract: the core must not throttle
 	@# itself, and samples-per-frame must match the advertised fps and
 	@# sample_rate, otherwise the frontend's audio driver becomes the pacing
-	@# bottleneck and fast-forward has nothing to give.
-	@if [ -f "test/roms/yarc.j64" ]; then \
-		./test/test_frontend_pacing ./$(TARGET) test/roms/yarc.j64 --quiet; \
-	else \
-		echo "  SKIP: yarc.j64 ROM not available (frontend pacing)"; \
-	fi
+	@# bottleneck and fast-forward has nothing to give.  Unguarded for the
+	@# same reason as test_state_compat above: yarc.j64 is committed in-tree,
+	@# so a missing ROM means a broken checkout and should fail the suite
+	@# rather than silently read as a pass.
+	./test/test_frontend_pacing ./$(TARGET) test/roms/yarc.j64 --quiet
 	@# EEPROM lifecycle test: generates a test ROM, then exercises load/unload/reload.
 	@$(CC) -O2 -Wall -o /tmp/gen_eeprom_test_rom test/tools/gen_eeprom_test_rom.c && \
 		/tmp/gen_eeprom_test_rom /tmp/eeprom_lifecycle_test.j64 && \

--- a/docs/frontend-pacing.md
+++ b/docs/frontend-pacing.md
@@ -1,0 +1,100 @@
+# Frontend pacing, fast-forward, and the av_info contract
+
+This note exists because "fast-forward doesn't work with this core" is a
+recurring report, and the answer is almost never a wall-clock limiter in the
+core. Read this before adding one, and before filing it as a core bug.
+
+## What the core promises the frontend
+
+`retro_get_system_av_info()` (libretro.c) advertises:
+
+| field | NTSC | PAL |
+|---|---|---|
+| `timing.fps` | 60 | 50 |
+| `timing.sample_rate` | 48000 | 48000 |
+
+`retro_run()` submits audio exactly once per frame via
+`SoundCallback()` (`src/jerry/dac.c`), with `BUFNTSC / 2 = 800`
+sample-frames for NTSC and `BUFPAL / 2 = 960` for PAL. Both work out to
+exactly 48 000 sample-frames per emulated second, so the advertised timing
+and the samples actually produced agree.
+
+**That agreement is load-bearing.** If the core submitted more samples per
+second than `sample_rate * 1` implies, the frontend's audio buffer would
+never drain, and the audio driver — not the emulation — would become the
+pacing bottleneck. In that state fast-forward has nothing to give, because
+the run loop is blocked on `audio_driver_write()` regardless of how fast
+`retro_run()` returns. `test/test_frontend_pacing.c` asserts this contract
+on every `make test`.
+
+The core contains **no** `usleep` / `nanosleep` / `clock_gettime`-based
+frame limiter, does not register
+`RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK` or
+`RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK`, and never blocks inside
+`retro_run()`. Do not add any of these. Pacing is the frontend's job.
+
+## Why fast-forward can still look broken
+
+RetroArch injects its own sleep in `runloop_iterate()` only when
+`frame_limit_minimum_time != 0`. That value comes from
+`runloop_set_frame_limit(av_info, ratio)`:
+
+```c
+if (fastforward_ratio < 0.1f)
+   frame_limit_minimum_time = 0;                       /* unlimited */
+else
+   frame_limit_minimum_time = 1000000.0f / (fps * fastforward_ratio);
+```
+
+So the frontend settings that decide whether fast-forward does anything are:
+
+- **Settings → Frame Throttle → Fast-Forward Rate** (`fastforward_ratio`).
+  Set to `1.0x` this paces fast-forward at exactly the content frame rate —
+  holding the fast-forward key then changes nothing at all. `0.0`
+  (unlimited) is what most people want.
+- **Settings → Frame Throttle → Sync to Exact Content Framerate**
+  (`vrr_runloop_enable`). When enabled, the frame limiter is applied on
+  every iteration rather than only during fast-forward.
+- **Settings → Audio → Synchronous Audio** (`audio_sync`) and
+  **Settings → Video → Vertical Sync**. RetroArch drops both into
+  non-blocking mode while fast-forwarding; if something keeps them
+  blocking, the run loop stays paced by the audio buffer or the display.
+- On macOS, a **background or occluded RetroArch window** is throttled by
+  the OS. Measured on an M2 Max with a 120 Hz panel: the same core, same
+  config, ran 1800 frames at 120.8 fps with the window forward and at
+  59.5 fps when it was not. That alone can look exactly like
+  "fast-forward is broken".
+
+## What the ceiling actually is
+
+Fast-forward cannot exceed the core's own throughput. Virtual Jaguar's
+`retro_run()` costs roughly 3.3 ms/frame on an idle Apple M2 Max for
+`test/roms/yarc.j64` (≈300 fps, ≈5x realtime) — but heavier titles and
+slower hosts land much closer to 16.7 ms, at which point holding
+fast-forward produces little or no visible speed-up even though everything
+is working as designed. Check `make benchmark` for the host's headroom
+before treating a small fast-forward gain as a bug.
+
+Instrumenting `retro_run()` under RetroArch is the way to tell the two
+apart: bracket the whole function and compare time spent *inside*
+`retro_run()` against wall-clock time between calls. Time outside
+`retro_run()` collapsing to near zero when fast-forward is engaged means
+the frontend is unblocked and the remaining limit is the core's own cost.
+
+## Regression test
+
+`test/test_frontend_pacing.c` (in `make test`, needs `test/roms/yarc.j64`):
+
+1. `fastest_frame_beats_realtime` — the quickest of 300 `retro_run()` calls
+   must finish in under half a frame period. A core that sleeps pays that
+   cost on nearly every frame, so even its fastest frame lands at ~1/fps.
+   Deliberately phrased against the *minimum* rather than the mean:
+   background CPU load can only make frames slower, so a busy CI host
+   cannot turn this red, while an average-based check can (measured 0.59x
+   realtime on a machine at load average 250).
+2. `audio_rate_contract` — submitted sample-frames must equal
+   `frames * sample_rate / fps` within 1%.
+3. `one_batch_per_frame` — exactly one `retro_audio_sample_batch` call per
+   `retro_run`.
+4. `geometry_stability` — `RETRO_ENVIRONMENT_SET_GEOMETRY` must not be
+   spammed; frontends re-allocate the video texture on each call.

--- a/docs/frontend-pacing.md
+++ b/docs/frontend-pacing.md
@@ -35,6 +35,15 @@ frame limiter, does not register
 
 ## Why fast-forward can still look broken
 
+> **As of RetroArch 1.22.2.** Everything in this section — the
+> `runloop_set_frame_limit()` logic below, the setting names
+> (`fastforward_ratio`, `vrr_runloop_enable`, `audio_sync`) and the menu paths
+> — was read off RetroArch 1.22.2, which is also the version the measurements
+> in this document were taken on. These are frontend internals, not a stable
+> API: re-check them against the user's actual RetroArch version before
+> concluding anything from them. The core-side contract above does not depend
+> on any of it.
+
 RetroArch injects its own sleep in `runloop_iterate()` only when
 `frame_limit_minimum_time != 0`. That value comes from
 `runloop_set_frame_limit(av_info, ratio)`:
@@ -83,7 +92,8 @@ the frontend is unblocked and the remaining limit is the core's own cost.
 
 ## Regression test
 
-`test/test_frontend_pacing.c` (in `make test`, needs `test/roms/yarc.j64`):
+`test/test_frontend_pacing.c` (unconditionally in `make test`, against
+`test/roms/yarc.j64`, which is committed in-tree):
 
 1. `fastest_frame_beats_realtime` — the quickest of 300 `retro_run()` calls
    must finish in under half a frame period. A core that sleeps pays that
@@ -91,7 +101,10 @@ the frontend is unblocked and the remaining limit is the core's own cost.
    Deliberately phrased against the *minimum* rather than the mean:
    background CPU load can only make frames slower, so a busy CI host
    cannot turn this red, while an average-based check can (measured 0.59x
-   realtime on a machine at load average 250).
+   realtime on a machine at load average 250). Because it is a minimum, the
+   measurement must come from a monotonic clock
+   (`harness_time_now()`); a backwards wall-clock step would fabricate a
+   short interval and pass the check.
 2. `audio_rate_contract` — submitted sample-frames must equal
    `frames * sample_rate / fps` within 1%.
 3. `one_batch_per_frame` — exactly one `retro_audio_sample_batch` call per

--- a/test/harness/harness.c
+++ b/test/harness/harness.c
@@ -2,6 +2,14 @@
  * test/harness/harness.c — Shared libretro core test harness implementation.
  */
 
+/* clock_gettime()/CLOCK_MONOTONIC (used by harness_time_now below) are
+ * POSIX.1-2001, and glibc hides them from a strictly-conforming translation
+ * unit — which is what every harness-linked test is, since they all build
+ * with -std=c99.  Must precede the first system header include. */
+#if !defined(__APPLE__) && !defined(_WIN32) && !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "harness.h"
 
 #include <stdio.h>
@@ -11,6 +19,12 @@
 #include <stdarg.h>
 #include <math.h>
 #include "../../libretro-common/include/libretro.h"
+
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#else
+#include <time.h>
+#endif
 
 #ifdef __APPLE__
 #define DEFAULT_CORE "virtualjaguar_libretro.dylib"
@@ -445,6 +459,52 @@ void harness_reset_audio(harness_config *cfg)
     cfg->audio.first_audio_frame = -1;
     cfg->audio.first_batch_frame = -1;
 }
+
+void harness_reset_video(harness_config *cfg)
+{
+    /* Zeroing total_frames_rendered also re-arms the dimension-change
+     * detector (see cb_video above): the first frame after a reset
+     * establishes the baseline instead of counting as a change. */
+    memset(&cfg->video, 0, sizeof(cfg->video));
+}
+
+/* ----------------------------------------------------------------
+ * Monotonic wall clock
+ *
+ * Same shape as test/tools/test_benchmark.c and test/harness/timing_probe.c,
+ * lifted here so tests that link only harness.c do not need a third copy.
+ * ---------------------------------------------------------------- */
+
+#ifdef __APPLE__
+static mach_timebase_info_data_t harness_timebase;
+
+uint64_t harness_time_now(void)
+{
+    return mach_absolute_time();
+}
+
+double harness_time_elapsed_sec(uint64_t start, uint64_t end)
+{
+    uint64_t elapsed = end - start;
+    if (harness_timebase.denom == 0)
+        mach_timebase_info(&harness_timebase);
+    /* Convert to nanoseconds, then seconds */
+    return (double)elapsed * (double)harness_timebase.numer /
+           (double)harness_timebase.denom / 1e9;
+}
+#else
+uint64_t harness_time_now(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+double harness_time_elapsed_sec(uint64_t start, uint64_t end)
+{
+    return (double)(end - start) / 1e9;
+}
+#endif
 
 void harness_report(harness_config *cfg, const harness_result *results, unsigned count)
 {

--- a/test/harness/harness.c
+++ b/test/harness/harness.c
@@ -49,6 +49,9 @@ static void cb_video(const void *data, unsigned w, unsigned h, size_t pitch)
 {
     (void)data; (void)pitch;
     if (!active_cfg) return;
+    if (active_cfg->video.total_frames_rendered > 0 &&
+        (w != active_cfg->video.last_width || h != active_cfg->video.last_height))
+        active_cfg->video.dimension_changes++;
     active_cfg->video.total_frames_rendered++;
     active_cfg->video.last_width = w;
     active_cfg->video.last_height = h;
@@ -152,9 +155,14 @@ static bool cb_environment(unsigned cmd, void *data)
     case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
     case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS:
     case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS:
-    case RETRO_ENVIRONMENT_SET_GEOMETRY:
     case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
     case RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER:
+        return true;
+    case RETRO_ENVIRONMENT_SET_GEOMETRY:
+        if (active_cfg) active_cfg->video.set_geometry_calls++;
+        return true;
+    case RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO:
+        if (active_cfg) active_cfg->video.set_av_info_calls++;
         return true;
     case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
         *(const char **)data = "/tmp";

--- a/test/harness/harness.h
+++ b/test/harness/harness.h
@@ -117,6 +117,15 @@ typedef struct {
     unsigned total_frames_rendered;
     unsigned last_width;
     unsigned last_height;
+    /* Frontend-negotiation counters.  A core that renegotiates geometry or
+     * A/V timing every frame makes real frontends re-init their texture /
+     * audio driver per frame, which pins the frame rate and defeats
+     * fast-forward.  See test/test_frontend_pacing.c. */
+    unsigned set_geometry_calls;
+    unsigned set_av_info_calls;
+    /* Number of frames whose reported width/height differed from the
+     * previous frame's (boot resolution changes are expected; churn is not). */
+    unsigned dimension_changes;
 } harness_video_stats;
 
 /* Per-frame callback: called after each retro_run().

--- a/test/harness/harness.h
+++ b/test/harness/harness.h
@@ -217,4 +217,20 @@ void harness_set_option(harness_config *cfg, const char *key, const char *value)
 /* Reset audio stats (useful between test phases). */
 void harness_reset_audio(harness_config *cfg);
 
+/* Reset video stats — counterpart to harness_reset_audio.  Use when a test
+ * measures a window of steady-state execution and must discard boot-time
+ * geometry / resolution churn.  Note this also zeroes total_frames_rendered
+ * and last_width/last_height, so harness_report's summary line then
+ * describes the window rather than the whole run. */
+void harness_reset_video(harness_config *cfg);
+
+/* Monotonic wall clock, for tests that measure durations.
+ *
+ * Deliberately not gettimeofday(): the wall clock can step backwards (NTP
+ * correction, manual clock change), and a negative interval can turn a
+ * timing assertion green.  Ticks are opaque; convert a pair with
+ * harness_time_elapsed_sec(). */
+uint64_t harness_time_now(void);
+double   harness_time_elapsed_sec(uint64_t start, uint64_t end);
+
 #endif /* HARNESS_H */

--- a/test/test_frontend_pacing.c
+++ b/test/test_frontend_pacing.c
@@ -1,0 +1,262 @@
+/*
+ * test/test_frontend_pacing.c — frontend pacing / fast-forward contract test.
+ *
+ * Regression guard for the class of bug where the core itself pins the frame
+ * rate, so no frontend can run it faster than realtime and RetroArch's
+ * fast-forward appears to "do nothing".
+ *
+ * Four assertions.  Three are exact integer/counter checks with no timing
+ * sensitivity; the timing one is deliberately built to survive a loaded CI
+ * machine (see fastest_frame_beats_realtime below).
+ *
+ *   1. fastest_frame_beats_realtime
+ *      The FASTEST of N retro_run() calls must complete in well under one
+ *      frame period (1/fps).  This is the load-immune form of "the core does
+ *      not throttle itself": a core that sleeps, busy-waits, or blocks on an
+ *      audio buffer inside retro_run pays that cost on essentially every
+ *      frame, so even its quickest frame lands at ~1/fps.  Background CPU
+ *      load can only make frames slower, never faster, so a busy host cannot
+ *      turn this check red — whereas an average-speed check can and did
+ *      (measured 0.59x realtime on this machine at load average 250).
+ *      The mean/effective fps is reported as INFO alongside.
+ *
+ *   2. audio_rate_contract
+ *      Sample-frames handed to retro_audio_sample_batch over N frames must
+ *      equal N * sample_rate / fps (within 1%).  A mismatch between the
+ *      advertised timing and the samples actually produced makes the
+ *      frontend's audio driver the pacing bottleneck: submit too many
+ *      samples and the audio buffer never drains, which throttles the
+ *      frontend run loop no matter how fast the emulation is.  This is what
+ *      catches a future BUFNTSC/BUFPAL vs timing.fps desync (e.g. moving fps
+ *      to 59.94 without touching the buffer size, or adding a region without
+ *      a matching buffer constant).
+ *
+ *   3. one_batch_per_frame
+ *      Exactly one audio batch submission per retro_run — no partial flushes
+ *      that would let the frontend block part-way through a frame.
+ *
+ *   4. geometry_stability
+ *      RETRO_ENVIRONMENT_SET_GEOMETRY must not be spammed.  Frontends
+ *      re-allocate the video texture on SET_GEOMETRY; doing it every frame
+ *      pins the frame rate however fast the core is, and plain benchmarks
+ *      cannot see it because their environment callback is a no-op stub.
+ *      Boot-time resolution changes are legitimate, hence a small allowance
+ *      rather than zero.
+ *
+ * Usage:
+ *   ./test/test_frontend_pacing [core] [rom] [--frames N]
+ *       [--max-fastest-frame-fraction F]   (default 0.5 of one frame period)
+ *       [--max-geometry-calls N]           (default 8)
+ *       [--force-fail-{throttle,audio,geometry}]  self-test of the asserts
+ *
+ * The --force-fail-* flags make the corresponding threshold impossible to
+ * satisfy, so the failure path can be demonstrated without editing the file.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <sys/time.h>
+
+#include "harness/harness.h"
+#include <libretro.h>
+
+typedef struct {
+    double t_prev;
+    double min_frame;
+    double max_frame;
+    double sum_frame;
+    unsigned samples;
+} frame_timer;
+
+static double now_seconds(void)
+{
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (double)tv.tv_sec + (double)tv.tv_usec / 1000000.0;
+}
+
+/* Called by the harness after every retro_run(). */
+static bool on_frame(void *userdata, unsigned frame)
+{
+    frame_timer *ft = (frame_timer *)userdata;
+    double now = now_seconds();
+    double dt = now - ft->t_prev;
+    (void)frame;
+    ft->t_prev = now;
+    if (dt < ft->min_frame) ft->min_frame = dt;
+    if (dt > ft->max_frame) ft->max_frame = dt;
+    ft->sum_frame += dt;
+    ft->samples++;
+    return true;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    void (*p_av_info)(struct retro_system_av_info *);
+    struct retro_system_av_info av;
+    harness_result results[8];
+    frame_timer ft;
+    unsigned nres = 0;
+    double max_fastest_fraction = 0.5;
+    unsigned max_geometry_calls = 8;
+    int force_fail_throttle = 0, force_fail_audio = 0, force_fail_geometry = 0;
+    double t0, elapsed, realtime, frame_period, mean_frame;
+    double expected_frames_f, tolerance, sample_err;
+    long expected_samples, actual_samples;
+    char detail_throttle[320], detail_audio[256], detail_batch[160], detail_geom[224];
+    int ok_throttle, ok_audio, ok_batch, ok_geom, all_ok;
+    int i;
+
+    cfg.frames = 300;
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--max-fastest-frame-fraction") == 0 && i + 1 < argc)
+            max_fastest_fraction = atof(argv[++i]);
+        else if (strcmp(argv[i], "--max-geometry-calls") == 0 && i + 1 < argc)
+            max_geometry_calls = (unsigned)atoi(argv[++i]);
+        else if (strcmp(argv[i], "--force-fail-throttle") == 0)
+            force_fail_throttle = 1;
+        else if (strcmp(argv[i], "--force-fail-audio") == 0)
+            force_fail_audio = 1;
+        else if (strcmp(argv[i], "--force-fail-geometry") == 0)
+            force_fail_geometry = 1;
+    }
+
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+
+    if (!cfg.rom_path) {
+        fprintf(stderr, "test_frontend_pacing: no ROM given; nothing to measure\n");
+        return 1;
+    }
+
+    p_av_info = (void (*)(struct retro_system_av_info *))
+                harness_dlsym(&cfg, "retro_get_system_av_info");
+    if (!p_av_info) {
+        fprintf(stderr, "test_frontend_pacing: retro_get_system_av_info missing\n");
+        return 1;
+    }
+
+    if (!harness_load_rom(&cfg))
+        return 1;
+
+    memset(&av, 0, sizeof(av));
+    p_av_info(&av);
+
+    if (!(av.timing.fps > 0.0) || !(av.timing.sample_rate > 0.0)) {
+        fprintf(stderr,
+                "test_frontend_pacing: bogus av_info (fps=%f sample_rate=%f)\n",
+                av.timing.fps, av.timing.sample_rate);
+        harness_shutdown(&cfg);
+        return 1;
+    }
+
+    if (!cfg.quiet)
+        printf("av_info: fps=%.6f sample_rate=%.1f base=%ux%u max=%ux%u\n",
+               av.timing.fps, av.timing.sample_rate,
+               av.geometry.base_width, av.geometry.base_height,
+               av.geometry.max_width, av.geometry.max_height);
+
+    /* Reset counters so boot-time SET_GEOMETRY from retro_load_game is not
+     * counted; we only care about steady-state churn. */
+    cfg.video.set_geometry_calls = 0;
+    cfg.video.set_av_info_calls  = 0;
+    cfg.video.dimension_changes  = 0;
+    harness_reset_audio(&cfg);
+
+    memset(&ft, 0, sizeof(ft));
+    ft.min_frame = 1.0e9;
+    cfg.frame_callback = on_frame;
+    cfg.frame_callback_data = &ft;
+
+    t0 = now_seconds();
+    ft.t_prev = t0;
+    harness_run(&cfg);
+    elapsed = now_seconds() - t0;
+
+    frame_period = 1.0 / av.timing.fps;
+    realtime     = (double)cfg.frames * frame_period;
+    mean_frame   = (ft.samples > 0) ? ft.sum_frame / (double)ft.samples : 0.0;
+    if (ft.samples == 0)
+        ft.min_frame = 0.0;
+    if (force_fail_throttle)
+        max_fastest_fraction = 0.0;
+    if (force_fail_geometry)
+        max_geometry_calls = 0;
+
+    /* --- 1. fastest frame must clear the frame period --------------- */
+    ok_throttle = (ft.samples > 0)
+               && (ft.min_frame < max_fastest_fraction * frame_period);
+    snprintf(detail_throttle, sizeof(detail_throttle),
+             "fastest frame %.3f ms must be < %.3f ms (%.2f x frame period "
+             "%.3f ms); mean %.3f ms, slowest %.3f ms; %u frames in %.3fs "
+             "(realtime %.3fs, %.2fx, %.1f eff. fps)",
+             ft.min_frame * 1000.0, max_fastest_fraction * frame_period * 1000.0,
+             max_fastest_fraction, frame_period * 1000.0,
+             mean_frame * 1000.0, ft.max_frame * 1000.0,
+             cfg.frames, elapsed, realtime,
+             (elapsed > 0.0) ? realtime / elapsed : 0.0,
+             (elapsed > 0.0) ? (double)cfg.frames / elapsed : 0.0);
+
+    /* --- 2. audio-rate contract ------------------------------------- */
+    expected_frames_f = (double)cfg.frames * av.timing.sample_rate / av.timing.fps;
+    expected_samples  = (long)(expected_frames_f + 0.5);
+    actual_samples    = (long)cfg.audio.total_samples;
+    if (force_fail_audio)
+        actual_samples = 0;
+    sample_err = (expected_frames_f > 0.0)
+               ? fabs((double)actual_samples - expected_frames_f) / expected_frames_f
+               : 1.0;
+    tolerance = 0.01;
+    ok_audio = (sample_err <= tolerance);
+    snprintf(detail_audio, sizeof(detail_audio),
+             "submitted %ld sample-frames, expected %ld "
+             "(%u frames x %.1f Hz / %.4f fps); error %.3f%% (limit %.1f%%)",
+             actual_samples, expected_samples, cfg.frames,
+             av.timing.sample_rate, av.timing.fps,
+             sample_err * 100.0, tolerance * 100.0);
+
+    /* --- 3. one batch per frame ------------------------------------- */
+    ok_batch = (cfg.audio.total_batch_calls == cfg.frames);
+    snprintf(detail_batch, sizeof(detail_batch),
+             "%u audio batch calls for %u frames (expected 1:1)",
+             cfg.audio.total_batch_calls, cfg.frames);
+
+    /* --- 4. geometry stability -------------------------------------- */
+    ok_geom = (cfg.video.set_geometry_calls <= max_geometry_calls);
+    snprintf(detail_geom, sizeof(detail_geom),
+             "SET_GEOMETRY x%u over %u frames (limit %u); SET_SYSTEM_AV_INFO x%u; "
+             "reported-dimension changes %u; last %ux%u",
+             cfg.video.set_geometry_calls, cfg.frames, max_geometry_calls,
+             cfg.video.set_av_info_calls, cfg.video.dimension_changes,
+             cfg.video.last_width, cfg.video.last_height);
+
+    results[nres].status = ok_throttle ? "PASS" : "FAIL";
+    results[nres].name   = "fastest_frame_beats_realtime";
+    results[nres].detail = detail_throttle;
+    nres++;
+
+    results[nres].status = ok_audio ? "PASS" : "FAIL";
+    results[nres].name   = "audio_rate_contract";
+    results[nres].detail = detail_audio;
+    nres++;
+
+    results[nres].status = ok_batch ? "PASS" : "FAIL";
+    results[nres].name   = "one_batch_per_frame";
+    results[nres].detail = detail_batch;
+    nres++;
+
+    results[nres].status = ok_geom ? "PASS" : "FAIL";
+    results[nres].name   = "geometry_stability";
+    results[nres].detail = detail_geom;
+    nres++;
+
+    harness_report(&cfg, results, nres);
+    harness_shutdown(&cfg);
+
+    all_ok = ok_throttle && ok_audio && ok_batch && ok_geom;
+    return all_ok ? 0 : 1;
+}

--- a/test/test_frontend_pacing.c
+++ b/test/test_frontend_pacing.c
@@ -57,6 +57,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <inttypes.h>
 
 #include "harness/harness.h"
 #include <libretro.h>
@@ -112,7 +113,9 @@ int main(int argc, char **argv)
     uint64_t t0;
     double elapsed, realtime, frame_period, mean_frame;
     double expected_frames_f, tolerance, sample_err;
-    long expected_samples, actual_samples;
+    /* 64-bit: --frames N is user-supplied, and total_samples can exceed
+     * 32-bit long on LLP64 platforms for large N. */
+    int64_t expected_samples, actual_samples;
     char detail_throttle[320], detail_audio[256], detail_batch[160], detail_geom[224];
     int ok_throttle, ok_audio, ok_batch, ok_geom, all_ok;
     int i;
@@ -120,10 +123,26 @@ int main(int argc, char **argv)
     cfg.frames = 300;
 
     for (i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--max-fastest-frame-fraction") == 0 && i + 1 < argc)
-            max_fastest_fraction = atof(argv[++i]);
-        else if (strcmp(argv[i], "--max-geometry-calls") == 0 && i + 1 < argc)
-            max_geometry_calls = (unsigned)atoi(argv[++i]);
+        if (strcmp(argv[i], "--max-fastest-frame-fraction") == 0 && i + 1 < argc) {
+            /* strtod, not atof: atof returns 0 on a malformed value, which
+             * would silently set the threshold to 0 and force a failure. */
+            char *end = NULL;
+            double v = strtod(argv[++i], &end);
+            if (end == argv[i] || *end != '\0' || v <= 0.0) {
+                fprintf(stderr, "invalid --max-fastest-frame-fraction: %s\n",
+                        argv[i]);
+                return 2;
+            }
+            max_fastest_fraction = v;
+        } else if (strcmp(argv[i], "--max-geometry-calls") == 0 && i + 1 < argc) {
+            char *end = NULL;
+            unsigned long v = strtoul(argv[++i], &end, 10);
+            if (end == argv[i] || *end != '\0') {
+                fprintf(stderr, "invalid --max-geometry-calls: %s\n", argv[i]);
+                return 2;
+            }
+            max_geometry_calls = (unsigned)v;
+        }
         else if (strcmp(argv[i], "--force-fail-throttle") == 0)
             force_fail_throttle = 1;
         else if (strcmp(argv[i], "--force-fail-audio") == 0)
@@ -213,8 +232,8 @@ int main(int argc, char **argv)
 
     /* --- 2. audio-rate contract ------------------------------------- */
     expected_frames_f = (double)cfg.frames * av.timing.sample_rate / av.timing.fps;
-    expected_samples  = (long)(expected_frames_f + 0.5);
-    actual_samples    = (long)cfg.audio.total_samples;
+    expected_samples  = (int64_t)(expected_frames_f + 0.5);
+    actual_samples    = (int64_t)cfg.audio.total_samples;
     if (force_fail_audio)
         actual_samples = 0;
     sample_err = (expected_frames_f > 0.0)
@@ -223,7 +242,7 @@ int main(int argc, char **argv)
     tolerance = 0.01;
     ok_audio = (sample_err <= tolerance);
     snprintf(detail_audio, sizeof(detail_audio),
-             "submitted %ld sample-frames, expected %ld "
+             "submitted %" PRId64 " sample-frames, expected %" PRId64 " "
              "(%u frames x %.1f Hz / %.4f fps); error %.3f%% (limit %.1f%%)",
              actual_samples, expected_samples, cfg.frames,
              av.timing.sample_rate, av.timing.fps,

--- a/test/test_frontend_pacing.c
+++ b/test/test_frontend_pacing.c
@@ -57,38 +57,44 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#include <sys/time.h>
 
 #include "harness/harness.h"
 #include <libretro.h>
 
-typedef struct {
-    double t_prev;
-    double min_frame;
-    double max_frame;
-    double sum_frame;
-    unsigned samples;
-} frame_timer;
+/* Timing comes from harness_time_now() / harness_time_elapsed_sec(), which
+ * are monotonic.  A wall clock (gettimeofday) must not be used here: the
+ * throttle assertion is phrased against the *minimum* frame interval, so a
+ * single backwards clock step — NTP correction, manual clock change — would
+ * produce a negative delta, drag min_frame below the limit and report a
+ * false PASS on exactly the bug this test exists to catch. */
 
-static double now_seconds(void)
-{
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (double)tv.tv_sec + (double)tv.tv_usec / 1000000.0;
-}
+typedef struct {
+    uint64_t t_prev;
+    double   min_frame;      /* smallest usable (positive) interval, seconds */
+    double   max_frame;
+    double   sum_frame;
+    unsigned timed_frames;   /* retro_run() calls timed */
+    unsigned usable_frames;  /* of those, ones with a positive interval */
+} frame_timer;
 
 /* Called by the harness after every retro_run(). */
 static bool on_frame(void *userdata, unsigned frame)
 {
     frame_timer *ft = (frame_timer *)userdata;
-    double now = now_seconds();
-    double dt = now - ft->t_prev;
+    uint64_t now = harness_time_now();
+    double dt = harness_time_elapsed_sec(ft->t_prev, now);
     (void)frame;
     ft->t_prev = now;
-    if (dt < ft->min_frame) ft->min_frame = dt;
+    ft->timed_frames++;
+    ft->sum_frame += (dt > 0.0) ? dt : 0.0;
     if (dt > ft->max_frame) ft->max_frame = dt;
-    ft->sum_frame += dt;
-    ft->samples++;
+    /* Belt and braces on top of the monotonic source: reject a non-positive
+     * interval rather than clamping it.  min_frame = 0 would satisfy the
+     * throttle assertion unconditionally. */
+    if (dt > 0.0) {
+        if (dt < ft->min_frame) ft->min_frame = dt;
+        ft->usable_frames++;
+    }
     return true;
 }
 
@@ -103,7 +109,8 @@ int main(int argc, char **argv)
     double max_fastest_fraction = 0.5;
     unsigned max_geometry_calls = 8;
     int force_fail_throttle = 0, force_fail_audio = 0, force_fail_geometry = 0;
-    double t0, elapsed, realtime, frame_period, mean_frame;
+    uint64_t t0;
+    double elapsed, realtime, frame_period, mean_frame;
     double expected_frames_f, tolerance, sample_err;
     long expected_samples, actual_samples;
     char detail_throttle[320], detail_audio[256], detail_batch[160], detail_geom[224];
@@ -160,11 +167,12 @@ int main(int argc, char **argv)
                av.geometry.base_width, av.geometry.base_height,
                av.geometry.max_width, av.geometry.max_height);
 
-    /* Reset counters so boot-time SET_GEOMETRY from retro_load_game is not
-     * counted; we only care about steady-state churn. */
-    cfg.video.set_geometry_calls = 0;
-    cfg.video.set_av_info_calls  = 0;
-    cfg.video.dimension_changes  = 0;
+    /* Reset counters so boot-time SET_GEOMETRY and the boot resolution change
+     * from retro_load_game are not counted; we only care about steady-state
+     * churn.  harness_reset_video clears total_frames_rendered and
+     * last_width/last_height too, so both dimension_changes and the reported
+     * "last WxH" below describe the timed window rather than boot state. */
+    harness_reset_video(&cfg);
     harness_reset_audio(&cfg);
 
     memset(&ft, 0, sizeof(ft));
@@ -172,15 +180,16 @@ int main(int argc, char **argv)
     cfg.frame_callback = on_frame;
     cfg.frame_callback_data = &ft;
 
-    t0 = now_seconds();
+    t0 = harness_time_now();
     ft.t_prev = t0;
     harness_run(&cfg);
-    elapsed = now_seconds() - t0;
+    elapsed = harness_time_elapsed_sec(t0, harness_time_now());
 
     frame_period = 1.0 / av.timing.fps;
     realtime     = (double)cfg.frames * frame_period;
-    mean_frame   = (ft.samples > 0) ? ft.sum_frame / (double)ft.samples : 0.0;
-    if (ft.samples == 0)
+    mean_frame   = (ft.timed_frames > 0)
+                 ? ft.sum_frame / (double)ft.timed_frames : 0.0;
+    if (ft.usable_frames == 0)
         ft.min_frame = 0.0;
     if (force_fail_throttle)
         max_fastest_fraction = 0.0;
@@ -188,15 +197,16 @@ int main(int argc, char **argv)
         max_geometry_calls = 0;
 
     /* --- 1. fastest frame must clear the frame period --------------- */
-    ok_throttle = (ft.samples > 0)
+    ok_throttle = (ft.usable_frames > 0)
                && (ft.min_frame < max_fastest_fraction * frame_period);
     snprintf(detail_throttle, sizeof(detail_throttle),
              "fastest frame %.3f ms must be < %.3f ms (%.2f x frame period "
-             "%.3f ms); mean %.3f ms, slowest %.3f ms; %u frames in %.3fs "
-             "(realtime %.3fs, %.2fx, %.1f eff. fps)",
+             "%.3f ms); mean %.3f ms, slowest %.3f ms; %u/%u intervals usable; "
+             "%u frames in %.3fs (realtime %.3fs, %.2fx, %.1f eff. fps)",
              ft.min_frame * 1000.0, max_fastest_fraction * frame_period * 1000.0,
              max_fastest_fraction, frame_period * 1000.0,
              mean_frame * 1000.0, ft.max_frame * 1000.0,
+             ft.usable_frames, ft.timed_frames,
              cfg.frames, elapsed, realtime,
              (elapsed > 0.0) ? realtime / elapsed : 0.0,
              (elapsed > 0.0) ? (double)cfg.frames / elapsed : 0.0);


### PR DESCRIPTION
Investigating a report that **RetroArch fast-forward does not work with this core**. Conclusion: **it is not a core bug.** No core code changed — `libretro.c` and everything under `src/` are untouched. What lands here is the regression test that pins the contract, plus documentation.

## Evidence the core is not at fault

**1. No wall-clock throttle.** Grep across `libretro.c`, `src/` and `libretro-common/` for sleep/timing primitives (`usleep`, `nanosleep`, `sleep(`, `clock_gettime`, `gettimeofday`, `SDL_Delay`, `sched_yield`, `pthread_cond`) finds nothing in the frame path — the only hit is `mach_absolute_time` inside `#ifdef BLITTER_TRACE`. No `SET_FRAME_TIME_CALLBACK`, no `SET_AUDIO_CALLBACK`, no `SET_AUDIO_BUFFER_STATUS_CALLBACK`. `make benchmark` reports **297 fps** on yarc, about 5x realtime.

**2. The av_info / audio contract is exact.** Reported `fps` is 60/50 and `sample_rate` is 48000; audio is submitted once per frame with 800 (NTSC) or 960 (PAL) sample-frames. 800x60 = 960x50 = 48000. Measured over 300 frames: 240000 submitted vs 240000 expected, **0.000% error**, one batch call per frame. The audio driver is therefore never forced into the pacing role.

**3. Geometry churn ruled out.** This was the leading hypothesis, since a per-frame texture reinit is invisible to headless benchmarks whose environment callback is a stub. Disproven: `SET_GEOMETRY` fires **once** in 600 frames on yarc, Doom and Alien vs Predator, and `SET_SYSTEM_AV_INFO` never fires.

**4. Decisive measurement.** `retro_run` bracketed from inside the core, running under real RetroArch 1.22.2, 1800 frames of yarc:

| | no fast-forward | with FAST_FORWARD |
|---|---|---|
| effective fps | 120.8 | 126.1 |
| time inside `retro_run` | 12.69 s | 13.87 s |
| time **outside** `retro_run` | **2.20 s** | **0.41 s** |

Fast-forward *does* unblock the frontend — out-of-core blocking collapses by 5x. The frame rate barely moves because `retro_run` itself costs about 7.6 ms/frame on that host (emulation 6.5 ms, `video_cb` 1.15 ms), capping the core near 130 fps. There is nothing left for fast-forward to give.

Worth recording: earlier readings that looked like a hard 59.5 fps pin turned out to be **macOS throttling the RetroArch window while it was not frontmost** — 120.8 fps frontmost versus 59.5 fps occluded, same core and same config. RetroArch's own limiter confirms the mechanism is frontend-side: `runloop_set_frame_limit()` only sets an unlimited frame limit when `fastforward_ratio < 0.1f`.

## What a user seeing this should change

All of this is written up in the new `docs/frontend-pacing.md`, including an explicit "do not add a limiter to the core" note:

- **Frame Throttle -> Fast-Forward Rate**: if this is `1.0x`, fast-forward paces at exactly the content frame rate and does nothing at all. Set it to `0.0` for unlimited.
- **Frame Throttle -> Sync to Exact Content Framerate** (`vrr_runloop_enable`): applies the frame limiter on every iteration, not just during fast-forward.
- **Synchronous Audio** and **Vertical Sync**: RetroArch drops both to non-blocking during fast-forward; anything keeping them blocking re-paces the loop.
- On macOS, keep the RetroArch window frontmost when judging fast-forward speed.
- Check headroom with `make benchmark` first — heavier titles on slower hosts already sit near 16.7 ms/frame, so fast-forward yields little even when working correctly.

## The regression test

`test/test_frontend_pacing.c`, four assertions, wired into `make test`:

1. **`fastest_frame_beats_realtime`** — the *fastest* of 300 `retro_run` calls must complete in under half a frame period. Phrased against the minimum rather than the mean on purpose: a mean-based first draft went red at 0.59x realtime purely because of a concurrent Xcode build (load average 250). Background load can only make frames slower, never faster, so a sleeping core cannot hide behind a busy host and a busy host cannot produce a false failure.
2. **`audio_rate_contract`** — submitted sample-frames must equal `frames * sample_rate / fps` within 1%. This is the assertion that would catch a future `BUFNTSC` / `fps` desync.
3. **`one_batch_per_frame`** — exactly 1:1.
4. **`geometry_stability`** — `SET_GEOMETRY` at most 8 times per 300 frames.

The shared harness gains `set_geometry_calls`, `set_av_info_calls` and `dimension_changes`; `SET_GEOMETRY` and `SET_SYSTEM_AV_INFO` are now counted rather than silently accepted.

**Fails before, passes after.** The real bug class was injected (a 1/60 s sleep at the end of `retro_run`) and then removed:

```
BEFORE: FAIL fastest frame 10.445 ms must be < 8.333 ms; 300 frames in 5.007s (1.00x, 59.9 fps)  exit=1
AFTER:  PASS fastest frame  3.200 ms must be < 8.333 ms; 300 frames in 1.001s (4.99x, 299.7 fps) exit=0
```

`--force-fail-throttle`, `--force-fail-audio` and `--force-fail-geometry` self-test each assertion (3 FAIL, exit 1).

The Makefile invokes the test **unconditionally**. `test/roms/yarc.j64` is tracked in git (added in a845760), so it is present in every checkout including CI and a guard would never fire there; running it ungated means a missing ROM fails loudly instead of silently skipping, matching `test_state_compat`.

## Testing

- `scripts/c89-lint.sh` on the new test and the harness: passed
- `make -j` and `make -j TEST_EXPORTS=1`: clean, no warnings
- `make TEST_EXPORTS=1 test`: **exit 0**, `test_frontend_pacing` 4/4 PASS

## Separate defect found, deliberately not bundled

`libretro.c:607` advertises `geometry.max_height = 240` for NTSC, but the core emits **326x241** frames (visible in this PR's test output, in the existing `test_framebuffer_integrity` output, and independently in an unrelated save-state harness). A frame taller than the advertised maximum violates the libretro spec and can cause clipped or dropped uploads on some video drivers. It is unrelated to pacing, so it is left for its own PR rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

