### PR TITLE
fix(blitter): read channel 0, not channel 2, from the data registers in pixel mode (#186)

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -291,23 +291,50 @@ PERF_COUNTER(blitter_phrase_writes);
 // z data write
 #define WRITE_ZDATA(a,f,d) WRITE_ZDATA_16(a,d);
 
+/* Register-sourced pixel data (SRCDATA / DSTDATA / DSTZ / SRCZINT /
+ * PATTERNDATA).  These are 64-bit registers; `p` selects phrase mode.
+ *
+ * PHRASE mode picks the field addressed by the current X position within
+ * the phrase, exactly as the hardware does.
+ *
+ * PIXEL (non-phrase) mode uses one fixed field: the one holding pixel /
+ * Gouraud channel 0.  In the layout this core keeps `blitter_ram` in,
+ * that channel lives in the LOW longword -- see `blitter_mmio.c`, which
+ * maps the Intensity 0 alias ($F0227C, "an alternate view of the
+ * computed intensity integer parts (pattern data)", JTRM rev 8 p.77) to
+ * `PATTERNDATA + 7`, and `blitter_blit`'s Gouraud init, which reads
+ * `gd_c[0]`/`gd_i[0]` from `PATTERNDATA + 6/7`.  The four pattern fields
+ * are the four consecutive pixels of a phrase (JTRM rev 8 p.82, the
+ * Gouraud/Z worked example: Pattern = 00DC00C700B1009C for four
+ * successive pixels), so channel 0 is the field the accurate
+ * (Midsummer2) path also uses in pixel mode -- there, ADDRGEN folds the
+ * byte-within-phrase into the address and the write takes `wdata`'s low
+ * 16/8/32 bits, i.e. the same low-longword field.
+ *
+ * These macros used to read `REG(r)` -- the HIGH longword, i.e. channel
+ * 2 -- for pixel mode, so a program that only ever wrote the low
+ * longword of a 64-bit register (Iron Soldier's wireframe line blits
+ * write $F02268 alone) got zero as its write data and drew nothing.
+ * Reading `REG(r + 4)` puts the fast path on the same field as the
+ * accurate path. */
+
 // 1 bpp r data read
-#define READ_RDATA_1(r,a,p)  ((p) ?  ((REG(r+(((uint32_t)a##_x >> 19) & 0x04))) >> (((uint32_t)a##_x >> 16) & 0x1F)) & 0x0001 : (REG(r) & 0x0001))
+#define READ_RDATA_1(r,a,p)  ((p) ?  ((REG(r+(((uint32_t)a##_x >> 19) & 0x04))) >> (((uint32_t)a##_x >> 16) & 0x1F)) & 0x0001 : (REG((r)+4) & 0x0001))
 
 // 2 bpp r data read
-#define READ_RDATA_2(r,a,p)  ((p) ?  ((REG(r+(((uint32_t)a##_x >> 18) & 0x04))) >> (((uint32_t)a##_x >> 15) & 0x3E)) & 0x0003 : (REG(r) & 0x0003))
+#define READ_RDATA_2(r,a,p)  ((p) ?  ((REG(r+(((uint32_t)a##_x >> 18) & 0x04))) >> (((uint32_t)a##_x >> 15) & 0x3E)) & 0x0003 : (REG((r)+4) & 0x0003))
 
 // 4 bpp r data read
-#define READ_RDATA_4(r,a,p)  ((p) ?  ((REG(r+(((uint32_t)a##_x >> 17) & 0x04))) >> (((uint32_t)a##_x >> 14) & 0x28)) & 0x000F : (REG(r) & 0x000F))
+#define READ_RDATA_4(r,a,p)  ((p) ?  ((REG(r+(((uint32_t)a##_x >> 17) & 0x04))) >> (((uint32_t)a##_x >> 14) & 0x28)) & 0x000F : (REG((r)+4) & 0x000F))
 
 // 8 bpp r data read
-#define READ_RDATA_8(r,a,p)  ((p) ?  ((REG(r+(((uint32_t)a##_x >> 16) & 0x04))) >> (((uint32_t)a##_x >> 13) & 0x18)) & 0x00FF : (REG(r) & 0x00FF))
+#define READ_RDATA_8(r,a,p)  ((p) ?  ((REG(r+(((uint32_t)a##_x >> 16) & 0x04))) >> (((uint32_t)a##_x >> 13) & 0x18)) & 0x00FF : (REG((r)+4) & 0x00FF))
 
 // 16 bpp r data read
-#define READ_RDATA_16(r,a,p)  ((p) ? ((REG(r+(((uint32_t)a##_x >> 15) & 0x04))) >> (((uint32_t)a##_x >> 12) & 0x10)) & 0xFFFF : (REG(r) & 0xFFFF))
+#define READ_RDATA_16(r,a,p)  ((p) ? ((REG(r+(((uint32_t)a##_x >> 15) & 0x04))) >> (((uint32_t)a##_x >> 12) & 0x10)) & 0xFFFF : (REG((r)+4) & 0xFFFF))
 
 // 32 bpp r data read
-#define READ_RDATA_32(r,a,p)  ((p) ? REG(r+(((uint32_t)a##_x >> 14) & 0x04)) : REG(r))
+#define READ_RDATA_32(r,a,p)  ((p) ? REG(r+(((uint32_t)a##_x >> 14) & 0x04)) : REG((r)+4))
 
 // register data read
 #define READ_RDATA(r,a,f,p) (\

--- a/src/tom/blitter_compare.c
+++ b/src/tom/blitter_compare.c
@@ -79,9 +79,13 @@ static void blit_cmp_verbose_dump(uint32_t cmd, int dsta2, uint32_t dst_base,
    /* Local register-decode aliases (offsets match blitter_mmio.c). */
    uint32_t a1_base   = GET32(pre_regs, 0x00);
    uint32_t a1_flags  = GET32(pre_regs, 0x04);
+   uint32_t a1_clip   = GET32(pre_regs, 0x08);
    uint32_t a1_pixel  = GET32(pre_regs, 0x0C);
    uint32_t a1_step   = GET32(pre_regs, 0x10);
    uint32_t a1_fstep  = GET32(pre_regs, 0x14);
+   uint32_t a1_fpixel = GET32(pre_regs, 0x18);
+   uint32_t a1_inc    = GET32(pre_regs, 0x1C);
+   uint32_t a1_finc   = GET32(pre_regs, 0x20);
    uint32_t a2_base   = GET32(pre_regs, 0x24);
    uint32_t a2_flags  = GET32(pre_regs, 0x28);
    uint32_t a2_pixel  = GET32(pre_regs, 0x30);
@@ -119,6 +123,9 @@ static void blit_cmp_verbose_dump(uint32_t cmd, int dsta2, uint32_t dst_base,
    LOG_WRN("[BLIT CMP V]   PRE  A1 BASE=%08X FLAGS=%08X PIXEL=%08X STEP=%08X FSTEP=%08X\n",
       (unsigned)a1_base, (unsigned)a1_flags, (unsigned)a1_pixel,
       (unsigned)a1_step, (unsigned)a1_fstep);
+   LOG_WRN("[BLIT CMP V]   PRE  A1 CLIP=%08X FPIXEL=%08X INC=%08X FINC=%08X xaddctl=%u\n",
+      (unsigned)a1_clip, (unsigned)a1_fpixel, (unsigned)a1_inc,
+      (unsigned)a1_finc, (unsigned)((a1_flags >> 16) & 0x03));
    LOG_WRN("[BLIT CMP V]   PRE  A2 BASE=%08X FLAGS=%08X PIXEL=%08X STEP=%08X\n",
       (unsigned)a2_base, (unsigned)a2_flags, (unsigned)a2_pixel,
       (unsigned)a2_step);
@@ -189,6 +196,35 @@ static void blit_cmp_verbose_dump(uint32_t cmd, int dsta2, uint32_t dst_base,
       (unsigned)(save_start + dump_start), fast_hex);
    LOG_WRN("[BLIT CMP V]   DST @%06X acc:  %s\n",
       (unsigned)(save_start + dump_start), acc_hex);
+
+   /* Decoded per-pixel diff list.  For a 16bpp destination, turn every
+    * differing word into an (x,y) coordinate in the destination bitmap so
+    * line-drawing blits can be read as geometry rather than hex. */
+   {
+      uint32_t dflags = dsta2 ? GET32(pre_regs, 0x28) : a1_flags;
+      uint32_t psz = (dflags >> 3) & 0x07;
+      uint32_t wm  = (dflags >> 9) & 0x03;
+      uint32_t we  = (dflags >> 11) & 0x0F;
+      uint32_t w   = ((0x04 | wm) << we) >> 2;
+      uint32_t shown = 0;
+      uint32_t o;
+      if (psz == 4 && w != 0)
+      {
+         for (o = (uint32_t)first_diff & ~1u;
+              o <= (uint32_t)last_diff && shown < 48; o += 2)
+         {
+            uint16_t fpx = ((uint16_t)fast_region[o] << 8) | fast_region[o + 1];
+            uint16_t apx = ((uint16_t)jaguarMainRAM[save_start + o] << 8)
+                         | jaguarMainRAM[save_start + o + 1];
+            if (fpx == apx)
+               continue;
+            LOG_WRN("[BLIT CMP V]   PX (%3u,%3u) fast=%04X acc=%04X\n",
+               (unsigned)((o >> 1) % w), (unsigned)((o >> 1) / w),
+               (unsigned)fpx, (unsigned)apx);
+            shown++;
+         }
+      }
+   }
 }
 
 void BlitterCompareEnable(int enable)


### PR DESCRIPTION
One field-offset error in the fast blitter, and it was breaking three games. Filed as Iron Soldier's missing wireframe tank (#186); two other titles fell out of the fix without being tuned against.

## The defect

The fast path's `READ_RDATA_*` macros read `REG(r)` — the **high** longword of the 64-bit blitter data register — for the non-phrase (pixel) case. This core holds pixel/Gouraud **channel 0** in the **low** longword. So a program that writes only the low longword of `B_PATD` got `$0000` as its write data on the fast blitter: the fast path was sampling bits [47:32], i.e. **channel 2**, a field these games never write.

First divergent blit (Iron Soldier briefing screen):

```
cmd=$00010340   CLIPA1|UPDA1F|UPDA1|PATDSEL   (no SRCEN/DSTEN, no Z, no GOURD)
PATD = $000000000000320F   (game writes long $0000320F to $F02268 before every line blit)
fast: all 42 pixels written as $0000 over $0000  -> invisible
acc : all 42 pixels written as $320F
```

## The DDA hypothesis in the ticket is wrong and can be retired

Both paths finish with **bit-identical** `A1_PIXEL=$0046FF7B` / `A1_FPIXEL=$92AE0000`. The address walk, the increment and the fractional accumulation were always correct — this is a pure data-path defect, not an address-generation one. (Localising it required adding `A1_INC`/`A1_FINC`/`xaddctl` to the comparator's verbose dump; without those the DDA lead can't be falsified. That diagnostic addition is included.)

## JTRM adjudication — accurate was right, fast was wrong

- **Rev 8 p.77**: the Intensity 0-3 registers "provide an alternate view of the computed intensity integer parts (**pattern data**)". `blitter_mmio.c` implements that alias with channel 0 in the **low** 16 bits as `blitter_ram` holds it, and `blitter_blit`'s Gouraud init agrees (`gd_c[0]`/`gd_i[0]` from `PATTERNDATA+6/7`).
- **Rev 8 p.82** (Gouraud/Z worked example): `Pattern = 00DC00C700B1009C` is four 16-bit fields = four consecutive pixels, which fixes the field-index ↔ pixel-position ordering.

The accurate path already used channel 0 in pixel mode. Fix: the non-phrase branch reads `REG((r)+4)`. Phrase mode untouched.

## Three titles fixed

| Title | Before | After |
|---|---|---|
| **Iron Soldier** briefing screen | tank absent on fast; 6462/6720 blits divergent (96.16%) | **0 divergent (0.00%)**, fast/accurate 100.000% pixel-identical at frames 1250/1300/1350/1400 |
| **Hover Strike** intro | rotating Earth on black, **entire intro text block missing** | all four lines render ("You fear the worst for the planet's missing colonists…") |
| **Kasumi Ninja** title | **solid green screen** with only "Press Fire to Start" | full title artwork — KASUMI/NINJA logos, yin-yang emblem, ninja and character roster |

All three are the same defect: PATDSEL blits with a single-longword `B_PATD` write. Hover Strike and Kasumi Ninja are independent corroboration from titles the fix was not developed against.

*Note on the gate wording:* the ticket says "3D DEMO renders the tank", but the tank is on the **mission briefing** screen; the 3D DEMO cockpit already rendered in all four blitter × BIOS combos before this.

## Not #189's A2_PIXEL remainder

Post-fix Iron Soldier: **0/6720** memory divergence, while `A2_PIXEL` writeback still diverges (fast advances, accurate stays parked). Destination bytes identical, register writeback divergent — disjoint defect, untouched here.

## Validation

- **`test_blitter_compare`: 0/0 divergence on 15 titles** including Tempest 2000 (131,976 blits), Battle Sphere, AvP, Ruiner Pinball, Super Burnout, Doom, Cybermorph, Rayman, Wolfenstein 3D, Hover Strike, Skyhammer — so no title's divergence count can have increased.
- **40-title A/B: 2 differing, both improvements** (the two above); 38 byte-identical, audio counts unchanged everywhere. (Brutal Sports Football is a `retro_load_game` reject on **both** builds — pre-existing.)
- **CD: 16/16 combinations byte-identical** — Battle Morph / IS2 / Myst / Primal Rage × {HLE, real BIOS} × {fast, accurate}, 2000 frames. `cd_boot_matrix.sh` zero backward moves; an initial run showed 4 apparently-backward rows that were wall-clock kills under host load 23, all carrying `[PASS]` evidence, and re-ran identical on both builds at a longer timeout.
- **Acid: 137/142 on both builds**, same 2 pre-existing failures, 0 differences. **All 33 blitter acid tests pass**, including `pattern_fill` and `copy_pix{1,2,4}_pixel` — the sub-byte pixel-mode cases this macro change also touches are covered by passing tests rather than inference.
- `make TEST_EXPORTS=1 test` exit 0 (both audio tests); c89-lint clean.
- **Benchmark: the decisive evidence is that `yarc.j64`'s framebuffer hash is bit-identical** between builds, so the emulated work is unchanged — the change reads `blitter_ram[+4..+7]` instead of `[+0..+3]` in the same cache line. FPS numbers were unusable under host load 23 (scatter ±25% in both directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)