### PR TITLE
fix(m68k,tom): re-sample held TOM interrupt requests — Tempest 2000's 161-frame playfield collapse (#187)

### DIFF
--- a/src/jerry/jerry.c
+++ b/src/jerry/jerry.c
@@ -419,6 +419,16 @@ bool JERRYIRQEnabled(int irq)
 }
 
 
+/* True while JERRY is driving its interrupt output (DINT) at the TOM
+ * input, i.e. an enabled JERRY source has an uncleared pending latch.
+ * TOM gates this with INT1 bit 4 before it reaches the 68K -- see
+ * TOMIRQRequestActive(). */
+bool JERRYIRQRequestActive(void)
+{
+   return (jerryPendingInterrupt & jerryInterruptMask) ? true : false;
+}
+
+
 void JERRYSetPendingIRQ(int irq)
 {
    // This is the shadow of INT (it's a split RO/WO register)

--- a/src/jerry/jerry.h
+++ b/src/jerry/jerry.h
@@ -41,6 +41,7 @@ enum
 };
 
 bool JERRYIRQEnabled(int irq);
+bool JERRYIRQRequestActive(void);
 void JERRYSetPendingIRQ(int irq);
 
 // This should stay inside this file, but it's here for now...

--- a/src/m68000/m68kinterface.c
+++ b/src/m68000/m68kinterface.c
@@ -48,6 +48,11 @@ extern const struct cputbl op_smalltbl_5_ff[];	/* 68000 slow but compatible.  */
 // Externs, supplied by the user...
 //extern int irq_ack_handler(int);
 
+// TOM drives the 68K's only interrupt input (all Jaguar IRQs arrive as a
+// level-2 request through TOM).  Declared here rather than via tom.h to
+// keep the UAE core free of TOM's header dependencies.
+extern int TOMIRQRequestActive(void);
+
 // Function prototypes...
 static INLINE void m68ki_check_interrupts(void);
 void m68ki_exception_interrupt(uint32_t intLevel);
@@ -172,6 +177,25 @@ int m68k_execute(int num_cycles)
 		{
 			checkForIRQToHandle = 0;
 			m68k_set_irq2(IRQLevelToHandle);
+		}
+		else if (regs.intLevel > regs.intmask && TOMIRQRequestActive())
+		{
+			// The 68000 samples IPL0-2 at every instruction boundary, and
+			// on the Jaguar every interrupt reaches the 68K as a level-2
+			// request that TOM holds until the CPU's acknowledge cycle
+			// (irq_ack_handler drops it).  So a request raised while SR's
+			// mask is already >= 2 is not lost: it is taken as soon as an
+			// RTE lowers the mask.
+			//
+			// Sampling only at the instant of assertion (the branch above)
+			// dropped such requests permanently.  Tempest 2000 enables
+			// video + TOM PIT (INT1 = $09); the PIT beats against the frame
+			// rate and fires inside the PIT handler once every 161 frames,
+			// swallowing that frame's vertical interrupt -- the game then
+			// skips its object-list refresh and the OP replays an exhausted
+			// bitmap object, collapsing the playfield into a band at the top
+			// of the screen for exactly one frame (#187).
+			m68ki_exception_interrupt(regs.intLevel);
 		}
 
 #ifdef M68K_HOOK_FUNCTION

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -260,6 +260,7 @@
 #include "event.h"
 #include "gpu.h"
 #include "jaguar.h"
+#include "jerry.h"
 #include "log.h"
 #include "m68000/m68kinterface.h"
 #include "op.h"
@@ -543,6 +544,36 @@ static void TOMAssertEnabledIRQs(void)
 
    if (pending & tomRam8[INT1 + 1])
       m68k_set_irq(2);
+}
+
+
+/* True while TOM is still driving the 68K's level-2 request, i.e. an
+ * enabled INT1 source has an uncleared pending latch (JTRM: the pending
+ * bits are only cleared by writing 1 to the matching C_*CLR bit in the
+ * high byte of INT1).  JERRY reaches the 68K through TOM's bit 4, so its
+ * own latch counts when C_JERENA is set.
+ *
+ * m68k_execute() consults this before re-presenting a request that had to
+ * wait for the CPU's interrupt mask to drop (#187): a game that polls and
+ * clears INT1 itself -- Pitfall runs at mask 1-2 and does exactly that --
+ * must not be handed an interrupt whose source it already serviced. */
+static uint8_t TOMPendingMask(void)
+{
+   uint8_t pending = (uint8_t)((tom_timer_int_pending << IRQ_TIMER)
+      | (tom_object_int_pending << IRQ_OPFLAG)
+      | (tom_gpu_int_pending << IRQ_GPU)
+      | (tom_video_int_pending << IRQ_VIDEO));
+
+   if (tom_jerry_int_pending || JERRYIRQRequestActive())
+      pending |= (uint8_t)(1 << IRQ_DSP);
+
+   return pending;
+}
+
+
+int TOMIRQRequestActive(void)
+{
+   return (TOMPendingMask() & tomRam8[INT1 + 1]) ? 1 : 0;
 }
 
 static void TOMClearPendingIRQs(uint8_t clear)
@@ -1263,9 +1294,28 @@ void TOMWriteByte(uint32_t offset, uint8_t data, uint32_t who)
                  m68k_get_reg(NULL, M68K_REG_PC));
       tomPrevInt1Ena = data;
    }
+   if (offset == INT1 + 1)
+   {
+      /* TOM's 68K request line is raised by an interrupt *event* and
+       * dropped when the 68K acknowledges (see irq_ack_handler); a write
+       * to INT1 does not re-present a request the CPU already took.  The
+       * one case a register write does create a request is a source that
+       * is pending and becomes *newly* enabled.
+       *
+       * Re-asserting on every INT1 write is what made NBA Jam TE storm
+       * once requests survived the CPU's interrupt mask (see #187): its
+       * level-2 handler leaves the TOM PIT pending bit latched and
+       * rewrites INT1 = $0009 on each entry, so an unconditional
+       * re-assert re-entered the handler forever. */
+      uint8_t newlyEnabled = (uint8_t)(data & ~tomRam8[INT1 + 1]);
+
+      tomRam8[offset] = data;
+
+      if (newlyEnabled & TOMPendingMask())
+         m68k_set_irq(2);
+      return;
+   }
    tomRam8[offset] = data;
-   if (offset == INT1 || offset == (INT1 + 1))
-      TOMAssertEnabledIRQs();
 }
 
 // TOM word access (write)

--- a/test/test_hle_bios.c
+++ b/test/test_hle_bios.c
@@ -104,6 +104,7 @@ static void (*p_TOMWriteByte)(uint32_t, uint8_t, uint32_t);
 static void (*p_TOMWriteWord)(uint32_t, uint16_t, uint32_t);
 static void (*p_TOMSetPendingVideoInt)(void);
 static void (*p_TOMSetPendingTimerInt)(void);
+static int  (*p_TOMIRQRequestActive)(void);
 static void (*p_JERRYWriteWord)(uint32_t, uint16_t, uint32_t);
 static void (*p_JERRYWriteByte)(uint32_t, uint8_t, uint32_t);
 static bool (*p_JERRYIRQEnabled)(int);
@@ -2523,20 +2524,36 @@ static void test_tom_ipl2_reassert_after_selective_clear(void)
          FAIL("INT1 pending=$%04X pre-clear (want video+timer bits)", pending);
    }
 
-   /* (3) Clear video pending only via byte write to $F000E0 = $01. The
-    * write triggers TOMAssertEnabledIRQs; timer is still pending+enabled,
-    * so IPL2 must be reasserted. */
+   /* (3) Clear video pending only via byte write to $F000E0 = $01. An
+    * INT1 register write is not an interrupt event, so it must NOT raise
+    * IPL2 on its own -- but TOM's request is still active, because the
+    * timer latch is set and enabled.
+    *
+    * This used to assert intLevel==2 here (TOMAssertEnabledIRQs ran on
+    * every INT1 write).  That is incompatible with holding a request
+    * across the CPU's interrupt mask (#187): NBA Jam TE's level-2 handler
+    * leaves the PIT latch set and rewrites INT1 on each entry, so an
+    * unconditional re-assert re-entered the handler forever.  The request
+    * line is raised by an *event* and dropped on the CPU's acknowledge;
+    * TOMIRQRequestActive() reports whether it is still up. */
    p_regs->intLevel = 0;
    p_TOMWriteByte(0xF000E0, 0x01, WHO_M68K);
-   if (p_regs->intLevel == 2)
-      PASS("clearing video alone keeps IPL2 asserted (timer still pending)");
+   if (p_regs->intLevel == 0)
+      PASS("clearing video does not re-raise IPL2 (register write, not event)");
    else
-      FAIL("after clearing video, intLevel=%d (want 2; timer still pending)",
+      FAIL("after clearing video, intLevel=%d (want 0; write is not an event)",
            p_regs->intLevel);
 
-   /* (4) Clear timer pending via byte write to $F000E0 = $08. Now
-    * nothing is pending+enabled, so TOMAssertEnabledIRQs must NOT call
-    * m68k_set_irq -- intLevel must stay 0. */
+   if (!p_TOMIRQRequestActive)
+      FAIL("TOMIRQRequestActive not exported");
+   else if (p_TOMIRQRequestActive())
+      PASS("TOM still reports its request active (timer pending+enabled)");
+   else
+      FAIL("TOMIRQRequestActive()=0 with timer pending+enabled");
+
+   /* (4) Clear timer pending via byte write to $F000E0 = $08. Now nothing
+    * is pending+enabled: TOM's request must read as inactive so a held
+    * request is not re-presented to the CPU. */
    p_regs->intLevel = 0;
    p_TOMWriteByte(0xF000E0, 0x08, WHO_M68K);
    if (p_regs->intLevel == 0)
@@ -2544,6 +2561,34 @@ static void test_tom_ipl2_reassert_after_selective_clear(void)
    else
       FAIL("after clearing timer (last source), intLevel=%d (want 0)",
            p_regs->intLevel);
+
+   if (p_TOMIRQRequestActive && !p_TOMIRQRequestActive())
+      PASS("TOM reports no active request after all sources cleared");
+   else if (p_TOMIRQRequestActive)
+      FAIL("TOMIRQRequestActive()=1 with nothing pending");
+
+   /* (4b) A source that is already pending and becomes *newly* enabled is
+    * a new request to the 68K, so that write does raise IPL2. */
+   p_TOMWriteByte(0xF000E1, 0x01, WHO_M68K);   /* video only */
+   p_TOMSetPendingTimerInt();                  /* latch, not enabled */
+   p_regs->intLevel = 0;
+   p_TOMWriteByte(0xF000E1, 0x09, WHO_M68K);   /* newly enable timer */
+   if (p_regs->intLevel == 2)
+      PASS("newly enabling an already-pending source raises IPL2");
+   else
+      FAIL("after enabling pending timer, intLevel=%d (want 2)",
+           p_regs->intLevel);
+
+   /* Rewriting the same enables with the source still pending must not
+    * present the request again (the NBA Jam TE storm shape). */
+   p_regs->intLevel = 0;
+   p_TOMWriteByte(0xF000E1, 0x09, WHO_M68K);
+   if (p_regs->intLevel == 0)
+      PASS("redundant INT1 enable write does not re-raise IPL2");
+   else
+      FAIL("redundant INT1 write raised IPL2 (intLevel=%d)", p_regs->intLevel);
+
+   p_TOMWriteByte(0xF000E0, 0x1F, WHO_M68K);   /* clear all pending again */
 
    /* (5) Sanity post-clear: INT1 reports no pending sources. */
    {
@@ -3091,6 +3136,7 @@ int main(int argc, char *argv[])
    LOAD(TOMWriteWord);
    LOAD(TOMSetPendingVideoInt);
    LOAD(TOMSetPendingTimerInt);
+   p_TOMIRQRequestActive = (int (*)(void))dlsym(core_handle, "TOMIRQRequestActive");
    LOAD(GPUReadLong);
    LOAD(GPUWriteLong);
    LOAD(GPUSetIRQLine);


### PR DESCRIPTION
Tempest 2000's playfield collapses into a ~40 px band at the top of the screen for exactly **one frame, every 161 frames** (~2.68 s), then recovers. Independent of blitter mode; real-BIOS mode only shifts the phase.

## The 161-frame arithmetic — it's a beat, not a wrap

T2K enables video + the TOM PIT (`INT1 = $09`) with prescaler `$656` / divider `$3F`. Per the JTRM formula `sysclk/((PIT0+1)(PIT1+1))`:

- PIT period = 1623 × 64 = 103,872 sysclk / 26.590906 MHz = **3906.3 µs**
- Frame = 524 halflines × 31.7778 µs = **16,651.6 µs**
- **161 frames = 2,680,900 µs vs 134 PIT periods = 2,680,917 µs — 16 µs apart (~½ halfline)**

161 and 134 are coprime, so 161 frames is the *first* re-alignment. In that window the PIT fires in the ~1-halfline gap before the vertical interrupt at `VI = 507`, the 68K is still inside the PIT handler at interrupt mask 2 — and **that frame's VBlank was dropped forever**.

## The defect

TOM *held* the request (`tom_video_int_pending` was still 1 a frame later), but the emulator only offered an interrupt at the moment it was raised. Logged evidence: object-list refresh writes to `$00EB50` = **0 on the pre-glitch frame vs 3 normally**, and `TOMSetPendingVideoInt` logged `SR=$2200` with PC inside the PIT handler.

With no VBlank refresh the OP replays the previous frame's already-exhausted object (HEIGHT 47 of 279, DATA advanced 232 lines) → it draws 47 halflines from YPOS 44 and stops. That is the band.

## The fix (three parts)

1. `m68k_execute` re-samples a held request at instruction boundaries — a real 68000 samples IPL every instruction, and TOM holds INT1 pending until the ISR clears it.
2. INT1 register writes no longer re-assert; only a source **newly enabled while pending** does. Without this, NBA Jam TE storms at 1108 IRQs/frame (its handler leaves the PIT latch set and rewrites `INT1=$0009`).
3. `TOMIRQRequestActive()` validates a held request at delivery. Without it, Pitfall (which polls and clears INT1 at mask 1-2) receives an already-serviced interrupt and crashes into the `$000404` exception stub.

Test 10j in `test_hle_bios.c` characterised the old unconditional re-assert, which is incompatible with holding requests; it now asserts both directions.

## Gates

1. **Glitch gone.** 4200 frames × {fast, accurate} × {HLE, BIOS}: base **19 anomalies with band collapses** at frames 775/936/1097/2379/2540/2701 (Δ161) → **7 anomalies, zero collapses**; the remaining 7 are all-black attract transitions present in base too. BIOS mode shifts phase by a constant +491 frames, matching the beat model's retrodiction.
2. **Plays correctly** — screenshots read at frames 500 (high-score table), 1500 (credits), 2400/2860 (web playfield with correct fold geometry, claw, enemies, HUD), 3400 (warp).
3. **40-title A/B: 37/40 bit-identical.** Differing: T2K (the fix); **NBA Jam TE is an improvement** — 3/1800 frames differ, all with *more* content (frame 1417 renders the title logo intact where base replaced its left third with noise, i.e. the documented "occasional screen jumping"); White Men Can't Jump is a benign 1-frame attract timing shift, both rendering identically well.
4. **CD titles — gap now closed.** Battle Morph, Iron Soldier 2, Myst and Primal Rage all clean in **both** boot modes (1800 frames, wedge probe). This was the highest-risk surface, since BUTCH's CD interrupt reaches the 68K through exactly the INT1 path this changes.
5. `make TEST_EXPORTS=1 test` exit 0; audio triple at documented baselines (Skyhammer 3079.8, IS2 2599.3, IS1 presence 1175.7); c89-lint clean; benchmark within noise.

Note: gate 4 was originally blocked because the private ROM tree was deleted mid-run by a concurrent session; it has been restored and the gate run since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)