### PR TITLE
feat(jerry): emulate the async serial UART (JagLink phase 1: core + loopback)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Frame loop is event-driven (not cycle-accurate): `JaguarExecuteNew()` in `src/co
 
 - `src/core/` — orchestration, memory map, events, settings, files, cheats
 - `src/tom/` — video, GPU, OP, blitter (+ SIMD)
-- `src/jerry/` — audio, DSP, DAC, EEPROM, input, wavetable
+- `src/jerry/` — audio, DSP, DAC, EEPROM, input, wavetable, UART/netlink (`uart.c` + `jlink.c`, see `docs/netlink-design.md`)
 - `src/cd/` — Jaguar CD: BUTCH/FIFO/DSA in `cdrom.c`, image loading (CUE/BIN, CHD, CDI) in `cdintf.c`; BIOS auth bypass + boot stub in `src/core/jaguar.c`
 - `src/bios/` — embedded BIOS / boot stubs
 - `src/m68000/` — UAE 68K (machine-generated; treat as opaque)

--- a/Makefile
+++ b/Makefile
@@ -807,11 +807,12 @@ test: test/test_cheat test/test_event_queue test/test_jlink test/test_uart_loopb
 		test/test_cart_format \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap \
 		test/test_audio_dac test/test_blitter \
-		test/tools/test_memory_map test/tools/test_op_gpu_object
+		test/tools/test_memory_map test/tools/test_op_gpu_object test/test_uart_core
 	./test/test_cheat
 	./test/test_event_queue
 	./test/test_jlink
 	./test/test_uart_loopback
+	./test/test_uart_core ./$(TARGET)
 	./test/test_blitter_mmio
 	./test/test_blitter_cmd ./$(TARGET)
 	./test/test_pit_clock_rate
@@ -940,6 +941,10 @@ test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h
 test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/core/event.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_uart_loopback.c src/jerry/uart.c src/jerry/jlink.c src/core/event.c -lm
+
+test/test_uart_core: test/test_uart_core.c test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
+		-o $@ test/test_uart_core.c test/harness/harness.c -ldl -lm
 
 # Regression guard: textually verifies that JERRYResetPIT1/2,
 # TOMResetPIT, and JERRYGetPIT*Frequency schedule using RISC clock

--- a/Makefile
+++ b/Makefile
@@ -795,7 +795,7 @@ else
 # rev (+ -dirty) against this before running -- a stale dylib fails loudly
 # instead of silently testing the wrong code (see scripts/build-id.sh).
 test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
-test: test/test_cheat test/test_event_queue test/test_jlink test/test_blitter_simd test/test_dsp_mac40 \
+test: test/test_cheat test/test_event_queue test/test_jlink test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
@@ -811,6 +811,7 @@ test: test/test_cheat test/test_event_queue test/test_jlink test/test_blitter_si
 	./test/test_cheat
 	./test/test_event_queue
 	./test/test_jlink
+	./test/test_uart_loopback
 	./test/test_blitter_mmio
 	./test/test_blitter_cmd ./$(TARGET)
 	./test/test_pit_clock_rate

--- a/Makefile
+++ b/Makefile
@@ -795,7 +795,7 @@ else
 # rev (+ -dirty) against this before running -- a stale dylib fails loudly
 # instead of silently testing the wrong code (see scripts/build-id.sh).
 test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
-test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp_mac40 \
+test: test/test_cheat test/test_event_queue test/test_jlink test/test_blitter_simd test/test_dsp_mac40 \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
@@ -810,6 +810,7 @@ test: test/test_cheat test/test_event_queue test/test_blitter_simd test/test_dsp
 		test/tools/test_memory_map test/tools/test_op_gpu_object
 	./test/test_cheat
 	./test/test_event_queue
+	./test/test_jlink
 	./test/test_blitter_mmio
 	./test/test_blitter_cmd ./$(TARGET)
 	./test/test_pit_clock_rate
@@ -930,6 +931,14 @@ test/test_cheat: test/test_cheat.c src/core/cheat.c src/core/cheat.h
 test/test_event_queue: test/test_event_queue.c src/core/event.c src/core/event.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_event_queue.c src/core/event.c
+
+test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_jlink.c src/jerry/jlink.c
+
+test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/core/event.c
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_uart_loopback.c src/jerry/uart.c src/jerry/jlink.c src/core/event.c -lm
 
 # Regression guard: textually verifies that JERRYResetPIT1/2,
 # TOMResetPIT, and JERRYGetPIT*Frequency schedule using RISC clock

--- a/Makefile.common
+++ b/Makefile.common
@@ -28,6 +28,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/core/jaguar.c \
 	$(CORE_DIR)/src/jerry/jerry.c \
 	$(CORE_DIR)/src/jerry/jlink.c \
+	$(CORE_DIR)/src/jerry/uart.c \
 	$(CORE_DIR)/src/tom/op.c \
 	$(CORE_DIR)/src/tom/tom.c  \
 	$(CORE_DIR)/src/cd/cdintf.c \

--- a/Makefile.common
+++ b/Makefile.common
@@ -27,6 +27,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/tom/gpu.c \
 	$(CORE_DIR)/src/core/jaguar.c \
 	$(CORE_DIR)/src/jerry/jerry.c \
+	$(CORE_DIR)/src/jerry/jlink.c \
 	$(CORE_DIR)/src/tom/op.c \
 	$(CORE_DIR)/src/tom/tom.c  \
 	$(CORE_DIR)/src/cd/cdintf.c \

--- a/docs/netlink-design.md
+++ b/docs/netlink-design.md
@@ -1,0 +1,212 @@
+# Jaguar Link Networking (JERRY UART + Pluggable Transport)
+
+**Date:** 2026-07-31
+**Status:** Approved (design), pending implementation plan
+**Branch:** `claude/jaguar-networking-support-0c8a86` (off `libretro/develop`)
+
+## Overview
+
+Add emulation of the Atari Jaguar's inter-console link hardware so networked
+titles — BattleSphere Gold, AirCars, and Jaguar Doom's 2-player deathmatch —
+can play against other emulator instances. Every real-world link peripheral
+(Atari's JagLink RJ11 interface and ICD's CatBox with its multi-drop CatNet
+bus) attaches to the DSP port and drives the same silicon: JERRY's
+asynchronous serial UART. Emulating that UART once, behind a small pluggable
+byte-transport interface, covers all of them.
+
+## Current state (verified 2026-07-31)
+
+- Reads/writes to the UART registers `$F10030`–`$F10034` fall through to
+  plain JERRY RAM (`src/jerry/jerry.c`, tail of the read/write dispatchers).
+  A game probing for a link partner reads back its own writes — nonsense.
+- `IRQ2_ASI` (0x10) is defined in `src/jerry/jerry.h` but never raised.
+- The J_ASYNENA enable bit and J_ASYNCLR clear bit already exist in the
+  JINTCTRL documentation/handling.
+- Bundled `libretro.h` already declares
+  `RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE` (env 78) and the
+  `retro_netpacket_callback` types.
+- The in-tree `libretro-common/` is trimmed and has **no `net/`** — the
+  socket abstraction must be vendored from upstream.
+
+## Why standard RetroArch netplay does not apply
+
+RetroArch's classic netplay frame-syncs the *inputs of one shared emulated
+console*. Jaguar link play is N separate consoles, each running its own
+machine, exchanging serial bytes. The correct RetroArch mechanism is the
+**netpacket interface** (env 78), which turns a netplay session into a raw
+packet pipe between independently running cores (as used by DOSBox-Pure for
+IPX). That is phase 3; a direct TCP transport ships first because it works in
+every frontend (including Provenance on iOS/macOS) and enables headless
+automated testing.
+
+## Goals
+
+1. Hardware-accurate JERRY UART emulation (registers, status bits, baud
+   pacing, interrupts), verified against the JTRM PDFs in
+   `docs/atari-jaguar-1999/` — not source comments.
+2. Pluggable link transport: loopback, TCP, libretro netpacket.
+3. Two-instance link play of BattleSphere Gold and Doom over TCP on
+   localhost/LAN; netpacket play under real RetroArch netplay.
+4. Automated tests at every layer, runnable headlessly on this Mac.
+
+## Non-goals (for now)
+
+- Internet-scale matchmaking or a public relay service (DCNet-style). Nothing
+  exists for Jaguar today; the TCP backend plus user-supplied tunneling
+  (Tailscale etc.) is the interim story. A relay is a separate future project.
+- Modeling CatBox RS-232 DSP-port registers beyond the UART itself, MIDI, or
+  ComLynx cross-compatibility.
+- Cycle-exact UART timing beyond baud-rate pacing (start/8-data/stop bit
+  times); games rate-limit on TBE/RBF status, not on bit edges.
+
+## Architecture
+
+### 1. UART core — new `src/jerry/uart.c` / `uart.h`
+
+Register behavior (JTRM "Asynchronous Serial" section; the distilled map is
+`docs/jtrm-jerry.md`, to be re-verified against the PDFs during planning):
+
+| Address   | Name    | Behavior |
+|-----------|---------|----------|
+| `$F10030` | ASIDATA | W: load TX holding register, clear TBE, schedule TX-complete event at baud. R: pop RX buffer, clear RBF. |
+| `$F10032` | ASICTRL (W) | ODD/PAREN/TXOPOL/RXIPOL config; TINTEN/RINTEN interrupt enables; CLRERR clears PE/FE/OE; TXBRK. |
+| `$F10032` | ASISTAT (R) | TBE (bit 8), RBF (bit 7), PE/FE/OE (9–11), SERIN (13), TXBRK (14), ERROR (15 = PE|FE|OE), plus config readback. |
+| `$F10034` | ASICLK  | Baud divider N; baud = sysclock / (16 × (N+1)) per the distilled doc — **verify the ×16 vs ×32 factor against the JTRM PDF before implementation**. |
+
+- **TX path:** ASIDATA write → TBE clears → event scheduled via the existing
+  event system (`src/core/event.c`) at 10 bit-times → byte handed to the
+  active transport → TBE sets → `IRQ2_ASI` raised if TINTEN and J_ASYNENA.
+- **RX path:** transport-delivered bytes queue in a small RX FIFO, delivered
+  to ASIDATA at baud pacing; RBF sets, `IRQ2_ASI` if RINTEN; OE latches if a
+  byte lands while RBF is still set. Parity/framing errors are only
+  synthesized where a transport can express them (loopback tests).
+- **Interrupt route:** `jerryPendingInterrupt |= IRQ2_ASI` gated by
+  J_ASYNENA, delivered over the existing JINTCTRL → 68K IPL2 path. Whether
+  the UART can also interrupt the DSP is a JTRM question resolved during
+  planning; the 68K path is the known-required one.
+- **Dispatch:** `JERRYReadWord/WriteWord` (and byte variants) get a
+  `$F10030–$F10035` branch calling into `uart.c`, placed before the RAM
+  fall-through.
+- **Savestates:** UART registers, FIFOs, and pending-event state serialize
+  with the rest of JERRY. Live socket state does not; loading a state during
+  a session behaves like a pulled link cable (games treat it as link drop).
+- **Reset/iOS:** full static-state reset in init/deinit (iOS cannot dlclose
+  cores — established project rule).
+
+### 2. Link transport — `src/jerry/jlink.c` / `jlink.h`
+
+Minimal internal API consumed only by `uart.c`:
+
+```c
+int  JLinkOpen(void);          /* per core option config */
+void JLinkClose(void);
+void JLinkSendByte(uint8_t b);
+int  JLinkRecvByte(uint8_t *b); /* nonblocking, 0 = none */
+void JLinkPoll(void);           /* once per frame from retro_run */
+int  JLinkConnected(void);
+```
+
+Backends selected by core option:
+
+- **loopback** — TX feeds RX after the baud delay. Zero network dependencies;
+  drives unit tests and lets a user smoke-test a game's link menu solo.
+- **tcp** (phase 2) — one instance is `tcp_server` (listen), the other
+  `tcp_client` (connect). Nonblocking BSD sockets with `TCP_NODELAY`; socket
+  files vendored from upstream libretro-common `net/net_socket.*` (MIT) into
+  the tree, giving POSIX (macOS/iOS/Linux/Android) + winsock coverage from
+  one codebase. Native per-platform frameworks (Network.framework etc.) are
+  unnecessary at ~31 kbaud serial rates. 2 endpoints in this phase.
+- **netpacket** (phase 3) — `RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE`;
+  bytes batched per frame, sent `RETRO_NETPACKET_RELIABLE |
+  RETRO_NETPACKET_FLUSH_HINT`, broadcast to peers. Gives RetroArch ≥ 1.16
+  lobby-based connection UX. Cores in frontends without env-78 support fall
+  back cleanly (env call returns false → option hidden/inert).
+- **multi-node hub** (phase 4, CatNet/AirCars) — TCP server rebroadcasts each
+  byte stream to all other endpoints, modeling the shared multi-drop wire.
+  Topology questions (whether a node hears its own TX) resolved against
+  AirCars' actual protocol behavior during that phase.
+
+### 3. Core options (`libretro_core_options.h`)
+
+- `virtualjaguar_netlink`: `disabled` (default; UART still emulated —
+  registers behave, SERIN reads idle, nothing connects) | `loopback` |
+  `tcp_server` | `tcp_client` | `netpacket` (phase 3).
+- `virtualjaguar_netlink_port`: enum of a few ports (default 42171).
+- Host for `tcp_client`: core options cannot take free text, so resolution
+  order is env `VJ_NETLINK_HOST`, then `<system_dir>/vj_netlink.txt`, then
+  `127.0.0.1`. Documented in README.
+
+### 4. Testing
+
+ROM corpus: `/Users/jmattiello/Workspace/Provenance/jaguar-roms-private`
+(symlinked at `test/roms/private`; discover with `find -L`).
+
+1. **Unit (phase 1):** harness-based (`test/harness/`) loopback test driving
+   the real registers via `harness_dlsym` — write ASIDATA, poll ASISTAT for
+   TBE/RBF transitions, assert byte round-trip, IRQ latch in
+   `jerryPendingInterrupt`, OE on deliberate overrun, CLRERR behavior.
+   Added to `make test`.
+2. **Two-instance TCP (phase 2):** `test/tools/netlink_pair_test` — forks two
+   processes, each dlopens the core (separate address spaces, so statics are
+   safe), server + client on localhost, asserts cross-instance byte streams
+   in both directions. Also added to `make test` (localhost only, no external
+   network).
+3. **Game acceptance (phase 2):** scripted `--press` navigation of
+   BattleSphere Gold and Doom into their link/comm menus on two linked
+   headless instances; the bar is **mutual link detection**. `cd_visual_verify`
+   -style screenshot output for agent-readable confirmation.
+4. **Real-RetroArch matrix (phase 3):** `test/tools/netlink_ra_matrix.sh`
+   spawns N real RetroArch instances on this Mac via CLI (`retroarch -L
+   <core> <rom> --host` / `--connect localhost`) to exercise the netpacket
+   backend end-to-end. The script auto-detects the installed
+   `/Applications/RetroArch.app` (verified present on this Mac; CLI binary at
+   `RetroArch.app/Contents/MacOS/RetroArch`) or `retroarch` on PATH, and
+   offers `brew install --cask retroarch` when absent. Windowed instances on macOS (RetroArch's macOS video needs a
+   window); still script-driven and assert-based via logs/network state.
+5. **Manual sign-off:** actual 2-player BattleSphere Gold dogfight and Doom
+   deathmatch on this Mac (and Provenance iOS for the TCP backend), per the
+   project rule that headless tests can't fully replace in-frontend checks.
+
+### 5. C89 / platform rules
+
+C89-strict (all vars at top of block; `scripts/c89-lint.sh` before push).
+Vendored socket files added to the lint exempt list only if upstream code
+requires it. `DEVELOPER_DIR=/Library/Developer/CommandLineTools` for host
+builds. Conventional commits: `feat(jerry): …`, `feat(net): …`,
+`test(net): …`.
+
+## Phases
+
+| Phase | Deliverable | Acceptance |
+|-------|-------------|------------|
+| 1 | UART emulation + loopback + unit tests + savestate | Loopback tests green in `make test`; no regressions in existing suite (UART idle when disabled) |
+| 2 | TCP backend + core options + pair test | Two headless instances exchange bytes; BSG + Doom mutual link detect on localhost |
+| 3 | netpacket backend | Link play under real RetroArch netplay on this Mac via `netlink_ra_matrix.sh` |
+| 4 | Multi-node hub | AirCars ≥3-instance session detect |
+
+Each phase is a separately reviewable PR to `develop`.
+
+## Risks
+
+- **Latency tolerance.** Link protocols assume a microsecond wire.
+  Localhost/LAN is the honest first target; internet play is best-effort
+  until BattleSphere's timeout behavior is measured. Netpacket's
+  reliable-ordered delivery adds RetroArch's own buffering on top.
+- **Baud-formula ambiguity.** The ÷16 vs ÷32 factor changes pacing 2×; must
+  be settled from the JTRM PDF (and, if ambiguous, against BattleSphere's
+  observed divider writes) before the event timing is coded.
+- **Game-side protocol unknowns.** BattleSphere's CatNet handshake may probe
+  status bits (SERIN idle level, break conditions) in ways only discoverable
+  by tracing; the phase-2 acceptance bar is deliberately "link detect," with
+  playable sessions proven in phase 3 sign-off.
+- **Frontend support matrix.** Netpacket needs RetroArch ≥ 1.16; Provenance
+  gets the TCP path. Both are by design, documented in README.
+
+## Decisions log
+
+- TCP before netpacket (user, 2026-07-31) — frontend-agnostic + testable first.
+- Validation corpus: BattleSphere Gold, Jaguar Doom, AirCars (user).
+- Plain BSD/winsock sockets everywhere; no per-platform native networking
+  frameworks (perf irrelevant at serial baud rates) (user OK'd).
+- Automated multi-client testing must support spawning real RetroArch
+  instances installed on this Mac, with a brew-installable fallback (user).

--- a/docs/netlink-design.md
+++ b/docs/netlink-design.md
@@ -1,7 +1,7 @@
 # Jaguar Link Networking (JERRY UART + Pluggable Transport)
 
 **Date:** 2026-07-31
-**Status:** Approved (design), pending implementation plan
+**Status:** Phase 1 (UART + loopback) implemented; phases 2–4 pending
 **Branch:** `claude/jaguar-networking-support-0c8a86` (off `libretro/develop`)
 
 ## Overview
@@ -201,6 +201,18 @@ Each phase is a separately reviewable PR to `develop`.
   playable sessions proven in phase 3 sign-off.
 - **Frontend support matrix.** Netpacket needs RetroArch ≥ 1.16; Provenance
   gets the TCP path. Both are by design, documented in README.
+
+## Phase 1 outcome (2026-07-31)
+
+Delivered: `src/jerry/uart.c` (registers, 11-bit-time frame pacing,
+double-buffered TX/RX, OE latching, TINTEN/RINTEN → JINTCTRL bit 4 → 68K
+IPL2), `src/jerry/jlink.c` (transport seam, loopback backend), core option
+`virtualjaguar_netlink` (disabled/loopback), STATE_VERSION 6 with a
+version-gated UART chunk (event callbacks registered as ids 8/9), and three
+test layers (`test_jlink`, `test_uart_loopback`, `test_uart_core`) in
+`make test`. Baud formula and frame length verified against JTRM Rev 8
+pp. 93–95 (`docs/atari-jaguar-1999/jag_v8.pdf`); JINTCTRL bit 4 assignment
+confirmed on p. 87 (the emulator's `IRQ2_ASI=0x10` was already correct).
 
 ## Decisions log
 

--- a/exports-test.list
+++ b/exports-test.list
@@ -25,6 +25,8 @@ _d0Queue
 _GPU*
 _gpu_*
 _JERRY*
+_UART*
+_JLink*
 _TOM*
 _OP*
 _tomRam8

--- a/libretro.c
+++ b/libretro.c
@@ -780,6 +780,7 @@ bool retro_serialize(void *data, size_t size)
    buf += JoystickStateSave(buf);
    buf += MTStateSave(buf);
    buf += DACStateSave(buf);
+   buf += UARTStateSave(buf);
 
    written = (size_t)(buf - start);
    if (written > STATE_SIZE)
@@ -840,6 +841,8 @@ bool retro_unserialize(const void *data, size_t size)
    buf += JoystickStateLoad(buf);
    buf += MTStateLoad(buf);
    buf += DACStateLoad(buf, version);
+   if (version >= STATE_VERSION_JERRY_UART)
+      buf += UARTStateLoad(buf, version);
 
    JaguarApplyHLEBIOSState();
 

--- a/libretro.c
+++ b/libretro.c
@@ -28,6 +28,8 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "jagcd_hle.h"
 #include "dac.h"
 #include "dsp.h"
+#include "jlink.h"
+#include "uart.h"
 #include "joystick.h"
 #include "settings.h"
 #include "tom.h"
@@ -369,6 +371,14 @@ static void check_variables(void)
       CDTraceSetEnabled(strcmp(var.value, "enabled") == 0);
    else
       CDTraceSetEnabled(0);
+
+   var.key = "virtualjaguar_netlink";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value
+       && strcmp(var.value, "loopback") == 0)
+      UARTSetLinkMode(JLINK_MODE_LOOPBACK);
+   else
+      UARTSetLinkMode(JLINK_MODE_DISABLED);
 
    var.key = "virtualjaguar_bios";
    var.value = NULL;

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -121,6 +121,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "enabled"
    },
    {
+      "virtualjaguar_netlink",
+      "Network Link (JagLink / CatBox)",
+      NULL,
+      "Emulates JERRY's serial link port used by networked games (BattleSphere, AirCars, Doom deathmatch). 'Loopback' echoes transmitted bytes back to this console, for testing link-detect menus without a partner. Linking two emulator instances over TCP arrives in a later release.",
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "loopback", "Loopback (echo to self)" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "virtualjaguar_cd_trace",
       "CD Trace (Diagnostic)",
       NULL,

--- a/link-test.T
+++ b/link-test.T
@@ -28,6 +28,8 @@
       GPU*;
       gpu_*;
       JERRY*;
+      UART*;
+      JLink*;
       TOM*;
       OP*;
       tomRam8;

--- a/src/core/event.c
+++ b/src/core/event.c
@@ -265,6 +265,8 @@ extern void JERRYPIT2Callback(void);
 extern void JERRYI2SCallback(void);
 extern void DSPSampleCallback(void);
 extern void GPUCPUINTCallback(void);
+extern void UARTTXCallback(void);
+extern void UARTRXCallback(void);
 
 typedef void (*event_callback_t)(void);
 
@@ -277,6 +279,8 @@ static const event_callback_t callback_registry[] = {
    JERRYI2SCallback,     /* 5 */
    DSPSampleCallback,    /* 6 */
    GPUCPUINTCallback,    /* 7 */
+   UARTTXCallback,       /* 8 */
+   UARTRXCallback,       /* 9 */
 };
 #define CALLBACK_REGISTRY_SIZE (sizeof(callback_registry) / sizeof(callback_registry[0]))
 

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -19,9 +19,10 @@ extern "C" {
 
 /* Save state format identifier and version.
  * v4: CDROM chunk gained the DSA response queue + serial-delay counter.
- * v5: CDROM chunk gained the latched drive speed (DSA Set Mode $15nn). */
+ * v5: CDROM chunk gained the latched drive speed (DSA Set Mode $15nn).
+ * v6: new UART chunk (JERRY async serial + jlink RX ring). */
 #define STATE_MAGIC     0x564A5353  /* "VJSS" */
-#define STATE_VERSION   5
+#define STATE_VERSION   6
 /* Oldest layout retro_unserialize still accepts.  States between
  * STATE_MIN_VERSION and STATE_VERSION load by skipping the fields added
  * after them (see DACStateLoad, CDROMStateLoad); STATE_VERSION is always
@@ -38,6 +39,8 @@ extern "C" {
 #define STATE_VERSION_CDROM_DSA_QUEUE 4
 /* First version whose CDROM block carries the latched drive speed. */
 #define STATE_VERSION_CDROM_DRIVE_SPEED 5
+/* First version carrying the JERRY UART + jlink chunk. */
+#define STATE_VERSION_JERRY_UART 6
 
 /* Header flags */
 #define STATE_FLAG_MEMTRACK  0x01
@@ -77,6 +80,11 @@ size_t EepromStateLoad(const uint8_t *buf);
 
 size_t JERRYStateSave(uint8_t *buf);
 size_t JERRYStateLoad(const uint8_t *buf);
+
+/* UART chunk is wholly new in v6; the caller gates on
+ * STATE_VERSION_JERRY_UART before invoking the loader. */
+size_t UARTStateSave(uint8_t *buf);
+size_t UARTStateLoad(const uint8_t *buf, uint32_t stateVersion);
 
 size_t TOMStateSave(uint8_t *buf);
 size_t TOMStateLoad(const uint8_t *buf);

--- a/src/jerry/jerry.c
+++ b/src/jerry/jerry.c
@@ -166,6 +166,8 @@
 
 PERF_COUNTER(timing_jerry_irqs);
 #include "joystick.h"
+#include "jlink.h"
+#include "uart.h"
 #include "m68000/m68kinterface.h"
 #include "memtrack.h"
 #include "settings.h"
@@ -379,6 +381,7 @@ void JERRYInit(void)
    jerryPendingInterrupt = 0x0000;
 
    DACInit();
+   UARTInit();
 }
 
 
@@ -400,6 +403,7 @@ void JERRYReset(void)
    jerryPendingInterrupt = 0x0000;
 
    DACReset();
+   UARTReset();
 }
 
 
@@ -409,6 +413,7 @@ void JERRYDone(void)
    DACDone();
    EepromDone();
    MTDone();
+   UARTDone();
 }
 
 
@@ -452,6 +457,13 @@ uint8_t JERRYReadByte(uint32_t offset, uint32_t who/*=UNKNOWN*/)
    // LRXD/RRXD/SSTAT $F1A148/4C/50 (really 16-bit registers...)
    else if (offset >= 0xF1A148 && offset <= 0xF1A153)
       return DACReadByte(offset, who);
+   // ASIDATA/ASISTAT/ASICLK $F10030-35 (16-bit UART registers)
+   else if ((offset >= 0xF10030) && (offset <= 0xF10035))
+   {
+      uint16_t value = UARTReadWord(offset & 0xFFFFFFFE);
+      return (offset & 0x01) ? (uint8_t)(value & 0xFF)
+                             : (uint8_t)(value >> 8);
+   }
    //	F10036          R     xxxxxxxx xxxxxxxx   JPIT1 - timer 1 pre-scaler
    //	F10038          R     xxxxxxxx xxxxxxxx   JPIT2 - timer 1 divider
    //	F1003A          R     xxxxxxxx xxxxxxxx   JPIT3 - timer 2 pre-scaler
@@ -503,6 +515,9 @@ uint16_t JERRYReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
    // LRXD/RRXD/SSTAT $F1A148/4C/50 (really 16-bit registers...)
    else if (offset >= 0xF1A148 && offset <= 0xF1A153)
       return DACReadWord(offset, who);
+   // ASIDATA/ASISTAT/ASICLK $F10030-35 (16-bit UART registers)
+   else if ((offset >= 0xF10030) && (offset <= 0xF10035))
+      return UARTReadWord(offset & 0xFFFFFFFE);
    //	F10036          R     xxxxxxxx xxxxxxxx   JPIT1 - timer 1 pre-scaler
    //	F10038          R     xxxxxxxx xxxxxxxx   JPIT2 - timer 1 divider
    //	F1003A          R     xxxxxxxx xxxxxxxx   JPIT3 - timer 2 pre-scaler
@@ -571,6 +586,21 @@ void JERRYWriteByte(uint32_t offset, uint8_t data, uint32_t who/*=UNKNOWN*/)
       /* Unhandled timer write (BYTE) */
       return;
    }
+   // ASIDATA/ASICTRL/ASICLK $F10030-35 (16-bit UART registers).  Byte
+   // writes carry the payload in the low byte for ASIDATA/ASICTRL;
+   // ASICLK merges the touched half into the existing divider.
+   else if (offset >= 0xF10030 && offset <= 0xF10035)
+   {
+      uint32_t base = offset & 0xFFFFFFFE;
+      uint16_t cur = (base == 0xF10034) ? UARTReadWord(base) : 0;
+      uint16_t v;
+      if (offset & 0x01)
+         v = (uint16_t)((cur & 0xFF00) | data);
+      else
+         v = (uint16_t)((cur & 0x00FF) | ((uint16_t)data << 8));
+      UARTWriteWord(base, v);
+      return;
+   }
    // JERRY -> 68K interrupt enables/latches (need to be handled!)
    else if (offset >= 0xF10020 && offset <= 0xF10021)//WAS:23)
    {
@@ -622,6 +652,12 @@ void JERRYWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
    else if (offset >= 0xF1A148 && offset <= 0xF1A156)
    {
       DACWriteWord(offset, data, who);
+      return;
+   }
+   // ASIDATA/ASICTRL/ASICLK $F10030-35 (16-bit UART registers)
+   else if (offset >= 0xF10030 && offset <= 0xF10035)
+   {
+      UARTWriteWord(offset & 0xFFFFFFFE, data);
       return;
    }
    else if (offset >= 0xF10000 && offset <= 0xF10007)

--- a/src/jerry/jerry.c
+++ b/src/jerry/jerry.c
@@ -592,13 +592,25 @@ void JERRYWriteByte(uint32_t offset, uint8_t data, uint32_t who/*=UNKNOWN*/)
    else if (offset >= 0xF10030 && offset <= 0xF10035)
    {
       uint32_t base = offset & 0xFFFFFFFE;
-      uint16_t cur = (base == 0xF10034) ? UARTReadWord(base) : 0;
-      uint16_t v;
-      if (offset & 0x01)
-         v = (uint16_t)((cur & 0xFF00) | data);
+
+      /* ASIDATA/ASICTRL: byte writes are meaningful only to the low byte. */
+      if ((base == 0xF10030 || base == 0xF10032) && !(offset & 0x01))
+         return;
+
+      if (base == 0xF10034)
+      {
+         uint16_t cur = UARTReadWord(base);
+         uint16_t v;
+         if (offset & 0x01)
+            v = (uint16_t)((cur & 0xFF00) | data);
+         else
+            v = (uint16_t)((cur & 0x00FF) | ((uint16_t)data << 8));
+         UARTWriteWord(base, v);
+      }
       else
-         v = (uint16_t)((cur & 0x00FF) | ((uint16_t)data << 8));
-      UARTWriteWord(base, v);
+      {
+         UARTWriteWord(base, (uint16_t)data);
+      }
       return;
    }
    // JERRY -> 68K interrupt enables/latches (need to be handled!)

--- a/src/jerry/jlink.c
+++ b/src/jerry/jlink.c
@@ -1,0 +1,87 @@
+/* jlink.c — byte-transport seam for the JERRY UART.
+   Loopback: bytes sent come back on the receive queue, modeling a
+   console whose UARTO is wired to its own UARTI. */
+#include <string.h>
+#include "jlink.h"
+#include "state.h"
+
+#define JLINK_RING_SIZE 256
+
+static int jlinkMode = JLINK_MODE_DISABLED;
+static uint8_t jlinkRing[JLINK_RING_SIZE];
+static uint32_t jlinkHead = 0;   /* next byte to pop */
+static uint32_t jlinkCount = 0;
+
+int JLinkOpen(int mode)
+{
+   JLinkClose();
+   if (mode == JLINK_MODE_LOOPBACK)
+      jlinkMode = mode;
+   return 1;
+}
+
+void JLinkClose(void)
+{
+   jlinkMode = JLINK_MODE_DISABLED;
+   jlinkHead = 0;
+   jlinkCount = 0;
+}
+
+int JLinkMode(void)
+{
+   return jlinkMode;
+}
+
+int JLinkConnected(void)
+{
+   return jlinkMode != JLINK_MODE_DISABLED;
+}
+
+void JLinkSendByte(uint8_t b)
+{
+   uint32_t tail;
+   if (jlinkMode != JLINK_MODE_LOOPBACK)
+      return;
+   if (jlinkCount >= JLINK_RING_SIZE)
+      return;   /* full: drop newest */
+   tail = (jlinkHead + jlinkCount) % JLINK_RING_SIZE;
+   jlinkRing[tail] = b;
+   jlinkCount++;
+}
+
+int JLinkRecvByte(uint8_t *b)
+{
+   if (jlinkCount == 0)
+      return 0;
+   *b = jlinkRing[jlinkHead];
+   jlinkHead = (jlinkHead + 1) % JLINK_RING_SIZE;
+   jlinkCount--;
+   return 1;
+}
+
+int JLinkRxPending(void)
+{
+   return (int)jlinkCount;
+}
+
+size_t JLinkStateSave(uint8_t *buf)
+{
+   uint8_t *start = buf;
+   STATE_SAVE_VAR(buf, jlinkHead);
+   STATE_SAVE_VAR(buf, jlinkCount);
+   STATE_SAVE_BUF(buf, jlinkRing, JLINK_RING_SIZE);
+   return (size_t)(buf - start);
+}
+
+size_t JLinkStateLoad(const uint8_t *buf)
+{
+   const uint8_t *start = buf;
+   STATE_LOAD_VAR(buf, jlinkHead);
+   STATE_LOAD_VAR(buf, jlinkCount);
+   STATE_LOAD_BUF(buf, jlinkRing, JLINK_RING_SIZE);
+   if (jlinkHead >= JLINK_RING_SIZE)
+      jlinkHead = 0;
+   if (jlinkCount > JLINK_RING_SIZE)
+      jlinkCount = JLINK_RING_SIZE;
+   return (size_t)(buf - start);
+}

--- a/src/jerry/jlink.c
+++ b/src/jerry/jlink.c
@@ -16,8 +16,11 @@ int JLinkOpen(int mode)
 {
    JLinkClose();
    if (mode == JLINK_MODE_LOOPBACK)
+   {
       jlinkMode = mode;
-   return 1;
+      return 1;
+   }
+   return 0;
 }
 
 void JLinkClose(void)

--- a/src/jerry/jlink.h
+++ b/src/jerry/jlink.h
@@ -1,0 +1,34 @@
+/* jlink.h — byte-transport seam for the JERRY UART (JagLink/CatBox link).
+   Phase 1 backends: disabled, loopback.  TCP and libretro-netpacket
+   backends arrive in later phases behind this same interface. */
+#ifndef __JLINK_H__
+#define __JLINK_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum
+{
+   JLINK_MODE_DISABLED = 0,
+   JLINK_MODE_LOOPBACK = 1
+};
+
+int  JLinkOpen(int mode);
+void JLinkClose(void);
+int  JLinkMode(void);
+int  JLinkConnected(void);
+void JLinkSendByte(uint8_t b);
+int  JLinkRecvByte(uint8_t *b);
+int  JLinkRxPending(void);
+size_t JLinkStateSave(uint8_t *buf);
+size_t JLinkStateLoad(const uint8_t *buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/jerry/uart.c
+++ b/src/jerry/uart.c
@@ -1,0 +1,250 @@
+/* uart.c — JERRY asynchronous serial interface (ComLynx / JagLink UART).
+ *
+ * Register behavior per the Jaguar Technical Reference Manual Rev 8,
+ * pp. 93-95 (docs/atari-jaguar-1999/jag_v8.pdf):
+ *   - baud = SystemClock / (16 * (ASICLK+1))
+ *   - a character frame is 11 bit times: start + 8 data + parity slot
+ *     (always transmitted) + stop
+ *   - transmitter and receiver are each double buffered
+ *   - JINTCTRL bit 4 (IRQ2_ASI) gates both interrupt classes; interrupts
+ *     reach the 68K only (IPL2)
+ *
+ * The wire itself is src/jerry/jlink.c; this file never touches a
+ * transport directly.
+ */
+#include <string.h>
+#include "uart.h"
+#include "jerry.h"
+#include "event.h"
+#include "settings.h"
+#include "state.h"
+#include "jlink.h"
+#include "m68000/m68kinterface.h"
+
+/* ASICTRL write bits */
+#define ASICTRL_TINTEN  0x0010
+#define ASICTRL_RINTEN  0x0020
+#define ASICTRL_CLRERR  0x0040
+#define ASICTRL_TXBRK   0x4000
+#define ASICTRL_CFGMASK 0x403F   /* stored bits; CLRERR is an action */
+
+/* ASISTAT read bits */
+#define ASISTAT_RBF     0x0080
+#define ASISTAT_TBE     0x0100
+#define ASISTAT_OE      0x0800
+#define ASISTAT_SERIN   0x2000
+#define ASISTAT_TXBRK   0x4000
+#define ASISTAT_ERROR   0x8000
+
+static uint16_t asiCtrl;
+static uint16_t asiClk;
+static uint16_t asiErr;         /* PE/FE/OE latches, ASISTAT positions */
+static uint8_t uartRxData;
+static uint8_t uartRxFull;      /* RBF */
+static uint8_t uartTxHold;
+static uint8_t uartTxHoldFull;  /* inverse of TBE */
+static uint8_t uartTxShift;
+static uint8_t uartTxBusy;      /* shift register clocking out */
+static uint8_t uartRxBusy;      /* an RX frame is in flight */
+
+/* One character frame in microseconds at the current divider. */
+static double UARTFrameUsec(void)
+{
+   double cyc = 11.0 * 16.0 * (double)((uint32_t)asiClk + 1u);
+   return cyc * (vjs.hardwareTypeNTSC ? RISC_CYCLE_IN_USEC
+                                      : RISC_CYCLE_PAL_IN_USEC);
+}
+
+static void UARTRaiseIRQ(void)
+{
+   if (JERRYIRQEnabled(IRQ2_ASI))
+   {
+      JERRYSetPendingIRQ(IRQ2_ASI);
+      m68k_set_irq(2);
+   }
+}
+
+/* Start an RX frame if the transport has data and none is in flight. */
+static void UARTKickRx(void)
+{
+   if (!uartRxBusy && JLinkRxPending())
+   {
+      uartRxBusy = 1;
+      SetCallbackTime(UARTRXCallback, UARTFrameUsec(), EVENT_JERRY);
+   }
+}
+
+void UARTTXCallback(void)
+{
+   uartTxBusy = 0;
+   JLinkSendByte(uartTxShift);
+   if (uartTxHoldFull)
+   {
+      uartTxShift = uartTxHold;
+      uartTxHoldFull = 0;       /* TBE edge: transmitter interrupt */
+      uartTxBusy = 1;
+      SetCallbackTime(UARTTXCallback, UARTFrameUsec(), EVENT_JERRY);
+      if (asiCtrl & ASICTRL_TINTEN)
+         UARTRaiseIRQ();
+   }
+   UARTKickRx();
+}
+
+void UARTRXCallback(void)
+{
+   uint8_t b;
+   uartRxBusy = 0;
+   if (JLinkRecvByte(&b))
+   {
+      if (uartRxFull)
+      {
+         /* Overrun: newest byte lost, buffered data kept.  OE is a
+            receiver-class interrupt source. */
+         asiErr |= ASISTAT_OE;
+         if (asiCtrl & ASICTRL_RINTEN)
+            UARTRaiseIRQ();
+      }
+      else
+      {
+         uartRxData = b;
+         uartRxFull = 1;
+         if (asiCtrl & ASICTRL_RINTEN)
+            UARTRaiseIRQ();
+      }
+   }
+   UARTKickRx();
+}
+
+uint16_t UARTReadWord(uint32_t offset)
+{
+   uint16_t v = 0;
+   switch (offset)
+   {
+      case 0xF10030:            /* ASIDATA */
+         v = uartRxData;
+         uartRxFull = 0;
+         UARTKickRx();
+         break;
+      case 0xF10032:            /* ASISTAT */
+         v = (uint16_t)(asiCtrl & 0x003F);
+         if (uartRxFull)
+            v |= ASISTAT_RBF;
+         if (!uartTxHoldFull)
+            v |= ASISTAT_TBE;
+         v |= asiErr;
+         v |= ASISTAT_SERIN;    /* phase 1: line idles at mark */
+         if (asiCtrl & ASICTRL_TXBRK)
+            v |= ASISTAT_TXBRK;
+         if (asiErr)
+            v |= ASISTAT_ERROR;
+         break;
+      case 0xF10034:            /* ASICLK */
+         v = asiClk;
+         break;
+      default:
+         break;
+   }
+   return v;
+}
+
+void UARTWriteWord(uint32_t offset, uint16_t data)
+{
+   switch (offset)
+   {
+      case 0xF10030:            /* ASIDATA */
+         if (!uartTxBusy)
+         {
+            uartTxShift = (uint8_t)(data & 0xFF);
+            uartTxBusy = 1;
+            SetCallbackTime(UARTTXCallback, UARTFrameUsec(), EVENT_JERRY);
+         }
+         else
+         {
+            uartTxHold = (uint8_t)(data & 0xFF);
+            uartTxHoldFull = 1;
+         }
+         break;
+      case 0xF10032:            /* ASICTRL */
+         asiCtrl = (uint16_t)(data & ASICTRL_CFGMASK);
+         if (data & ASICTRL_CLRERR)
+            asiErr = 0;
+         break;
+      case 0xF10034:            /* ASICLK */
+         asiClk = data;
+         break;
+      default:
+         break;
+   }
+}
+
+void UARTInit(void)
+{
+   UARTReset();
+}
+
+void UARTReset(void)
+{
+   RemoveCallback(UARTTXCallback);
+   RemoveCallback(UARTRXCallback);
+   asiCtrl = 0;
+   asiClk = 0;
+   asiErr = 0;
+   uartRxData = 0;
+   uartRxFull = 0;
+   uartTxHold = 0;
+   uartTxHoldFull = 0;
+   uartTxShift = 0;
+   uartTxBusy = 0;
+   uartRxBusy = 0;
+}
+
+void UARTDone(void)
+{
+   UARTReset();
+   JLinkClose();
+}
+
+void UARTSetLinkMode(int mode)
+{
+   if (mode != JLinkMode())
+   {
+      JLinkClose();
+      if (mode != JLINK_MODE_DISABLED)
+         JLinkOpen(mode);
+   }
+}
+
+size_t UARTStateSave(uint8_t *buf)
+{
+   uint8_t *start = buf;
+   STATE_SAVE_VAR(buf, asiCtrl);
+   STATE_SAVE_VAR(buf, asiClk);
+   STATE_SAVE_VAR(buf, asiErr);
+   STATE_SAVE_VAR(buf, uartRxData);
+   STATE_SAVE_VAR(buf, uartRxFull);
+   STATE_SAVE_VAR(buf, uartTxHold);
+   STATE_SAVE_VAR(buf, uartTxHoldFull);
+   STATE_SAVE_VAR(buf, uartTxShift);
+   STATE_SAVE_VAR(buf, uartTxBusy);
+   STATE_SAVE_VAR(buf, uartRxBusy);
+   buf += JLinkStateSave(buf);
+   return (size_t)(buf - start);
+}
+
+size_t UARTStateLoad(const uint8_t *buf, uint32_t stateVersion)
+{
+   const uint8_t *start = buf;
+   (void)stateVersion;   /* whole chunk is gated by the caller */
+   STATE_LOAD_VAR(buf, asiCtrl);
+   STATE_LOAD_VAR(buf, asiClk);
+   STATE_LOAD_VAR(buf, asiErr);
+   STATE_LOAD_VAR(buf, uartRxData);
+   STATE_LOAD_VAR(buf, uartRxFull);
+   STATE_LOAD_VAR(buf, uartTxHold);
+   STATE_LOAD_VAR(buf, uartTxHoldFull);
+   STATE_LOAD_VAR(buf, uartTxShift);
+   STATE_LOAD_VAR(buf, uartTxBusy);
+   STATE_LOAD_VAR(buf, uartRxBusy);
+   buf += JLinkStateLoad(buf);
+   return (size_t)(buf - start);
+}

--- a/src/jerry/uart.h
+++ b/src/jerry/uart.h
@@ -1,0 +1,31 @@
+/* uart.h — JERRY asynchronous serial interface (ComLynx / JagLink UART). */
+#ifndef __UART_H__
+#define __UART_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void UARTInit(void);
+void UARTReset(void);
+void UARTDone(void);
+void UARTSetLinkMode(int mode);   /* JLINK_MODE_* from jlink.h */
+
+uint16_t UARTReadWord(uint32_t offset);
+void UARTWriteWord(uint32_t offset, uint16_t data);
+
+/* Event-system callbacks (registered in src/core/event.c). */
+void UARTTXCallback(void);
+void UARTRXCallback(void);
+
+size_t UARTStateSave(uint8_t *buf);
+size_t UARTStateLoad(const uint8_t *buf, uint32_t stateVersion);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/test_event_queue.c
+++ b/test/test_event_queue.c
@@ -63,6 +63,8 @@ void DSPSampleCallback(void)
 {
 }
 
+void UARTTXCallback(void) {}
+void UARTRXCallback(void) {}
 void GPUCPUINTCallback(void)
 {
 }

--- a/test/test_jlink.c
+++ b/test/test_jlink.c
@@ -1,0 +1,78 @@
+/* test_jlink.c — unit test for the JagLink byte-transport seam. */
+#include <stdio.h>
+#include <stdint.h>
+#include "src/jerry/jlink.h"
+
+static int failures = 0;
+
+#define CHECK(cond, msg) \
+    do { if (cond) printf("PASS %s\n", msg); \
+         else { printf("FAIL %s\n", msg); failures++; } } while (0)
+
+static void test_disabled_mode(void)
+{
+    uint8_t b = 0xEE;
+    JLinkClose();
+    CHECK(JLinkMode() == JLINK_MODE_DISABLED, "closed -> mode disabled");
+    CHECK(!JLinkConnected(), "disabled -> not connected");
+    JLinkSendByte(0x41);
+    CHECK(JLinkRxPending() == 0, "disabled send discards");
+    CHECK(JLinkRecvByte(&b) == 0 && b == 0xEE, "disabled recv returns none");
+}
+
+static void test_loopback_roundtrip(void)
+{
+    uint8_t b = 0;
+    CHECK(JLinkOpen(JLINK_MODE_LOOPBACK) == 1, "open loopback");
+    CHECK(JLinkConnected(), "loopback -> connected");
+    JLinkSendByte(0x11);
+    JLinkSendByte(0x22);
+    JLinkSendByte(0x33);
+    CHECK(JLinkRxPending() == 3, "three bytes pending");
+    CHECK(JLinkRecvByte(&b) == 1 && b == 0x11, "recv 1st in order");
+    CHECK(JLinkRecvByte(&b) == 1 && b == 0x22, "recv 2nd in order");
+    CHECK(JLinkRecvByte(&b) == 1 && b == 0x33, "recv 3rd in order");
+    CHECK(JLinkRxPending() == 0, "drained");
+    JLinkClose();
+}
+
+static void test_overflow_drops_newest(void)
+{
+    int i;
+    uint8_t b = 0;
+    JLinkOpen(JLINK_MODE_LOOPBACK);
+    for (i = 0; i < 300; i++)
+        JLinkSendByte((uint8_t)i);
+    CHECK(JLinkRxPending() == 256, "ring capped at 256");
+    CHECK(JLinkRecvByte(&b) == 1 && b == 0, "oldest byte survives overflow");
+    JLinkClose();
+}
+
+static void test_state_roundtrip(void)
+{
+    uint8_t buf[1024];
+    uint8_t b = 0;
+    size_t n;
+    JLinkOpen(JLINK_MODE_LOOPBACK);
+    JLinkSendByte(0xAB);
+    JLinkSendByte(0xCD);
+    n = JLinkStateSave(buf);
+    CHECK(n > 0, "state save wrote bytes");
+    (void)JLinkRecvByte(&b);
+    (void)JLinkRecvByte(&b);
+    CHECK(JLinkRxPending() == 0, "drained before load");
+    CHECK(JLinkStateLoad(buf) == n, "state load consumed same size");
+    CHECK(JLinkRxPending() == 2, "load restored 2 pending bytes");
+    CHECK(JLinkRecvByte(&b) == 1 && b == 0xAB, "restored byte order");
+    JLinkClose();
+}
+
+int main(void)
+{
+    test_disabled_mode();
+    test_loopback_roundtrip();
+    test_overflow_drops_newest();
+    test_state_roundtrip();
+    printf(failures ? "FAILED (%d)\n" : "OK\n", failures);
+    return failures ? 1 : 0;
+}

--- a/test/test_uart_core.c
+++ b/test/test_uart_core.c
@@ -1,0 +1,112 @@
+/* test_uart_core.c — integration: UART reachable through the JERRY
+   memory dispatcher inside the real core, loopback echo works across
+   retro_run, and the ASI pending bit latches in JINTCTRL. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "harness/harness.h"
+
+typedef void     (*jerry_ww_t)(uint32_t, uint16_t, uint32_t);
+typedef uint16_t (*jerry_rw_t)(uint32_t, uint32_t);
+typedef void     (*set_mode_t)(int);
+
+/* Minimal synthetic cartridge: entry vector -> $802000, bra.s * there.
+   Same shape as test_irq_cascade's in-memory ROM, but written to a temp
+   file so the standard harness load path can be used. */
+#define ROM_SIZE 131072
+
+static const char *make_synth_rom(void)
+{
+    static char path[256];
+    static uint8_t rom_buf[ROM_SIZE];
+    FILE *f;
+    const char *tmp = getenv("TMPDIR");
+    snprintf(path, sizeof(path), "%s/vj_uart_core_stub.j64",
+             tmp ? tmp : "/tmp");
+    memset(rom_buf, 0, ROM_SIZE);
+    rom_buf[0x404] = 0x00; rom_buf[0x405] = 0x80;
+    rom_buf[0x406] = 0x20; rom_buf[0x407] = 0x00;
+    rom_buf[0x2000] = 0x60; rom_buf[0x2001] = 0xFE;   /* bra.s * */
+    f = fopen(path, "wb");
+    if (!f) return NULL;
+    fwrite(rom_buf, 1, ROM_SIZE, f);
+    fclose(f);
+    return path;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    harness_result res[8];
+    unsigned nres = 0;
+    jerry_ww_t jerry_ww;
+    jerry_rw_t jerry_rw;
+    set_mode_t set_mode;
+    uint16_t st, data, jint;
+    int ok_rbf, ok_data, ok_pending;
+
+    cfg.frames = 2;
+    cfg.options[0].key = "virtualjaguar_netlink";
+    cfg.options[0].value = "loopback";
+    cfg.num_options = 1;
+
+    if (!harness_init_from_args(&cfg, argc, argv)) return 1;
+    if (!cfg.rom_path)
+    {
+        cfg.rom_path = make_synth_rom();
+        if (!cfg.rom_path)
+        {
+            fprintf(stderr, "cannot write synthetic ROM stub\n");
+            return 1;
+        }
+    }
+    if (!harness_load_rom(&cfg))                   return 1;
+
+    jerry_ww = (jerry_ww_t)harness_dlsym(&cfg, "JERRYWriteWord");
+    jerry_rw = (jerry_rw_t)harness_dlsym(&cfg, "JERRYReadWord");
+    if (!jerry_ww || !jerry_rw)
+    {
+        fprintf(stderr, "JERRY dispatch symbols not exported — "
+                        "build with TEST_EXPORTS=1\n");
+        return 1;
+    }
+
+    /* Task 4 scaffolding (removed in Task 5 when the core option becomes
+       the activation path): force loopback mode directly. */
+    set_mode = (set_mode_t)harness_dlsym(&cfg, "UARTSetLinkMode");
+    if (set_mode)
+        set_mode(1 /* JLINK_MODE_LOOPBACK */);
+
+    /* J_ASYNENA (bit 4) on; RINTEN on; fastest baud; send a byte. */
+    jerry_ww(0xF10020, 0x0010, 0);
+    jerry_ww(0xF10032, 0x0020, 0);
+    jerry_ww(0xF10034, 0x0000, 0);
+    jerry_ww(0xF10030, 0x00C3, 0);
+
+    harness_run(&cfg);   /* 2 frames ~= 33 ms >> 2 frame times at N=0 */
+
+    st   = jerry_rw(0xF10032, 0);
+    data = jerry_rw(0xF10030, 0);
+    jint = jerry_rw(0xF10020, 0);
+    ok_rbf     = (st & 0x0080) != 0;
+    ok_data    = (data & 0xFF) == 0xC3;
+    ok_pending = (jint & 0x0010) != 0;
+
+    res[nres].status = ok_rbf ? "PASS" : "FAIL";
+    res[nres].name   = "uart_core_rbf";
+    res[nres].detail = "loopback byte sets RBF through dispatcher";
+    nres++;
+    res[nres].status = ok_data ? "PASS" : "FAIL";
+    res[nres].name   = "uart_core_data";
+    res[nres].detail = "ASIDATA returns echoed byte";
+    nres++;
+    res[nres].status = ok_pending ? "PASS" : "FAIL";
+    res[nres].name   = "uart_core_jint";
+    res[nres].detail = "IRQ2_ASI pending latched in JINTCTRL";
+    nres++;
+
+    harness_report(&cfg, res, nres);
+    harness_shutdown(&cfg);
+    return (ok_rbf && ok_data && ok_pending) ? 0 : 1;
+}

--- a/test/test_uart_core.c
+++ b/test/test_uart_core.c
@@ -72,11 +72,9 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    /* Task 4 scaffolding (removed in Task 5 when the core option becomes
-       the activation path): force loopback mode directly. */
-    set_mode = (set_mode_t)harness_dlsym(&cfg, "UARTSetLinkMode");
-    if (set_mode)
-        set_mode(1 /* JLINK_MODE_LOOPBACK */);
+    /* Loopback mode arrives via the virtualjaguar_netlink core option
+       (cfg.options above) — no direct mode forcing. */
+    (void)set_mode;
 
     /* J_ASYNENA (bit 4) on; RINTEN on; fastest baud; send a byte. */
     jerry_ww(0xF10020, 0x0010, 0);

--- a/test/test_uart_core.c
+++ b/test/test_uart_core.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
     jerry_rw_t jerry_rw;
     set_mode_t set_mode;
     uint16_t st, data, jint;
-    int ok_rbf, ok_data, ok_pending;
+    int ok_rbf, ok_data, ok_pending, ok_state;
 
     cfg.frames = 2;
     cfg.options[0].key = "virtualjaguar_netlink";
@@ -104,7 +104,39 @@ int main(int argc, char **argv)
     res[nres].detail = "IRQ2_ASI pending latched in JINTCTRL";
     nres++;
 
+    /* Savestate round-trip: with a byte buffered (RBF set), serialize;
+       consume the byte; restore; the byte and RBF must be back. */
+    {
+        typedef size_t (*rsz_t)(void);
+        typedef int    (*rser_t)(void *, size_t);
+        typedef int    (*runser_t)(const void *, size_t);
+        rsz_t    r_size  = (rsz_t)harness_dlsym(&cfg, "retro_serialize_size");
+        rser_t   r_ser   = (rser_t)harness_dlsym(&cfg, "retro_serialize");
+        runser_t r_unser = (runser_t)harness_dlsym(&cfg, "retro_unserialize");
+        static uint8_t state_buf[0x300000];
+        size_t sz = r_size ? r_size() : 0;
+
+        ok_state = 0;
+        if (r_ser && r_unser && sz > 0 && sz <= sizeof(state_buf))
+        {
+            jerry_ww(0xF10030, 0x0077, 0);
+            harness_run(&cfg);                  /* deliver into RBF */
+            if ((jerry_rw(0xF10032, 0) & 0x0080) && r_ser(state_buf, sz))
+            {
+                (void)jerry_rw(0xF10030, 0);    /* consume: RBF clears */
+                if (!(jerry_rw(0xF10032, 0) & 0x0080)
+                    && r_unser(state_buf, sz))
+                    ok_state = ((jerry_rw(0xF10032, 0) & 0x0080) != 0)
+                        && (jerry_rw(0xF10030, 0) & 0xFF) == 0x77;
+            }
+        }
+        res[nres].status = ok_state ? "PASS" : "FAIL";
+        res[nres].name   = "uart_state_roundtrip";
+        res[nres].detail = "RBF + data survive serialize/unserialize";
+        nres++;
+    }
+
     harness_report(&cfg, res, nres);
     harness_shutdown(&cfg);
-    return (ok_rbf && ok_data && ok_pending) ? 0 : 1;
+    return (ok_rbf && ok_data && ok_pending && ok_state) ? 0 : 1;
 }

--- a/test/test_uart_core.c
+++ b/test/test_uart_core.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include "harness/harness.h"
 
 typedef void     (*jerry_ww_t)(uint32_t, uint16_t, uint32_t);
@@ -108,8 +109,8 @@ int main(int argc, char **argv)
        consume the byte; restore; the byte and RBF must be back. */
     {
         typedef size_t (*rsz_t)(void);
-        typedef int    (*rser_t)(void *, size_t);
-        typedef int    (*runser_t)(const void *, size_t);
+        typedef bool   (*rser_t)(void *, size_t);
+        typedef bool   (*runser_t)(const void *, size_t);
         rsz_t    r_size  = (rsz_t)harness_dlsym(&cfg, "retro_serialize_size");
         rser_t   r_ser   = (rser_t)harness_dlsym(&cfg, "retro_serialize");
         runser_t r_unser = (runser_t)harness_dlsym(&cfg, "retro_unserialize");

--- a/test/test_uart_loopback.c
+++ b/test/test_uart_loopback.c
@@ -166,6 +166,50 @@ static void test_disabled_link(void)
     CHECK((UARTReadWord(ASISTAT) & ST_TBE) != 0, "disabled: TX still drains");
 }
 
+static void test_rx_interrupt(void)
+{
+    fresh();
+    UARTWriteWord(ASICLK, 0);
+    UARTWriteWord(ASICTRL, CT_RINTEN);
+    UARTWriteWord(ASIDATA, 0x99);
+    pump(2);                               /* TX + RX frames */
+    CHECK((stubPending & IRQ2_ASI) != 0, "RINTEN: RX raises IRQ2_ASI");
+    CHECK(stubIpl == 2, "RX interrupt asserts 68K IPL2");
+}
+
+static void test_rx_interrupt_masked(void)
+{
+    fresh();
+    stubIrqMask = 0;                       /* J_ASYNENA off */
+    UARTWriteWord(ASICLK, 0);
+    UARTWriteWord(ASICTRL, CT_RINTEN);
+    UARTWriteWord(ASIDATA, 0x99);
+    pump(2);
+    CHECK(stubPending == 0, "JINTCTRL gate blocks RX IRQ");
+    CHECK(stubIpl == -1, "no IPL2 when masked");
+}
+
+static void test_rx_interrupt_disabled(void)
+{
+    fresh();                               /* mask on, RINTEN off */
+    UARTWriteWord(ASICLK, 0);
+    UARTWriteWord(ASIDATA, 0x99);
+    pump(2);
+    CHECK(stubPending == 0, "RINTEN off: RX raises nothing");
+}
+
+static void test_tx_interrupt_on_holding_drain(void)
+{
+    fresh();
+    UARTWriteWord(ASICLK, 0);
+    UARTWriteWord(ASICTRL, CT_TINTEN);
+    UARTWriteWord(ASIDATA, 0x01);          /* straight to shift: no IRQ */
+    CHECK(stubPending == 0, "straight-to-shift write raises no TX IRQ");
+    UARTWriteWord(ASIDATA, 0x02);          /* parks in holding */
+    pump(1);                               /* holding drains -> TBE edge */
+    CHECK((stubPending & IRQ2_ASI) != 0, "TINTEN: holding drain raises IRQ");
+}
+
 int main(void)
 {
     vjs.hardwareTypeNTSC = true;
@@ -175,6 +219,10 @@ int main(void)
     test_double_buffering();
     test_overrun();
     test_disabled_link();
+    test_rx_interrupt();
+    test_rx_interrupt_masked();
+    test_rx_interrupt_disabled();
+    test_tx_interrupt_on_holding_drain();
     printf(failures ? "FAILED (%d)\n" : "OK\n", failures);
     return failures ? 1 : 0;
 }

--- a/test/test_uart_loopback.c
+++ b/test/test_uart_loopback.c
@@ -1,0 +1,180 @@
+/* test_uart_loopback.c — unit test for JERRY UART emulation over the
+   loopback transport, driving the real event queue. */
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <math.h>
+#include "src/core/event.h"
+#include "src/core/settings.h"
+#include "src/jerry/jerry.h"
+#include "src/jerry/uart.h"
+#include "src/jerry/jlink.h"
+
+/* ---- stubs required by event.c's savestate callback registry ---- */
+void HalflineCallback(void) {}
+void TOMPITCallback(void) {}
+void JERRYPIT1Callback(void) {}
+void JERRYPIT2Callback(void) {}
+void JERRYI2SCallback(void) {}
+void DSPSampleCallback(void) {}
+void GPUCPUINTCallback(void) {}
+
+/* ---- stubs required by uart.c ---- */
+struct VJSettings vjs;
+static int stubIrqMask = 0;
+static int stubPending = 0;
+static int stubIpl = -1;
+bool JERRYIRQEnabled(int irq) { return (stubIrqMask & irq) != 0; }
+void JERRYSetPendingIRQ(int irq) { stubPending |= irq; }
+void m68k_set_irq(unsigned int level) { stubIpl = (int)level; }
+
+#define ASIDATA 0xF10030u
+#define ASISTAT 0xF10032u
+#define ASICTRL 0xF10032u
+#define ASICLK  0xF10034u
+
+#define ST_RBF   0x0080
+#define ST_TBE   0x0100
+#define ST_OE    0x0800
+#define ST_SERIN 0x2000
+#define ST_ERROR 0x8000
+#define CT_TINTEN 0x0010
+#define CT_RINTEN 0x0020
+#define CT_CLRERR 0x0040
+
+static int failures = 0;
+#define CHECK(cond, msg) \
+    do { if (cond) printf("PASS %s\n", msg); \
+         else { printf("FAIL %s\n", msg); failures++; } } while (0)
+
+static void fresh(void)
+{
+    InitializeEventList();
+    UARTReset();
+    UARTSetLinkMode(JLINK_MODE_LOOPBACK);
+    stubIrqMask = IRQ2_ASI;   /* J_ASYNENA on unless a test clears it */
+    stubPending = 0;
+    stubIpl = -1;
+}
+
+/* Fire JERRY events one at a time, mirroring the production loop:
+   HandleNextEvent() dispatches the slot located by the LAST
+   GetTimeToNextEvent() call, so the pair must always run together. */
+static void pump(int max_events)
+{
+    int i;
+    for (i = 0; i < max_events; i++)
+    {
+        (void)GetTimeToNextEvent(EVENT_JERRY);
+        HandleNextEvent(EVENT_JERRY);
+    }
+}
+
+static void test_reset_defaults(void)
+{
+    uint16_t st;
+    fresh();
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_TBE) != 0,   "reset: TBE set");
+    CHECK((st & ST_RBF) == 0,   "reset: RBF clear");
+    CHECK((st & ST_ERROR) == 0, "reset: no error");
+    CHECK((st & ST_SERIN) != 0, "reset: SERIN idles at mark");
+    CHECK(UARTReadWord(ASICLK) == 0, "reset: ASICLK zero");
+}
+
+static void test_baud_timing(void)
+{
+    double t, expect;
+    fresh();
+    UARTWriteWord(ASICLK, 0);              /* N=0: frame = 11*16*1 clocks */
+    UARTWriteWord(ASIDATA, 0x41);
+    t = GetTimeToNextEvent(EVENT_JERRY);
+    expect = 11.0 * 16.0 * 1.0 * RISC_CYCLE_IN_USEC;
+    CHECK(fabs(t - expect) < 0.001, "N=0 frame time = 176 clocks");
+
+    fresh();
+    UARTWriteWord(ASICLK, 171);            /* ~9600 baud on NTSC clock */
+    UARTWriteWord(ASIDATA, 0x41);
+    t = GetTimeToNextEvent(EVENT_JERRY);
+    expect = 11.0 * 16.0 * 172.0 * RISC_CYCLE_IN_USEC;
+    CHECK(fabs(t - expect) < 0.01, "N=171 frame time = 302,720 clocks");
+}
+
+static void test_loopback_roundtrip(void)
+{
+    uint16_t st;
+    fresh();
+    UARTWriteWord(ASICLK, 0);
+    UARTWriteWord(ASIDATA, 0x5A);
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_TBE) != 0, "straight-to-shift write keeps TBE");
+    pump(1);                               /* TX completes -> byte to jlink */
+    pump(1);                               /* RX frame completes -> RBF */
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_RBF) != 0, "byte looped back: RBF set");
+    CHECK((UARTReadWord(ASIDATA) & 0xFF) == 0x5A, "ASIDATA returns byte");
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_RBF) == 0, "ASIDATA read clears RBF");
+}
+
+static void test_double_buffering(void)
+{
+    uint16_t st;
+    fresh();
+    UARTWriteWord(ASICLK, 0);
+    UARTWriteWord(ASIDATA, 0x01);          /* -> shift */
+    UARTWriteWord(ASIDATA, 0x02);          /* -> holding, TBE drops */
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_TBE) == 0, "holding full: TBE clear");
+    pump(1);                               /* TX#1: byte out, holding -> shift */
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_TBE) != 0, "holding drained: TBE set");
+    pump(2);                               /* TX#2 + RX#1 (tie order converges) */
+    CHECK((UARTReadWord(ASIDATA) & 0xFF) == 0x01, "1st byte received first");
+    pump(1);                               /* RX#2 delivers into now-empty RBF */
+    CHECK((UARTReadWord(ASIDATA) & 0xFF) == 0x02, "2nd byte follows");
+    /* NOTE: pump counts are exact (4 events scheduled in total) because
+       HandleNextEvent() re-fires a stale slot if called on an empty list. */
+}
+
+static void test_overrun(void)
+{
+    uint16_t st;
+    fresh();
+    UARTWriteWord(ASICLK, 0);
+    UARTWriteWord(ASIDATA, 0x01);
+    UARTWriteWord(ASIDATA, 0x02);
+    pump(4);                               /* TX#1, TX#2, RX#1, RX#2 — no reads */
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_RBF) != 0, "first byte still buffered");
+    CHECK((st & ST_OE) != 0,  "second byte overruns: OE");
+    CHECK((st & ST_ERROR) != 0, "ERROR mirrors OE");
+    CHECK((UARTReadWord(ASIDATA) & 0xFF) == 0x01, "old data kept on overrun");
+    UARTWriteWord(ASICTRL, CT_CLRERR);
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_OE) == 0 && (st & ST_ERROR) == 0, "CLRERR clears OE");
+}
+
+static void test_disabled_link(void)
+{
+    fresh();
+    UARTSetLinkMode(JLINK_MODE_DISABLED);
+    UARTWriteWord(ASICLK, 0);
+    UARTWriteWord(ASIDATA, 0x7E);
+    pump(1);                               /* TX only; nothing echoes back */
+    CHECK((UARTReadWord(ASISTAT) & ST_RBF) == 0, "disabled: nothing echoes");
+    CHECK((UARTReadWord(ASISTAT) & ST_TBE) != 0, "disabled: TX still drains");
+}
+
+int main(void)
+{
+    vjs.hardwareTypeNTSC = true;
+    test_reset_defaults();
+    test_baud_timing();
+    test_loopback_roundtrip();
+    test_double_buffering();
+    test_overrun();
+    test_disabled_link();
+    printf(failures ? "FAILED (%d)\n" : "OK\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

First phase of Jaguar link networking (BattleSphere Gold, AirCars, Doom deathmatch — all drive the same JERRY UART via JagLink/CatBox). Design doc: `docs/netlink-design.md`.

- Emulates JERRY's asynchronous serial UART (`$F10030`–`$F10034`): register semantics, 11-bit-time frame pacing off ASICLK (JTRM Rev 8 pp. 93–95: baud = sysclk/(16×(N+1)), parity slot always transmitted), double-buffered TX/RX, OE latching, TINTEN/RINTEN interrupts through JINTCTRL bit 4 to 68K IPL2. Previously these registers fell through to plain JERRY RAM — a game probing for a link partner read back its own writes.
- New byte-transport seam (`src/jerry/jlink.c`) with a loopback backend; TCP (any frontend, incl. Provenance) and libretro netpacket (RetroArch netplay) backends follow in later PRs behind the same interface.
- Core option `virtualjaguar_netlink` (`disabled` default / `loopback`).
- Savestates bump to STATE_VERSION 6 with a version-gated UART chunk; UART TX/RX event callbacks join the event registry (append-only ids 8/9). States v2–v5 still load (verified by test_state_compat).

## Test plan

- [x] `make TEST_EXPORTS=1 test` — full suite green, including three new layers: `test_jlink` (transport unit), `test_uart_loopback` (register/timing/IRQ semantics against the real event queue), `test_uart_core` (dispatch + JINTCTRL latch + savestate round-trip inside the real core)
- [x] `scripts/c89-lint.sh` clean on `uart.c`, `jlink.c`, `jerry.c`
- [x] `make benchmark` parity (option disabled by default; 3.1 ms/frame p50, 0 frame overruns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)