### PR TITLE
fix: untrack the self-referential test/roms/private symlink (data-loss hazard)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,13 @@ test/*.log
 # Test ROMs (keep source scripts, ignore binaries)
 test/roms/*.jag
 test/roms/*.rom
+# The private ROM/disc tree. Both forms are ignored deliberately: the data
+# lives OUTSIDE every checkout and this path is a symlink to it, so neither
+# the directory nor the link may ever be tracked. A tracked symlink here was
+# self-referential and let a forced checkout replace the real directory,
+# destroying the collection once already (2026-07-30).
 test/roms/private/
+test/roms/private
 
 # Reference docs (large PDFs, not source)
 docs/atari-jaguar-1999/

--- a/test/roms/private
+++ b/test/roms/private
@@ -1,1 +1,0 @@
-/Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro/test/roms/private


### PR DESCRIPTION
**This is a live data-loss hazard on `develop` right now.** `test/roms/private` is tracked as a **symlink whose target is its own absolute path**:

```
$ git ls-files -s test/roms/private
120000 34d2aa4 0  test/roms/private
$ git show develop:test/roms/private
/Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro/test/roms/private
```

Any forced checkout, stash, or worktree operation that materialises that link must first remove whatever occupies the path. On a machine where the private ROM/disc tree lives there, **git replaces the collection with a link to itself.** That happened on 2026-07-30 — a 5.4 GB set of commercial discs and carts, with no Time Machine local snapshots and an empty Trash. It was rebuilt from other copies; the save-state directory was not recoverable.

It entered via a `git add -A` in f8a1543 that swept up a symlink an agent had created inside its own worktree. My mistake, and worth fixing loudly rather than quietly.

The fix:
- `git rm --cached test/roms/private` — untrack the link. Nothing in the build or test system wants it tracked; the path is meant to be created locally.
- `.gitignore` now ignores **both** forms — `test/roms/private/` (the directory, already ignored) **and** the bare `test/roms/private` (a link at that path, which was not) — with a comment recording why, so the same shape can't be committed again.

Worth noting the misleading evidence trail, since it cost real debugging time: an agent that had run `rm -f test/roms/private` looked like the culprit, and three sibling worktrees held dangling links to the same path. Both were downstream symptoms. The trigger was in the repository itself, which is exactly why it could strike any checkout rather than just the session that appeared to touch it.

The companion CLAUDE.md guidance (keep the tree outside every checkout, never `git clean -xfd` at the root, `find` needs `-L` to cross the link) is in #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)