### PR TITLE
docs: correct the CRY pixel field layout in jtrm-object-processor.md

### DIFF
--- a/docs/jtrm-object-processor.md
+++ b/docs/jtrm-object-processor.md
@@ -152,7 +152,7 @@ The name spells the field order: **C**yan, **R**ed, intensit**Y**.
   had the layout inverted (intensity in the high byte), which is wrong.
 - The actual RGB values are computed from CRY via lookup tables in hardware
 
-CRY advantages: smooth Gouraud shading (just interpolate C), compact colour space.
+CRY advantages: smooth Gouraud shading (just interpolate intensity/Y), compact colour space.
 
 ### RGB16
 16-bit per pixel: R[15:11] (5-bit), G[10:5] (6-bit?), B[4:0] (5-bit)

--- a/docs/jtrm-object-processor.md
+++ b/docs/jtrm-object-processor.md
@@ -143,9 +143,13 @@ Line buffer width = HP (horizontal period) worth of pixels. For NTSC at divisor 
 The Jaguar supports two primary colour modes:
 
 ### CRY (Cyan-Red-Yellow)
-16-bit per pixel: C[15:8] (8-bit intensity), R[7:4] (4-bit red-yellow), Y[3:0] (4-bit cyan-green)
-- C component is intensity (0=black, $FF=full brightness)
-- R and Y select a chrominance (hue + saturation) from a 16x16 lookup table
+16-bit per pixel: Cyan[15:12] (4 bits), Red[11:8] (4 bits), intensitY[7:0] (8 bits).
+The name spells the field order: **C**yan, **R**ed, intensit**Y**.
+- The intensity field is the LOW byte (0=black, $FF=full brightness)
+- Cyan and Red select a chrominance (hue + saturation) from a 16x16 lookup table
+- Verified against the implementation: `src/tom/tom.c` (cyan `>>12`, red `>>8`,
+  intensity `& 0x00FF`) and `src/tom/op.c`.  An earlier revision of this file
+  had the layout inverted (intensity in the high byte), which is wrong.
 - The actual RGB values are computed from CRY via lookup tables in hardware
 
 CRY advantages: smooth Gouraud shading (just interpolate C), compact colour space.


### PR DESCRIPTION
`docs/jtrm-object-processor.md` described CRY pixels as `C[15:8]` intensity / `R[7:4]` / `Y[3:0]`. It is inverted: **Cyan[15:12], Red[11:8], intensitY[7:0]** — the acronym itself spells the field order, and intensity is the *low* byte.

Verified against the implementation, which is correct: `src/tom/tom.c` extracts cyan `>>12`, red `>>8`, intensity `& 0x00FF`; `src/tom/op.c` carries the same note.

Found while investigating Battle Sphere's menu text — the wrong layout would have sent the reader hunting a nonexistent CRY decode bug. These distilled docs are the LLM-facing hardware reference and are explicitly meant to supersede source comments, so an inverted field layout actively misleads future accuracy work.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)