### PR TITLE
fix(libretro): advertise a max_height that bounds what we emit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -814,8 +814,12 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 	fi
 	./test/tools/test_memory_map ./$(TARGET)
 	@# Framebuffer integrity: alpha corruption + screen position shift detection.
+	@# Run both regions: max_height is region-independent, but the emitted
+	@# height is not, so a region-specific overflow must not hide.
 	@if [ -f "test/roms/yarc.j64" ]; then \
 		./test/test_framebuffer_integrity ./$(TARGET) test/roms/yarc.j64; \
+		./test/test_framebuffer_integrity ./$(TARGET) test/roms/yarc.j64 \
+			--option virtualjaguar_pal=enabled; \
 	else \
 		echo "  SKIP: yarc.j64 ROM not available (framebuffer integrity)"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -816,8 +816,10 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 	@# Framebuffer integrity: alpha corruption + screen position shift detection.
 	@# Run both regions: max_height is region-independent, but the emitted
 	@# height is not, so a region-specific overflow must not hide.
+	@# Chained with && so an NTSC failure cannot be masked by a passing PAL
+	@# run -- with `;` the block would still exit 0 on the second command.
 	@if [ -f "test/roms/yarc.j64" ]; then \
-		./test/test_framebuffer_integrity ./$(TARGET) test/roms/yarc.j64; \
+		./test/test_framebuffer_integrity ./$(TARGET) test/roms/yarc.j64 && \
 		./test/test_framebuffer_integrity ./$(TARGET) test/roms/yarc.j64 \
 			--option virtualjaguar_pal=enabled; \
 	else \

--- a/libretro.c
+++ b/libretro.c
@@ -604,7 +604,14 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    info->geometry.base_width   = game_width;
    info->geometry.base_height  = game_height;
    info->geometry.max_width    = 652; // Highest value encountered during testing
-   info->geometry.max_height   = vjs.hardwareTypeNTSC ? 240 : 256;
+   /* Must bound every height the core can emit, not the nominal active
+    * display.  VDB/VDE are game-programmable, so a title can open a window
+    * taller than the nominal 240 NTSC lines (yarc programs VDB=25/VDE=507 =
+    * 241 lines), and TOMGetVideoModeHeight() accepts anything up to 256.
+    * Advertising 240 for NTSC let the core submit frames taller than the
+    * declared maximum, which some video drivers clip or drop.  The nominal
+    * size is carried by base_height above; this is the allocation bound. */
+   info->geometry.max_height   = 256;
    info->geometry.aspect_ratio = 4.0 / 3.0;
 }
 

--- a/test/test_framebuffer_integrity.c
+++ b/test/test_framebuffer_integrity.c
@@ -23,7 +23,8 @@
 
 #include "harness/harness.h"
 
-#include <libretro.h>
+#include "../libretro-common/include/libretro.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -92,6 +93,7 @@ int main(int argc, char **argv)
     uint32_t *fb;
     int w, h;
     void (*av_info_fn)(struct retro_system_av_info *);
+    int max_w, max_h;
     char geom_detail_buf[128];
     unsigned total_pixels, nonblack_count;
     unsigned i, x, y;
@@ -134,7 +136,9 @@ int main(int argc, char **argv)
     fb_ptr = (uint32_t **)harness_dlsym(&cfg, "videoBuffer");
     width_ptr = (int *)harness_dlsym(&cfg, "game_width");
     height_ptr = (int *)harness_dlsym(&cfg, "game_height");
-    *(void **)(&av_info_fn) = harness_dlsym(&cfg, "retro_get_system_av_info");
+    /* Direct assignment, matching how harness.c resolves the retro_* entry
+     * points (harness.c:260+), rather than casting through void **. */
+    av_info_fn = harness_dlsym(&cfg, "retro_get_system_av_info");
     if (!fb_ptr || !width_ptr || !height_ptr) {
         fprintf(stderr, "Cannot resolve videoBuffer/game_width/game_height\n");
         harness_shutdown(&cfg);
@@ -188,11 +192,15 @@ int main(int argc, char **argv)
         /* Own buffer, not the shared detail_buf: check() stores the pointer
          * rather than copying, so a shared buffer would report whatever the
          * last assertion wrote. */
+        /* Compare in the signed domain: w/h are ints already validated > 0
+         * above, and the advertised maxima are far below INT_MAX, so this
+         * avoids a sign conversion in the comparison. */
+        max_w = (int)av.geometry.max_width;
+        max_h = (int)av.geometry.max_height;
         snprintf(geom_detail_buf, sizeof(geom_detail_buf),
-                 "emitted %dx%d must fit advertised max %ux%u",
-                 w, h, av.geometry.max_width, av.geometry.max_height);
-        check((unsigned)w <= av.geometry.max_width
-              && (unsigned)h <= av.geometry.max_height,
+                 "emitted %dx%d must fit advertised max %dx%d",
+                 w, h, max_w, max_h);
+        check(w <= max_w && h <= max_h,
               "frame_within_advertised_geometry", geom_detail_buf,
               results, &num_results);
     } else {

--- a/test/test_framebuffer_integrity.c
+++ b/test/test_framebuffer_integrity.c
@@ -136,9 +136,14 @@ int main(int argc, char **argv)
     fb_ptr = (uint32_t **)harness_dlsym(&cfg, "videoBuffer");
     width_ptr = (int *)harness_dlsym(&cfg, "game_width");
     height_ptr = (int *)harness_dlsym(&cfg, "game_height");
-    /* Direct assignment, matching how harness.c resolves the retro_* entry
-     * points (harness.c:260+), rather than casting through void **. */
-    av_info_fn = harness_dlsym(&cfg, "retro_get_system_av_info");
+    /* Object pointer -> function pointer via memcpy: the conversion is not
+     * defined by ISO C in either direction (neither a plain assignment nor a
+     * cast through void **), so copy the representation instead.  This is the
+     * POSIX-recommended idiom for dlsym results. */
+    {
+        void *av_info_sym = harness_dlsym(&cfg, "retro_get_system_av_info");
+        memcpy(&av_info_fn, &av_info_sym, sizeof(av_info_fn));
+    }
     if (!fb_ptr || !width_ptr || !height_ptr) {
         fprintf(stderr, "Cannot resolve videoBuffer/game_width/game_height\n");
         harness_shutdown(&cfg);

--- a/test/test_framebuffer_integrity.c
+++ b/test/test_framebuffer_integrity.c
@@ -23,6 +23,7 @@
 
 #include "harness/harness.h"
 
+#include <libretro.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -90,6 +91,8 @@ int main(int argc, char **argv)
     int *height_ptr;
     uint32_t *fb;
     int w, h;
+    void (*av_info_fn)(struct retro_system_av_info *);
+    char geom_detail_buf[128];
     unsigned total_pixels, nonblack_count;
     unsigned i, x, y;
     double nonblack_frac;
@@ -131,6 +134,7 @@ int main(int argc, char **argv)
     fb_ptr = (uint32_t **)harness_dlsym(&cfg, "videoBuffer");
     width_ptr = (int *)harness_dlsym(&cfg, "game_width");
     height_ptr = (int *)harness_dlsym(&cfg, "game_height");
+    *(void **)(&av_info_fn) = harness_dlsym(&cfg, "retro_get_system_av_info");
     if (!fb_ptr || !width_ptr || !height_ptr) {
         fprintf(stderr, "Cannot resolve videoBuffer/game_width/game_height\n");
         harness_shutdown(&cfg);
@@ -163,6 +167,39 @@ int main(int argc, char **argv)
     }
 
     total_pixels = (unsigned)(w * h);
+
+    /* ================================================================
+     * Test 0: the emitted frame must fit inside the advertised geometry
+     *
+     * libretro requires every frame passed to video_cb to be no larger
+     * than the max_width/max_height reported by retro_get_system_av_info;
+     * frontends size their texture from those values, and an oversized
+     * frame gets clipped or dropped.  VDB/VDE are game-programmable, so
+     * this is not hypothetical: yarc programs VDB=25/VDE=507 = 241 lines,
+     * one more than the nominal 240 NTSC active lines.  Runs in whichever
+     * region the harness was given, so the Makefile invokes the test for
+     * both NTSC and PAL.
+     * ================================================================ */
+
+    if (av_info_fn) {
+        struct retro_system_av_info av;
+        memset(&av, 0, sizeof(av));
+        av_info_fn(&av);
+        /* Own buffer, not the shared detail_buf: check() stores the pointer
+         * rather than copying, so a shared buffer would report whatever the
+         * last assertion wrote. */
+        snprintf(geom_detail_buf, sizeof(geom_detail_buf),
+                 "emitted %dx%d must fit advertised max %ux%u",
+                 w, h, av.geometry.max_width, av.geometry.max_height);
+        check((unsigned)w <= av.geometry.max_width
+              && (unsigned)h <= av.geometry.max_height,
+              "frame_within_advertised_geometry", geom_detail_buf,
+              results, &num_results);
+    } else {
+        check(0, "frame_within_advertised_geometry",
+              "could not resolve retro_get_system_av_info",
+              results, &num_results);
+    }
 
     /* ================================================================
      * Test 1: Basic sanity — rendering is happening


### PR DESCRIPTION
`retro_get_system_av_info` advertised `geometry.max_height = 240` for NTSC, but the core submits **326x241** frames on `test/roms/yarc.j64`. libretro requires every frame passed to `video_cb` to fit inside the advertised `max_width`/`max_height` — frontends size their texture from those values, so an oversized frame can be clipped or dropped outright. Observed independently by three harnesses (`test_frontend_pacing`, `test_framebuffer_integrity`, and a save-state compatibility harness).

## Which side is wrong — measured, not assumed

The open question was whether 241 rows is correct hardware behaviour (so the bound must rise) or the core emits one row too many (so the emission must be fixed). I probed TOM's vertical timing registers live while yarc runs:

```
VP=523  VBB=500  VBE=24  VDB=25  VDE=507
(VDE - VDB) / 2 = 482 / 2 = 241     exactly, no rounding
```

So this is **not** an off-by-one in our derivation:

- `VDB`/`VDE` are game-programmable, and the game itself opens a 241-line window. `TOMGetVideoModeHeight()` reports it faithfully.
- The NTSC reset defaults (`VDB=38`, `VDE=518`) give exactly 240, confirming the derivation is right and that yarc is deliberately doing something taller.
- The nominal 240 active NTSC lines is a convention, not a hardware ceiling. `VP=523` means the raster carries 262 lines, so a taller window is physically representable, and `TOMGetVideoModeHeight()` already accepts anything up to 256.

Note the distilled `docs/jtrm-clocks-timing.md` says "Active display lines ~240" — with a tilde, and its own Source line cites `src/tom/tom.c` rather than the manual, so per the repo's guidance it is not authoritative for this question. The register measurement is.

**Conclusion: the emission is correct and the advertised bound was wrong.**

## The fix

`max_height` becomes **256 for both regions**, matching the clamp inside `TOMGetVideoModeHeight()`, so it bounds every height the core can produce. The nominal size is still carried by `base_height`, which is what frontends use for scaling — `max_*` is only the allocation bound, so raising it costs a marginally larger texture and nothing else. No emulation behaviour changes.

## Test

`test/test_framebuffer_integrity.c` gains `frame_within_advertised_geometry`, asserting the emitted frame fits the advertised maximum, and the Makefile now runs the test for **NTSC and PAL** so a region-specific overflow cannot hide.

| | emitted | advertised max | result |
|---|---|---|---|
| before, NTSC | 326x241 | 652x**240** | **FAIL** |
| after, NTSC | 326x241 | 652x256 | PASS |
| after, PAL | 326x256 | 652x256 | PASS |

`make TEST_EXPORTS=1 test` exits 0; C89 lint passed.

## Two incidental findings, deliberately not fixed here

**1. `check()` stores the detail pointer instead of copying it**, so assertions sharing one `detail_buf` all report whatever the last one wrote — the failure text is attached to the right assertion name but shows another assertion's detail. My new assertion uses its own buffer to sidestep it; the pre-existing sharing is untouched. Worth a follow-up, since it makes this test's output misleading on any failure.

**2. The height derivation ignores vertical blanking, while the width derivation does not.** `TOMGetVideoModeWidth()` clamps to the visible window via `TOMGetLeftVisibleHC()`/`TOMGetRightVisibleHC()`, but `TOMGetVideoModeHeight()` uses `VDB`/`VDE` raw. For yarc that matters: `VDE=507` runs 7 halflines past `VBB=500`, so the programmed window extends into vertical blank, and a blanking-clamped height would be ~238 rather than 241. Whether the core should clamp is a genuine accuracy question, but it would change the emitted size for many titles and needs its own validation sweep — out of scope for a spec-compliance fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
