### PR TITLE
fix(test): restore the ROM-gated audio checks (stale paths + a committed self-referential symlink)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -828,9 +828,16 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 	./test/test_boot_patterns
 	./test/test_audio_pipeline ./$(TARGET)
 	./test/test_audio_clipping ./$(TARGET) --self-test
+	@# Cartridges live either flat in test/roms/private/ or under its ROMS/
+	@# subdirectory, depending on how the local corpus was laid out.  Each
+	@# lookup below tries both, because checking only one silently turns the
+	@# test into a SKIP -- which still prints and still exits 0, so the suite
+	@# stays green while the check is not running at all.
 	@# Negative control: healthy boot should not trip the clipping detector.
-	@if [ -f "test/roms/private/Atari Karts (1995).jag" ]; then \
-		./test/test_audio_clipping ./$(TARGET) "test/roms/private/Atari Karts (1995).jag" --label "Atari Karts (negative control)" --quiet; \
+	@rom="test/roms/private/Atari Karts (1995).jag"; \
+	[ -f "$$rom" ] || rom="test/roms/private/ROMS/Atari Karts (1995).jag"; \
+	if [ -f "$$rom" ]; then \
+		./test/test_audio_clipping ./$(TARGET) "$$rom" --label "Atari Karts (negative control)" --quiet; \
 	else \
 		echo "  SKIP: Atari Karts ROM (private) not available"; \
 	fi
@@ -838,13 +845,17 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 	@# the MMULT secondary-bank fix (JTRM: the vector operand is always
 	@# register bank 1, not "the non-current bank").  These now assert
 	@# clean audio so a regression flips them red again.
-	@if [ -f "test/roms/private/Skyhammer_(1999).jag" ]; then \
-		./test/test_audio_clipping ./$(TARGET) "test/roms/private/Skyhammer_(1999).jag" --label Skyhammer --quiet; \
+	@rom="test/roms/private/Skyhammer_(1999).jag"; \
+	[ -f "$$rom" ] || rom="test/roms/private/ROMS/Skyhammer_(1999).jag"; \
+	if [ -f "$$rom" ]; then \
+		./test/test_audio_clipping ./$(TARGET) "$$rom" --label Skyhammer --quiet; \
 	else \
 		echo "  SKIP: Skyhammer ROM (private) not available"; \
 	fi
-	@if [ -f "test/roms/private/Iron Soldier 2 (World).j64" ]; then \
-		./test/test_audio_clipping ./$(TARGET) "test/roms/private/Iron Soldier 2 (World).j64" --label "Iron Soldier 2" --quiet; \
+	@rom="test/roms/private/Iron Soldier 2 (World).j64"; \
+	[ -f "$$rom" ] || rom="test/roms/private/ROMS/Iron Soldier 2 (World).j64"; \
+	if [ -f "$$rom" ]; then \
+		./test/test_audio_clipping ./$(TARGET) "$$rom" --label "Iron Soldier 2" --quiet; \
 	else \
 		echo "  SKIP: Iron Soldier 2 ROM (private) not available"; \
 	fi
@@ -854,8 +865,10 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 	@# Soldier 1 boots straight to a music-on title; envelope was
 	@# measured on develop (RMS ~1175).  Floor 200 catches silence
 	@# regressions; ceiling 25000 catches loud-broken regressions.
-	@if [ -f "test/roms/private/Iron Soldier (1994).jag" ]; then \
-		./test/test_audio_presence ./$(TARGET) "test/roms/private/Iron Soldier (1994).jag" --label "Iron Soldier 1" --rms-floor 200 --rms-ceiling 25000 --quiet; \
+	@rom="test/roms/private/Iron Soldier (1994).jag"; \
+	[ -f "$$rom" ] || rom="test/roms/private/ROMS/Iron Soldier (1994).jag"; \
+	if [ -f "$$rom" ]; then \
+		./test/test_audio_presence ./$(TARGET) "$$rom" --label "Iron Soldier 1" --rms-floor 200 --rms-ceiling 25000 --quiet; \
 	else \
 		echo "  SKIP: Iron Soldier 1 ROM (private) not available (audio presence)"; \
 	fi


### PR DESCRIPTION
Three of the four ROM-gated audio checks in `make test` had stopped running. They did not fail — they printed `SKIP` and the suite still exited 0, so the audio regression guard was silently absent while every run read green.

**Rebased onto current develop and reduced to the `Makefile` change only.** The original second commit untracked `test/roms/private` and rewrote the `.gitignore` rule; #221 has since landed on develop and does both, more thoroughly (it ignores `test/roms/private/` *and* `test/roms/private`, with the 2026-07-30 data-loss incident recorded in the comment). Keeping this branch's version would have conflicted and dropped that comment for no functional gain.

## The bug

Each lookup checked only `test/roms/private/<rom>` flat. Where the corpus keeps cartridges under `test/roms/private/ROMS/`, all four take the `else` branch and skip. Each lookup now tries the flat path first, then `ROMS/`.

## Verification

CI cannot exercise this — the private corpus is never present there, so these lines `SKIP` on GitHub by design, before and after. Verified locally against the real corpus instead, running the recipe's path-selection logic with the harness stubbed out:

| check | before (flat only) | after (both) |
|---|---|---|
| Atari Karts (negative control) | `SKIP` | **RUNS** → `ROMS/Atari Karts (1995).jag` |
| Iron Soldier 2 clipping | `SKIP` | **RUNS** → `ROMS/Iron Soldier 2 (World).j64` |
| Iron Soldier 1 presence | `SKIP` | **RUNS** → `ROMS/Iron Soldier (1994).jag` |
| Skyhammer clipping | `SKIP` | `SKIP` — genuinely absent from this machine |

Iron Soldier 1 presence is the check CLAUDE.md calls mandatory for audio work ("running only one masks the silencing-regression class"). It had not been executing.

`make TEST_EXPORTS=1 test` exits 0 with 0 failures both before and after — which is the point: the suite could not tell the difference, and now three real checks are back.

No emulator code is touched; `Makefile` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
