### PR TITLE
fix(test): make cd_boot_matrix build stamps converge across chunked runs

### DIFF
--- a/scripts/build-id.sh
+++ b/scripts/build-id.sh
@@ -5,13 +5,50 @@
 # string reported by a loaded core (VJ_EXPECT_BUILD) so a stale or
 # wrong-branch binary fails loudly instead of silently testing the
 # wrong code.  POSIX sh compatible -- no bashisms.
+#
+# `--ignores` prints the ignore list below, one path per line, so a caller
+# can check whether the file it is about to write is covered.
 
 set -e
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 
+# Tracked files that are RESULTS of running the test tools, never inputs to
+# the build.  Changes to these do not make the binary "dirty", because they
+# cannot change a single byte of it.
+#
+# Why this list has to exist: a tool that records its results into a tracked
+# file AND stamps those results with this build id cannot converge without
+# it.  test/tools/cd_boot_matrix.sh computes the id once per invocation and
+# writes rows stamped with it into docs/cd-boot-matrix.md; writing the first
+# row would flip the tree to "-dirty", so the next chunked invocation would
+# compute a different id, judge every row it had just written to be stale
+# evidence, and re-run all of them -- forever.  Excluding the results file
+# keeps the stamp meaningful (a real source edit still yields "-dirty")
+# while letting a chunked sweep settle.
+#
+# Keep this minimal and results-only.  Anything that feeds a compile, a link
+# or a code-generation step must NOT be listed here: the whole point of the
+# stamp is that it changes when the emulator code under test changes.
+#
+# Repo-root-relative paths, ONE PER LINE -- the list is fed to `grep -vxF`,
+# which reads a newline-separated pattern set.  Space-separating two entries
+# makes a single literal pattern that matches no filename at all, silently
+# restoring the non-convergence this list exists to prevent.
+BUILD_ID_IGNORE='docs/cd-boot-matrix.md'
+
+if [ "${1:-}" = "--ignores" ]; then
+  printf '%s\n' "$BUILD_ID_IGNORE"
+  exit 0
+fi
+
 REV=$(cd "$ROOT" && git rev-parse --short HEAD 2>/dev/null || echo unknown)
 if [ "$REV" != "unknown" ]; then
-  if ! (cd "$ROOT" && git diff-index --quiet HEAD -- 2>/dev/null); then
+  # Name filtering rather than an ':(exclude)' pathspec: it needs no
+  # pathspec-magic support, and a malformed entry can only ever fail
+  # towards "-dirty" (the safe direction) instead of silently matching
+  # everything and disabling the guard.
+  if (cd "$ROOT" && git diff-index --name-only HEAD -- 2>/dev/null) \
+       | grep -vxF "$BUILD_ID_IGNORE" | grep -q .; then
     REV="${REV}-dirty"
   fi
 fi

--- a/test/tools/cd_boot_matrix.sh
+++ b/test/tools/cd_boot_matrix.sh
@@ -52,7 +52,11 @@
 #                         mktemp -d; NOT committed -- path is printed at the end)
 #   CD_MATRIX_MAX_RUNS    max NEW title x mode runs per invocation (default 0 =
 #                         unlimited). Combined with the resume guard this lets
-#                         a long sweep be chunked across short invocations.
+#                         a long sweep be chunked across short invocations:
+#                         each chunk skips the rows earlier chunks recorded,
+#                         because the build stamp does not move when the only
+#                         thing that changed is this script's own output
+#                         (scripts/build-id.sh BUILD_ID_IGNORE).
 set -u
 
 # ---------------------------------------------------------------------------
@@ -68,6 +72,7 @@ FRAMES="${CD_MATRIX_FRAMES:-3000}"
 TIMEOUT_SECS="${CD_MATRIX_TIMEOUT:-120}"
 OUT="${CD_MATRIX_OUT:-docs/cd-boot-matrix.md}"
 LOGDIR="${CD_MATRIX_LOGDIR:-$(mktemp -d "${TMPDIR:-/tmp}/cd_boot_matrix.XXXXXX")}"
+MAX_RUNS="${CD_MATRIX_MAX_RUNS:-0}"   # 0 = unlimited; see the resume guard below
 
 mkdir -p "$LOGDIR"
 
@@ -107,6 +112,25 @@ fi
 # Build-identity guard: every harness invocation below verifies that the
 # core's embedded git rev matches the working tree (scripts/build-id.sh),
 # so matrix rows can never be produced by a stale/wrong-branch binary.
+#
+# The id is computed ONCE per invocation and stamped into every row this
+# invocation writes (see run_title).  Resuming across invocations only
+# works because scripts/build-id.sh excludes the results file from its
+# dirty check -- otherwise writing the first row would flip the id and the
+# next invocation would re-run everything it had just recorded.  The
+# default $OUT is on that ignore list; a custom tracked $OUT is not, so
+# warn rather than let the sweep silently fail to converge.  (This applies
+# to any re-invocation, chunked or not: an interrupted unlimited sweep
+# resumes through the same guard.)
+if git ls-files --error-unmatch "$OUT" >/dev/null 2>&1 \
+   && ! scripts/build-id.sh --ignores 2>/dev/null | grep -qxF "$OUT"; then
+    echo "WARNING: CD_MATRIX_OUT=$OUT is tracked by git but is not in" >&2
+    echo "  scripts/build-id.sh's ignore list. Writing rows will flip the build" >&2
+    echo "  id to '-dirty', so the next chunked invocation will treat every row" >&2
+    echo "  this one records as stale and re-run it. Add the path to" >&2
+    echo "  BUILD_ID_IGNORE, or point CD_MATRIX_OUT at an untracked file." >&2
+fi
+
 VJ_EXPECT_BUILD=$(scripts/build-id.sh 2>/dev/null || true)
 export VJ_EXPECT_BUILD
 if [ -n "$VJ_EXPECT_BUILD" ]; then
@@ -352,7 +376,12 @@ echo "=== CD boot matrix: $FRAMES frames/title/mode, ${TIMEOUT_SECS}s wall-clock
 # every actual harness run of that title passed).  Row matching is also
 # scoped to the primary results table, so rows quoted in prose notes can
 # never satisfy the resume guard.
-MAX_RUNS="${CD_MATRIX_MAX_RUNS:-0}"   # 0 = unlimited
+#
+# The stamp stays stable across the chunks of one sweep because
+# scripts/build-id.sh does not count writes to this results file as a
+# source change (its BUILD_ID_IGNORE list); a real edit to emulator code
+# still flips it to "-dirty" and correctly invalidates earlier rows.
+# MAX_RUNS is set with the other env knobs at the top of the script.
 RUNS_DONE=0
 
 # Write the header only on a fresh file; strip any previous footer so
@@ -391,7 +420,10 @@ else
     printf 'recorded **by the same core build** (each row carries a hidden\n'
     printf '`<!-- build:<rev> -->` stamp) are skipped, so an interrupted sweep resumes\n'
     printf 'where it left off; rows recorded by a different build, or unstamped legacy\n'
-    printf 'rows, are re-run and replaced in place rather than silently reused. For\n'
+    printf 'rows, are re-run and replaced in place rather than silently reused.\n'
+    printf 'Recording rows does not itself move the stamp -- `scripts/build-id.sh`\n'
+    printf 'excludes this results file from its dirty check -- so the chunks of one\n'
+    printf 'sweep share a stamp and each chunk resumes where the last stopped. For\n'
     printf 'long sweeps (or agent sessions with per-command time limits), run chunked:\n\n'
     printf '```bash\n'
     printf '# ~3 runs x <=120s wall each per invocation; repeat until every line\n'

--- a/test/tools/cd_boot_matrix.sh
+++ b/test/tools/cd_boot_matrix.sh
@@ -122,8 +122,20 @@ fi
 # warn rather than let the sweep silently fail to converge.  (This applies
 # to any re-invocation, chunked or not: an interrupted unlimited sweep
 # resumes through the same guard.)
+#
+# The ignore list is written repo-root-relative, so an absolute $OUT has to
+# be normalised before the comparison.  `git ls-files` resolves an absolute
+# path inside the repo on its own, but the string compare below does not:
+# without this, CD_MATRIX_OUT=/abs/path/to/docs/cd-boot-matrix.md -- a file
+# that IS ignored -- fails the compare and draws a warning stating the exact
+# opposite of the truth.
+OUT_REL=$OUT
+OUT_DIR=$(dirname "$OUT")
+if OUT_PREFIX=$(cd "$OUT_DIR" 2>/dev/null && git rev-parse --show-prefix 2>/dev/null); then
+    OUT_REL="${OUT_PREFIX}$(basename "$OUT")"
+fi
 if git ls-files --error-unmatch "$OUT" >/dev/null 2>&1 \
-   && ! scripts/build-id.sh --ignores 2>/dev/null | grep -qxF "$OUT"; then
+   && ! scripts/build-id.sh --ignores 2>/dev/null | grep -qxF "$OUT_REL"; then
     echo "WARNING: CD_MATRIX_OUT=$OUT is tracked by git but is not in" >&2
     echo "  scripts/build-id.sh's ignore list. Writing rows will flip the build" >&2
     echo "  id to '-dirty', so the next chunked invocation will treat every row" >&2


### PR DESCRIPTION
## Problem

`test/tools/cd_boot_matrix.sh` stamps every row it writes with `scripts/build-id.sh`'s output, and on resume re-runs any row whose stamp differs from the current build. That stale-row guard exists for a good reason — it is what stops an old `docs/cd-boot-matrix.md` from resurrecting ancient results as if they were fresh (the phantom "intermittent" Battle Morph `? (pc_escape)` row, `final_pc=$8FBFB758`, was exactly that).

But the default results file is itself tracked, and `build-id.sh` appends `-dirty` when any tracked file is modified. So:

1. Invocation 1 on a clean tree computes e.g. `abc1234` and stamps its rows with it. Writing those rows dirties the tree.
2. Invocation 2 computes `abc1234-dirty`, sees every row invocation 1 recorded as "recorded by a different build", and re-runs all of them.
3. Invocation 3 sees the same thing. It never settles.

Observed directly: a chunked sweep produced 6 rows stamped `5a83d3d`, and the next invocation reported `pass 1: 0/20 rows stamped 5a83d3d-dirty` and started over from the top. Only a single unlimited invocation (`CD_MATRIX_MAX_RUNS=0`) from a clean tree could ever finish — which defeats `CD_MATRIX_MAX_RUNS`, whose documented reason for existing is "lets a long sweep be chunked across short invocations".

## Fix

Exclude the results file from the dirty check via a new `BUILD_ID_IGNORE` list in `scripts/build-id.sh`.

The exclusion has to live in `build-id.sh` specifically, not in the matrix script: `gen-version-h.sh` stamps the binary from that same script, so an exclusion known only to the matrix would desync the binary's embedded id from the harnesses' `VJ_EXPECT_BUILD` and put the script into a rebuild loop that fails the build-identity guard on every run. One list, both sides agree.

Implemented as name filtering rather than an `:(exclude)` pathspec, so it needs no pathspec-magic support and a malformed entry can only fail toward `-dirty` (safe) instead of silently matching everything and disabling the guard.

**The guard is not weakened.** A real source edit still yields `-dirty` and still invalidates earlier rows; only writes to the results file — which cannot change a byte of the binary — are ignored. The script also now warns if `CD_MATRIX_OUT` points at some *other* tracked file, which hits the identical wall without being covered by the list.

## Verification

From a clean tree at this commit, with the core rebuilt to match (`v2.3.2 d8a7c79`):

- **Two chunked invocations back to back** — chunk 2 printed `already recorded by this build, skipping` for exactly the rows chunk 1 wrote, then advanced to the next titles. This is the behaviour the bug prevented.
- **Negative control** — appending a line to `src/cd/cdrom.c` flipped the stamp to `-dirty`, triggered the core rebuild, and made previously-recorded rows read as `stale row (recorded by 'd8a7c79', current 'd8a7c79-dirty')`. Stale-row resurrection stays impossible.
- **Dirty-check directions** — results file alone → clean; source edit and tool-script edit → `-dirty`; multi-entry ignore lists behave as documented.
- **Sufficiency of the one-path list** — after a genuine disc run (real Battle Morph hle + bios, `GAME_CODE 1/1` on the hle row), `git status --porcelain` showed only `docs/cd-boot-matrix.md` dirty. No other tracked file is written by a sweep.

The matrix table was restored after each run, so no measured rows are included here — this is a tooling fix only, with no stage re-baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)