### PR TITLE
fix(cart): skip a 512-byte copier header instead of rejecting the image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -752,6 +752,7 @@ clean:
 		test/test_blitter_mmio test/test_blitter_cmd test/test_eeprom_lifecycle \
 		test/test_tom_visible_window test/test_framebuffer_integrity \
 		test/test_butch_cd test/test_bios_config test/test_boot_config \
+		test/test_cart_format \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup \
 		test/test_audio_dac test/test_blitter \
 		test/test_state_compat test/test_frontend_pacing \
@@ -803,6 +804,7 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 		test/test_framebuffer_integrity test/test_state_compat \
 		test/test_frontend_pacing \
 		test/test_butch_cd test/test_bios_config test/test_boot_config \
+		test/test_cart_format \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup \
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object
@@ -860,6 +862,7 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 	./test/test_cd_hle_idempotent
 	./test/test_bios_config
 	./test/test_boot_config
+	./test/test_cart_format ./$(TARGET)
 	./test/test_audio_dac
 	./test/tools/test_memory_map ./$(TARGET)
 	./test/tools/test_op_gpu_object ./$(TARGET) test/roms/yarc.j64
@@ -1062,6 +1065,10 @@ test/test_bios_config: test/test_bios_config.c
 test/test_boot_config: test/test_boot_config.c
 	$(CC) -O2 -Wall -Wno-unused-function -Wno-unused-variable -std=c99 $(INCFLAGS) \
 		-o $@ test/test_boot_config.c -ldl
+
+test/test_cart_format: test/test_cart_format.c
+	$(CC) -O2 -Wall -Wno-unused-function -Wno-unused-variable -std=c99 $(INCFLAGS) \
+		-o $@ test/test_cart_format.c -ldl
 
 test/test_cd_boot: test/test_cd_boot.c
 	$(CC) -O2 -Wall -Wno-unused-function -Wno-unused-variable -std=c99 $(INCFLAGS) \

--- a/docs/cart-issue-triage.md
+++ b/docs/cart-issue-triage.md
@@ -757,3 +757,72 @@ done
    (`gpu_pc_ring*` unresolved); `flicker_detect.c` swallows core logs and cannot
    set core options; `test_blitter_compare`'s register-diff reporting is capped at
    10 lines with no counter.
+
+## `Brutal Sports Football (1994) (Telegames).jag` rejected at load — prepended copier header
+
+Found incidentally during a 40-title sweep: this dump is refused while every
+other cartridge in the same local set loads.
+
+```
+[CART] JaguarLoadFile rejected the content
+[Virtual Jaguar] unsupported or invalid content format
+```
+
+**Cause: a 512-byte copier/dumper header glued to the front of a byte-perfect
+image.** Not a bad dump, and not a size-gate bug.
+
+| field | value |
+|---|---|
+| file size | 2 097 664 = 2 MiB **+ 512** |
+| header bytes | `00 01 30 00  00 00 00 00  AA BB 04 00`, then zero-fill to `0x200` |
+| whole-file CRC32 | `0x0FDCEB66` → `src/core/filedb.c` *"Brutal Sports Football (World)"*, `FF_ROM \| FF_BAD_DUMP` |
+| payload CRC32 (skip 512) | `0xBCB1A4BF` → same title, `FF_ROM \| FF_VERIFIED` |
+
+The payload is **byte-identical** to the verified dump — only the container is
+wrong — so the loader now skips the header instead of refusing the file.
+
+### Detection
+
+`DetectPrependedHeaderSize` (`src/core/file.c`) requires *both*:
+
+* the file overhangs a whole number of megabytes by exactly 512 bytes, and
+* the cartridge universal-header marker `$04040404` — which precedes the run
+  address `JaguarLoadFile` reads from ROM offset `$404` — appears at that offset
+  measured **from the payload** (file offset `0x600` here, vs `0x400` for a
+  headerless image).
+
+The size test alone would start accepting arbitrary junk, so both must hold.
+Stripping happens before the CRC is taken, before `EepromInit`, and before type
+detection, so the core reports the payload's identity (`0xBCB1A4BF`) rather than
+the file's — a headered image and a `dd`-stripped one are indistinguishable
+downstream.
+
+Across the 139-image local set, this file is the only one with that size shape,
+and it carries the marker.
+
+### Not a power-of-two gate
+
+The size rule is `size % 1 MiB == 0` (plus the 131 072-byte Memory Track size),
+never a power of two: **84 of 87** distinct file sizes in the local set are
+non-power-of-two and load fine via `JST_ALPINE`, the ABS/COFF headers, or the
+raw-binary heuristic. There is no "rejects any cart whose size is not a power of
+two" class of breakage.
+
+### Verified
+
+Same build, headered original vs `dd bs=512 skip=1` payload, 1200 frames each —
+identical on every measure:
+
+| check | headered | stripped |
+|---|---|---|
+| load | OK | OK |
+| `jaguarMainROMCRC32` | `BCB1A4BF` | `BCB1A4BF` |
+| `jaguarROMSize` | 2 097 152 | 2 097 152 |
+| non-black peak | 71 856 / 78 240 (91.8 %) | 71 856 / 78 240 |
+| non-black mean | 37.77 % | 37.77 % |
+| audio | RMS 997.3, onset frame 118 | RMS 997.3, onset frame 118 |
+
+Regression coverage is `test/test_cart_format.c` (in `make test`): synthesises
+images in memory, asserts the headered one loads with the payload's CRC and
+size, and asserts a 512-over-a-MiB image *without* the marker, a 256-byte
+overhang, and a lone 512-byte file all stay rejected.

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -22,7 +22,50 @@
 #include "filedb.h"
 #include "eeprom.h"
 #include "jaguar.h"
+#include "log.h"
 #include "vjag_memory.h"
+
+/* Some circulating cartridge dumps carry a copier/dumper header glued to the
+ * front of an otherwise byte-perfect image.  "Brutal Sports Football (1994)
+ * (Telegames).jag" is the known case: 2 MiB + 512 bytes, where the payload's
+ * CRC32 ($BCB1A4BF) matches the FF_VERIFIED row in filedb.c exactly, while the
+ * whole-file CRC ($0FDCEB66) is catalogued as FF_BAD_DUMP.  Nothing about the
+ * image data is wrong, so skip the header instead of refusing the file.
+ *
+ * Detection is deliberately narrow, because the size test alone would start
+ * accepting arbitrary junk.  Both must hold:
+ *
+ *   - the file overhangs a whole number of megabytes by exactly the header
+ *     length, and
+ *   - the cartridge universal-header marker ($04040404, which precedes the run
+ *     address that JaguarLoadFile reads from ROM offset $404) is present at
+ *     that offset measured from the payload rather than from the file.
+ */
+#define CART_HEADER_SKIP_SIZE   512
+#define CART_UNIVERSAL_MARKER_OFFSET   0x400
+#define CART_UNIVERSAL_MARKER          0x04040404
+
+static uint32_t DetectPrependedHeaderSize(uint8_t *buffer, uint32_t size)
+{
+   uint32_t payloadSize;
+
+   /* Ordered first so a zero-length or undersized buffer is never read. */
+   if (size <= CART_HEADER_SKIP_SIZE)
+      return 0;
+
+   payloadSize = size - CART_HEADER_SKIP_SIZE;
+
+   if ((payloadSize % 1048576) != 0)
+      return 0;
+
+   /* payloadSize is a non-zero multiple of 1 MiB here, so the marker offset is
+    * comfortably inside the buffer. */
+   if (GET32(buffer, CART_HEADER_SKIP_SIZE + CART_UNIVERSAL_MARKER_OFFSET)
+         != CART_UNIVERSAL_MARKER)
+      return 0;
+
+   return CART_HEADER_SKIP_SIZE;
+}
 
 static bool InferRawBinaryLoadAddress(uint8_t *buffer, uint32_t size, uint32_t *loadAddress)
 {
@@ -119,9 +162,25 @@ static uint32_t ParseFileType(uint8_t * buffer, uint32_t size)
 bool JaguarLoadFile(uint8_t *buffer, size_t bufsize)
 {
    int fileType;
-   jaguarROMSize = bufsize;
+   uint32_t headerSize;
+
    jaguarLoadedRAMStart = 0;
    jaguarLoadedRAMEnd = 0;
+
+   /* Taken off before anything else looks at the image: the CRC below, the
+    * EEPROM init, the type detection and every load path must all see the
+    * payload rather than the header. */
+   headerSize = DetectPrependedHeaderSize(buffer, (uint32_t)bufsize);
+
+   if (headerSize != 0)
+   {
+      LOG_INF("[CART] skipping a %u-byte header prepended to a %u-byte cartridge image\n",
+            (unsigned)headerSize, (unsigned)(bufsize - headerSize));
+      buffer  += headerSize;
+      bufsize -= headerSize;
+   }
+
+   jaguarROMSize = bufsize;
 
    if (jaguarROMSize == 0)
       return false;

--- a/test/test_cart_format.c
+++ b/test/test_cart_format.c
@@ -1,0 +1,290 @@
+/*
+ * test_cart_format.c — cartridge container detection.
+ *
+ * Covers the prepended copier/dumper header path added for images like
+ * "Brutal Sports Football (1994) (Telegames).jag": 2 MiB + 512 bytes, whose
+ * payload CRC32 matches the FF_VERIFIED row in filedb.c while the whole-file
+ * CRC is catalogued FF_BAD_DUMP.  The loader must skip the header rather than
+ * refuse the file, and must do so before the CRC is taken so the core reports
+ * the payload's identity.
+ *
+ * Images are synthesised in memory and handed to retro_load_game() the way a
+ * frontend does (info->data / info->size), so no ROM on disk is required.
+ *
+ * The negative cases matter as much as the positive one: a bare
+ * "size overhangs a MiB by 512" rule would start accepting arbitrary junk,
+ * so detection also requires the cartridge universal-header marker at the
+ * offset measured from the payload.
+ *
+ * Build:
+ *   make -j4 && make TEST_EXPORTS=1 test/test_cart_format
+ *
+ * Run:
+ *   test/test_cart_format [core.dylib]
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <dlfcn.h>
+
+#include "../libretro-common/include/libretro.h"
+
+/* ------------------------------------------------------------------ */
+/* Minimal test runner                                                 */
+/* ------------------------------------------------------------------ */
+
+static int tf_pass = 0, tf_fail = 0;
+static const char *tf_name = "";
+static bool tf_failed = false;
+
+#define TEST(n) static void test_##n(void)
+#define RUN(n) do { tf_name = #n; tf_failed = false; test_##n(); \
+    if (tf_failed) tf_fail++; \
+    else { tf_pass++; fprintf(stderr, "  PASS  %s\n", #n); } } while(0)
+#define FAIL(fmt, ...) do { fprintf(stderr, "  FAIL  %s:%d: " fmt "\n", \
+    tf_name, __LINE__, ##__VA_ARGS__); tf_failed = true; return; } while(0)
+#define ASSERT(cond) do { if (!(cond)) FAIL("expected true: %s", #cond); } while(0)
+#define ASSERT_EQ_U(a, b) do { unsigned _a=(unsigned)(a), _b=(unsigned)(b); \
+    if (_a != _b) FAIL("%s == %s: got %u, want %u", #a, #b, _a, _b); } while(0)
+
+/* ------------------------------------------------------------------ */
+/* Core plumbing                                                       */
+/* ------------------------------------------------------------------ */
+
+#define MIB              1048576u
+#define HEADER_SIZE      512u
+#define MARKER_OFFSET    0x400u
+
+static void  *core;
+static void  (*p_retro_init)(void);
+static void  (*p_retro_deinit)(void);
+static void  (*p_retro_set_environment)(retro_environment_t);
+static bool  (*p_retro_load_game)(const struct retro_game_info *);
+static void  (*p_retro_unload_game)(void);
+static uint32_t *p_crc;
+static uint32_t *p_romsize;
+
+static bool env_cb(unsigned cmd, void *data)
+{
+   switch (cmd)
+   {
+      case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+      case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+         *(const char **)data = "/tmp";
+         return true;
+      case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+      case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS:
+      case RETRO_ENVIRONMENT_SET_VARIABLES:
+      case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
+      case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+      case RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS:
+      case RETRO_ENVIRONMENT_SET_CONTROLLER_INFO:
+         return true;
+      default:
+         return false;
+   }
+}
+
+/* A cartridge image the loader will take as JST_ROM: `payload` bytes of
+ * filler carrying the universal-header marker and run address at $400.
+ * `header` bytes of copier junk are prepended when non-zero. */
+static uint8_t *make_image(unsigned payload, unsigned header, bool with_marker,
+                           unsigned *out_size)
+{
+   uint8_t *img = (uint8_t *)malloc(header + payload);
+   uint8_t *body;
+   unsigned i;
+
+   if (!img)
+      return NULL;
+
+   /* Deterministic filler — the test asserts CRC equality between two
+    * images, so the payload bytes must be reproducible. */
+   for (i = 0; i < header + payload; i++)
+      img[i] = (uint8_t)(i * 7u + 0x5Au);
+
+   /* Mimic the observed real header: near-zero-fill with a few magic bytes. */
+   if (header)
+   {
+      memset(img, 0, header);
+      img[1] = 0x01;
+      img[2] = 0x30;
+      img[8] = 0xAA;
+      img[9] = 0xBB;
+      img[10] = 0x04;
+   }
+
+   body = img + header;
+
+   if (with_marker)
+   {
+      body[MARKER_OFFSET + 0] = 0x04;
+      body[MARKER_OFFSET + 1] = 0x04;
+      body[MARKER_OFFSET + 2] = 0x04;
+      body[MARKER_OFFSET + 3] = 0x04;
+      /* Run address at $404, as every commercial image carries. */
+      body[MARKER_OFFSET + 4] = 0x00;
+      body[MARKER_OFFSET + 5] = 0x80;
+      body[MARKER_OFFSET + 6] = 0x20;
+      body[MARKER_OFFSET + 7] = 0x00;
+   }
+   else
+   {
+      body[MARKER_OFFSET + 0] = 0x11;
+      body[MARKER_OFFSET + 1] = 0x22;
+      body[MARKER_OFFSET + 2] = 0x33;
+      body[MARKER_OFFSET + 3] = 0x44;
+   }
+
+   *out_size = header + payload;
+   return img;
+}
+
+static bool load_image(const uint8_t *img, unsigned size)
+{
+   struct retro_game_info info;
+   memset(&info, 0, sizeof(info));
+   info.data = img;
+   info.size = size;
+   info.path = NULL;
+   return p_retro_load_game(&info);
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+/* Baseline: an exact-MiB image with no header still loads unchanged. */
+TEST(plain_rom_loads)
+{
+   unsigned size = 0;
+   uint8_t *img = make_image(MIB, 0, true, &size);
+
+   ASSERT(img != NULL);
+   ASSERT_EQ_U(size, MIB);
+   ASSERT(load_image(img, size));
+   ASSERT_EQ_U(*p_romsize, MIB);
+   p_retro_unload_game();
+   free(img);
+}
+
+/* The fix: the same payload with 512 bytes of copier junk in front loads,
+ * and the core settles on the payload's size and CRC — not the file's. */
+TEST(headered_rom_loads_as_payload)
+{
+   unsigned plain_size = 0, headered_size = 0;
+   uint32_t plain_crc;
+   uint8_t *plain = make_image(2u * MIB, 0, true, &plain_size);
+   uint8_t *headered = make_image(2u * MIB, HEADER_SIZE, true, &headered_size);
+
+   ASSERT(plain != NULL);
+   ASSERT(headered != NULL);
+   ASSERT_EQ_U(headered_size, plain_size + HEADER_SIZE);
+
+   /* Both images must carry identical payload bytes for the CRC comparison
+    * below to mean anything. */
+   ASSERT(memcmp(plain, headered + HEADER_SIZE, plain_size) == 0);
+
+   ASSERT(load_image(plain, plain_size));
+   ASSERT_EQ_U(*p_romsize, 2u * MIB);
+   plain_crc = *p_crc;
+   p_retro_unload_game();
+
+   ASSERT(load_image(headered, headered_size));
+   ASSERT_EQ_U(*p_romsize, 2u * MIB);
+   /* Taken over the payload, so the headered file reports the same identity
+    * as the stripped one. */
+   ASSERT_EQ_U(*p_crc, plain_crc);
+   p_retro_unload_game();
+
+   free(plain);
+   free(headered);
+}
+
+/* Guard: the size shape alone must not be enough, or the loader would start
+ * accepting arbitrary 512-over-a-MiB junk as a cartridge. */
+TEST(headered_without_marker_rejected)
+{
+   unsigned size = 0;
+   uint8_t *img = make_image(MIB, HEADER_SIZE, false, &size);
+
+   ASSERT(img != NULL);
+   ASSERT(!load_image(img, size));
+   free(img);
+}
+
+/* Guard: only a 512-byte overhang is a header.  Anything else stays
+ * unrecognised, exactly as before. */
+TEST(other_overhang_rejected)
+{
+   unsigned size = 0;
+   uint8_t *img = make_image(MIB, 256, true, &size);
+
+   ASSERT(img != NULL);
+   ASSERT_EQ_U(size, MIB + 256u);
+   ASSERT(!load_image(img, size));
+   free(img);
+}
+
+/* Guard: a lone 512-byte file must not be read past its end. */
+TEST(header_sized_file_rejected)
+{
+   uint8_t tiny[HEADER_SIZE];
+   memset(tiny, 0, sizeof(tiny));
+   ASSERT(!load_image(tiny, (unsigned)sizeof(tiny)));
+}
+
+int main(int argc, char **argv)
+{
+   const char *core_path = (argc > 1) ? argv[1]
+      : "./virtualjaguar_libretro.dylib";
+
+   core = dlopen(core_path, RTLD_LAZY);
+   if (!core)
+   {
+      fprintf(stderr, "FATAL: cannot dlopen %s: %s\n", core_path, dlerror());
+      return 1;
+   }
+
+   p_retro_init            = (void (*)(void))dlsym(core, "retro_init");
+   p_retro_deinit          = (void (*)(void))dlsym(core, "retro_deinit");
+   p_retro_set_environment = (void (*)(retro_environment_t))dlsym(core, "retro_set_environment");
+   p_retro_load_game       = (bool (*)(const struct retro_game_info *))dlsym(core, "retro_load_game");
+   p_retro_unload_game     = (void (*)(void))dlsym(core, "retro_unload_game");
+   p_crc                   = (uint32_t *)dlsym(core, "jaguarMainROMCRC32");
+   p_romsize               = (uint32_t *)dlsym(core, "jaguarROMSize");
+
+   if (!p_retro_init || !p_retro_set_environment || !p_retro_load_game
+         || !p_retro_unload_game || !p_retro_deinit)
+   {
+      fprintf(stderr, "FATAL: core is missing required retro_* symbols\n");
+      return 1;
+   }
+
+   if (!p_crc || !p_romsize)
+   {
+      fprintf(stderr, "FATAL: jaguarMainROMCRC32 / jaguarROMSize not exported "
+                      "-- build with TEST_EXPORTS=1\n");
+      return 1;
+   }
+
+   fprintf(stderr, "\n=== cart container format ===\n");
+
+   p_retro_set_environment(env_cb);
+   p_retro_init();
+
+   RUN(plain_rom_loads);
+   RUN(headered_rom_loads_as_payload);
+   RUN(headered_without_marker_rejected);
+   RUN(other_overhang_rejected);
+   RUN(header_sized_file_rejected);
+
+   p_retro_deinit();
+
+   fprintf(stderr, "\n--- cart container format: %d passed, %d failed ---\n\n",
+         tf_pass, tf_fail);
+   return tf_fail ? 1 : 0;
+}


### PR DESCRIPTION
`Brutal Sports Football (1994) (Telegames).jag` is refused at load while every other cartridge in the same local set loads:

```
[CART] JaguarLoadFile rejected the content
[Virtual Jaguar] unsupported or invalid content format
```

## Cause

A **512-byte copier/dumper header** glued to the front of a byte-perfect image. Not a bad dump, and not a size gate.

| field | value |
|---|---|
| file size | 2 097 664 = 2 MiB **+ 512** |
| header bytes | `00 01 30 00  00 00 00 00  AA BB 04 00`, then zero-fill to `0x200` |
| whole-file CRC32 | `0x0FDCEB66` → `filedb.c`, `FF_ROM \| FF_BAD_DUMP` |
| payload CRC32 (skip 512) | `0xBCB1A4BF` → same title, `FF_ROM \| FF_VERIFIED` |

The payload is **byte-identical** to the verified dump — only the container is wrong — so the loader skips the header instead of refusing the file.

## Detection

`DetectPrependedHeaderSize` requires **both**:

* the file overhangs a whole number of megabytes by exactly 512 bytes, **and**
* the cartridge universal-header marker `$04040404` — which precedes the run address `JaguarLoadFile` reads from ROM offset `$404` — appears at that offset measured **from the payload** (file offset `0x600` here, vs `0x400` for a headerless image).

The size test alone would start accepting arbitrary junk, so both must hold. Across the 139-image local set this file is the only one with that size shape, and it carries the marker.

Stripping happens before the CRC is taken, before `EepromInit`, and before type detection, so the core reports the payload's identity — a headered image and a `dd`-stripped one are indistinguishable downstream. `DetectPrependedHeaderSize` returns 0 for every file that loads today, so the change is strictly additive.

## Not a power-of-two gate

The size rule is `size % 1 MiB == 0` (plus the 131 072-byte Memory Track size), never a power of two. **84 of 87** distinct file sizes in the local set are non-power-of-two and load fine via `JST_ALPINE`, the ABS/COFF headers, or the raw-binary heuristic. There is no "rejects any cart whose size is not a power of two" class of breakage — that hypothesis is disproved, not merely unaddressed.

## Verified

Same build, headered original vs `dd bs=512 skip=1` payload, 1200 frames each — identical on every measure:

| check | headered | stripped |
|---|---|---|
| load | OK | OK |
| `jaguarMainROMCRC32` | `BCB1A4BF` | `BCB1A4BF` |
| `jaguarROMSize` | 2 097 152 | 2 097 152 |
| non-black peak | 71 856 / 78 240 (91.8 %) | 71 856 / 78 240 |
| non-black mean | 37.77 % | 37.77 % |
| audio | RMS 997.3, onset frame 118 | RMS 997.3, onset frame 118 |

It renders and produces audio — not a "`retro_load_game` returned true" result.

## Tests

`make TEST_EXPORTS=1 test` exits 0.

New `test/test_cart_format.c` (5/5, wired into `make test`) synthesises images in memory and hands them to `retro_load_game` the way a frontend does, so it needs no ROM on disk:

* an exact-MiB image with no header still loads (baseline)
* the headered image loads and reports the **payload's** CRC and size, identical to the same payload without a header
* a 512-over-a-MiB image **without** the marker stays rejected
* a 256-byte overhang stays rejected
* a lone 512-byte file stays rejected (no read past the end)

The three rejection cases are the point: they pin down that the gate did not simply get looser.

`test_audio_clipping` / `test_audio_presence` are unaffected — this touches container detection, not `dac.c`, `dsp.c`, or the HLE audio engine.

## Interaction with #224

#224 touches `src/core/file.c` and `docs/cart-issue-triage.md` too, so whichever lands second needs a small reconcile. Its reporting plumbing (naming a known bad dump on rejection) is orthogonal and still useful, but its triage section concludes *"Verdict: bad dump. The loader is intentionally left alone"* and *"No core change is warranted"* — that conclusion is contradicted by the payload CRC matching the `FF_VERIFIED` row exactly, and should be dropped in favour of the section added here.
