### PR TITLE
ci: publish a rolling nightly prerelease on every develop push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -557,7 +557,7 @@ jobs:
 
           CHANGES=""
           if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "$SHA" ] \
-             && git cat-file -e "${PREV_SHA}^{commit}" 2>/dev/null; then
+            && git cat-file -e "${PREV_SHA}^{commit}" 2>/dev/null; then
             CHANGES=$(git log --oneline --no-merges "${PREV_SHA}..${SHA}" | head -40)
           fi
           [ -n "$CHANGES" ] || CHANGES=$(git log --oneline --no-merges -10)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -483,7 +483,7 @@ jobs:
   # tracking issue that always shows the current build.
   #
   # Gating: `needs` covers the build jobs only, so this publishes a
-  # commit that COMPILES on all 18 targets.  It does NOT wait on
+  # commit that COMPILES on all 16 targets.  It does NOT wait on
   # c-cpp.yml / acid-test.yml / regression-test.yml, which run
   # independently on the same push — a commit that builds but fails a
   # test can still ship a nightly.  The release body says so; do not
@@ -573,7 +573,7 @@ jobs:
             echo "| **Branch** | \`develop\` |"
             echo
             echo "> Automatic build of the \`develop\` tip, replaced on every push."
-            echo "> It compiled on all 18 targets; it has **not** been through the"
+            echo "> It compiled on all 16 targets; it has **not** been through the"
             echo "> test suite or any manual QA. For a stable build use the"
             echo "> [latest release](${GITHUB_SERVER_URL}/${REPO}/releases/latest)."
             echo
@@ -662,14 +662,14 @@ jobs:
             echo
             echo "### What these are"
             echo
-            echo "Every push to \`develop\` rebuilds the core for all 18 supported"
+            echo "Every push to \`develop\` rebuilds the core for all 16 supported"
             echo "platforms and replaces the single [\`nightly\`](${GITHUB_SERVER_URL}/${REPO}/releases/tag/nightly)"
             echo "prerelease. There is only ever one nightly — the current tip."
             echo
             echo "| | Stable | Nightly |"
             echo "|---|---|---|"
             echo "| Source | tagged \`vX.Y.Z\` on \`master\` | every push to \`develop\` |"
-            echo "| Gate | full CI + release checklist | compiles on all 18 targets |"
+            echo "| Gate | full CI + release checklist | compiles on all 16 targets |"
             echo "| Frequency | periodic | continuous |"
             echo "| Use it for | playing | testing a fix before it ships |"
             echo
@@ -679,12 +679,17 @@ jobs:
             echo
             echo "### Installing"
             echo
-            echo "1. Download the archive for your platform from the"
-            echo "   [\`nightly\` release](${GITHUB_SERVER_URL}/${REPO}/releases/tag/nightly)."
-            echo "2. Drop the library into RetroArch's \`cores/\` directory, replacing"
-            echo "   the existing \`virtualjaguar_libretro\` for your platform."
-            echo "3. Copy \`virtualjaguar_libretro.info\` into RetroArch's \`info/\` directory"
-            echo "   if you want the core to show the nightly version string."
+            echo "1. Download \`virtualjaguar_libretro-<platform>.<ext>\` for your system from"
+            echo "   the [\`nightly\` release](${GITHUB_SERVER_URL}/${REPO}/releases/tag/nightly)."
+            echo "2. **Rename it**, dropping the \`-<platform>\` part —"
+            echo "   \`virtualjaguar_libretro-linux-x86_64.so\` becomes"
+            echo "   \`virtualjaguar_libretro.so\`. RetroArch pairs a core with its"
+            echo "   metadata by exact basename, so a core left under the download name"
+            echo "   loads with no name, no version and no core options."
+            echo "3. Drop it into RetroArch's \`cores/\` directory, replacing the existing"
+            echo "   \`virtualjaguar_libretro.<ext>\`."
+            echo "4. Copy \`virtualjaguar_libretro.info\` into RetroArch's \`info/\` directory"
+            echo "   to see the nightly version string in the core list."
             echo
             echo "RetroArch's own Core Updater always serves the **stable** buildbot core."
             echo "Installing a nightly by hand means the updater may overwrite it later."
@@ -714,30 +719,48 @@ jobs:
             echo "> Auto-updated by CI on every nightly build. Edits here are overwritten."
           } > "$BODY_FILE"
 
-          # Exact-title match over the issue list rather than the search API:
-          # search is eventually-consistent, and a miss here would open a
-          # duplicate tracking issue on every run.
-          NUM=$(gh issue list --repo "${REPO}" --state all --limit 200 \
-                  --json number,title \
-                  --jq "map(select(.title == \"${ISSUE_TITLE}\")) | .[0].number // empty")
+          # Find the existing tracker without the search API, which is
+          # eventually-consistent — a miss opens a DUPLICATE issue, and then
+          # another on every run after that, so the lookup has to be exact.
+          #
+          # Label first: filtering is server-side and stays exact no matter how
+          # many issues the repo accumulates.  Exact-title match is the fallback
+          # for the very first run (before the label exists) and for the case
+          # where the label was removed by hand.  Both must miss to duplicate.
+          LABEL=nightly-tracker
+          gh label create "$LABEL" --repo "${REPO}" --color 0E8A16 \
+            --description "Auto-updated nightly build tracker" >/dev/null 2>&1 || true
+
+          NUM=$(gh issue list --repo "${REPO}" --state all --label "$LABEL" \
+                  --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+          if [ -z "$NUM" ]; then
+            NUM=$(gh issue list --repo "${REPO}" --state all --limit 500 \
+                    --json number,title \
+                    --jq "map(select(.title == \"${ISSUE_TITLE}\")) | .[0].number // empty")
+          fi
 
           if [ -n "$NUM" ]; then
-            gh issue edit "$NUM" --repo "${REPO}" --body-file "$BODY_FILE"
+            gh issue edit "$NUM" --repo "${REPO}" --body-file "$BODY_FILE" \
+              --add-label "$LABEL" >/dev/null
           else
             NUM=$(gh issue create --repo "${REPO}" \
                     --title "${ISSUE_TITLE}" \
                     --body-file "$BODY_FILE" \
                     | grep -oE '[0-9]+$')
+            gh issue edit "$NUM" --repo "${REPO}" --add-label "$LABEL" >/dev/null 2>&1 || \
+              echo "::warning::could not label tracking issue #${NUM}; title match is now the only lookup"
             echo "==> Created tracking issue #${NUM}"
           fi
 
           # Pinning has no REST endpoint; pinIssue is GraphQL-only and caps at
-          # 3 pinned issues per repo.  Already-pinned re-pins are a no-op error,
-          # so a failure here is not worth surfacing.
+          # 3 pinned issues per repo.  Re-pinning an already-pinned issue errors
+          # harmlessly, but so does hitting the cap or lacking permission — and
+          # a pinned issue is the whole point, so warn rather than swallow it.
           ID=$(gh api "repos/${REPO}/issues/${NUM}" --jq '.node_id')
           # shellcheck disable=SC2016  # $id is a GraphQL variable; it must NOT
           # be expanded by the shell — gh binds it from the -f id= argument.
           gh api graphql -f query='mutation($id:ID!){pinIssue(input:{issueId:$id}){issue{number}}}' \
-            -f id="$ID" >/dev/null 2>&1 || true
+            -f id="$ID" >/dev/null 2>&1 || \
+            echo "::warning::could not pin issue #${NUM} (already pinned, 3-pin cap, or permission)"
 
           echo "==> Tracking issue: ${GITHUB_SERVER_URL}/${REPO}/issues/${NUM}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,14 @@ name: Release
 # The build/vita-build/switch-build jobs below are trigger-agnostic; only the
 # final publishing job differs.  The nightly tag is deliberately NOT named
 # v-anything so a CI-pushed tag can never re-enter the release path.
+#
+# workflow_dispatch exists ONLY to re-publish the nightly, so it must be run
+# with the branch set to `develop`.  GitHub defaults the branch picker to the
+# repo default (`master` here), and both publishing jobs are ref-gated, so a
+# dispatch left on the default would build all 16 targets and publish nothing.
+# The `guard` job below fails that case immediately instead of burning the
+# matrix.  To test-build an arbitrary branch, use c-cpp.yml — it has its own
+# workflow_dispatch and runs on PRs.
 on:
   push:
     tags: ['v*']
@@ -27,12 +35,35 @@ concurrency:
 
 jobs:
   # ----------------------------------------------------------------
+  # Fail a pointless dispatch in seconds rather than after 16 builds.
+  # Only reachable via workflow_dispatch: push events always arrive on a
+  # ref one of the two publishing jobs accepts.
+  # ----------------------------------------------------------------
+  guard:
+    name: Check dispatch ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse a dispatch that would publish nothing
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/develop' }}
+        run: |
+          # Built up in one variable because a ::error:: annotation has to be a
+          # single line to render as one.
+          MSG="Run this workflow with the branch set to 'develop'."
+          MSG="$MSG Both publishing jobs are ref-gated (tags v* -> release,"
+          MSG="$MSG develop -> nightly), so a dispatch from '${GITHUB_REF_NAME}'"
+          MSG="$MSG would build all 16 targets and publish nothing."
+          MSG="$MSG To test-build a branch, use the C/C++ CI workflow instead."
+          echo "::error::$MSG"
+          exit 1
+
+  # ----------------------------------------------------------------
   # Native + cross builds (Linux/macOS/Windows/iOS/tvOS/Android/WASM)
   # Each job builds with RELEASE_DEBUG_INFO=1 so we keep -g on the
   # optimized binary, then extracts split debug symbols and strips the
   # shipped binary.
   # ----------------------------------------------------------------
   build:
+    needs: [guard]
     strategy:
       fail-fast: false
       matrix:
@@ -302,6 +333,7 @@ jobs:
   # ----------------------------------------------------------------
   vita-build:
     name: build-vita
+    needs: [guard]
     runs-on: ubuntu-latest
     container:
       image: vitasdk/vitasdk:latest
@@ -339,6 +371,7 @@ jobs:
   # ----------------------------------------------------------------
   switch-build:
     name: build-switch
+    needs: [guard]
     runs-on: ubuntu-latest
     container:
       image: devkitpro/devkita64:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,29 @@
 name: Release
 
+# Two publication paths share one build matrix:
+#   push tag v*        -> the `release` job: a real, permanent GitHub release
+#   push to develop    -> the `nightly` job: the rolling `nightly` prerelease
+# The build/vita-build/switch-build jobs below are trigger-agnostic; only the
+# final publishing job differs.  The nightly tag is deliberately NOT named
+# v-anything so a CI-pushed tag can never re-enter the release path.
 on:
   push:
     tags: ['v*']
+    branches: [develop]
+  workflow_dispatch:
 
 permissions:
   contents: write
+
+# Tag pushes always run to completion — a release build must never be
+# cancelled.  Develop pushes cancel superseded runs, because only the newest
+# commit's binaries matter for a rolling prerelease and an in-flight build of
+# an older tip is pure waste.  This deliberately differs from c-cpp.yml /
+# acid-test.yml, which let develop pushes finish so there is a green-or-red
+# record per commit: that record is their job, not this one's.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/develop' }}
 
 jobs:
   # ----------------------------------------------------------------
@@ -360,6 +378,11 @@ jobs:
   # ----------------------------------------------------------------
   release:
     needs: [build, vita-build, switch-build]
+    # Tag pushes only.  Everything below assumes GITHUB_REF_NAME is a vX.Y.Z
+    # tag (release-notes lookup, release title, `gh release create <TAG>`), so
+    # this guard is what keeps a develop push from creating a release literally
+    # named "develop".  The nightly job handles that case instead.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -391,7 +414,15 @@ jobs:
           cd release
           # Deterministic ordering, two-space format compatible with
           # `sha256sum -c SHA256SUMS.txt` on Linux + Mac (with coreutils).
-          sha256sum -- *  | sort -k 2 > SHA256SUMS.txt
+          #
+          # Build it OUTSIDE the directory and move it in.  Redirecting straight
+          # to ./SHA256SUMS.txt races: the shell starts both pipeline stages at
+          # once, so `sort`'s redirect can create the (empty) file before
+          # `sha256sum`'s glob expands, leaving the manifest listing itself with
+          # the empty-file hash — which then fails `sha256sum --check` on that
+          # one line.  v2.3.2 happened to win the race; nightlies would not.
+          sha256sum -- * | sort -k 2 > "$RUNNER_TEMP/SHA256SUMS.txt"
+          mv "$RUNNER_TEMP/SHA256SUMS.txt" SHA256SUMS.txt
           echo "==> SHA256SUMS.txt:"
           cat SHA256SUMS.txt
 
@@ -445,3 +476,268 @@ jobs:
             --title "${TAG}" \
             --notes-file "${{ steps.prep_body.outputs.body_file }}" \
             release/*
+
+  # ----------------------------------------------------------------
+  # Nightly: same artifacts, published to a single rolling `nightly`
+  # prerelease that is moved onto each new develop tip, plus a pinned
+  # tracking issue that always shows the current build.
+  #
+  # Gating: `needs` covers the build jobs only, so this publishes a
+  # commit that COMPILES on all 18 targets.  It does NOT wait on
+  # c-cpp.yml / acid-test.yml / regression-test.yml, which run
+  # independently on the same push — a commit that builds but fails a
+  # test can still ship a nightly.  The release body says so; do not
+  # upgrade that wording to "passes all CI" without also switching this
+  # to a `workflow_run` trigger (see artifacts.yml for that idiom).
+  # ----------------------------------------------------------------
+  nightly:
+    name: Update nightly prerelease
+    needs: [build, vita-build, switch-build]
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # move the tag, create/update the release
+      issues: write     # update + pin the tracking issue
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      TAG: nightly
+      ISSUE_TITLE: 'Nightly builds — download, install, and what they are'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history: the release body diffs against the commit the
+          # `nightly` tag pointed at on the previous run.
+          fetch-depth: 0
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts/
+
+      - name: Stage release files
+        run: |
+          set -e
+          mkdir -p release
+          find artifacts/ -mindepth 2 -type f -exec cp {} release/ \;
+          # The .info file's display_version names the last TAGGED release, so
+          # shipping it verbatim would label a nightly "v2.3.2".  Rewrite it to
+          # the build's actual identity — this also makes it obvious that a
+          # nightly .info is not the file to PR to libretro-super.
+          if [ -f dist/info/virtualjaguar_libretro.info ]; then
+            sed "s/^display_version = \".*\"/display_version = \"$(sed -n 's/^CORE_BASE_VERSION[[:space:]]*:*=[[:space:]]*\(.*\)/\1/p' Makefile | head -1)-nightly-${GITHUB_SHA:0:7}\"/" \
+              dist/info/virtualjaguar_libretro.info > release/virtualjaguar_libretro.info
+          fi
+          echo "==> Staged nightly files:"
+          ls -la release/
+
+      - name: Generate SHA256SUMS
+        run: |
+          set -e
+          cd release
+          # Written outside the directory then moved in — see the release job's
+          # copy of this step for why the obvious redirect races.
+          sha256sum -- * | sort -k 2 > "$RUNNER_TEMP/SHA256SUMS.txt"
+          mv "$RUNNER_TEMP/SHA256SUMS.txt" SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Prepare nightly body
+        id: prep_body
+        run: |
+          set -e
+          SHA="${GITHUB_SHA}"
+          SHORT_SHA="${SHA:0:7}"
+          BODY_FILE="$RUNNER_TEMP/nightly_body.md"
+          RUN_URL="${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}"
+          BASE_VERSION=$(sed -n 's/^CORE_BASE_VERSION[[:space:]]*:*=[[:space:]]*\(.*\)/\1/p' Makefile | head -1)
+
+          # Where the nightly tag pointed BEFORE this run — captured here
+          # because the next step moves it.
+          PREV_SHA=$(gh api "repos/${REPO}/git/refs/tags/${TAG}" --jq '.object.sha' 2>/dev/null || echo "")
+
+          CHANGES=""
+          if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "$SHA" ] \
+             && git cat-file -e "${PREV_SHA}^{commit}" 2>/dev/null; then
+            CHANGES=$(git log --oneline --no-merges "${PREV_SHA}..${SHA}" | head -40)
+          fi
+          [ -n "$CHANGES" ] || CHANGES=$(git log --oneline --no-merges -10)
+
+          {
+            echo "### Nightly \`${SHORT_SHA}\` — \`${BASE_VERSION}\` development build"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Commit** | [\`${SHORT_SHA}\`](${GITHUB_SERVER_URL}/${REPO}/commit/${SHA}) |"
+            echo "| **Built** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+            echo "| **CI run** | [build log](${RUN_URL}) |"
+            echo "| **Branch** | \`develop\` |"
+            echo
+            echo "> Automatic build of the \`develop\` tip, replaced on every push."
+            echo "> It compiled on all 18 targets; it has **not** been through the"
+            echo "> test suite or any manual QA. For a stable build use the"
+            echo "> [latest release](${GITHUB_SERVER_URL}/${REPO}/releases/latest)."
+            echo
+            echo "The core logs its identity as \`${BASE_VERSION} ${SHORT_SHA}\` at startup —"
+            echo "quote that line when reporting a bug against a nightly."
+            echo
+            echo "### Changes since the previous nightly"
+            echo
+            echo '```'
+            echo "${CHANGES}"
+            echo '```'
+            echo
+            echo "### Artifacts"
+            echo
+            echo '```'
+            find release -mindepth 1 -maxdepth 1 -type f -printf "%f\n" | sort
+            echo '```'
+            echo
+            echo "Each platform ships alongside a \`-debug.tar.gz\` of its split debug"
+            echo "symbols; extract it next to the binary to get symbolised backtraces."
+            echo
+            echo "### SHA-256 checksums"
+            echo
+            echo "Verify with \`sha256sum --check SHA256SUMS.txt\` (Linux) or"
+            echo "\`shasum -a 256 --check SHA256SUMS.txt\` (macOS). See"
+            echo "[SECURITY.md](${GITHUB_SERVER_URL}/${REPO}/blob/${{ github.event.repository.default_branch }}/SECURITY.md)."
+            echo
+            echo '```'
+            cat release/SHA256SUMS.txt
+            echo '```'
+          } > "$BODY_FILE"
+          echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Move nightly tag
+        run: |
+          set -e
+          # -F (typed) for force so it serialises as a JSON boolean; -f would
+          # send the string "true", which the refs API rejects with 422.
+          gh api "repos/${REPO}/git/refs/tags/${TAG}" \
+            -X PATCH -f sha="${GITHUB_SHA}" -F force=true >/dev/null 2>&1 || \
+          gh api "repos/${REPO}/git/refs" \
+            -X POST -f ref="refs/tags/${TAG}" -f sha="${GITHUB_SHA}" >/dev/null
+
+      - name: Publish nightly prerelease
+        run: |
+          set -e
+          TITLE="Nightly ${{ steps.prep_body.outputs.short_sha }}"
+          # Update in place rather than delete-and-recreate: asset names are
+          # deterministic per platform, so --clobber replaces them without ever
+          # leaving /releases/tag/nightly 404ing mid-run, and the release keeps
+          # its id (so anyone watching it stays subscribed).
+          if gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+            gh release edit "${TAG}" --repo "${REPO}" \
+              --title "${TITLE}" \
+              --notes-file "${{ steps.prep_body.outputs.body_file }}" \
+              --prerelease --draft=false
+            gh release upload "${TAG}" --repo "${REPO}" release/* --clobber
+          else
+            gh release create "${TAG}" --repo "${REPO}" \
+              --title "${TITLE}" \
+              --notes-file "${{ steps.prep_body.outputs.body_file }}" \
+              --prerelease \
+              --target "${GITHUB_SHA}" \
+              release/*
+          fi
+
+      - name: Update pinned tracking issue
+        # Never fail the publish over the issue: the binaries are already out.
+        continue-on-error: true
+        run: |
+          set -e
+          SHORT_SHA="${{ steps.prep_body.outputs.short_sha }}"
+          BODY_FILE="$RUNNER_TEMP/issue_body.md"
+          {
+            echo "## Latest nightly"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Build** | [\`${SHORT_SHA}\`](${GITHUB_SERVER_URL}/${REPO}/commit/${GITHUB_SHA}) |"
+            echo "| **Built** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+            echo "| **Download** | [\`nightly\` release](${GITHUB_SERVER_URL}/${REPO}/releases/tag/nightly) |"
+            echo "| **CI run** | [build log](${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}) |"
+            echo
+            echo "---"
+            echo
+            echo "### What these are"
+            echo
+            echo "Every push to \`develop\` rebuilds the core for all 18 supported"
+            echo "platforms and replaces the single [\`nightly\`](${GITHUB_SERVER_URL}/${REPO}/releases/tag/nightly)"
+            echo "prerelease. There is only ever one nightly — the current tip."
+            echo
+            echo "| | Stable | Nightly |"
+            echo "|---|---|---|"
+            echo "| Source | tagged \`vX.Y.Z\` on \`master\` | every push to \`develop\` |"
+            echo "| Gate | full CI + release checklist | compiles on all 18 targets |"
+            echo "| Frequency | periodic | continuous |"
+            echo "| Use it for | playing | testing a fix before it ships |"
+            echo
+            echo "Nightlies are **not** gated on the test suite, the acid suite, or"
+            echo "the screenshot regression run — those workflows report separately on"
+            echo "the same commit. A nightly can build cleanly and still be broken."
+            echo
+            echo "### Installing"
+            echo
+            echo "1. Download the archive for your platform from the"
+            echo "   [\`nightly\` release](${GITHUB_SERVER_URL}/${REPO}/releases/tag/nightly)."
+            echo "2. Drop the library into RetroArch's \`cores/\` directory, replacing"
+            echo "   the existing \`virtualjaguar_libretro\` for your platform."
+            echo "3. Copy \`virtualjaguar_libretro.info\` into RetroArch's \`info/\` directory"
+            echo "   if you want the core to show the nightly version string."
+            echo
+            echo "RetroArch's own Core Updater always serves the **stable** buildbot core."
+            echo "Installing a nightly by hand means the updater may overwrite it later."
+            echo
+            echo "### Reporting a bug in a nightly"
+            echo
+            echo "The core logs its exact identity at startup:"
+            echo
+            echo '```'
+            echo "Virtual Jaguar vX.Y.Z <gitrev>"
+            echo '```'
+            echo
+            echo "Include that line — it is the only way to tell which nightly you ran."
+            echo "A RetroArch log is worth more than a description: the core has a"
+            echo "watchdog that names the failing subsystem (\`gpu_pc_escape\`,"
+            echo "\`cd_seek_wedge\`, \`video_stall\`, …) at the moment it breaks."
+            echo
+            echo "### Verifying a download"
+            echo
+            echo "Each release lists SHA-256 checksums, and every platform has a"
+            echo "matching \`-debug.tar.gz\` of split debug symbols. See"
+            echo "[SECURITY.md](${GITHUB_SERVER_URL}/${REPO}/blob/${{ github.event.repository.default_branch }}/SECURITY.md)"
+            echo "for verification steps and antivirus false-positive guidance."
+            echo
+            echo "---"
+            echo
+            echo "> Auto-updated by CI on every nightly build. Edits here are overwritten."
+          } > "$BODY_FILE"
+
+          # Exact-title match over the issue list rather than the search API:
+          # search is eventually-consistent, and a miss here would open a
+          # duplicate tracking issue on every run.
+          NUM=$(gh issue list --repo "${REPO}" --state all --limit 200 \
+                  --json number,title \
+                  --jq "map(select(.title == \"${ISSUE_TITLE}\")) | .[0].number // empty")
+
+          if [ -n "$NUM" ]; then
+            gh issue edit "$NUM" --repo "${REPO}" --body-file "$BODY_FILE"
+          else
+            NUM=$(gh issue create --repo "${REPO}" \
+                    --title "${ISSUE_TITLE}" \
+                    --body-file "$BODY_FILE" \
+                    | grep -oE '[0-9]+$')
+            echo "==> Created tracking issue #${NUM}"
+          fi
+
+          # Pinning has no REST endpoint; pinIssue is GraphQL-only and caps at
+          # 3 pinned issues per repo.  Already-pinned re-pins are a no-op error,
+          # so a failure here is not worth surfacing.
+          ID=$(gh api "repos/${REPO}/issues/${NUM}" --jq '.node_id')
+          # shellcheck disable=SC2016  # $id is a GraphQL variable; it must NOT
+          # be expanded by the shell — gh binds it from the -f id= argument.
+          gh api graphql -f query='mutation($id:ID!){pinIssue(input:{issueId:$id}){issue{number}}}' \
+            -f id="$ID" >/dev/null 2>&1 || true
+
+          echo "==> Tracking issue: ${GITHUB_SERVER_URL}/${REPO}/issues/${NUM}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ When spawning agents for work in this repo, include these rules:
 
 Full details in [`docs/release-process.md`](docs/release-process.md). Quick reference:
 
-**Nightlies:** every push to `develop` reruns `release.yml`'s full 18-platform
+**Nightlies:** every push to `develop` reruns `release.yml`'s full 16-platform
 matrix and replaces the rolling `nightly` prerelease plus its pinned tracking
 issue. Gated on *compiling*, not on the test suite — don't describe nightlies as
 "CI-verified". The `nightly` tag sits outside the `v*` filter so it can never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,12 @@ When spawning agents for work in this repo, include these rules:
 
 Full details in [`docs/release-process.md`](docs/release-process.md). Quick reference:
 
+**Nightlies:** every push to `develop` reruns `release.yml`'s full 18-platform
+matrix and replaces the rolling `nightly` prerelease plus its pinned tracking
+issue. Gated on *compiling*, not on the test suite — don't describe nightlies as
+"CI-verified". The `nightly` tag sits outside the `v*` filter so it can never
+trigger a real release.
+
 ### Cutting a release
 
 1. **Branch**: `git checkout develop && git checkout -b release/vX.Y.Z`

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -90,6 +90,14 @@ publishing step is the `nightly` job instead of `release`:
    exact-title match as fallback — both have to miss before it could duplicate
    itself.
 
+`workflow_dispatch` is also wired up, but **only to re-publish the nightly** —
+run it with the branch picker set to `develop`. GitHub defaults that picker to
+the repo default (`master`), and both publishing jobs are ref-gated, so a
+dispatch left on the default would build all 16 targets and publish nothing.
+The `guard` job rejects that in seconds instead of burning the matrix. To
+test-build an arbitrary branch, use `c-cpp.yml`, which has its own
+`workflow_dispatch` and runs on PRs.
+
 The two paths can't collide: the `release` job is gated on
 `startsWith(github.ref, 'refs/tags/v')`, the `nightly` job on
 `github.ref == 'refs/heads/develop'`, and the `nightly` tag deliberately sits

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -71,6 +71,41 @@ After all platform builds finish, the `release` job:
 4. Reads `docs/RELEASE_NOTES_v<TAG>.md` if present and uses it as the release body, with the artifact list appended. Falls back to GitHub `--generate-notes` if no curated file is found.
 5. Creates the GitHub release with all of `release/*` attached.
 
+### 3b. Nightly builds (develop pushes)
+
+`release.yml` also fires on every push to `develop`. The build matrix is
+identical — the same 18 jobs, the same split-debug packaging — but the
+publishing step is the `nightly` job instead of `release`:
+
+1. Moves the `nightly` git tag onto the pushed commit.
+2. Updates the single rolling `nightly` prerelease **in place**
+   (`gh release edit` + `gh release upload --clobber`, not delete-and-recreate,
+   so `/releases/tag/nightly` never 404s mid-run and the release keeps its id).
+3. Rewrites `display_version` in the bundled `.info` to
+   `v<X.Y.Z>-nightly-<sha>`, so a nightly `.info` can never be mistaken for the
+   file that gets PR'd to libretro-super.
+4. Creates-or-updates a pinned tracking issue (matched by exact title, so it
+   can't duplicate itself) with the current build and install instructions.
+
+The two paths can't collide: the `release` job is gated on
+`startsWith(github.ref, 'refs/tags/v')`, the `nightly` job on
+`github.ref == 'refs/heads/develop'`, and the `nightly` tag deliberately sits
+outside the `v*` tag filter so a CI-pushed tag can never re-enter the release
+path.
+
+**What a nightly is gated on:** the 18 builds compiling. It is *not* gated on
+`c-cpp.yml`, the acid suite, or the screenshot regression run — those report
+separately on the same commit. A nightly can build cleanly and still be broken,
+and the release body says so. Upgrading that claim means switching the job to a
+`workflow_run` trigger (see `artifacts.yml` for the idiom in this repo).
+
+Concurrency differs from `c-cpp.yml`/`acid-test.yml` on purpose: develop pushes
+here **do** cancel superseded runs, because only the newest commit's binaries
+matter for a rolling prerelease. Tag pushes always run to completion. If build
+queue contention ever becomes a problem, the lever is a `paths-ignore` for
+docs-only pushes — not a smaller matrix. (Test it carefully: path filters
+interact badly with tag pushes, and this workflow serves both.)
+
 ### 4. Post-tag: update libretro-super
 
 RetroArch ships with a `.info` file per core, sourced from `libretro/libretro-super/dist/info/`. Update is **manual** — there's no automated mirror.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -74,7 +74,7 @@ After all platform builds finish, the `release` job:
 ### 3b. Nightly builds (develop pushes)
 
 `release.yml` also fires on every push to `develop`. The build matrix is
-identical — the same 18 jobs, the same split-debug packaging — but the
+identical — the same 16 jobs (14 matrix entries + Vita + Switch), the same split-debug packaging — but the
 publishing step is the `nightly` job instead of `release`:
 
 1. Moves the `nightly` git tag onto the pushed commit.
@@ -84,8 +84,11 @@ publishing step is the `nightly` job instead of `release`:
 3. Rewrites `display_version` in the bundled `.info` to
    `v<X.Y.Z>-nightly-<sha>`, so a nightly `.info` can never be mistaken for the
    file that gets PR'd to libretro-super.
-4. Creates-or-updates a pinned tracking issue (matched by exact title, so it
-   can't duplicate itself) with the current build and install instructions.
+4. Creates-or-updates a pinned tracking issue with the current build and
+   install instructions. Located by the `nightly-tracker` label first
+   (server-side, exact, independent of how many issues the repo has) with an
+   exact-title match as fallback — both have to miss before it could duplicate
+   itself.
 
 The two paths can't collide: the `release` job is gated on
 `startsWith(github.ref, 'refs/tags/v')`, the `nightly` job on
@@ -93,7 +96,7 @@ The two paths can't collide: the `release` job is gated on
 outside the `v*` tag filter so a CI-pushed tag can never re-enter the release
 path.
 
-**What a nightly is gated on:** the 18 builds compiling. It is *not* gated on
+**What a nightly is gated on:** the 16 builds compiling. It is *not* gated on
 `c-cpp.yml`, the acid suite, or the screenshot regression run — those report
 separately on the same commit. A nightly can build cleanly and still be broken,
 and the release body says so. Upgrading that claim means switching the job to a


### PR DESCRIPTION
Every push to `develop` now rebuilds all 16 platforms (14 matrix entries + Vita + Switch) and replaces a single rolling `nightly` prerelease, plus a pinned tracking issue — the same model Provenance uses for its alpha channel.

## Reusing rather than duplicating

`release.yml`'s `build` / `vita-build` / `switch-build` jobs were already trigger-agnostic, so this adds a develop-push trigger to the existing workflow and branches only the final publishing job. No second matrix, no reusable-workflow refactor.

```
push tag v*   →  release job   if: startsWith(github.ref, 'refs/tags/v')
push develop  →  nightly job   if: github.ref == 'refs/heads/develop'
```

The `nightly` tag deliberately sits **outside** the `v*` tag filter, so a CI-pushed tag can never re-enter the release path. `workflow_dispatch` is also added, giving a manual "rebuild the nightly" button.

## What the nightly job does

1. Moves the `nightly` tag onto the pushed commit.
2. Updates the rolling prerelease **in place** — `gh release edit` + `gh release upload --clobber`, rather than Provenance's delete-then-create. Asset names are deterministic per platform, so clobbering works, and it means `/releases/tag/nightly` never 404s mid-run and the release keeps its id (watchers stay subscribed).
3. Rewrites `display_version` in the bundled `.info` to `v2.3.2-nightly-<sha>`.
4. Creates-or-updates a pinned tracking issue, located by a `nightly-tracker` label (server-side, exact, and independent of how many issues the repo accumulates) with an exact-title match as fallback. Not the search API — it is eventually consistent, and a miss would open a duplicate on every subsequent run. Pinned via the GraphQL `pinIssue` mutation (REST has no pin endpoint; the repo has all 3 slots free). The whole step is `continue-on-error` — the binaries are already published by then, and an issue-edit hiccup shouldn't fail the run.

The release body diffs against wherever the `nightly` tag pointed on the previous run, captured *before* the tag moves.

## What a nightly is and isn't gated on

`needs: [build, vita-build, switch-build]` — so a nightly means **it compiled on all 16 targets**. It does *not* wait on `c-cpp.yml`, the acid suite, or the screenshot regression run, which report separately on the same commit. A nightly can build cleanly and still be broken.

The release body and the pinned issue both say this outright rather than borrowing Provenance's "passes all CI checks before being published" wording, which would be false here. Upgrading the claim means switching to a `workflow_run` trigger — the idiom already exists in this repo in `artifacts.yml`.

## Concurrency inverts the house convention, on purpose

`c-cpp.yml` and `acid-test.yml` let develop pushes run to completion so there's always a green-or-red record per commit. This workflow cancels superseded develop runs, because only the newest commit's binaries matter for a rolling prerelease and an in-flight build of an older tip is pure waste. Tag pushes still always run to completion. Commented at the `concurrency:` block so the divergence doesn't read as an oversight.

## Two bugs fixed in passing

Both because the nightly path would otherwise have inherited them.

**`SHA256SUMS.txt` could list itself with the empty-file hash.** `sha256sum -- * | sort -k 2 > SHA256SUMS.txt` starts both pipeline stages concurrently, so `sort`'s redirect can create the empty file *before* `sha256sum`'s glob expands. The manifest then fails `sha256sum --check` on its own line. v2.3.2's published manifest happened to win the race — I checked — but at ~6 nightlies a day it wouldn't stay lucky. Now built in `$RUNNER_TEMP` and moved in. Fixed in the `release` job too.

**The bundled `.info` carries the last *tagged* version.** Each build job uploads all of `dist/`, which includes the tracked `dist/info/`, so a nightly would have shipped an `.info` reading `display_version = "v2.3.2"`. Rewritten to `v2.3.2-nightly-<sha>`, which also makes it obvious that a nightly `.info` isn't the file to PR to libretro-super.

## Checked

- `build-id.sh` uses `git rev-parse --short HEAD`, not `git describe --tags` — so the floating `nightly` tag on develop's tip **cannot** perturb the embedded core version, `VJ_EXPECT_BUILD`, or `cd_boot_matrix.sh`'s build stamps. That was the one failure mode here that would have been silent, and it doesn't apply.
- `actionlint` clean; `shellcheck -S warning` clean on every `run` block.
- Dry-ran locally against the live repo: body generation, the `.info` rewrite, the checksum race fix (10/10 runs no self-reference), and **both** branches of the issue-title lookup — the not-found path returns empty, and an existing title resolves to the right number.
- `pinIssue` confirmed present in the GraphQL schema; the label lookup degrades cleanly (empty, exit 0) when the label doesn't exist yet, so the first run falls through to the title match.
- The 16 was counted from the parsed YAML, not from a CI check list — I had it wrong as 18 in the first commit, which would have republished in the release body and pinned issue on every nightly.

Second commit also fixes: the install steps omitted the **rename**. Assets ship as `virtualjaguar_libretro-<platform>.<ext>`, but RetroArch pairs a core to its `.info` by exact basename — following the original wording literally gave you a core with no name, no version and no core options, and made the "copy the .info" step silently useless.

## Not done / worth a look

- **The first run is the real test.** The publishing steps can't execute from a feature branch by design, so they've been validated by dry-run and lint, not end-to-end. Failure modes are all recoverable (delete a release, delete a tag, close an issue) and the release-path gate is the part I was most careful about.
- **Cadence:** 183 commits to develop in the last 30 days ≈ 6 pushes/day × 16 jobs, on top of the existing c-cpp/acid/regression/clang-format load on the same branch. `cancel-in-progress` absorbs bursts and public-repo minutes are free, but if queue contention shows up the lever is a `paths-ignore` for docs-only pushes — not a smaller matrix. Left out for now because path filters interact badly with tag pushes and this workflow serves both.
- **Home repo:** this publishes a bot-updated prerelease and pins an issue on the org repo, where the libretro buildbot already distributes stable cores. That's the intended target as I read the ask, but flagging it since it's outward-facing and consumes one of three pin slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
