### PR TITLE
feat(cart): name known bad dumps at load time

### DIFF
--- a/docs/cart-issue-triage.md
+++ b/docs/cart-issue-triage.md
@@ -779,6 +779,73 @@ done
 
 ---
 
+## Naming known bad dumps at load time
+
+`romList` used to be dead data: `src/core/file.c` included `filedb.h` and the
+comment in `ParseFileType` promised *"We can also check our CRC32 against the
+internal ROM database to be sure"*, but nothing ever queried the table, so the
+core could never say more than *"unsupported or invalid content format"*.
+`FindRomIdentifier()` / `FindVerifiedRomVariant()` (`src/core/filedb.c`) are now
+wired into both load outcomes.
+
+### A bad dump that loads anyway
+
+This is the case that matters. Every `FF_BAD_DUMP` row in the table is
+cart-sized, so `ParseFileType` accepts it as a plain `JST_ROM`, the game runs
+subtly wrong, and the glitch gets attributed to the emulator. Two such images are
+in circulation locally:
+
+| CRC32 | title | local file | verified counterpart |
+|---|---|---|---|
+| `$4A08A2BD` | SuperCross 3D (World) | `Super Cross 3D (1995).jag` (2 MiB) | `$EC22F572` — `Super Cross 3D (1995) [a1].jag` |
+| `$C6C7BA62` | Fight for Life (World) (alt) | `Fight For Your Life (1996) [a1].jag` (4 MiB) | none in the table |
+
+Loading the first now prints:
+
+```
+[WRN] [CART] this is a known bad dump: "SuperCross 3D (World)" (CRC32 $4A08A2BD) -- it will run, but expect glitches
+[WRN] [CART] a verified dump of the same title exists (CRC32 $EC22F572)
+```
+
+The second prints the first line only — no same-named verified row exists, and a
+guessed match would be worse than silence. The verified `[a1]` SuperCross dump,
+Iron Soldier and every other image in the set load silently. `JaguarLoadFile` is
+a thin wrapper so this is reported from one place rather than from each of the
+seven load paths, all of which return directly.
+
+### A rejected image
+
+The same lookup runs on the `JST_NONE` return, so a rejected image that is in the
+table is named and pointed at its verified counterpart, and one that is not still
+carries its size and CRC so a reporter can say exactly what they have:
+
+```
+[ERR] [CART] unrecognized content format: 4000 bytes, CRC32 $E674A98B (no matching row in the ROM database)
+```
+
+Worth being straight about the reach of this half. The only `FF_BAD_DUMP` row
+that ever reached the rejection path was the headered *Brutal Sports Football
+(1994) (Telegames)* image, and #225 makes it load — under the payload's verified
+CRC `$BCB1A4BF`, so it correctly stops tripping the bad-dump warning as well.
+That leaves the named-rejection branch with no known reachable case; it stays as
+cover for a future bad dump whose container is also unloadable. The generic line
+is the half that earns its keep.
+
+### Limits of the table
+
+`jaguarMainROMCRC32` is a whole-file CRC, while `romList` mixes whole-file CRCs
+with CRCs taken over the file minus a universal header (see the comment at the
+top of `src/core/filedb.c`), so a UH-carrying cart misses the table and falls
+through to the generic line — correct behaviour, but it means a miss is **not**
+evidence the image is unknown. `FF_BAD_DUMP` is the whole story for known-problem
+images; the table has no `FF_NON_WORKING` rows.
+
+One known wart: `libretro.c` calls `JaguarLoadFile` twice for RAM-loaded images
+(`.abs`/`.cof`/Jag Server) — once through the boot strategy and again after
+`JaguarReset()` — so such an image would warn twice. Unreachable today, since
+every `FF_BAD_DUMP` row is an `FF_ROM` cart that loads once; the warning carries
+no state, so a duplicate would be cosmetic.
+
 ## Cross-cutting observations
 
 1. **The two blitter paths now agree far more than they used to.** Zero pixel

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -97,6 +97,28 @@ static void ReportUnrecognizedContent(uint32_t crc, uint32_t size)
             (unsigned)verified->crc32);
 }
 
+/* A dump can be bad and still load: every FF_BAD_DUMP row in the database is
+ * cart-sized, so ParseFileType takes it as a plain JST_ROM and the game runs
+ * subtly wrong with nothing said. Say it, so a glitch report can be attributed to
+ * the image rather than to the emulator. */
+static void ReportKnownBadDumpLoaded(uint32_t crc)
+{
+   const struct RomIdentifier *entry = FindRomIdentifier(crc);
+   const struct RomIdentifier *verified;
+
+   if (!entry || !(entry->flags & FF_BAD_DUMP))
+      return;
+
+   LOG_WRN("[CART] this is a known bad dump: \"%s\" (CRC32 $%08X) -- it will run, but expect glitches\n",
+         entry->name, (unsigned)crc);
+
+   verified = FindVerifiedRomVariant(entry);
+
+   if (verified)
+      LOG_WRN("[CART] a verified dump of the same title exists (CRC32 $%08X)\n",
+            (unsigned)verified->crc32);
+}
+
 static bool InferRawBinaryLoadAddress(uint8_t *buffer, uint32_t size, uint32_t *loadAddress)
 {
    static const uint32_t candidates[] = { 0x00802000, 0x00020000, 0x00004000 };
@@ -189,7 +211,7 @@ static uint32_t ParseFileType(uint8_t * buffer, uint32_t size)
    return JST_NONE;
 }
 
-bool JaguarLoadFile(uint8_t *buffer, size_t bufsize)
+static bool JaguarLoadFileInternal(uint8_t *buffer, size_t bufsize)
 {
    int fileType;
    uint32_t headerSize;
@@ -313,4 +335,16 @@ bool JaguarLoadFile(uint8_t *buffer, size_t bufsize)
    // We can assume we have JST_NONE at this point. :-P
    ReportUnrecognizedContent(jaguarMainROMCRC32, jaguarROMSize);
    return false;
+}
+
+bool JaguarLoadFile(uint8_t *buffer, size_t bufsize)
+{
+   bool loaded = JaguarLoadFileInternal(buffer, bufsize);
+
+   /* Reported from here rather than from each of the load paths above, all of
+    * which return directly. */
+   if (loaded)
+      ReportKnownBadDumpLoaded(jaguarMainROMCRC32);
+
+   return loaded;
 }

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -67,6 +67,36 @@ static uint32_t DetectPrependedHeaderSize(uint8_t *buffer, uint32_t size)
    return CART_HEADER_SKIP_SIZE;
 }
 
+/* Say what we were handed when ParseFileType came up empty. Several images in
+ * the CRC database are known to be unloadable -- bad dumps, and dumps with a
+ * header glued to the front -- so name the one in front of us instead of
+ * leaving the caller to print a generic "invalid content" line. */
+static void ReportUnrecognizedContent(uint32_t crc, uint32_t size)
+{
+   const struct RomIdentifier *entry = FindRomIdentifier(crc);
+   const struct RomIdentifier *verified;
+
+   if (!entry)
+   {
+      LOG_ERR("[CART] unrecognized content format: %u bytes, CRC32 $%08X (no matching row in the ROM database)\n",
+            (unsigned)size, (unsigned)crc);
+      return;
+   }
+
+   if (entry->flags & FF_BAD_DUMP)
+      LOG_ERR("[CART] known bad dump: \"%s\" -- %u bytes, CRC32 $%08X\n",
+            entry->name, (unsigned)size, (unsigned)crc);
+   else
+      LOG_ERR("[CART] \"%s\" (%u bytes, CRC32 $%08X) is a known image, but this container is not loadable\n",
+            entry->name, (unsigned)size, (unsigned)crc);
+
+   verified = FindVerifiedRomVariant(entry);
+
+   if (verified)
+      LOG_ERR("[CART] a verified dump of the same title exists (CRC32 $%08X) -- re-dump, or strip any header prepended to this image\n",
+            (unsigned)verified->crc32);
+}
+
 static bool InferRawBinaryLoadAddress(uint8_t *buffer, uint32_t size, uint32_t *loadAddress)
 {
    static const uint32_t candidates[] = { 0x00802000, 0x00020000, 0x00004000 };
@@ -281,5 +311,6 @@ bool JaguarLoadFile(uint8_t *buffer, size_t bufsize)
    }
 
    // We can assume we have JST_NONE at this point. :-P
+   ReportUnrecognizedContent(jaguarMainROMCRC32, jaguarROMSize);
    return false;
 }

--- a/src/core/filedb.c
+++ b/src/core/filedb.c
@@ -13,6 +13,8 @@
 
 #include "filedb.h"
 
+#include <string.h>
+
 // Should have another flag for whether or not it requires DSP, BIOS,
 // whether it's a .rom, it's a BIOS, etc...
 // ... And now we do! :-D
@@ -122,3 +124,41 @@ struct RomIdentifier romList[] = {
 	{ 0xF7756A03, "Tripper Getem (World)", FF_ROM | FF_VERIFIED },
 	{ 0xFFFFFFFF, "***END***", 0 }
 };
+
+/* romList is sentinel-terminated rather than sized, so every scan has to stop on
+ * the sentinel CRC. It is also not fully sorted (0xF7756A03 sits after
+ * 0xFDF37F47), so this is a linear scan, not a bisection. */
+#define ROMLIST_END_CRC32 0xFFFFFFFF
+
+const struct RomIdentifier * FindRomIdentifier(uint32_t crc32)
+{
+	unsigned i;
+
+	for (i = 0; romList[i].crc32 != ROMLIST_END_CRC32; i++)
+	{
+		if (romList[i].crc32 == crc32)
+			return &romList[i];
+	}
+
+	return NULL;
+}
+
+const struct RomIdentifier * FindVerifiedRomVariant(const struct RomIdentifier *entry)
+{
+	unsigned i;
+
+	if (!entry)
+		return NULL;
+
+	for (i = 0; romList[i].crc32 != ROMLIST_END_CRC32; i++)
+	{
+		if (romList[i].crc32 == entry->crc32)
+			continue;
+
+		if ((romList[i].flags & FF_VERIFIED)
+				&& strcmp(romList[i].name, entry->name) == 0)
+			return &romList[i];
+	}
+
+	return NULL;
+}

--- a/src/core/filedb.h
+++ b/src/core/filedb.h
@@ -44,6 +44,17 @@ struct RomIdentifier
 
 extern struct RomIdentifier romList[];
 
+/* Look up an image by CRC32. Returns NULL when the CRC is not in the database.
+ * Note that romList mixes whole-file CRCs with CRCs taken over the file minus a
+ * universal header (see the comment at the top of filedb.c), so a miss does not
+ * mean the image is unknown to the wider world -- only that this table has no
+ * row for the CRC it was handed. */
+const struct RomIdentifier * FindRomIdentifier(uint32_t crc32);
+
+/* Look up a verified dump carrying the same title as `entry`. Used to point a
+ * bad dump at its good counterpart. Returns NULL when there is none. */
+const struct RomIdentifier * FindVerifiedRomVariant(const struct RomIdentifier *entry);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## What this does

Wires the core's existing ROM CRC database (`romList`) into the loader. It was dead data: `file.c` included `filedb.h` and `ParseFileType`'s comment promised *"We can also check our CRC32 against the internal ROM database to be sure"*, but nothing ever queried the table — so the core could never say more than *"unsupported or invalid content format"*.

Adds `FindRomIdentifier()` / `FindVerifiedRomVariant()` to `filedb.c` and uses them on both load outcomes.

### A bad dump that loads anyway — the case that matters

Every `FF_BAD_DUMP` row in the table is cart-sized, so `ParseFileType` accepts it as a plain `JST_ROM`, the game runs subtly wrong, and the glitch gets attributed to the emulator. Two such images are in circulation:

```
[WRN] [CART] this is a known bad dump: "SuperCross 3D (World)" (CRC32 $4A08A2BD) -- it will run, but expect glitches
[WRN] [CART] a verified dump of the same title exists (CRC32 $EC22F572)
```

`Fight For Your Life (1996) [a1].jag` (`$C6C7BA62`) prints the first line only — no same-named verified row exists, and a guessed match would be worse than silence.

`JaguarLoadFile` becomes a thin wrapper so this is reported from one place rather than from each of the seven load paths, all of which return directly. The exported symbol and every load behaviour are unchanged.

### A rejected image

The same lookup runs on the `JST_NONE` return. An unlisted image still reports generically, but now carries size and CRC so a reporter can say exactly what they have:

```
[ERR] [CART] unrecognized content format: 4000 bytes, CRC32 $E674A98B (no matching row in the ROM database)
```

**Straight about the reach of this half:** the only `FF_BAD_DUMP` row that ever reached the rejection path was the headered *Brutal Sports Football* image, and #225 makes it load — under the payload's verified CRC `$BCB1A4BF`, so it correctly stops tripping the bad-dump warning too. That leaves the named-rejection branch with no known reachable case; it stays as cover for a future bad dump whose container is also unloadable. The generic line is the half that earns its keep.

## Relationship to #225

This branch started from the Brutal Sports Football report and originally concluded *"bad dump, leave the loader alone, tell the user to `dd` it"*. **That verdict was wrong** and has been withdrawn — the payload CRC matches the `FF_VERIFIED` row for the same title exactly, so the image data is not defective, only the container is. #225 skips the 512-byte header on exactly that basis and is the correct fix.

The last commit here drops the cause/offset-proof/remedy narrative (which #225 now owns) so the two do not contradict each other in `docs/cart-issue-triage.md`. What remains is the reporting plumbing, which is orthogonal.

**Merge order:** these two touch adjacent lines in `src/core/file.c` (both add `#include "log.h"`, both edit the top of `JaguarLoadFile`) — one conflict hunk. Whichever lands second needs a small manual reconcile; happy to rebase this one on top of #225 if that is preferred.

## Testing

| ROM | expected | result |
|---|---|---|
| `Super Cross 3D (1995).jag` (`$4A08A2BD`) | warn + counterpart | ✅ both lines, renders |
| `Super Cross 3D (1995) [a1].jag` (`$EC22F572`) | silent | ✅ silent |
| `Fight For Your Life (1996) [a1].jag` (`$C6C7BA62`) | warn, no counterpart | ✅ one line |
| `Iron Soldier (1994).jag` | silent | ✅ silent |
| 4 KB of random bytes | generic + size/CRC | ✅ |
| Brutal Sports Football (headered) | named on reject, no duplicate | ✅ exactly 4 lines (superseded by #225) |
| `BadCode0 (cof)` — ABS type 2 | RAM path intact | ✅ renders |

That last row matters: RAM-loaded images pass through the wrapper **twice** (`libretro.c` reloads after `JaguarReset()`), so that path was exercised rather than assumed.

The core printing `$0FDCEB66` for the headered file is the load-bearing check — it proves `crc32_calcCheckSum` agrees with the database's algorithm. Had it printed anything else the whole lookup would be inert.

- `bash scripts/c89-lint.sh src/core/file.c src/core/filedb.c` — passed
- `make -j10` — zero errors, zero warnings; shipped ABI unchanged (46 exports, all `retro_*`)
- `make TEST_EXPORTS=1 test` — exit 0, 0 failures; `test_audio_clipping` (Skyhammer, IS2) and `test_audio_presence` (IS1) both ran and passed
- CI: 32/32 green

## Notes for review

- **`file.c` now includes `log.h`**, previously reached only from `crash_detect.c`. Both MSVC legs pass.
- **A RAM-loaded bad dump would warn twice** (the double `JaguarLoadFile` call). Unreachable today — every `FF_BAD_DUMP` row is an `FF_ROM` cart that loads once. Deliberately not guarded with a static flag, which would need a `retro_deinit` reset for iOS for a case that cannot currently occur.
- **A table miss is not evidence an image is unknown.** `jaguarMainROMCRC32` is always a whole-file CRC, while `romList` mixes whole-file CRCs with CRCs taken over the file minus a universal header, so UH-carrying carts fall through to the generic line by design.
- `FF_BAD_DUMP` is complete coverage of known-problem images — the table has no `FF_NON_WORKING` rows.

Unrelated finding, not fixed here: `make test` looks for `test/roms/private/Atari Karts (1995).jag` but the file lives under `test/roms/private/ROMS/`, so the clipping suite's negative control has been silently printing `SKIP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)