### PR TITLE
fix(video): blank the presented rows TOM never writes (AvP in-game brown bar, #178)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ test/acid/tests/**/*.jag
 /test/tools/test_frame_timing
 /test/tools/cd_visual_verify
 /test/tools/cue2cdi
+/test/tools/fb_row_digest
+/test/tools/tom_window_trace
+test/tools/__pycache__/
 .link-mode
 
 # gcov instrumentation output (make coverage)

--- a/docs/cart-issue-triage.md
+++ b/docs/cart-issue-triage.md
@@ -35,7 +35,7 @@ Two classes of evidence are used, and they are **not** equally strong:
 | # | Title | Verdict | Basis |
 |---|---|---|---|
 | **138** | Pitfall: The Mayan Adventure — black screen | **STILL REPRODUCES** (worst offender) | deterministic hard wedge — `video_stall` at **3989** (run+jump script) / **3491** (no-input control, i.e. it dies sooner without input); 68K parked on an `RTE` stub at `$000404`; bit-identical under both blitters |
-| **178** | Alien vs Predator — display issues | **PARTLY REPRODUCES** | cyan boot bar confirmed `rgb(0,255,255)` 320×3 at frame 0 (and it is **not** AvP-specific); in-game brown bottom bar confirmed rows 236–239; green dot / green bar **not** reproduced |
+| **178** | Alien vs Predator — display issues | **PARTLY REPRODUCES; brown bar FIXED** | cyan boot bar confirmed `rgb(0,255,255)` 320×3 at frame 0 (and it is **not** AvP-specific); in-game brown bottom bar confirmed rows 236–239 — **root-caused and fixed**, see below; green dot / green bar **not** reproduced |
 | **186** | Iron Soldier (cart) — unplayable | **CHANGED (DEMO path fixed; mission-start path untested)** | 3D DEMO mode renders + animates in **all 4** blitter×BIOS combos, no signature; fast-blitter missing wireframe tank still reproduces exactly; `*`+`#` is not a core bug; **mission start was never reached — see caveat** |
 | *180* | BIOS cube top-edge pixels (referenced by #189) | **NO LONGER REPRODUCES** | all 37 BIOS-on frames, including the entire cube animation, are **byte-identical** between fast and accurate blitter |
 | **187** | Tempest 2000 — graphical glitches | **NOT OBJECTIVELY VERIFIABLE HEADLESS** | no signature over 3600 BIOS-mode frames; 133 656 blits with **0** fast-vs-accurate pixel diffs; stable geometry. Glitch class cannot be distinguished from intended effects without a reference |
@@ -45,9 +45,11 @@ Two classes of evidence are used, and they are **not** equally strong:
 
 * **#138** — keep open, **raise priority**. Now has a deterministic headless repro
   and a captured 68K crash state; this is the most actionable ticket of the five.
-* **#178** — keep open but **split**. Two of four sub-symptoms are confirmed with
-  exact pixel values; the cyan bar is a core-wide boot artefact and deserves its
-  own ticket, not an AvP one. The green dot/bar needs a RetroArch check.
+* **#178** — keep open but **split**. Two of four sub-symptoms were confirmed with
+  exact pixel values, and both now have fixes: the cyan bar is a core-wide boot
+  artefact (its own change — the framebuffer was seeded `0xFF00FFFF`), and the
+  in-game brown bar is a window/height mismatch that left rows 236–239 unwritten
+  (fixed here). The green dot/bar still needs a RetroArch check.
 * **#186** — **edit the ticket, do not close.** The DEMO half of the headline
   claim is fixed in all four combos. The mission-start half was never reached, so
   it is still unverified. What is additionally confirmed is one fast-blitter
@@ -311,12 +313,62 @@ Rows **236–239** carry ~456+ full-width pixels whose channels are consistently
 `R > G > B` (brown/orange) where the letterbox should be black. This matches the
 report, including that it is present in every configuration.
 
-*Lead:* four rows at the very bottom of the visible field, full width — that is
-OP/TOM territory, not the blitter (see below). Check where the active display
-window ends versus where the OP stops emitting objects: the last 4 lines look
-like they are rendering stale line-buffer content instead of the background
-colour. `docs/jtrm-object-processor.md` (display pipeline / STOP object) and
-`docs/jtrm-register-map.md` (`VDB`/`VDE`, `BORD1`/`BORD2`) are the references.
+**RESOLVED** — the lead was right that this is TOM territory, but the mechanism
+is not stale *line-buffer* content: those rows are never written at all.
+
+`TOMExecHalfline` writes one framebuffer row per even halfline in
+`[topVisible, bottomVisible)`, while the presented height comes from
+`TOMGetVideoModeHeight()`, derived independently from `VDB`/`VDE`. AvP boots
+with `VDB=28` and switches to `VDB=40` at frame **2031** (`VDE=2047`,
+`VP=523`). From that point `topVisible=VDB=40`, but `bottomVisible` falls back
+to the field bottom **511** because `VDE > VP` — so 236 rows are rendered
+against a presented height of **240** (the NTSC fallback, since
+`(2047-40)/2 = 1003 > 256`). Rows 236–239 keep whatever was drawn there under
+`VDB=28` and freeze: byte-identical at frames 2200 and 2800 while rows 232–235
+correctly go black. `BGEN` is set with `BG=0x0000`, so the line buffer *is*
+being cleared — this was never a background-colour bug.
+
+Fixed by giving every presented row defined content: `TOMExecHalfline` records
+each framebuffer row as it writes it, `TOMGetWrittenRowExtent()` reports one past
+the highest row written in the frame that just completed, and `retro_run` blanks
+anything past it to opaque black before presenting.
+
+The extent is **measured, not derived from the registers**. A register-derived
+version read at end of frame gets mid-frame reprogramming wrong — rows are
+written across the whole frame, but the registers only describe the window as of
+the last halfline. The A/B sweep caught this on **DEMO1B (PD)**, which
+reprograms TOM at frame 476: the end-of-frame window computed 8 rows for a frame
+that had just been rendered 240 rows wide, so 232 legitimate rows were blanked.
+Recording rows as they are written cannot disagree with itself. The latched value
+is the max over the two most recent frames, which interlace needs (each field
+writes only every other row) and which errs towards blanking less when the window
+shrinks.
+
+The blank is also bounded to a genuine *tail* (shortfall ≤ 32 rows, and never
+when TOM wrote nothing at all). A large shortfall does not mean the rows are
+stale — it means TOM and the presented geometry disagree about the mode, and
+erasing the last good frame is worse than leaving it up. **DEMO1C (PD)** is that
+case: at frame 434 it switches to 328×135 and stops rendering entirely, and an
+unbounded blank turned a visible red colour field into a black screen. The bound
+is measured — across the 115-ROM corpus every *sustained* gap is small (4 rows
+for Evolution and AvP, 7, 8, 14, 15, 17), while DEMO1C's is 102 on a single
+mode-switch frame.
+
+Note this class of collateral is invisible to the row-level classifier — it
+rated DEMO1C `unexpected=0`, because "erased stale content" and "erased live
+content" look identical to a rule that only checks *which* rows changed and that
+they became black. It was caught by looking at the frames.
+
+Black rather than `BORD1`/`BORD2` because
+the gap rows sit *below* the visible field — `bottomVisible` **is** the field
+bottom — so they are blanking lines, not border lines; the border branch in
+`TOMExecHalfline` already covers rows inside the field but outside the active
+window.
+
+Verified with an A/B digest sweep against a stock build
+(`test/tools/fb_ab_sweep.sh` + `fb_row_diff.py`): on the AvP repro every
+differing pixel is in rows 236–239 from frame 2031 onward and becomes opaque
+black, and the audio digest is bit-identical.
 
 ### Not reproduced — green dot / green bar on the title screen
 

--- a/libretro.c
+++ b/libretro.c
@@ -56,6 +56,24 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
  * lands on a future PR. */
 #define JAGUAR_VALID_EXTENSIONS "j64|jag|rom|abs|cof|bin|prg|cue|cdi"
 
+/* Framebuffer allocation: the widest/tallest geometry TOM can advertise,
+ * not the geometry currently presented. */
+#define VIDEO_BUFFER_WIDTH   1024
+#define VIDEO_BUFFER_HEIGHT  512
+#define VIDEO_BUFFER_PIXELS  (VIDEO_BUFFER_WIDTH * VIDEO_BUFFER_HEIGHT)
+
+/* Bounds on what counts as a stale TAIL worth blanking, rather than a sign
+ * that TOM and the presented geometry disagree about the video mode.  Both
+ * must hold; see the use site in retro_run() for the measurements these are
+ * drawn from.  MAX_BLANK_TAIL_ROWS caps the shortfall in absolute rows;
+ * MIN_BLANK_COVERAGE_{NUM,DEN} additionally require the frame to be
+ * essentially fully rendered, which is the clause that catches the same
+ * situation in a short video mode (where a small absolute shortfall can
+ * still be most of the screen). */
+#define MAX_BLANK_TAIL_ROWS      32
+#define MIN_BLANK_COVERAGE_NUM   3
+#define MIN_BLANK_COVERAGE_DEN   4
+
 int videoWidth               = 0;
 int videoHeight              = 0;
 uint32_t *videoBuffer        = NULL;
@@ -1380,9 +1398,35 @@ void retro_deinit(void)
    enable_alt_inputs = false;
 }
 
+/* Fill the entire framebuffer allocation with opaque black.
+ *
+ * Not videoWidth * videoHeight: the geometry can grow to a wider stride
+ * later (320x240 -> 326x240), and rows re-laid-out at the larger pitch
+ * reach past the smaller region, so a partial fill leaves presentable
+ * pixels undefined. */
+static void video_buffer_blank(void)
+{
+   int i;
+
+   if (!videoBuffer)
+      return;
+
+   for (i = 0; i < VIDEO_BUFFER_PIXELS; ++i)
+      videoBuffer[i] = 0xFF000000;
+}
+
 void retro_reset(void)
 {
    JaguarReset();
+
+   /* Re-blank the framebuffer, or the reset presents the PREVIOUS session's
+    * pixels.  TOMReset puts tomWidth back to 0, and the border-fill path in
+    * TOMExecHalfline writes tomWidth pixels -- so until the game reprograms
+    * a TOM video register ($F00028-$F0004F) the rows above VDB get no pixels
+    * written at all and keep what was on screen before the reset.  This is
+    * the same window retro_load_game seeds for on a fresh load; a reset has
+    * to go through it too. */
+   video_buffer_blank();
 }
 
 #ifdef DEBUG_PRESENTATION
@@ -1462,6 +1506,71 @@ void retro_run(void)
    JaguarExecuteNew();
    cheat_apply_all();
    SoundCallback(NULL, sampleBuffer, vjs.hardwareTypeNTSC == 1 ? BUFNTSC : BUFPAL);
+
+   /* Give every presented row defined content.
+    *
+    * TOM renders one row per even halfline in [topVisible, bottomVisible),
+    * but the presented height comes from TOMGetVideoModeHeight(), derived
+    * independently from VDB/VDE.  When the two disagree the tail rows are
+    * never written and keep whatever was last drawn there -- frozen stale
+    * pixels that persist while the rest of the screen animates.  Alien vs
+    * Predator in-game is the reported case (#178): VDB=40, VDE=2047, VP=523
+    * gives 236 rendered rows against a presented height of 240, so rows
+    * 236-239 held a brown bar left over from an earlier VDB=28 frame.
+    *
+    * Opaque black, not the border colour: these rows sit BELOW the visible
+    * field (bottomVisible is the field bottom), so they are blanking lines,
+    * not border lines.  The border branch in TOMExecHalfline already covers
+    * rows that are inside the field but outside the active display window.
+    *
+    * The reverse mismatch also exists -- a narrow window (e.g. VDB=38,
+    * VDE=100 -> 34 rendered rows, presented height 31) writes past the
+    * presented height.  That is harmless here (the allocation is 1024x512
+    * and the extra rows are simply not shown) and is left alone. */
+   {
+      uint32_t written = TOMGetWrittenRowExtent();
+
+      /* Only blank a genuine TAIL.  A large shortfall does not mean "these
+       * rows are stale", it means TOM and the presented geometry disagree
+       * about what mode we are in -- our window model has failed, and
+       * erasing the last good frame is worse than leaving it up.
+       *
+       * The bound is measured, not a guess.  Across the 115-ROM corpus every
+       * SUSTAINED gap is small: 4 rows (Evolution, and Alien vs Predator --
+       * the reported case), 7 (Cannon Fodder, Gorf 2000), 8 (Bubsy), 14
+       * (Pitfall), 15, 17 (Sensible Soccer).  The one pathological case is
+       * DEMO1C (PD) at 102 rows on a single frame as it switches to a
+       * 328x135 mode and then stops rendering entirely -- blanking there
+       * erased a visible colour field and left a black screen.  32 leaves
+       * generous headroom over the observed maximum while excluding that
+       * class by a wide margin.
+       *
+       * The coverage clause is what makes this hold at any frame height: in
+       * a short mode a shortfall well inside 32 rows can still be most of
+       * the screen (height 40 with 8 rows written is the DEMO1C shape at
+       * small scale), and requiring the frame to be >= 3/4 rendered rejects
+       * it.  Measured coverage separates the two classes by a wide margin --
+       * every real tail above is 93-98% rendered, DEMO1C's transition frame
+       * is 24%.
+       *
+       * written == 0 (TOM addressed no rows at all) is the degenerate form
+       * of the same thing; the coverage test already rejects it, but keep it
+       * explicit so the intent survives a future tweak of the bounds. */
+      if (written > 0 && written < (uint32_t)game_height
+          && (uint32_t)game_height - written <= MAX_BLANK_TAIL_ROWS
+          && written * MIN_BLANK_COVERAGE_DEN
+             >= (uint32_t)game_height * MIN_BLANK_COVERAGE_NUM)
+      {
+         uint32_t row;
+         uint32_t col;
+         for (row = written; row < (uint32_t)game_height; row++)
+         {
+            uint32_t *line = videoBuffer + (row * (uint32_t)game_width);
+            for (col = 0; col < (uint32_t)game_width; col++)
+               line[col] = 0xFF000000;
+         }
+      }
+   }
 
    /* Runtime watchdog: looks for GPU/DSP PC escape, GPU/DSP wedge,
     * and video stall. Fires LOG_WRN/LOG_ERR via vj_log_cb so the

--- a/libretro.c
+++ b/libretro.c
@@ -1423,9 +1423,14 @@ void retro_reset(void)
     * pixels.  TOMReset puts tomWidth back to 0, and the border-fill path in
     * TOMExecHalfline writes tomWidth pixels -- so until the game reprograms
     * a TOM video register ($F00028-$F0004F) the rows above VDB get no pixels
-    * written at all and keep what was on screen before the reset.  This is
-    * the same window retro_load_game seeds for on a fresh load; a reset has
-    * to go through it too. */
+    * written at all and keep what was on screen before the reset.
+    *
+    * retro_load_game seeds the buffer for that same window on a fresh load,
+    * so a reset has to cover it too -- but note it currently seeds a cyan
+    * placeholder (0xFF00FFFF), not black.  Blanking to opaque black here is
+    * deliberate and independent of that: black is what a display shows with
+    * no signal, and it is correct whatever the load-time seed turns out to
+    * be.  #218 changes the load path to seed black as well. */
    video_buffer_blank();
 }
 

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -400,6 +400,22 @@ uint32_t tomTimerPrescaler;
 uint32_t tomTimerDivider;
 int32_t tomTimerCounter;
 static uint16_t tomHCReadPhase;
+
+/* Rows TOMExecHalfline actually wrote, tracked live so a mid-frame VDB/VDE
+ * change cannot make the count disagree with what was drawn.  `Cur`
+ * accumulates the frame in progress; `Prev` and `Last` are latched at the
+ * halfline wrap.
+ *
+ * `Last` is the max of the two most recent frames rather than just the last
+ * one, for interlace: each field writes only every other row, so a single
+ * frame's maximum alternates by one and blanking on it alone would erase and
+ * rewrite the bottom row of the opposite field every frame.  Taking the max
+ * also adds a frame of hysteresis when the window shrinks, which errs towards
+ * blanking less -- the safe direction, since blanking too much is the failure
+ * mode that matters. */
+static uint32_t tomRowsWrittenCur;
+static uint32_t tomRowsWrittenPrev;
+static uint32_t tomRowsWrittenLast;
 uint16_t tom_jerry_int_pending, tom_timer_int_pending, tom_object_int_pending,
          tom_gpu_int_pending, tom_video_int_pending;
 
@@ -888,8 +904,22 @@ void TOMExecHalfline(uint16_t halfline, bool render)
    uint16_t topVisible;
    uint16_t bottomVisible;
    uint16_t hp = GET16(tomRam8, HP);
+   uint32_t writtenRow;
 
    halfline &= 0x07FF;
+
+   /* Halfline 0 is the frame wrap: latch the row count for the frame that
+    * just finished before halfline 0 contributes to the next one.
+    * JaguarExecuteNew ends its frame right after this call, so a caller
+    * reading TOMGetWrittenRowExtent() from retro_run sees the frame it is
+    * about to present. */
+   if (halfline == 0)
+   {
+      tomRowsWrittenLast = (tomRowsWrittenCur > tomRowsWrittenPrev)
+                         ? tomRowsWrittenCur : tomRowsWrittenPrev;
+      tomRowsWrittenPrev = tomRowsWrittenCur;
+      tomRowsWrittenCur  = 0;
+   }
 
    // Update HC to approximate position within the scanline.
    // Bit 10 (0x0400) is the half-line indicator, analogous to VC's
@@ -950,9 +980,21 @@ void TOMExecHalfline(uint16_t halfline, bool render)
    {
       // Bit 0 in VP is interlace flag. 0 = interlace, 1 = non-interlaced
       if (tomRam8[VP + 1] & 0x01)
-         TOMCurrentLine = &(screenBuffer[((halfline - topVisible) / 2) * screenPitch]);//non-interlace
+      {
+         writtenRow = (halfline - topVisible) / 2;//non-interlace
+         TOMCurrentLine = &(screenBuffer[writtenRow * screenPitch]);
+      }
       else
-         TOMCurrentLine = &(screenBuffer[(((halfline - topVisible) / 2) * screenPitch * 2) + (field2 ? 0 : screenPitch)]);//interlace
+      {
+         writtenRow = (((halfline - topVisible) / 2) * 2) + (field2 ? 0 : 1);//interlace
+         TOMCurrentLine = &(screenBuffer[(((halfline - topVisible) / 2) * screenPitch * 2) + (field2 ? 0 : screenPitch)]);
+      }
+
+      /* Record the row regardless of which branch below fills it: both the
+       * scanline renderer and the border fill count as TOM having addressed
+       * this row.  See TOMGetWrittenRowExtent(). */
+      if (writtenRow + 1 > tomRowsWrittenCur)
+         tomRowsWrittenCur = writtenRow + 1;
 
       if (inActiveDisplayArea)
          scanline_render[TOMGetVideoMode()](TOMCurrentLine);
@@ -1014,6 +1056,32 @@ uint32_t TOMGetVideoModeWidth(void)
    }
 
    return ((rightHC - leftHC) / pwidth) * pwidth_scale;
+}
+
+/* One past the highest framebuffer row TOMExecHalfline wrote in the frame that
+ * just completed.
+ *
+ * MEASURED, not derived from the registers.  Deriving it from VDB/VDE at the
+ * end of the frame gets the mid-frame reprogramming case wrong: rows are
+ * written across the whole frame, but the registers only describe the window
+ * as of the last halfline.  DEMO1B (PD) reprograms TOM at frame 476 -- the
+ * end-of-frame window computes 8 rows while the frame had actually just been
+ * rendered 240 rows wide, so a register-derived extent would report a
+ * 232-row gap that does not exist.  TOMExecHalfline records each row as it
+ * writes it instead, which cannot disagree with itself.
+ *
+ * This is NOT the same quantity as TOMGetVideoModeHeight(), which is the
+ * presented height and is derived independently from VDB/VDE.  The two
+ * disagree whenever the visible window and the mode height fall back
+ * differently -- e.g. Alien vs Predator in-game programs VDB=40, VDE=2047,
+ * VP=523, so topVisible=VDB=40 but bottomVisible falls back to the field
+ * bottom (511) because VDE > VP, giving 236 written rows against a presented
+ * height of 240 (the NTSC fallback, since (2047-40)/2 > 256).  Callers use
+ * this to give the leftover rows defined content instead of letting them keep
+ * whatever was last drawn there. */
+uint32_t TOMGetWrittenRowExtent(void)
+{
+   return tomRowsWrittenLast;
 }
 
 uint32_t TOMGetVideoModeHeight(void)
@@ -1090,6 +1158,10 @@ void TOMReset(void)
 
    tomWidth = 0;
    tomHeight = 0;
+
+   tomRowsWrittenCur = 0;
+   tomRowsWrittenPrev = 0;
+   tomRowsWrittenLast = 0;
 
    tom_jerry_int_pending = 0;
    tom_timer_int_pending = 0;

--- a/src/tom/tom.h
+++ b/src/tom/tom.h
@@ -43,6 +43,7 @@ void TOMWriteWord(uint32_t offset, uint16_t data, uint32_t who);
 void TOMExecHalfline(uint16_t halfline, bool render);
 uint32_t TOMGetVideoModeWidth(void);
 uint32_t TOMGetVideoModeHeight(void);
+uint32_t TOMGetWrittenRowExtent(void);
 uint8_t TOMGetVideoMode(void);
 uint8_t * TOMGetRamPointer(void);
 uint16_t TOMGetHDB(void);

--- a/test/tools/fb_ab_sweep.sh
+++ b/test/tools/fb_ab_sweep.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# test/tools/fb_ab_sweep.sh — A/B framebuffer sweep across a ROM corpus.
+#
+# Runs every ROM under $ROMS_ROOT through fb_row_digest against two cores and
+# classifies the difference with fb_row_diff.py.  Written for the AvP "brown
+# bar" change (#178), where the fix is only acceptable if every differing
+# pixel is a row the old build left unwritten becoming opaque black.
+#
+# Usage:
+#   ROMS_ROOT=/path/to/roms \
+#   STOCK_CORE=/path/to/stock.dylib \
+#   PATCHED_CORE=./virtualjaguar_libretro.dylib \
+#   [FRAMES=1200] [OUTDIR=/tmp/fbsweep] [PRESS="--press 700:b:8 ..."] \
+#     bash test/tools/fb_ab_sweep.sh
+#
+# Exits non-zero if any title shows a difference the rule does not allow.
+
+set -uo pipefail
+
+ROMS_ROOT=${ROMS_ROOT:?set ROMS_ROOT to the ROM corpus root}
+STOCK_CORE=${STOCK_CORE:?set STOCK_CORE to the reference build}
+PATCHED_CORE=${PATCHED_CORE:-./virtualjaguar_libretro.dylib}
+FRAMES=${FRAMES:-1200}
+OUTDIR=${OUTDIR:-/tmp/fbsweep}
+PRESS=${PRESS:-}
+DIGEST=${DIGEST:-./test/tools/fb_row_digest}
+DIFF=${DIFF:-./test/tools/fb_row_diff.py}
+
+mkdir -p "$OUTDIR"
+: > "$OUTDIR/summary.txt"
+
+# Does this digest hold at least one video frame?
+#
+# Read the frame count out of the header rather than judging on file size.
+# fb_row_digest patches that count in with an fseek at the END of the run, so
+# a digest from an interrupted run is large but still reports zero -- and a
+# size test would wave it through as valid, silently comparing against
+# nothing.  A ROM the core refused to load leaves just the 16-byte header.
+has_frames() {
+    [ -f "$1" ] || { echo no; return; }
+    if [ "$(od -An -tu4 -j8 -N4 "$1" | tr -d ' ')" -gt 0 ] 2>/dev/null; then
+        echo yes
+    else
+        echo no
+    fi
+}
+
+fail=0
+count=0
+changed=0
+
+# shellcheck disable=SC2206
+press_args=($PRESS)
+
+while IFS= read -r rom; do
+    name=$(basename "$rom")
+    name=${name%.*}
+    slug=$(printf '%s' "$name" | tr -c 'A-Za-z0-9' '_')
+    count=$((count + 1))
+
+    # The reference build does not change between iterations of the fix, so
+    # keep its digest.  Delete $OUTDIR (or set REDO_STOCK=1) to force a re-run.
+    if [ -s "$OUTDIR/$slug.stock.bin" ] && [ "${REDO_STOCK:-0}" != 1 ]; then
+        s_out="frames=cached"
+    else
+        s_out=$("$DIGEST" "$STOCK_CORE" "$rom" --frames "$FRAMES" \
+                    "${press_args[@]}" --out "$OUTDIR/$slug.stock.bin" --quiet 2>&1)
+    fi
+    p_out=$("$DIGEST" "$PATCHED_CORE" "$rom" --frames "$FRAMES" \
+                "${press_args[@]}" --out "$OUTDIR/$slug.patched.bin" --quiet 2>&1)
+
+    # A ROM the core refuses to load writes only the 16-byte header.  That is
+    # a corpus fact, not a regression -- but it must be true of BOTH builds,
+    # so report a one-sided failure loudly instead of skipping it.  Judge on
+    # file size rather than stdout so the cached-stock path behaves the same.
+    s_ok=$(has_frames "$OUTDIR/$slug.stock.bin")
+    p_ok=$(has_frames "$OUTDIR/$slug.patched.bin")
+    : "$s_out" "$p_out"
+    if [ "$s_ok" != yes ] || [ "$p_ok" != yes ]; then
+        if [ "$s_ok" = "$p_ok" ]; then
+            echo "SKIP $name: neither build loads this ROM" \
+                | tee -a "$OUTDIR/summary.txt"
+        else
+            echo "FAIL $name: loads on one build only (stock=$s_ok patched=$p_ok)" \
+                | tee -a "$OUTDIR/summary.txt"
+            fail=$((fail + 1))
+        fi
+        continue
+    fi
+
+    line=$(python3 "$DIFF" "$OUTDIR/$slug.stock.bin" "$OUTDIR/$slug.patched.bin" \
+                   --label "$name")
+    rc=$?
+    echo "$line" | tee -a "$OUTDIR/summary.txt"
+    [ $rc -ne 0 ] && fail=$((fail + 1))
+    case "$line" in *"changed_frames=0 "*) ;; *) changed=$((changed + 1));; esac
+done < <(find "$ROMS_ROOT" -type f \( -iname '*.j64' -o -iname '*.jag' \) | sort)
+
+echo "" | tee -a "$OUTDIR/summary.txt"
+echo "titles=$count changed=$changed unexpected=$fail" | tee -a "$OUTDIR/summary.txt"
+exit $((fail > 0 ? 1 : 0))

--- a/test/tools/fb_row_diff.py
+++ b/test/tools/fb_row_diff.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Classify the A/B difference between two fb_row_digest dumps.
+
+Written for the AvP "brown bar" sweep (#178).  The fix under test must only
+ever change rows the core previously left unwritten, and must only ever
+change them to opaque black.  This checks that mechanically so a 46-title
+sweep does not depend on reading 46 screenshots.
+
+Checks, in order of severity:
+  1. Geometry must match frame for frame.  Any difference is a hard failure.
+  2. Per-frame audio digests must match.  A video-window change cannot alter
+     audio; any difference is a hard failure.
+  3. Every row whose hash differs must be >= the patched build's written-row
+     extent for that frame, and its patched hash must equal the all-opaque-
+     black hash for that width.  Anything else is a hard failure.
+
+Usage:  fb_row_diff.py <stock.bin> <patched.bin> [--label NAME] [--quiet]
+Exit:   0 = identical or only expected differences, 1 = unexpected difference,
+        2 = usage/format error.
+"""
+
+import struct
+import sys
+
+MAGIC = b"VJFBDIG2"
+HDR = struct.Struct("<4I")          # width, height, frame_hash, written_extent
+NO_EXTENT = 0xFFFFFFFF
+
+
+def fnv1a(data, h=2166136261):
+    for b in data:
+        h ^= b
+        h = (h * 16777619) & 0xFFFFFFFF
+    return h
+
+
+_black_cache = {}
+
+
+def black_row_hash(width):
+    """Hash of a row of `width` opaque-black XRGB8888 pixels, in the same
+    little-endian byte order fb_row_digest hashes the framebuffer in."""
+    if width not in _black_cache:
+        _black_cache[width] = fnv1a(b"\x00\x00\x00\xff" * width)
+    return _black_cache[width]
+
+
+def load(path):
+    with open(path, "rb") as f:
+        blob = f.read()
+    if blob[:8] != MAGIC:
+        raise ValueError(f"{path}: bad magic {blob[:8]!r}")
+    nvideo, naudio = struct.unpack_from("<2I", blob, 8)
+    frames = []
+    off = 16
+    for _ in range(nvideo):
+        w, h, fh, extent = HDR.unpack_from(blob, off)
+        off += HDR.size
+        rows = struct.unpack_from(f"<{h}I", blob, off)
+        off += 4 * h
+        frames.append((w, h, fh, extent, rows))
+    audio = struct.unpack_from(f"<{naudio}I", blob, off) if naudio else ()
+    return frames, list(audio)
+
+
+def main():
+    argv = sys.argv[1:]
+    label = "run"
+    args = []
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--label" and i + 1 < len(argv):
+            label = argv[i + 1]
+            i += 2
+        elif argv[i].startswith("--"):
+            i += 1
+        else:
+            args.append(argv[i])
+            i += 1
+    if len(args) != 2:
+        print(__doc__)
+        return 2
+
+    frames_a, audio_a = load(args[0])
+    frames_b, audio_b = load(args[1])
+
+    unexpected = []
+    changed_frames = 0
+    changed_rows = set()
+    first_changed_frame = None
+
+    # How many frames actually had a tail gap for the fix to act on, and how
+    # often the written-row extent moved.  Without these, "changed_frames=0"
+    # is ambiguous: it cannot distinguish "this title is unaffected" from
+    # "this run never reached an affected state", so a wall of OKs would
+    # imply coverage the sweep does not have.
+    #
+    # extent_changes also bounds a class the row check cannot see: the extent
+    # is read at end of frame, but rows are written across the frame, so a
+    # title that moves VDB mid-frame could have a legitimately-written row
+    # blanked using the new extent.  A title whose extent barely moves cannot
+    # be hitting that; one that churns every frame deserves a look.
+    gap_frames = sum(1 for (_w, h, _fh, ext, _r) in frames_b
+                     if ext != NO_EXTENT and ext < h)
+    extents = [ext for (_w, _h, _fh, ext, _r) in frames_b if ext != NO_EXTENT]
+    extent_changes = sum(1 for a_, b_ in zip(extents, extents[1:]) if a_ != b_)
+
+    if len(frames_a) != len(frames_b):
+        unexpected.append((-1, -1,
+                           f"frame count {len(frames_a)} != {len(frames_b)}"))
+    if audio_a != audio_b:
+        n = sum(1 for x, y in zip(audio_a, audio_b) if x != y)
+        first = next((k for k, (x, y) in enumerate(zip(audio_a, audio_b))
+                      if x != y), None)
+        unexpected.append((-1, -1, f"audio differs in {n} frames, "
+                                   f"first at audio frame {first}"))
+
+    for n, (fa, fb_) in enumerate(zip(frames_a, frames_b)):
+        wa, ha, fha, _exta, rowsa = fa
+        wb, hb, fhb, extb, rowsb = fb_
+
+        if (wa, ha) != (wb, hb):
+            unexpected.append((n, -1, f"geometry {wa}x{ha} -> {wb}x{hb}"))
+            continue
+        if fha == fhb:
+            continue
+
+        changed_frames += 1
+        if first_changed_frame is None:
+            first_changed_frame = n
+
+        blk = black_row_hash(wb)
+        for r in range(ha):
+            if rowsa[r] == rowsb[r]:
+                continue
+            changed_rows.add(r)
+            if extb != NO_EXTENT and r < extb:
+                unexpected.append((n, r, f"row < written extent {extb}"))
+            elif rowsb[r] != blk:
+                unexpected.append((n, r, "patched row is not opaque black"))
+
+    ok = not unexpected
+    rows_desc = (f"{min(changed_rows)}-{max(changed_rows)}"
+                 if changed_rows else "none")
+    print(f"{'OK  ' if ok else 'FAIL'} {label}: frames={len(frames_a)} "
+          f"gap_frames={gap_frames} extent_changes={extent_changes} "
+          f"changed_frames={changed_frames} changed_rows={rows_desc} "
+          f"first_changed_frame={first_changed_frame} "
+          f"unexpected={len(unexpected)}")
+    for frame, row, why in unexpected[:10]:
+        print(f"       frame {frame} row {row}: {why}")
+    if len(unexpected) > 10:
+        print(f"       ... {len(unexpected) - 10} more")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/tools/fb_row_digest.c
+++ b/test/tools/fb_row_digest.c
@@ -20,7 +20,14 @@
  * Usage:
  *   fb_row_digest <core> <rom> --frames N --out FILE [harness flags...]
  *
- * File format (host byte order, LE in practice):
+ * File format.  Every uint32 is written LITTLE-ENDIAN regardless of host, so
+ * the dump is stable and matches fb_row_diff.py, which unpacks with "<".
+ *
+ * (The row hashes themselves are taken over the raw host framebuffer bytes,
+ * so digests are only meaningful when compared between runs on the same
+ * host -- which is the intended use, two builds on one machine.  The reader's
+ * all-black row constant likewise assumes little-endian XRGB8888 in memory.)
+ *
  *   magic  "VJFBDIG2"                        8 bytes
  *   uint32 video_frame_count
  *   uint32 audio_frame_count
@@ -62,9 +69,17 @@ static uint32_t fnv1a(const void *data, size_t len, uint32_t hash)
     return hash;
 }
 
+/* Write little-endian explicitly rather than dumping the host's uint32.
+ * fb_row_diff.py unpacks with "<", so a big-endian host writing native order
+ * would produce a digest the reader silently misparses. */
 static void put_u32(FILE *f, uint32_t v)
 {
-    fwrite(&v, sizeof(v), 1, f);
+    uint8_t b[4];
+    b[0] = (uint8_t)(v & 0xFF);
+    b[1] = (uint8_t)((v >> 8) & 0xFF);
+    b[2] = (uint8_t)((v >> 16) & 0xFF);
+    b[3] = (uint8_t)((v >> 24) & 0xFF);
+    fwrite(b, 1, sizeof(b), f);
 }
 
 static void on_video(void *userdata, const void *data,
@@ -92,7 +107,8 @@ static void on_video(void *userdata, const void *data,
     put_u32(st->out, rows);
     put_u32(st->out, frame_hash);
     put_u32(st->out, st->get_extent ? st->get_extent() : 0xFFFFFFFFu);
-    fwrite(row_hash, sizeof(uint32_t), rows, st->out);
+    for (row = 0; row < rows; row++)
+        put_u32(st->out, row_hash[row]);
 
     st->frames_written++;
 }

--- a/test/tools/fb_row_digest.c
+++ b/test/tools/fb_row_digest.c
@@ -1,0 +1,187 @@
+/*
+ * test/tools/fb_row_digest.c — per-frame framebuffer + audio digest dumper.
+ *
+ * Runs a ROM headlessly and writes a compact binary digest: geometry, a
+ * whole-frame hash and a per-row hash for every presented row, plus a
+ * per-frame audio hash.  Two builds can then be diffed row-exactly by
+ * test/tools/fb_row_diff.py without keeping raw framebuffers around.
+ *
+ * Written for the AvP "brown bar" A/B sweep (#178): the claim under test is
+ * that the fix only ever changes rows the core previously left unwritten,
+ * and only ever changes them to opaque black.  fb_row_diff.py checks exactly
+ * that, so a 46-title sweep is validated mechanically instead of by eye.
+ *
+ * Build:
+ *   cc -O2 -Wall -std=c99 -I. -I./src -I./src/core -I./src/tom -I./src/jerry \
+ *      -I./src/cd -I./src/bios -I./src/m68000 -I./libretro-common/include \
+ *      -o test/tools/fb_row_digest test/tools/fb_row_digest.c \
+ *      test/harness/harness.c -ldl -lm
+ *
+ * Usage:
+ *   fb_row_digest <core> <rom> --frames N --out FILE [harness flags...]
+ *
+ * File format (host byte order, LE in practice):
+ *   magic  "VJFBDIG2"                        8 bytes
+ *   uint32 video_frame_count
+ *   uint32 audio_frame_count
+ *   video_frame_count records of:
+ *     uint32 width, height, frame_hash, written_extent
+ *       (written_extent is 0xFFFFFFFF when the core does not export
+ *        TOMGetWrittenRowExtent, i.e. for a pre-fix reference build)
+ *     uint32 row_hash[height]
+ *   audio_frame_count records of:
+ *     uint32 audio_hash   (samples, peaks, non-silent count, RMS L/R)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../harness/harness.h"
+
+#define MAX_ROWS 512
+#define FNV_SEED 2166136261u
+
+typedef struct {
+    FILE     *out;
+    uint32_t  frames_written;
+    uint32_t (*get_extent)(void);
+} digest_state;
+
+/* FNV-1a, 32-bit. */
+static uint32_t fnv1a(const void *data, size_t len, uint32_t hash)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    size_t i;
+    for (i = 0; i < len; i++)
+    {
+        hash ^= p[i];
+        hash *= 16777619u;
+    }
+    return hash;
+}
+
+static void put_u32(FILE *f, uint32_t v)
+{
+    fwrite(&v, sizeof(v), 1, f);
+}
+
+static void on_video(void *userdata, const void *data,
+                     unsigned width, unsigned height, size_t pitch)
+{
+    digest_state *st = (digest_state *)userdata;
+    uint32_t row_hash[MAX_ROWS];
+    uint32_t frame_hash = FNV_SEED;
+    unsigned row;
+    unsigned rows = height;
+
+    if (!data || !st->out)
+        return;
+    if (rows > MAX_ROWS)
+        rows = MAX_ROWS;
+
+    for (row = 0; row < rows; row++)
+    {
+        const uint8_t *line = (const uint8_t *)data + (size_t)row * pitch;
+        row_hash[row] = fnv1a(line, (size_t)width * 4, FNV_SEED);
+        frame_hash = fnv1a(&row_hash[row], sizeof(uint32_t), frame_hash);
+    }
+
+    put_u32(st->out, width);
+    put_u32(st->out, rows);
+    put_u32(st->out, frame_hash);
+    put_u32(st->out, st->get_extent ? st->get_extent() : 0xFFFFFFFFu);
+    fwrite(row_hash, sizeof(uint32_t), rows, st->out);
+
+    st->frames_written++;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    digest_state st;
+    const char *out_path = NULL;
+    uint32_t run_audio_hash = FNV_SEED;
+    unsigned i;
+
+    memset(&st, 0, sizeof(st));
+
+    for (i = 1; i < (unsigned)argc; i++)
+    {
+        if (!strcmp(argv[i], "--out") && i + 1 < (unsigned)argc)
+        {
+            out_path = argv[i + 1];
+            /* Neutralise both args so the harness parser ignores them. */
+            argv[i] = (char *)"--quiet";
+            argv[i + 1] = (char *)"--quiet";
+            i++;
+        }
+    }
+
+    if (!out_path)
+    {
+        fprintf(stderr, "fb_row_digest: --out FILE is required\n");
+        return 2;
+    }
+
+    cfg.frames = 1200;
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+
+    st.out = fopen(out_path, "wb");
+    if (!st.out)
+    {
+        fprintf(stderr, "fb_row_digest: cannot write %s\n", out_path);
+        return 1;
+    }
+
+    /* Only a build carrying the fix exports this. */
+    st.get_extent = (uint32_t (*)(void))harness_dlsym(&cfg, "TOMGetWrittenRowExtent");
+
+    cfg.video_callback      = on_video;
+    cfg.video_callback_data = &st;
+
+    fwrite("VJFBDIG2", 1, 8, st.out);
+    put_u32(st.out, 0);   /* video frame count, patched below */
+    put_u32(st.out, 0);   /* audio frame count, patched below */
+
+    if (!harness_load_rom(&cfg))
+    {
+        fclose(st.out);
+        return 1;
+    }
+
+    harness_run(&cfg);
+
+    /* Audio trailer.  A video-window change must not touch audio, so these
+     * have to match bit-exactly between the two builds.  RMS is included
+     * because peak + non-silent count alone are too coarse to notice a
+     * changed waveform with the same envelope. */
+    for (i = 0; i < cfg.audio.frame_count; i++)
+    {
+        const harness_audio_frame *af = &cfg.audio.frames[i];
+        uint32_t h = FNV_SEED;
+        h = fnv1a(&af->samples,   sizeof(af->samples),   h);
+        h = fnv1a(&af->peak_l,    sizeof(af->peak_l),    h);
+        h = fnv1a(&af->peak_r,    sizeof(af->peak_r),    h);
+        h = fnv1a(&af->nonsilent, sizeof(af->nonsilent), h);
+        h = fnv1a(&af->rms_l,     sizeof(af->rms_l),     h);
+        h = fnv1a(&af->rms_r,     sizeof(af->rms_r),     h);
+        put_u32(st.out, h);
+        run_audio_hash = fnv1a(&h, sizeof(h), run_audio_hash);
+    }
+
+    fseek(st.out, 8, SEEK_SET);
+    put_u32(st.out, st.frames_written);
+    put_u32(st.out, cfg.audio.frame_count);
+    fclose(st.out);
+
+    printf("frames=%u audio_frames=%u total_samples=%zu audio_digest=%08X "
+           "extent_export=%s\n",
+           st.frames_written, cfg.audio.frame_count, cfg.audio.total_samples,
+           run_audio_hash, st.get_extent ? "yes" : "no");
+
+    harness_shutdown(&cfg);
+    return 0;
+}

--- a/test/tools/tom_window_trace.c
+++ b/test/tools/tom_window_trace.c
@@ -1,0 +1,187 @@
+/*
+ * test/tools/tom_window_trace.c — trace TOM's vertical display window.
+ *
+ * Prints VDB / VDE / VP / presented geometry / written-row extent whenever
+ * any of them changes, plus the framebuffer contents of the last few rows so
+ * an unwritten tail is directly visible.  Written to pin down the AvP
+ * "brown bar" window mismatch (#178).
+ *
+ * Build:
+ *   cc -O2 -Wall -std=c99 -I. -I./src -I./src/core -I./src/tom -I./src/jerry \
+ *      -I./src/cd -I./src/bios -I./src/m68000 -I./libretro-common/include \
+ *      -o test/tools/tom_window_trace test/tools/tom_window_trace.c \
+ *      test/harness/harness.c -ldl -lm
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../harness/harness.h"
+
+typedef struct {
+    const uint8_t *tom_ram;
+    uint32_t (*get_extent)(void);
+    uint32_t (*get_height)(void);
+    unsigned frame;
+    unsigned last_vdb, last_vde, last_vp, last_w, last_h, last_ext;
+    int      have_last;
+    /* last presented frame, for tail-row inspection */
+    uint32_t tail[8][4];
+    unsigned tail_rows;
+    unsigned top_nonblack;   /* non-black rows among the top 16 */
+} trace_state;
+
+/* Count rows in the top `n` of the presented frame that are not entirely
+ * opaque black.  Used to check that a reset does not present the previous
+ * session's pixels in the rows above VDB. */
+static unsigned nonblack_top_rows(const uint32_t *fb, unsigned w, unsigned h,
+                                  size_t pitch, unsigned n)
+{
+    unsigned r, c, count = 0;
+    if (n > h)
+        n = h;
+    for (r = 0; r < n; r++)
+    {
+        const uint32_t *line =
+            (const uint32_t *)((const uint8_t *)fb + (size_t)r * pitch);
+        for (c = 0; c < w; c++)
+            if (line[c] != 0xFF000000u)
+            {
+                count++;
+                break;
+            }
+    }
+    return count;
+}
+
+static unsigned rd16(const uint8_t *p, unsigned off)
+{
+    return ((unsigned)p[off] << 8) | p[off + 1];
+}
+
+static void on_video(void *ud, const void *data, unsigned w, unsigned h,
+                     size_t pitch)
+{
+    trace_state *st = (trace_state *)ud;
+    unsigned vdb, vde, vp, ext;
+    unsigned r;
+
+    if (!data || !st->tom_ram)
+        return;
+
+    vdb = rd16(st->tom_ram, 0x46);
+    vde = rd16(st->tom_ram, 0x48);
+    vp  = rd16(st->tom_ram, 0x3E);
+    ext = st->get_extent ? st->get_extent() : 0;
+
+    if (!st->have_last || vdb != st->last_vdb || vde != st->last_vde ||
+        vp != st->last_vp || w != st->last_w || h != st->last_h ||
+        ext != st->last_ext)
+    {
+        printf("frame %5u: VDB=%-5u VDE=%-5u VP=%-5u  present=%ux%u  "
+               "modeHeight=%u  writtenExtent=%u%s\n",
+               st->frame, vdb, vde, vp, w, h,
+               st->get_height ? st->get_height() : 0, ext,
+               (ext < h) ? "   <-- TAIL GAP" : "");
+        st->have_last = 1;
+        st->last_vdb = vdb; st->last_vde = vde; st->last_vp = vp;
+        st->last_w = w; st->last_h = h; st->last_ext = ext;
+    }
+
+    /* Keep the bottom 8 rows' first 4 pixels so the caller can see whether
+     * the tail is stale content, border colour, or black. */
+    st->tail_rows = (h < 8) ? h : 8;
+    for (r = 0; r < st->tail_rows; r++)
+    {
+        const uint32_t *line =
+            (const uint32_t *)((const uint8_t *)data +
+                               (size_t)(h - st->tail_rows + r) * pitch);
+        memcpy(st->tail[r], line, sizeof(uint32_t) * 4);
+    }
+
+    st->top_nonblack = nonblack_top_rows((const uint32_t *)data, w, h, pitch, 16);
+}
+
+static int arg_matches_frame(const char *flag, unsigned f, int argc, char **argv)
+{
+    int i;
+    for (i = 1; i < argc; i++)
+        if (!strcmp(argv[i], flag) && i + 1 < argc &&
+            (unsigned)atoi(argv[i + 1]) == f)
+            return 1;
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    trace_state st;
+    void (*lr_reset)(void);
+    unsigned f;
+
+    memset(&st, 0, sizeof(st));
+
+    cfg.frames = 3000;
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+
+    st.tom_ram    = (const uint8_t *)harness_dlsym(&cfg, "tomRam8");
+    st.get_extent = (uint32_t (*)(void))harness_dlsym(&cfg, "TOMGetWrittenRowExtent");
+    st.get_height = (uint32_t (*)(void))harness_dlsym(&cfg, "TOMGetVideoModeHeight");
+    if (!st.tom_ram)
+    {
+        fprintf(stderr, "tom_window_trace: tomRam8 not exported "
+                        "(build the core with TEST_EXPORTS=1)\n");
+        return 1;
+    }
+
+    cfg.video_callback      = on_video;
+    cfg.video_callback_data = &st;
+
+    if (!harness_load_rom(&cfg))
+        return 1;
+
+    lr_reset = (void (*)(void))harness_dlsym(&cfg, "retro_reset");
+
+    for (f = 0; f < cfg.frames; f++)
+    {
+        st.frame = f;
+        harness_step(&cfg);
+
+        /* --reset-at N: reset after frame N, then report how many of the
+         * top 16 presented rows are still non-black on the next frame.
+         * Those rows are the ones TOM cannot write until the game
+         * reprograms a video register, so a non-zero count means the
+         * reset presented the previous session's pixels. */
+        if (lr_reset && arg_matches_frame("--reset-at", f, argc, argv))
+        {
+            printf("  frame %u: top-16 non-black rows before reset: %u\n",
+                   f, st.top_nonblack);
+            lr_reset();
+            st.frame = f + 1;
+            harness_step(&cfg);
+            printf("  frame %u: top-16 non-black rows after reset:  %u%s\n",
+                   f + 1, st.top_nonblack,
+                   st.top_nonblack ? "   <-- STALE" : "   (clean)");
+        }
+
+        if (arg_matches_frame("--dump-at", f, argc, argv))
+        {
+            unsigned r, c;
+            printf("  tail rows at frame %u (bottom %u rows, first 4 px):\n",
+                   f, st.tail_rows);
+            for (r = 0; r < st.tail_rows; r++)
+            {
+                printf("    row %-3u:", st.last_h - st.tail_rows + r);
+                for (c = 0; c < 4; c++)
+                    printf(" %08X", st.tail[r][c]);
+                printf("\n");
+            }
+        }
+    }
+
+    harness_shutdown(&cfg);
+    return 0;
+}


### PR DESCRIPTION
Fixes the Alien vs Predator in-game "brown bar" reported in #178: rows 236-239 of the presented framebuffer hold frozen stale content (full-width R>G>B browns like `0x382008`) where black belongs.

Split out of #218 (the first-frame cyan bar) because it has a different root cause and a much larger blast radius.

## Root cause

The presented frame is taller than the number of rows TOM renders. `TOMExecHalfline` writes one row per even halfline in `[topVisible, bottomVisible)`, but the presented height comes from `TOMGetVideoModeHeight()`, derived *independently* from VDB/VDE. When the two fall back differently, the tail rows are never written and keep whatever was last drawn there.

Measured on AvP: it boots with VDB=28 and switches to **VDB=40 at frame 2031** (VDE=2047, VP=523). From there `topVisible`=VDB=40, but `bottomVisible` falls back to the field bottom 511 because VDE > VP — so 236 rows are rendered against a presented height of 240 (the NTSC fallback, since `(2047-40)/2 = 1003 > 256`). Rows 236-239 keep the content drawn under VDB=28 and freeze: byte-identical at frames 2200 and 2800 while rows 232-235 correctly go black.

Not a background-colour bug (BGEN is set, BG=0x0000, so the line buffer *is* being cleared) and not the framebuffer seed.

## Approach

The ticket offered two options: blank the unrendered tail, or unify the row origin on the visible field. **This takes the first**, deliberately.

Option (b) only closes the gap because NTSC's `(511-31)/2` happens to equal 240. Give a title a sane VDE — `VDB=38, VDE=400` — and it yields 184 rendered rows against a reported height of 200: the gap is inverted, not fixed. Making (b) correct requires the presented height to become `(bottomVisible - topVisible)/2` as well, which changes advertised geometry for many titles. That's a separate, larger change.

So: fix the invariant instead. **Every presented row must have defined content.** `TOMExecHalfline` records each framebuffer row as it writes it, `TOMGetWrittenRowExtent()` reports one past the highest row written in the frame that just completed, and `retro_run` blanks anything past it before presenting.

### The extent is measured, not derived

A register-derived extent read at end of frame gets mid-frame reprogramming wrong: rows are written *across* the whole frame, but the registers only describe the window as of the last halfline. **DEMO1B (PD)** reprograms TOM at frame 476, so the end-of-frame window computed 8 rows for a frame that had just been rendered 240 rows wide — the register-derived version reported a 232-row gap that did not exist, and blanking wiped live content. Recording rows as they are written cannot disagree with itself.

The latched value is the max over the **two** most recent frames. Interlace needs this: each field writes only every other row, so a single frame's maximum alternates by one, and blanking on it alone would erase and rewrite the bottom row of the opposite field every frame. It also adds a frame of hysteresis when the window shrinks.

### Bounded to a genuine tail

The blank applies only when TOM wrote something, the shortfall is ≤32 rows, **and** the frame is ≥3/4 rendered. A large shortfall does not mean the rows are stale — it means TOM and the presented geometry disagree about the mode, and erasing the last good frame is worse than leaving it up. **DEMO1C (PD)** is that case: at frame 434 it switches to 328x135 and stops rendering entirely, and an unbounded blank turned a visible red colour field into a black screen.

The bounds are measured: across the corpus every *sustained* gap is 4-17 rows at 93-98% coverage, while DEMO1C's transition frame is 102 rows at 24%. The coverage clause is what makes this hold at any frame height, where the absolute bound alone would admit a short mode whose small shortfall is still most of the screen.

### Black, not border colour

The gap rows sit *below* the visible field (`bottomVisible` **is** the field bottom), so they are blanking lines, not border lines. The border branch in `TOMExecHalfline` already covers rows inside the field but outside the active display window. Black also keeps the change provable: every differing pixel is a previously-unwritten row becoming `0xFF000000`.

### Also folded in

`retro_reset` re-blanks the framebuffer. `TOMReset` puts `tomWidth` back to 0, and the border-fill path writes `tomWidth` pixels — so until the game reprograms a TOM video register the rows above VDB get no pixels at all and the reset presents the **previous session's** screen. Measured: 3 stale rows before, 0 after.

## Validation

**Read this limitation first:** the classifier bounds *where* a change lands and that it landed on black. It cannot tell "erased stale content" from "erased live content" — it rated DEMO1C `unexpected=0` while the fix was wiping a visible colour field. Screenshots caught that. A clean sweep is necessary, not sufficient.

Against a stock build of the same `develop` commit (`b8d4c7e`):

- **AvP repro** (3000 frames, ticket's press script): `changed_rows=236-239 unexpected=0`, audio digest **bit-identical** on both builds.
- **Corpus sweep, 115 ROMs × 1200 frames**: `titles=115 changed=14 unexpected=0`. 15 ROMs load on neither build (a corpus fact, reported as SKIP).
  - All 14 changed titles change **exactly one frame — frame 0**, the load-time `0xFF00FFFF` seed rows being blanked.
  - **12 titles exercise the gap path in a sustained way with no pixel change**: Sensible Soccer (1192 gap frames), Bubsy (1185), Evolution (1183), Zool 2 (1181), Pitfall (1176), Cannon Fodder (1188), Raiden (1163), Rayman (1133), DEMO1C (767), Ladybug Demo (762), CRZ Demo, Painter. Either the stale tail was already black, or the bounds correctly declined to act. This is what makes the OKs non-vacuous.
- **PAL**: no corpus title exhibits the gap under `virtualjaguar_pal=enabled` — PAL's fallbacks agree exactly, `(579-67)/2 = 256` = the PAL height fallback. Checked on Pitfall and Evolution (`gap_frames=0` both). The clauses would still admit a PAL-shaped gap (VDB=76 → 252 of 256 = 98% coverage, gap 4); there is simply nothing to fix.
- **CD boot matrix** (10 discs × HLE/BIOS): **17 unchanged, 3 forward, 0 backward.** The forward moves — Battle Morph bios `? (pc_escape)` → `GAME_CODE`, and the two `baldies.cdi` rows losing their harness crash — are baseline rows recorded by older builds (Battle Morph's is the known stale-row phantom documented in CLAUDE.md), not effects of this change.
- **`make TEST_EXPORTS=1 test`** — green (56103 acid tests + every sub-suite, 0 failed). Savestate layout unchanged: DAC block still at offset `2330464`.
- **`scripts/c89-lint.sh`** — clean on all touched files.

## Not fixed here

The reverse mismatch: a narrow window (e.g. `VDB=38, VDE=100` → 34 written rows against a presented height of 31) writes *past* the presented height. Harmless — the allocation is 1024×512 and the extra rows are simply not shown.

## Tooling

The second commit adds the harness this was validated with (`fb_row_digest`, `fb_row_diff.py`, `fb_ab_sweep.sh`, `tom_window_trace`), so the next presented-row change can be swept the same way rather than eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
