### PR TITLE
fix(gpu): sync the GPU to the 68000 on writes into GPU local RAM (Pitfall crash, #138)

### DIFF
--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -430,6 +430,25 @@ unsigned int m68k_read_memory_32(unsigned int address)
 }
 
 
+/* A 68000 write into GPU local RAM is a handshake with a concurrently running
+ * coprocessor, so let the GPU catch up to where the 68000 already is inside
+ * this scheduler slice before the 68000 goes any further.  Full explanation on
+ * gpuSliceBudget in gpu.c (issue #138).
+ *
+ * m68kInLongWrite suppresses the sync for the two halves of a 68000 long
+ * write, which reaches TOM as two word writes: the GPU must never observe a
+ * half-written longword (Pitfall's mailbox poll loop read $00F00000 and jumped
+ * into the TOM register file). */
+static int m68kInLongWrite = 0;
+
+static void M68KGPURAMSync(unsigned int address)
+{
+   if (m68kInLongWrite)
+      return;
+   if (address >= GPU_WORK_RAM_BASE && address < GPU_WORK_RAM_BASE + 0x1000)
+      GPUSyncToM68K();
+}
+
 void m68k_write_memory_8(unsigned int address, unsigned int value)
 {
 #ifdef ALPINE_FUNCTIONS
@@ -452,6 +471,8 @@ void m68k_write_memory_8(unsigned int address, unsigned int value)
       JERRYWriteByte(address, value, M68K);
    else
       jaguar_unknown_writebyte(address, value, M68K);
+
+   M68KGPURAMSync(address);
 }
 
 
@@ -487,6 +508,8 @@ void m68k_write_memory_16(unsigned int address, unsigned int value)
    {
       jaguar_unknown_writeword(address, value, M68K);
    }
+
+   M68KGPURAMSync(address);
 }
 
 
@@ -506,8 +529,12 @@ void m68k_write_memory_32(unsigned int address, unsigned int value)
       SET32(jaguarMainRAM, address, value);
       return;
    }
+   m68kInLongWrite++;
    m68k_write_memory_16(address, value >> 16);
    m68k_write_memory_16(address + 2, value & 0xFFFF);
+   m68kInLongWrite--;
+
+   M68KGPURAMSync(address);
 }
 
 /* Disassemble M68K instructions at the given offset */
@@ -1023,22 +1050,31 @@ void JaguarExecuteNew(void)
       double timeToMainEvent = GetTimeToNextEvent(EVENT_MAIN);
       double timeToJerryEvent = GetTimeToNextEvent(EVENT_JERRY);
       double timeDelta;
+      uint32_t riscCycles;
 
+      /* GPUBeginSlice/GPUSliceRemaining: part of the GPU's slice may already
+       * have been run from GPUSyncToM68K(), so the end-of-slice call runs only
+       * what is left.  The total per slice is unchanged -- see the comment on
+       * gpuSliceBudget in gpu.c. */
       if (timeToJerryEvent < timeToMainEvent)
       {
          timeDelta = timeToJerryEvent;
+         riscCycles = USEC_TO_RISC_CYCLES(timeDelta);
+         GPUBeginSlice(riscCycles);
          m68k_execute(USEC_TO_M68K_CYCLES(timeDelta));
-         GPUExec(USEC_TO_RISC_CYCLES(timeDelta));
-         DSPExec(USEC_TO_RISC_CYCLES(timeDelta));
+         GPUExec(GPUSliceRemaining());
+         DSPExec(riscCycles);
          SubtractEventTimes(timeDelta, EVENT_MAIN);
          HandleNextEvent(EVENT_JERRY);
       }
       else
       {
          timeDelta = timeToMainEvent;
+         riscCycles = USEC_TO_RISC_CYCLES(timeDelta);
+         GPUBeginSlice(riscCycles);
          m68k_execute(USEC_TO_M68K_CYCLES(timeDelta));
-         GPUExec(USEC_TO_RISC_CYCLES(timeDelta));
-         DSPExec(USEC_TO_RISC_CYCLES(timeDelta));
+         GPUExec(GPUSliceRemaining());
+         DSPExec(riscCycles);
          SubtractEventTimes(timeDelta, EVENT_JERRY);
          HandleNextEvent(EVENT_MAIN);
       }

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -441,11 +441,17 @@ unsigned int m68k_read_memory_32(unsigned int address)
  * into the TOM register file). */
 static int m68kInLongWrite = 0;
 
-static void M68KGPURAMSync(unsigned int address)
+/* length is the width of the access in bytes.  Testing the whole written
+ * span rather than just its base address matters at the bottom edge of the
+ * region: a long write starting at GPU_WORK_RAM_BASE - 2 puts its second
+ * word inside GPU local RAM, and a base-address test would miss it and leave
+ * the GPU un-synced for exactly the write that needs it. */
+static void M68KGPURAMSync(unsigned int address, unsigned int length)
 {
    if (m68kInLongWrite)
       return;
-   if (address >= GPU_WORK_RAM_BASE && address < GPU_WORK_RAM_BASE + 0x1000)
+   if (address < GPU_WORK_RAM_BASE + 0x1000
+       && address + length > GPU_WORK_RAM_BASE)
       GPUSyncToM68K();
 }
 
@@ -472,7 +478,7 @@ void m68k_write_memory_8(unsigned int address, unsigned int value)
    else
       jaguar_unknown_writebyte(address, value, M68K);
 
-   M68KGPURAMSync(address);
+   M68KGPURAMSync(address, 1);
 }
 
 
@@ -509,7 +515,7 @@ void m68k_write_memory_16(unsigned int address, unsigned int value)
       jaguar_unknown_writeword(address, value, M68K);
    }
 
-   M68KGPURAMSync(address);
+   M68KGPURAMSync(address, 2);
 }
 
 
@@ -534,7 +540,7 @@ void m68k_write_memory_32(unsigned int address, unsigned int value)
    m68k_write_memory_16(address + 2, value & 0xFFFF);
    m68kInLongWrite--;
 
-   M68KGPURAMSync(address);
+   M68KGPURAMSync(address, 4);
 }
 
 /* Disassemble M68K instructions at the given offset */

--- a/src/m68000/m68kinterface.c
+++ b/src/m68000/m68kinterface.c
@@ -366,7 +366,14 @@ unsigned int m68k_is_valid_instruction(unsigned int instruction, unsigned int cp
 /* 68000 cycles executed so far inside the current m68k_execute() call.  Used
  * by GPUSyncToM68K() to work out how far the GPU has to be advanced when the
  * 68000 writes into GPU local RAM mid-slice (see gpu.c).  Valid only while
- * m68k_execute() is on the stack; callers outside it clamp the result. */
+ * m68k_execute() is on the stack; callers outside it clamp the result.
+ *
+ * NOT monotonic, and not always spent-cycles: m68k_end_timeslice() moves
+ * regs.remainingCycles into initialCycles and zeroes the former, so every
+ * call after an early timeslice end reports the UNSPENT count instead.
+ * GPUSyncToM68K() survives that because it clamps upward to the slice budget
+ * and returns early when the delta is <= 0 -- a caller that needs a true
+ * spent-cycle count must not use this without its own bound. */
 int m68k_cycles_run(void) { return initialCycles - regs.remainingCycles; }
 int m68k_cycles_remaining(void) { return 0; }        /* Number of cycles left */
 

--- a/src/m68000/m68kinterface.c
+++ b/src/m68000/m68kinterface.c
@@ -363,7 +363,11 @@ unsigned int m68k_is_valid_instruction(unsigned int instruction, unsigned int cp
 
 // Dummy functions, for now, until we prove the concept here. :-)
 
-int m68k_cycles_run(void) { return 0; }              /* Number of cycles run so far */
+/* 68000 cycles executed so far inside the current m68k_execute() call.  Used
+ * by GPUSyncToM68K() to work out how far the GPU has to be advanced when the
+ * 68000 writes into GPU local RAM mid-slice (see gpu.c).  Valid only while
+ * m68k_execute() is on the stack; callers outside it clamp the result. */
+int m68k_cycles_run(void) { return initialCycles - regs.remainingCycles; }
 int m68k_cycles_remaining(void) { return 0; }        /* Number of cycles left */
 
 void m68k_modify_timeslice(int cycles)

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -226,6 +226,41 @@ static uint32_t gpu_ds_branch_target;
 static uint8_t  gpu_in_delay_slot;
 static uint8_t  gpu_ds_irq_dispatched;
 
+/* 68K -> GPU-local-RAM communication sync.
+ *
+ * JaguarExecuteNew() runs the 68000 for a whole scheduler slice and only then
+ * gives the GPU the matching number of RISC cycles, so the 68000 can advance
+ * a couple of hundred cycles -- easily a whole interrupt entry -- before the
+ * GPU observes anything the 68000 wrote.  On silicon the two run
+ * concurrently: the GPU is clocked at the full system clock and the 68000 at
+ * system_clock/2 (JTRM clock hierarchy: 26.590906 MHz vs 13.295453 MHz NTSC,
+ * exactly 2:1), and the 68000 is the *lowest* priority bus master (JTRM bus
+ * priority table: CPU is 11 of 11, below GPU normal at 9), so a GPU spinning
+ * on a location in its own local RAM samples a 68000 write within a handful
+ * of RISC cycles.
+ *
+ * Pitfall: The Mayan Adventure depends on that.  Its GPU parks in a 3-word
+ * poll loop on a mailbox at $F03E30, and the 68000 feeds it a parameter block
+ * at $F03E00 followed by the routine address in the mailbox.  With the
+ * coarse-grained interleaving the 68000 got as far as taking an interrupt and
+ * rewriting a parameter before the GPU sampled the mailbox, so the object
+ * list builder ran with the *next* caller's element count (800 instead of
+ * 213) and wrote 587 longwords of colour data past the end of its buffer,
+ * over the game's own data at $43FBC-$448E8 (issue #138: it corrupts the
+ * palette-fade parameter block, whose GPU ISR then loops for ~65000
+ * iterations, never reaches its epilogue, and leaks 4 bytes of GPU stack per
+ * interrupt until r31 walks out of local RAM; it also leaves the odd pointer
+ * that makes the 68000 take the address error fixed in 3ba2f56).
+ *
+ * GPUSyncToM68K() closes the gap without changing anybody's cycle budget: at
+ * a 68000 write into GPU local RAM the GPU is advanced to the position the
+ * 68000 has already reached inside the current slice (68K cycles run x 2),
+ * clamped to the slice budget, and the scheduler's end-of-slice call then
+ * runs only the remainder.  Total RISC cycles per slice are unchanged; only
+ * *when* within the slice they are spent moves. */
+static int32_t gpuSliceBudget;
+static int32_t gpuSliceSpent;
+
 #define GPU_RUNNING	(gpu_control & 0x01)
 
 #define RM		gpu_reg[gpu_opcode_first_parameter]
@@ -817,6 +852,12 @@ void GPUReset(void)
    gpu_in_delay_slot     = 0;
    gpu_ds_irq_dispatched = 0;
 
+   /* Scheduler-slice sync state.  Like the delay-slot hazard flags above this
+    * is transient inside one JaguarExecuteNew() slice and is never live at a
+    * savestate boundary, so it is deliberately not serialized. */
+   gpuSliceBudget        = 0;
+   gpuSliceSpent         = 0;
+
    gpu_reg = gpu_reg_bank_0;
    gpu_alternate_reg = gpu_reg_bank_1;
 
@@ -867,6 +908,55 @@ void GPUDumpState(const char *tag)
 {
    LOG_INF("[GPU %s] PC=%08X ctrl=%08X flags=%08X running=%d\n",
       tag ? tag : "", gpu_pc, gpu_control, gpu_flags, GPU_RUNNING ? 1 : 0);
+}
+
+/* Called by JaguarExecuteNew() before the 68000 runs, with the RISC cycle
+ * count the GPU will be given for this slice.  See the comment on
+ * gpuSliceBudget. */
+void GPUBeginSlice(uint32_t riscCycles)
+{
+   gpuSliceBudget = (int32_t)riscCycles;
+   gpuSliceSpent  = 0;
+}
+
+/* RISC cycles of the current slice that the scheduler still owes the GPU. */
+int32_t GPUSliceRemaining(void)
+{
+   int32_t left = gpuSliceBudget - gpuSliceSpent;
+   return (left > 0 ? left : 0);
+}
+
+/* Advance the GPU to the 68000's position inside the current slice.  Called
+ * once per completed 68000 write access into GPU local RAM (see
+ * m68k_write_memory_* in jaguar.c).
+ *
+ * It has to be the *whole* 68000 access, not each bus half: a 68000 MOVE.L
+ * reaches TOM as two word writes, and running the GPU between them let it
+ * sample a half-written mailbox -- Pitfall's poll loop read $00F00000 and
+ * jumped into the TOM register file during boot.  Our 68000 core executes an
+ * instruction atomically, so the closest available approximation to real
+ * concurrency is to advance the GPU only once the access is complete. */
+void GPUSyncToM68K(void)
+{
+   int32_t target, run;
+
+   /* A halted or single-step-paused GPU is not executing; nothing to sync.
+    * gpu_in_exec guards against re-entering the exec loop (the OP runs the
+    * GPU inline from inside a halfline callback -- see op.c). */
+   if (!GPU_RUNNING || (gpu_control & 0x08) || gpu_in_exec)
+      return;
+
+   /* GPU is clocked at twice the 68000 (JTRM clock hierarchy). */
+   target = (int32_t)m68k_cycles_run() * 2;
+   if (target > gpuSliceBudget)
+      target = gpuSliceBudget;
+
+   run = target - gpuSliceSpent;
+   if (run <= 0)
+      return;
+
+   gpuSliceSpent += run;
+   GPUExec(run);
 }
 
 // Main GPU execution core

--- a/src/tom/gpu.h
+++ b/src/tom/gpu.h
@@ -18,6 +18,14 @@ void GPUInit(void);
 void GPUDone(void);
 void GPUReset(void);
 void GPUExec(int32_t);
+/* Slice bookkeeping for the 68K->GPU-local-RAM sync; see the comment on
+ * gpuSliceBudget in gpu.c.  GPUBeginSlice() declares the RISC cycles the
+ * scheduler will hand the GPU for this slice, GPUSliceRemaining() reports
+ * what is left after any mid-slice syncs, and GPUSyncToM68K() advances the
+ * GPU to the 68000's position when the two processors communicate. */
+void GPUBeginSlice(uint32_t riscCycles);
+int32_t GPUSliceRemaining(void);
+void GPUSyncToM68K(void);
 void GPUUpdateRegisterBanks(void);
 void GPUHandleIRQs(void);
 void GPUSetIRQLine(int irqline, int state);


### PR DESCRIPTION
Closes the third and final defect behind #138. Pitfall: The Mayan Adventure went permanently black ~16 s into level 1 and stayed frozen; with the two earlier fixes (#212) in place, the remaining failure was `gpu_pc_escape frame=5615`.

## Not a GPU interrupt bug — a scheduling-order bug

The task premise (a leaking GPU ISR stack pointer) turned out to be three layers downstream. Measurements that killed the obvious hypotheses:

- **Dispatch rate**: `disp == irq0` at every sample, so nothing re-dispatches — the latch is being cleared correctly.
- **Nesting**: the ISR clears IMASK at `$F03022` (unmask + clear the int0 latch), which per `docs/jtrm-gpu-dsp.md` is exactly what silicon permits — so the nesting we perform is legitimate.
- Push/pop stayed balanced for **5407 frames** (320 executions each of the ISR entry and its epilogue). The 1-per-frame dispatch rate after that is the *consequence*, not the cause.

**What actually happens:** from frame 5408 the epilogue count drops to zero while the ISR body's palette-fade loop runs **73,422 times in five frames**. Its iteration count comes from `LOADW ($00044036)`, and that word had been overwritten with `$FE7C` (65,148) — so one invocation can no longer finish inside a frame. Every subsequent int0 nests, pushes 4 more bytes, never returns, and `r31` walks 4 KB down GPU local RAM until it overwrites the GPU's own code at `$F03CBC`.

The corruption is the GPU's own object-list builder, driven through a mailbox the 68000 writes. Traced ordering on frame 5407:

```
68kpc $031FF4  p5 $F03E14 = $00043C68
68kpc $031FFE  mailbox    = $00F03080      (kick)
68kpc $004A02  p3 $F03E0C = $0000031F      (interrupt clobbers the count)
GPU            enters $F03080 with p3 = $0000031F
```

Store-pass table: pass 0 writes 213 stores over `$43C68-$43FB8` (correct); **pass 1 writes 800**, flooding `$043FBC-$0448E8` — which is where the fade parameter block lives, and where the odd pointer behind the address error fixed in #212 also lived.

## Why the old ordering is wrong per hardware

`docs/jtrm-clocks-timing.md`: the GPU runs at the full system clock (26.590906 MHz) and the 68000 at half — **exactly 2:1** — and the bus-priority table puts the **CPU last of 11**, below GPU normal. A GPU spinning on its own local RAM cannot lag the CPU by ~200 cycles. `JaguarExecuteNew()` ran `m68k_execute(whole slice)` and only then `GPUExec(whole slice)`, so it did.

## The fix

`GPUSyncToM68K()` advances the GPU to the 68000's position inside the current slice (`m68k_cycles_run() * 2`, clamped to the slice budget) on a 68000 write into GPU local RAM. `GPUBeginSlice()`/`GPUSliceRemaining()` make the end-of-slice call run only the remainder, so **total RISC cycles per slice are unchanged** — only *when* they are spent moves. `m68k_cycles_run()` was a stub returning 0 with no callers; it is now real.

Two failed attempts worth recording: an unclamped `GPUExec(64)` per write let the GPU run ~30x its budget and broke boot at frame 75 (**the clamp is the fix, not an optimisation**); and hooking `GPUWriteWord` fired *between* the two word writes a `MOVE.L` decomposes into, so the guest's poll loop read a partial pointer and jumped into the TOM register file. The hook therefore sits at the 68000 access boundary with in-long-write suppression.

## Gates

1. **Pitfall: 10,800 frames (3x the old crash window), both blitter modes — clean.** Alive at the end, not merely un-crashed: **89.5% non-black, 25.97% frame-to-frame motion**, RMS 808, and the frame-10800 screenshot shows real gameplay (score 000580, 27 items, 3 lives, Harry on a jungle ledge). Control: stock gives `gpu_pc_escape frame=5615` on the same command.
2. **40-title A/B: 33/40 bit-identical**, and the trigger table explains the rest — 19 titles run the sync yet only 7 diverge (the title with the most sync runs, 10,332, is bit-identical). Four of the seven are **video bit-identical** with audio counts moving ≤0.0075%. The three with real video changes were behaviour-validated instead: Power Drive Rally and jagniccc are **pixel-identical** at frame 2400; Doom differs only in attract-demo phase (same scene, same HUD — AMMO 28 / HEALTH 100% / AREA 6 — a few frames further along). Many titles have thousands of *calls* and zero *runs* because their GPU is halted while the 68000 writes (Theme Park 202831/0, Tempest 2000 66511/0, Super Burnout 1183/0).
3. **CD titles — gap closed since the original run.** `cd_wedge_probe` at 3000 frames: **BrainDead 13 clean in both boot modes** — this was the specific open question, since BD13 is the title whose lost-wakeup bug motivated the event-scheduled CPUINT delivery this touches. Battle Morph, Iron Soldier 2, Myst and Primal Rage signature sets byte-identical to stock. Hover Strike HLE wedges at frame 2025 — **identically on stock develop**, byte-for-byte the same signature, so pre-existing and untouched.
4. `make TEST_EXPORTS=1 test` exit 0; audio triple at documented baselines (Skyhammer 3079.8, IS2 2599.3, IS1 presence 1175.7); c89-lint clean on all three touched files; benchmark within noise.

**Reviewer note:** after `m68k_end_timeslice()`, `m68k_cycles_run()` returns the *unspent* count, so the clamp hands the GPU its whole remaining slice — harmless, since the 68000 has already stopped for that slice. The DSP still runs end-of-slice unchanged (deliberately out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)