### PR TITLE
fix(video): stop presenting a cyan placeholder before the game programs TOM

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -56,8 +56,10 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
  * lands on a future PR. */
 #define JAGUAR_VALID_EXTENSIONS "j64|jag|rom|abs|cof|bin|prg|cue|cdi"
 
-/* Framebuffer allocation: the widest/tallest geometry TOM can advertise,
- * not the geometry currently presented. */
+/* Framebuffer allocation, in pixels.  Sized for the widest / tallest video
+ * mode TOM can be programmed into (TOMWriteWord clamps tomWidth to 1024 and
+ * tomHeight to 512), so the buffer never has to be reallocated when the game
+ * changes resolution mid-run. */
 #define VIDEO_BUFFER_WIDTH   1024
 #define VIDEO_BUFFER_HEIGHT  512
 #define VIDEO_BUFFER_PIXELS  (VIDEO_BUFFER_WIDTH * VIDEO_BUFFER_HEIGHT)
@@ -1079,7 +1081,7 @@ bool retro_load_game(const struct retro_game_info *info)
 
    videoWidth           = 320;
    videoHeight          = 240;
-   videoBuffer  = (uint32_t *)calloc(sizeof(uint32_t), 1024 * 512);
+   videoBuffer  = (uint32_t *)calloc(sizeof(uint32_t), VIDEO_BUFFER_PIXELS);
    sampleBuffer = (uint16_t *)malloc(BUFMAX * sizeof(uint16_t));
 
    if (!videoBuffer || !sampleBuffer)
@@ -1162,9 +1164,26 @@ bool retro_load_game(const struct retro_game_info *info)
    JaguarSetScreenPitch(videoWidth);
    JaguarSetScreenBuffer(videoBuffer);
 
-   /* Init video */
-   for (i = 0; i < videoWidth * videoHeight; ++i)
-      videoBuffer[i] = 0xFF00FFFF;
+   /* Initialise the whole framebuffer to opaque black.
+    *
+    * TOM only writes the rows of the presented frame that fall inside its
+    * visible window, and the border-fill path in TOMExecHalfline writes
+    * `tomWidth` pixels -- which is still 0 until the game programs a TOM
+    * video register ($F00028-$F0004F).  Until then, any presented row above
+    * VDB gets no pixels written at all, so whatever this buffer was seeded
+    * with is what the frontend displays.  It has to be a defined value, and
+    * opaque black is the correct one: it is both what a display shows with
+    * no signal and what the border colour resolves to in that window
+    * (TOMReset zeroes BORD1/BORD2, and any write that makes them non-zero
+    * also makes tomWidth non-zero, so the border path is live by then).
+    *
+    * Fill the entire allocation rather than videoWidth * videoHeight: the
+    * geometry can grow to a wider stride later (320x240 -> 326x240), and
+    * rows re-laid-out at the larger pitch reach past the initial 320x240
+    * region.  Seeding all of it keeps every presentable pixel defined and
+    * the X byte consistent no matter which geometry is in force. */
+   for (i = 0; i < VIDEO_BUFFER_PIXELS; ++i)
+      videoBuffer[i] = 0xFF000000;
 
    /* Dispatch through the selected boot strategy (cart / HLE / real BIOS).
     * The cart strategy handles the existing JaguarLoadFile + JaguarReset

--- a/libretro.c
+++ b/libretro.c
@@ -1010,9 +1010,41 @@ static void stage_cd_bios(void)
    LOG_INF("[CD-BIOS] using embedded CD BIOS\n");
 }
 
+/* Fill the entire framebuffer allocation with opaque black.
+ *
+ * TOM only writes the rows of the presented frame that fall inside its
+ * visible window, and the border-fill path in TOMExecHalfline writes
+ * `tomWidth` pixels -- which is 0 until the game programs a TOM video
+ * register ($F00028-$F0004F).  Until then, any presented row above VDB gets
+ * no pixels written at all, so whatever this buffer holds is what the
+ * frontend displays.  It has to be a defined value, and opaque black is the
+ * correct one: it is both what a display shows with no signal and what the
+ * border colour resolves to in that window (TOMReset zeroes BORD1/BORD2, and
+ * any write that makes them non-zero also makes tomWidth non-zero, so the
+ * border path is live by then).
+ *
+ * Fill the entire allocation rather than videoWidth * videoHeight: the
+ * geometry can grow to a wider stride later (320x240 -> 326x240), and rows
+ * re-laid-out at the larger pitch reach past the smaller region.  Covering
+ * all of it keeps every presentable pixel defined and the X byte consistent
+ * no matter which geometry is in force.
+ *
+ * Both retro_load_game and retro_reset go through here: a reset re-enters
+ * exactly the same window (TOMReset puts tomWidth back to 0), so the two
+ * must agree on the value. */
+static void video_buffer_blank(void)
+{
+   int i;
+
+   if (!videoBuffer)
+      return;
+
+   for (i = 0; i < VIDEO_BUFFER_PIXELS; ++i)
+      videoBuffer[i] = 0xFF000000;
+}
+
 bool retro_load_game(const struct retro_game_info *info)
 {
-   unsigned i;
    enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_XRGB8888;
 
    struct retro_input_descriptor desc[] = {
@@ -1164,26 +1196,9 @@ bool retro_load_game(const struct retro_game_info *info)
    JaguarSetScreenPitch(videoWidth);
    JaguarSetScreenBuffer(videoBuffer);
 
-   /* Initialise the whole framebuffer to opaque black.
-    *
-    * TOM only writes the rows of the presented frame that fall inside its
-    * visible window, and the border-fill path in TOMExecHalfline writes
-    * `tomWidth` pixels -- which is still 0 until the game programs a TOM
-    * video register ($F00028-$F0004F).  Until then, any presented row above
-    * VDB gets no pixels written at all, so whatever this buffer was seeded
-    * with is what the frontend displays.  It has to be a defined value, and
-    * opaque black is the correct one: it is both what a display shows with
-    * no signal and what the border colour resolves to in that window
-    * (TOMReset zeroes BORD1/BORD2, and any write that makes them non-zero
-    * also makes tomWidth non-zero, so the border path is live by then).
-    *
-    * Fill the entire allocation rather than videoWidth * videoHeight: the
-    * geometry can grow to a wider stride later (320x240 -> 326x240), and
-    * rows re-laid-out at the larger pitch reach past the initial 320x240
-    * region.  Seeding all of it keeps every presentable pixel defined and
-    * the X byte consistent no matter which geometry is in force. */
-   for (i = 0; i < VIDEO_BUFFER_PIXELS; ++i)
-      videoBuffer[i] = 0xFF000000;
+   /* Seed the framebuffer.  See video_buffer_blank() for why opaque black
+    * and why the whole allocation. */
+   video_buffer_blank();
 
    /* Dispatch through the selected boot strategy (cart / HLE / real BIOS).
     * The cart strategy handles the existing JaguarLoadFile + JaguarReset
@@ -1417,23 +1432,6 @@ void retro_deinit(void)
    enable_alt_inputs = false;
 }
 
-/* Fill the entire framebuffer allocation with opaque black.
- *
- * Not videoWidth * videoHeight: the geometry can grow to a wider stride
- * later (320x240 -> 326x240), and rows re-laid-out at the larger pitch
- * reach past the smaller region, so a partial fill leaves presentable
- * pixels undefined. */
-static void video_buffer_blank(void)
-{
-   int i;
-
-   if (!videoBuffer)
-      return;
-
-   for (i = 0; i < VIDEO_BUFFER_PIXELS; ++i)
-      videoBuffer[i] = 0xFF000000;
-}
-
 void retro_reset(void)
 {
    JaguarReset();
@@ -1442,14 +1440,9 @@ void retro_reset(void)
     * pixels.  TOMReset puts tomWidth back to 0, and the border-fill path in
     * TOMExecHalfline writes tomWidth pixels -- so until the game reprograms
     * a TOM video register ($F00028-$F0004F) the rows above VDB get no pixels
-    * written at all and keep what was on screen before the reset.
-    *
-    * retro_load_game seeds the buffer for that same window on a fresh load,
-    * so a reset has to cover it too -- but note it currently seeds a cyan
-    * placeholder (0xFF00FFFF), not black.  Blanking to opaque black here is
-    * deliberate and independent of that: black is what a display shows with
-    * no signal, and it is correct whatever the load-time seed turns out to
-    * be.  #218 changes the load path to seed black as well. */
+    * written at all and keep what was on screen before the reset.  That is
+    * the same window, and the same seed, retro_load_game establishes on a
+    * fresh load; a reset has to go through it too. */
    video_buffer_blank();
 }
 


### PR DESCRIPTION
Every game shows a **cyan bar, `rgb(0,255,255)`, 320x3 px** at the top of the framebuffer for the first ~5-36 frames (Myst: 14,400 px on frame 0). Originally filed as an Alien vs Predator bug (#178), but it reproduces in Pitfall, Raiden, Zool 2, Bubsy, I-War, Kasumi Ninja and Myst — it is core-wide.

## Why the colour is cyan: it's a hardcoded placeholder, not a colour-space bug

`libretro.c` seeded the framebuffer with `0xFF00FFFF` — in XRGB8888 that is X=FF, R=00, G=FF, B=FF = `rgb(0,255,255)`. Sole occurrence in the tree; it dates to the original libretro port (73bf95f) and survived the C conversion (682b6fd).

The CRY/RGB16 decode hypothesis was **falsified experimentally**, not argued away: substituting `0xFF123456` produced the *identical* 960 px / 3-row footprint, proving the pixels come from the seed rather than any decode path.

**Why those rows keep the seed:** rows above `VDB` take the border-colour branch in `TOMExecHalfline`, which loops `for (i = 0; i < tomWidth; i++)` — and `tomWidth` is still **0** until the game programs a TOM video register. Those rows therefore receive **zero pixel writes** and simply present whatever the buffer was seeded with. A numeric model of the window logic reproduces every measurement exactly (AvP boot: `topVisible=31`, `VDB=38`, renderedRows 240 = presentedH → 3 inert border rows = the measured 960 px).

## Fix

Seed `0xFF000000` instead, and fill the **whole allocation** rather than `videoWidth*videoHeight` — geometry grows to a wider stride (320x240 → 326x240) and rows re-laid-out at the larger pitch reach past the original region.

Black is *correct*, not merely cosmetic: it is what a display shows with no signal, **and** what the border colour itself resolves to in exactly the window where the border path is inert (`TOMReset` zeroes BORD1/BORD2, and any write that makes them non-zero also makes `tomWidth` non-zero).

## Before → after (exact `#00FFFF` count)

| Title | before | after |
|---|---|---|
| AvP | 960/frame, frames 0-30 | **0** |
| Pitfall | 960/frame, frames 0-23 | **0** |
| Raiden | 960/frame, frames 0-36 | **0** |
| Zool 2 / Evolution / Bubsy / I-War / Kasumi | 960/frame | **0** |
| Myst (HLE **and** BIOS) | 14,400 on frame 0 | **0** |
| Tempest 2000, Doom, IS1, yarc, Battle Morph | 0 | **0** |

No legitimate `#00FFFF` exists in these titles — 1200-frame runs on Tempest 2000, Rayman and Zool 2 all report 0 — so the strict global predicate holds.

## Validation

- **40/40 A/B compared**: 23 byte-identical; the 17 that differ do so *only* within frames 0-36, and a pixel classification over frames 0-44 shows **every differing pixel is cyan→black** (`diff_px == cyan_to_black` for all 17). **Audio digests bit-identical on all 40** — proof no emulation was touched.
- CD: Battle Morph HLE+BIOS, IS2, Myst probes all report 0 cyan; Myst visual+audio identical across all four runs (RMS 2698, onset f218) and the intro renders correctly. Matrix 20/20 with **zero genuine backward moves** — six rows initially showed `HARNESS_HANG`, which re-running on *both* builds at a workable time budget resolved to identical `final_pc` values with logs byte-identical apart from the build-id string.
- `make TEST_EXPORTS=1 test` exit 0. Notably `test_framebuffer_integrity` (6/6) and `test_tom_visible_window` (19/19) still pass — the whole-buffer fill *strengthens* the alpha invariant rather than weakening it.
- c89-lint clean; benchmark within noise (a one-time load-time fill has no steady-state cost).

## The AvP brown bar does NOT share this cause — separate ticket

Proven three ways: BGEN=1 with BG=`0x0000` (the line buffer *is* cleared, so it isn't a background bug); rows 236-239 are **byte-identical** at frames 1500/2200/2800 while the game animates (frozen stale content); and **byte-identical before and after** this change. Mechanism: `VDB=40` becomes the row origin while `VDE=2047` clamps `bottomVisible`, giving renderedRows 236 vs presentedH 240 → **4 unwritten tail rows**. The same model predicts 3 inert border rows for cyan and 4 unwritten tail rows for brown, each matching its measurement.

Deliberately not fixed here: both candidate fixes change in-game pixels for many titles, which would destroy the provable "every diff is cyan→black" property of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)