### PR TITLE
feat(net): TCP link backend (JagLink phase 2) — BSG link detect + Doom deathmatch working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ test/tools/test_op_gpu_object
 test/tools/test_dsp_audio_diag
 test/tools/cd_wedge_probe
 test/tools/sram_test
+test/tools/netlink_pair
+test/tools/netlink_game
 test/dump_caller
 test/dump_pc
 test/heap_search

--- a/Makefile
+++ b/Makefile
@@ -564,7 +564,7 @@ else
 	CC ?= gcc
 	CXX ?= g++
 	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=$(LINK_SCRIPT)
-	LDFLAGS += -static-libgcc -static-libstdc++ -lwinmm
+	LDFLAGS += -static-libgcc -static-libstdc++ -lwinmm -lws2_32
 
 endif
 
@@ -795,7 +795,7 @@ else
 # rev (+ -dirty) against this before running -- a stale dylib fails loudly
 # instead of silently testing the wrong code (see scripts/build-id.sh).
 test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
-test: test/test_cheat test/test_event_queue test/test_jlink test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 \
+test: test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
@@ -811,6 +811,7 @@ test: test/test_cheat test/test_event_queue test/test_jlink test/test_uart_loopb
 	./test/test_cheat
 	./test/test_event_queue
 	./test/test_jlink
+	./test/test_jlink_tcp
 	./test/test_uart_loopback
 	./test/test_uart_core ./$(TARGET)
 	./test/test_blitter_mmio
@@ -934,9 +935,13 @@ test/test_event_queue: test/test_event_queue.c src/core/event.c src/core/event.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_event_queue.c src/core/event.c
 
-test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h
+test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h src/jerry/jlink_tcp.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_jlink.c src/jerry/jlink.c
+		-o $@ test/test_jlink.c src/jerry/jlink.c src/jerry/jlink_tcp.c
+
+test/test_jlink_tcp: test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink.h src/jerry/jlink_tcp.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c
 
 test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/core/event.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -957,6 +957,10 @@ test/tools/netlink_pair: test/tools/netlink_pair.c test/harness/harness.c test/h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
 		-o $@ test/tools/netlink_pair.c test/harness/harness.c -ldl -lm
 
+test/tools/netlink_game: test/tools/netlink_game.c test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
+		-o $@ test/tools/netlink_game.c test/harness/harness.c -ldl -lm
+
 # Regression guard: textually verifies that JERRYResetPIT1/2,
 # TOMResetPIT, and JERRYGetPIT*Frequency schedule using RISC clock
 # constants (full system clock).  Catches the recurring "halve PIT

--- a/Makefile
+++ b/Makefile
@@ -807,13 +807,15 @@ test: test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp 
 		test/test_cart_format \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap \
 		test/test_audio_dac test/test_blitter \
-		test/tools/test_memory_map test/tools/test_op_gpu_object test/test_uart_core
+		test/tools/test_memory_map test/tools/test_op_gpu_object test/test_uart_core \
+		test/tools/netlink_pair
 	./test/test_cheat
 	./test/test_event_queue
 	./test/test_jlink
 	./test/test_jlink_tcp
 	./test/test_uart_loopback
 	./test/test_uart_core ./$(TARGET)
+	bash test/tools/netlink_pair_test.sh ./$(TARGET)
 	./test/test_blitter_mmio
 	./test/test_blitter_cmd ./$(TARGET)
 	./test/test_pit_clock_rate
@@ -943,13 +945,17 @@ test/test_jlink_tcp: test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c
 
-test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/core/event.c
+test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/jerry/jlink_tcp.c src/core/event.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_uart_loopback.c src/jerry/uart.c src/jerry/jlink.c src/core/event.c -lm
+		-o $@ test/test_uart_loopback.c src/jerry/uart.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/core/event.c -lm
 
 test/test_uart_core: test/test_uart_core.c test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
 		-o $@ test/test_uart_core.c test/harness/harness.c -ldl -lm
+
+test/tools/netlink_pair: test/tools/netlink_pair.c test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
+		-o $@ test/tools/netlink_pair.c test/harness/harness.c -ldl -lm
 
 # Regression guard: textually verifies that JERRYResetPIT1/2,
 # TOMResetPIT, and JERRYGetPIT*Frequency schedule using RISC clock

--- a/Makefile.common
+++ b/Makefile.common
@@ -28,6 +28,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/core/jaguar.c \
 	$(CORE_DIR)/src/jerry/jerry.c \
 	$(CORE_DIR)/src/jerry/jlink.c \
+	$(CORE_DIR)/src/jerry/jlink_tcp.c \
 	$(CORE_DIR)/src/jerry/uart.c \
 	$(CORE_DIR)/src/tom/op.c \
 	$(CORE_DIR)/src/tom/tom.c  \

--- a/docs/netlink-design.md
+++ b/docs/netlink-design.md
@@ -1,7 +1,7 @@
 # Jaguar Link Networking (JERRY UART + Pluggable Transport)
 
 **Date:** 2026-07-31
-**Status:** Phase 1 (UART + loopback) implemented; phases 2–4 pending
+**Status:** Phases 1–2 (UART + loopback + TCP link) implemented; phases 3–4 pending. Integration branch: `feature/netlink` (phases merge there, not develop, until the feature is proven).
 **Branch:** `claude/jaguar-networking-support-0c8a86` (off `libretro/develop`)
 
 ## Overview
@@ -213,6 +213,37 @@ test layers (`test_jlink`, `test_uart_loopback`, `test_uart_core`) in
 `make test`. Baud formula and frame length verified against JTRM Rev 8
 pp. 93–95 (`docs/atari-jaguar-1999/jag_v8.pdf`); JINTCTRL bit 4 assignment
 confirmed on p. 87 (the emulator's `IRQ2_ASI=0x10` was already correct).
+
+## Phase 2 outcome (2026-07-31)
+
+Delivered: `src/jerry/jlink_tcp.c` (compact nonblocking POSIX/winsock layer —
+**deviation from this spec:** libretro-common `net_socket`/`net_compat` was
+NOT vendored; it is a multi-console portability layer far larger than the
+~300 lines actually needed, and socketless console targets compile an inert
+stub instead), TCP server/client modes with client reconnect retry,
+per-frame link polling from `retro_run`, core options
+(`tcp_server`/`tcp_client` values + `virtualjaguar_netlink_port`), host
+resolution (`VJ_NETLINK_HOST` → `<system_dir>/vj_netlink.txt` → 127.0.0.1),
+the two-process `netlink_pair` test in `make test`, and the `netlink_game`
+probe tool (per-frame UART sampling + PPM screenshots + `--realtime` pacing).
+
+**Game validation results (two instances on localhost TCP):**
+
+- **BattleSphere Gold** — programs the UART at ~72.3 kbaud (ASICLK=0x16,
+  ODD parity) on leaving the title screen. Menu path: title → A →
+  Main Menu → down → B ("Network Mode") → B ("Free-For-All"). Loopback
+  control: full scan then explicit "Network Failure / unable to locate any
+  other players" (correct — it only hears its own echo). Over TCP, **both
+  instances passed "Locating Players" and reached the networked Free For
+  All Options screen** — mutual link detection achieved.
+- **Doom** — menu path: title → A → set "Game Mode: Deathmatch" (right) →
+  A to start. Programs ASICLK=0x0D (~118.7 kbaud, JagLink's rate class) and
+  handshakes. Over TCP, **both instances entered the deathmatch level**
+  (frag-counter HUD, distinct spawn views). Playability/lockstep quality
+  over longer sessions is phase-3 validation work.
+
+Both games poll ASISTAT rather than enabling TINTEN/RINTEN, so interrupt
+delivery remains covered by unit tests only so far.
 
 ## Decisions log
 

--- a/libretro.c
+++ b/libretro.c
@@ -334,6 +334,65 @@ void retro_set_environment(retro_environment_t cb)
    environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS, &achievements);
 }
 
+/* Resolve the TCP endpoint for the network link and apply the mode.
+ * Host (client mode): VJ_NETLINK_HOST env, else first line of
+ * <system_dir>/vj_netlink.txt, else 127.0.0.1.  Port: VJ_NETLINK_PORT
+ * env overrides the virtualjaguar_netlink_port option. */
+static void netlink_apply(int mode)
+{
+   char host[128];
+   int port = 42171;
+   const char *env;
+   struct retro_variable pvar;
+
+   host[0] = '\0';
+
+   pvar.key = "virtualjaguar_netlink_port";
+   pvar.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pvar) && pvar.value)
+   {
+      int p = atoi(pvar.value);
+      if (p > 0)
+         port = p;
+   }
+   env = getenv("VJ_NETLINK_PORT");
+   if (env && env[0] && atoi(env) > 0)
+      port = atoi(env);
+
+   env = getenv("VJ_NETLINK_HOST");
+   if (env && env[0])
+   {
+      strncpy(host, env, sizeof(host) - 1);
+      host[sizeof(host) - 1] = '\0';
+   }
+   else
+   {
+      const char *system_dir = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir)
+          && system_dir)
+      {
+         char path[1024];
+         FILE *f;
+         snprintf(path, sizeof(path), "%s/vj_netlink.txt", system_dir);
+         f = fopen(path, "r");
+         if (f)
+         {
+            if (fgets(host, sizeof(host), f))
+            {
+               size_t n = strlen(host);
+               while (n > 0 && (host[n - 1] == '\n' || host[n - 1] == '\r'
+                                || host[n - 1] == ' '))
+                  host[--n] = '\0';
+            }
+            fclose(f);
+         }
+      }
+   }
+
+   JLinkSetTCPEndpoint(host[0] ? host : NULL, port);
+   UARTSetLinkMode(mode);
+}
+
 static void check_variables(void)
 {
    unsigned i;
@@ -374,11 +433,19 @@ static void check_variables(void)
 
    var.key = "virtualjaguar_netlink";
    var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value
-       && strcmp(var.value, "loopback") == 0)
-      UARTSetLinkMode(JLINK_MODE_LOOPBACK);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int mode = JLINK_MODE_DISABLED;
+      if (strcmp(var.value, "loopback") == 0)
+         mode = JLINK_MODE_LOOPBACK;
+      else if (strcmp(var.value, "tcp_server") == 0)
+         mode = JLINK_MODE_TCP_SERVER;
+      else if (strcmp(var.value, "tcp_client") == 0)
+         mode = JLINK_MODE_TCP_CLIENT;
+      netlink_apply(mode);
+   }
    else
-      UARTSetLinkMode(JLINK_MODE_DISABLED);
+      netlink_apply(JLINK_MODE_DISABLED);
 
    var.key = "virtualjaguar_bios";
    var.value = NULL;
@@ -1529,6 +1596,12 @@ void retro_run(void)
       retro_get_system_av_info(&g_av_info);
       environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &g_av_info);
    }
+
+   /* Service the network link: progress TCP connect/accept, drain the
+    * socket into the transport ring, then let the UART start an RX
+    * frame for anything that arrived. */
+   JLinkPoll();
+   UARTPoll();
 
    update_input();
 

--- a/libretro.c
+++ b/libretro.c
@@ -389,7 +389,7 @@ static void netlink_apply(int mode)
       }
    }
 
-   JLinkSetTCPEndpoint(host[0] ? host : NULL, port);
+   JLinkSetTCPEndpoint(host[0] ? host : "127.0.0.1", port);
    UARTSetLinkMode(mode);
 }
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -124,15 +124,33 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_netlink",
       "Network Link (JagLink / CatBox)",
       NULL,
-      "Emulates JERRY's serial link port used by networked games (BattleSphere, AirCars, Doom deathmatch). 'Loopback' echoes transmitted bytes back to this console, for testing link-detect menus without a partner. Linking two emulator instances over TCP arrives in a later release.",
+      "Emulates JERRY's serial link port used by networked games (BattleSphere, AirCars, Doom deathmatch). 'Loopback' echoes transmitted bytes back to this console, for testing link-detect menus without a partner. TCP Host listens for a second emulator instance; TCP Client connects to one (host from VJ_NETLINK_HOST env or vj_netlink.txt in the system directory, default 127.0.0.1). Localhost/LAN latency recommended.",
       NULL,
       NULL,
       {
-         { "disabled", NULL },
-         { "loopback", "Loopback (echo to self)" },
+         { "disabled",   NULL },
+         { "loopback",   "Loopback (echo to self)" },
+         { "tcp_server", "TCP Host (listen)" },
+         { "tcp_client", "TCP Client (connect)" },
          { NULL, NULL },
       },
       "disabled"
+   },
+   {
+      "virtualjaguar_netlink_port",
+      "Network Link Port",
+      NULL,
+      "TCP port for the network link (both sides must match). Overridable with the VJ_NETLINK_PORT environment variable.",
+      NULL,
+      NULL,
+      {
+         { "42171", NULL },
+         { "42172", NULL },
+         { "42173", NULL },
+         { "42174", NULL },
+         { NULL, NULL },
+      },
+      "42171"
    },
    {
       "virtualjaguar_cd_trace",

--- a/src/jerry/jlink.c
+++ b/src/jerry/jlink.c
@@ -3,6 +3,7 @@
    console whose UARTO is wired to its own UARTI. */
 #include <string.h>
 #include "jlink.h"
+#include "jlink_tcp.h"
 #include "state.h"
 
 #define JLINK_RING_SIZE 256
@@ -12,6 +13,30 @@ static uint8_t jlinkRing[JLINK_RING_SIZE];
 static uint32_t jlinkHead = 0;   /* next byte to pop */
 static uint32_t jlinkCount = 0;
 
+static char jlinkTCPHost[128] = "127.0.0.1";
+static int jlinkTCPPort = 42171;
+
+static void JLinkRingPush(uint8_t b)
+{
+   uint32_t tail;
+   if (jlinkCount >= JLINK_RING_SIZE)
+      return;   /* full: drop newest */
+   tail = (jlinkHead + jlinkCount) % JLINK_RING_SIZE;
+   jlinkRing[tail] = b;
+   jlinkCount++;
+}
+
+void JLinkSetTCPEndpoint(const char *host, int port)
+{
+   if (host && host[0])
+   {
+      strncpy(jlinkTCPHost, host, sizeof(jlinkTCPHost) - 1);
+      jlinkTCPHost[sizeof(jlinkTCPHost) - 1] = '\0';
+   }
+   if (port > 0 && port < 65536)
+      jlinkTCPPort = port;
+}
+
 int JLinkOpen(int mode)
 {
    JLinkClose();
@@ -20,11 +45,20 @@ int JLinkOpen(int mode)
       jlinkMode = mode;
       return 1;
    }
+   if (mode == JLINK_MODE_TCP_SERVER || mode == JLINK_MODE_TCP_CLIENT)
+   {
+      if (!JLinkTCPOpen(mode == JLINK_MODE_TCP_SERVER,
+                        jlinkTCPHost, jlinkTCPPort))
+         return 0;
+      jlinkMode = mode;
+      return 1;
+   }
    return 0;
 }
 
 void JLinkClose(void)
 {
+   JLinkTCPClose();
    jlinkMode = JLINK_MODE_DISABLED;
    jlinkHead = 0;
    jlinkCount = 0;
@@ -37,19 +71,34 @@ int JLinkMode(void)
 
 int JLinkConnected(void)
 {
+   if (jlinkMode == JLINK_MODE_TCP_SERVER || jlinkMode == JLINK_MODE_TCP_CLIENT)
+      return JLinkTCPConnected();
    return jlinkMode != JLINK_MODE_DISABLED;
 }
 
 void JLinkSendByte(uint8_t b)
 {
-   uint32_t tail;
-   if (jlinkMode != JLINK_MODE_LOOPBACK)
+   if (jlinkMode == JLINK_MODE_LOOPBACK)
+      JLinkRingPush(b);
+   else if (jlinkMode == JLINK_MODE_TCP_SERVER
+            || jlinkMode == JLINK_MODE_TCP_CLIENT)
+      JLinkTCPSend(b);
+}
+
+void JLinkPoll(void)
+{
+   if (jlinkMode != JLINK_MODE_TCP_SERVER && jlinkMode != JLINK_MODE_TCP_CLIENT)
       return;
-   if (jlinkCount >= JLINK_RING_SIZE)
-      return;   /* full: drop newest */
-   tail = (jlinkHead + jlinkCount) % JLINK_RING_SIZE;
-   jlinkRing[tail] = b;
-   jlinkCount++;
+   JLinkTCPPoll();
+   /* Drain socket bytes into the RX ring while space remains; the
+      kernel socket buffer holds anything beyond that (backpressure). */
+   while (jlinkCount < JLINK_RING_SIZE)
+   {
+      uint8_t b;
+      if (!JLinkTCPRecv(&b))
+         break;
+      JLinkRingPush(b);
+   }
 }
 
 int JLinkRecvByte(uint8_t *b)

--- a/src/jerry/jlink.h
+++ b/src/jerry/jlink.h
@@ -13,9 +13,15 @@ extern "C" {
 
 enum
 {
-   JLINK_MODE_DISABLED = 0,
-   JLINK_MODE_LOOPBACK = 1
+   JLINK_MODE_DISABLED   = 0,
+   JLINK_MODE_LOOPBACK   = 1,
+   JLINK_MODE_TCP_SERVER = 2,
+   JLINK_MODE_TCP_CLIENT = 3
 };
+
+/* TCP endpoint config; call before JLinkOpen for the TCP modes.
+   host is ignored in server mode (listens on INADDR_ANY). */
+void JLinkSetTCPEndpoint(const char *host, int port);
 
 int  JLinkOpen(int mode);
 void JLinkClose(void);
@@ -24,6 +30,10 @@ int  JLinkConnected(void);
 void JLinkSendByte(uint8_t b);
 int  JLinkRecvByte(uint8_t *b);
 int  JLinkRxPending(void);
+/* Per-frame service: progress TCP connect/accept, drain socket into the
+   RX ring (bounded by ring space), flush pending TX.  No-op for
+   loopback/disabled. */
+void JLinkPoll(void);
 size_t JLinkStateSave(uint8_t *buf);
 size_t JLinkStateLoad(const uint8_t *buf);
 

--- a/src/jerry/jlink_tcp.c
+++ b/src/jerry/jlink_tcp.c
@@ -1,0 +1,329 @@
+/* jlink_tcp.c — nonblocking TCP endpoint for the JagLink transport.
+ *
+ * Deliberately minimal: two Jaguars on a wire, so one listener + one
+ * peer socket.  POSIX and winsock share the code behind a thin macro
+ * layer; platforms without BSD-style sockets (bare console targets)
+ * compile the stub tail of this file instead.
+ */
+#include <string.h>
+#include "jlink_tcp.h"
+
+#if defined(_WIN32) || defined(__unix__) || defined(__APPLE__) || \
+    defined(__linux__) || defined(__ANDROID__)
+#define JLINK_HAVE_TCP 1
+#endif
+
+#ifdef JLINK_HAVE_TCP
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#ifdef _MSC_VER
+#pragma comment(lib, "ws2_32.lib")
+#endif
+typedef SOCKET jlink_sock_t;
+#define JLINK_INVALID_SOCK  INVALID_SOCKET
+#define jlink_sock_valid(s) ((s) != INVALID_SOCKET)
+#define jlink_closesock(s)  closesocket(s)
+#define jlink_sockerr()     WSAGetLastError()
+#define JLINK_EWOULDBLOCK   WSAEWOULDBLOCK
+#define JLINK_EINPROGRESS   WSAEWOULDBLOCK
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+typedef int jlink_sock_t;
+#define JLINK_INVALID_SOCK  (-1)
+#define jlink_sock_valid(s) ((s) >= 0)
+#define jlink_closesock(s)  close(s)
+#define jlink_sockerr()     errno
+#define JLINK_EWOULDBLOCK   EWOULDBLOCK
+#define JLINK_EINPROGRESS   EINPROGRESS
+#endif
+
+#define JLINK_TCP_TXPEND_SIZE 1024
+
+static jlink_sock_t tcpListen = JLINK_INVALID_SOCK;
+static jlink_sock_t tcpPeer = JLINK_INVALID_SOCK;
+static int tcpIsServer = 0;
+static int tcpConnecting = 0;    /* client connect in flight */
+static uint8_t tcpTxPend[JLINK_TCP_TXPEND_SIZE];
+static uint32_t tcpTxHead = 0;
+static uint32_t tcpTxCount = 0;
+
+static void jlink_set_nonblock(jlink_sock_t s)
+{
+#ifdef _WIN32
+   u_long one = 1;
+   ioctlsocket(s, FIONBIO, &one);
+#else
+   int fl = fcntl(s, F_GETFL, 0);
+   fcntl(s, F_SETFL, fl | O_NONBLOCK);
+#endif
+}
+
+static void jlink_set_nodelay(jlink_sock_t s)
+{
+   int one = 1;
+   setsockopt(s, IPPROTO_TCP, TCP_NODELAY, (const char *)&one, sizeof(one));
+}
+
+#ifdef _WIN32
+static int wsaStarted = 0;
+static void jlink_wsa_init(void)
+{
+   WSADATA wd;
+   if (!wsaStarted)
+   {
+      if (WSAStartup(MAKEWORD(2, 2), &wd) == 0)
+         wsaStarted = 1;
+   }
+}
+#endif
+
+int JLinkTCPAvailable(void)
+{
+   return 1;
+}
+
+int JLinkTCPOpen(int is_server, const char *host, int port)
+{
+   struct sockaddr_in sa;
+
+   JLinkTCPClose();
+#ifdef _WIN32
+   jlink_wsa_init();
+#endif
+
+   memset(&sa, 0, sizeof(sa));
+   sa.sin_family = AF_INET;
+   sa.sin_port = htons((unsigned short)port);
+
+   if (is_server)
+   {
+      int one = 1;
+      tcpListen = socket(AF_INET, SOCK_STREAM, 0);
+      if (!jlink_sock_valid(tcpListen))
+         return 0;
+      setsockopt(tcpListen, SOL_SOCKET, SO_REUSEADDR,
+                 (const char *)&one, sizeof(one));
+      sa.sin_addr.s_addr = htonl(INADDR_ANY);
+      if (bind(tcpListen, (struct sockaddr *)&sa, sizeof(sa)) != 0
+          || listen(tcpListen, 1) != 0)
+      {
+         jlink_closesock(tcpListen);
+         tcpListen = JLINK_INVALID_SOCK;
+         return 0;
+      }
+      jlink_set_nonblock(tcpListen);
+   }
+   else
+   {
+      int rc;
+      if (!host || !host[0])
+         host = "127.0.0.1";
+      sa.sin_addr.s_addr = inet_addr(host);
+      if (sa.sin_addr.s_addr == INADDR_NONE)
+         return 0;
+      tcpPeer = socket(AF_INET, SOCK_STREAM, 0);
+      if (!jlink_sock_valid(tcpPeer))
+         return 0;
+      jlink_set_nonblock(tcpPeer);
+      rc = connect(tcpPeer, (struct sockaddr *)&sa, sizeof(sa));
+      if (rc != 0)
+      {
+         int err = jlink_sockerr();
+         if (err != JLINK_EINPROGRESS && err != JLINK_EWOULDBLOCK)
+         {
+            jlink_closesock(tcpPeer);
+            tcpPeer = JLINK_INVALID_SOCK;
+            return 0;
+         }
+         tcpConnecting = 1;
+      }
+      else
+         jlink_set_nodelay(tcpPeer);
+   }
+
+   tcpIsServer = is_server;
+   return 1;
+}
+
+void JLinkTCPClose(void)
+{
+   if (jlink_sock_valid(tcpPeer))
+      jlink_closesock(tcpPeer);
+   if (jlink_sock_valid(tcpListen))
+      jlink_closesock(tcpListen);
+   tcpPeer = JLINK_INVALID_SOCK;
+   tcpListen = JLINK_INVALID_SOCK;
+   tcpIsServer = 0;
+   tcpConnecting = 0;
+   tcpTxHead = 0;
+   tcpTxCount = 0;
+}
+
+int JLinkTCPConnected(void)
+{
+   return jlink_sock_valid(tcpPeer) && !tcpConnecting;
+}
+
+static void jlink_tcp_drop_peer(void)
+{
+   if (jlink_sock_valid(tcpPeer))
+      jlink_closesock(tcpPeer);
+   tcpPeer = JLINK_INVALID_SOCK;
+   tcpConnecting = 0;
+   tcpTxHead = 0;
+   tcpTxCount = 0;
+}
+
+static void jlink_tcp_queue_pending(uint8_t b)
+{
+   uint32_t tail;
+   if (tcpTxCount >= JLINK_TCP_TXPEND_SIZE)
+      return;                    /* full: drop newest */
+   tail = (tcpTxHead + tcpTxCount) % JLINK_TCP_TXPEND_SIZE;
+   tcpTxPend[tail] = b;
+   tcpTxCount++;
+}
+
+static void jlink_tcp_flush_pending(void)
+{
+   while (tcpTxCount > 0)
+   {
+      char c = (char)tcpTxPend[tcpTxHead];
+      long n = (long)send(tcpPeer, &c, 1, 0);
+      if (n == 1)
+      {
+         tcpTxHead = (tcpTxHead + 1) % JLINK_TCP_TXPEND_SIZE;
+         tcpTxCount--;
+      }
+      else
+      {
+         int err = jlink_sockerr();
+         if (n < 0 && err == JLINK_EWOULDBLOCK)
+            break;               /* kernel buffer full; retry next poll */
+         jlink_tcp_drop_peer();
+         break;
+      }
+   }
+}
+
+void JLinkTCPSend(uint8_t b)
+{
+   if (!JLinkTCPConnected())
+      return;
+   if (tcpTxCount > 0)
+   {
+      /* Preserve ordering behind already-pending bytes. */
+      jlink_tcp_queue_pending(b);
+      jlink_tcp_flush_pending();
+      return;
+   }
+   {
+      char c = (char)b;
+      long n = (long)send(tcpPeer, &c, 1, 0);
+      if (n == 1)
+         return;
+      if (n < 0 && jlink_sockerr() == JLINK_EWOULDBLOCK)
+      {
+         jlink_tcp_queue_pending(b);
+         return;
+      }
+      jlink_tcp_drop_peer();
+   }
+}
+
+int JLinkTCPRecv(uint8_t *b)
+{
+   char c;
+   long n;
+   if (!JLinkTCPConnected())
+      return 0;
+   n = (long)recv(tcpPeer, &c, 1, 0);
+   if (n == 1)
+   {
+      *b = (uint8_t)c;
+      return 1;
+   }
+   if (n == 0)
+   {
+      /* Orderly shutdown by the peer. */
+      jlink_tcp_drop_peer();
+      return 0;
+   }
+   if (jlink_sockerr() != JLINK_EWOULDBLOCK)
+      jlink_tcp_drop_peer();
+   return 0;
+}
+
+void JLinkTCPPoll(void)
+{
+   if (tcpIsServer && jlink_sock_valid(tcpListen) && !jlink_sock_valid(tcpPeer))
+   {
+      jlink_sock_t s = accept(tcpListen, NULL, NULL);
+      if (jlink_sock_valid(s))
+      {
+         jlink_set_nonblock(s);
+         jlink_set_nodelay(s);
+         tcpPeer = s;
+         tcpTxHead = 0;
+         tcpTxCount = 0;
+      }
+   }
+
+   if (tcpConnecting && jlink_sock_valid(tcpPeer))
+   {
+      /* A nonblocking connect has completed when the socket reports
+         writability; poll cheaply via getsockopt(SO_ERROR) after a
+         zero-timeout select. */
+      fd_set wfds;
+      struct timeval tv;
+      int rc;
+      FD_ZERO(&wfds);
+      FD_SET(tcpPeer, &wfds);
+      tv.tv_sec = 0;
+      tv.tv_usec = 0;
+      rc = select((int)(tcpPeer + 1), NULL, &wfds, NULL, &tv);
+      if (rc > 0)
+      {
+         int soerr = 0;
+         socklen_t slen = (socklen_t)sizeof(soerr);
+         if (getsockopt(tcpPeer, SOL_SOCKET, SO_ERROR,
+                        (char *)&soerr, &slen) == 0 && soerr == 0)
+         {
+            tcpConnecting = 0;
+            jlink_set_nodelay(tcpPeer);
+         }
+         else
+            jlink_tcp_drop_peer();
+      }
+   }
+
+   if (JLinkTCPConnected() && tcpTxCount > 0)
+      jlink_tcp_flush_pending();
+}
+
+#else /* !JLINK_HAVE_TCP — socketless console targets get inert stubs */
+
+int JLinkTCPAvailable(void) { return 0; }
+int JLinkTCPOpen(int is_server, const char *host, int port)
+{
+   (void)is_server;
+   (void)host;
+   (void)port;
+   return 0;
+}
+void JLinkTCPClose(void) {}
+int JLinkTCPConnected(void) { return 0; }
+void JLinkTCPSend(uint8_t b) { (void)b; }
+int JLinkTCPRecv(uint8_t *b) { (void)b; return 0; }
+void JLinkTCPPoll(void) {}
+
+#endif /* JLINK_HAVE_TCP */

--- a/src/jerry/jlink_tcp.c
+++ b/src/jerry/jlink_tcp.c
@@ -51,10 +51,18 @@ typedef int jlink_sock_t;
 static jlink_sock_t tcpListen = JLINK_INVALID_SOCK;
 static jlink_sock_t tcpPeer = JLINK_INVALID_SOCK;
 static int tcpIsServer = 0;
+static int tcpIsClient = 0;
 static int tcpConnecting = 0;    /* client connect in flight */
+static int tcpRetryTimer = 0;    /* polls until next client reconnect */
+static char tcpHost[128] = "127.0.0.1";
+static int tcpPort = 0;
 static uint8_t tcpTxPend[JLINK_TCP_TXPEND_SIZE];
 static uint32_t tcpTxHead = 0;
 static uint32_t tcpTxCount = 0;
+
+/* A refused/dropped client connect retries after this many polls
+   (one poll per frame => roughly half a second). */
+#define JLINK_TCP_RETRY_POLLS 30
 
 static void jlink_set_nonblock(jlink_sock_t s)
 {
@@ -91,6 +99,38 @@ int JLinkTCPAvailable(void)
    return 1;
 }
 
+/* Kick off (or re-kick) a nonblocking client connect to tcpHost:tcpPort. */
+static void jlink_tcp_start_connect(void)
+{
+   struct sockaddr_in sa;
+   int rc;
+
+   memset(&sa, 0, sizeof(sa));
+   sa.sin_family = AF_INET;
+   sa.sin_port = htons((unsigned short)tcpPort);
+   sa.sin_addr.s_addr = inet_addr(tcpHost);
+
+   tcpPeer = socket(AF_INET, SOCK_STREAM, 0);
+   if (!jlink_sock_valid(tcpPeer))
+      return;
+   jlink_set_nonblock(tcpPeer);
+   rc = connect(tcpPeer, (struct sockaddr *)&sa, sizeof(sa));
+   if (rc != 0)
+   {
+      int err = jlink_sockerr();
+      if (err != JLINK_EINPROGRESS && err != JLINK_EWOULDBLOCK)
+      {
+         jlink_closesock(tcpPeer);
+         tcpPeer = JLINK_INVALID_SOCK;
+         tcpRetryTimer = JLINK_TCP_RETRY_POLLS;
+         return;
+      }
+      tcpConnecting = 1;
+   }
+   else
+      jlink_set_nodelay(tcpPeer);
+}
+
 int JLinkTCPOpen(int is_server, const char *host, int port)
 {
    struct sockaddr_in sa;
@@ -124,30 +164,18 @@ int JLinkTCPOpen(int is_server, const char *host, int port)
    }
    else
    {
-      int rc;
       if (!host || !host[0])
          host = "127.0.0.1";
       sa.sin_addr.s_addr = inet_addr(host);
       if (sa.sin_addr.s_addr == INADDR_NONE)
          return 0;
-      tcpPeer = socket(AF_INET, SOCK_STREAM, 0);
-      if (!jlink_sock_valid(tcpPeer))
-         return 0;
-      jlink_set_nonblock(tcpPeer);
-      rc = connect(tcpPeer, (struct sockaddr *)&sa, sizeof(sa));
-      if (rc != 0)
-      {
-         int err = jlink_sockerr();
-         if (err != JLINK_EINPROGRESS && err != JLINK_EWOULDBLOCK)
-         {
-            jlink_closesock(tcpPeer);
-            tcpPeer = JLINK_INVALID_SOCK;
-            return 0;
-         }
-         tcpConnecting = 1;
-      }
-      else
-         jlink_set_nodelay(tcpPeer);
+      strncpy(tcpHost, host, sizeof(tcpHost) - 1);
+      tcpHost[sizeof(tcpHost) - 1] = '\0';
+      tcpPort = port;
+      tcpIsClient = 1;
+      /* First attempt now; refusals retry from JLinkTCPPoll (the peer
+         instance may simply not be listening yet). */
+      jlink_tcp_start_connect();
    }
 
    tcpIsServer = is_server;
@@ -163,7 +191,9 @@ void JLinkTCPClose(void)
    tcpPeer = JLINK_INVALID_SOCK;
    tcpListen = JLINK_INVALID_SOCK;
    tcpIsServer = 0;
+   tcpIsClient = 0;
    tcpConnecting = 0;
+   tcpRetryTimer = 0;
    tcpTxHead = 0;
    tcpTxCount = 0;
 }
@@ -181,6 +211,8 @@ static void jlink_tcp_drop_peer(void)
    tcpConnecting = 0;
    tcpTxHead = 0;
    tcpTxCount = 0;
+   if (tcpIsClient)
+      tcpRetryTimer = JLINK_TCP_RETRY_POLLS;
 }
 
 static void jlink_tcp_queue_pending(uint8_t b)
@@ -265,6 +297,16 @@ int JLinkTCPRecv(uint8_t *b)
 
 void JLinkTCPPoll(void)
 {
+   /* Client: retry a refused or dropped connection — the partner
+      instance may not have been listening yet. */
+   if (tcpIsClient && !jlink_sock_valid(tcpPeer))
+   {
+      if (tcpRetryTimer > 0)
+         tcpRetryTimer--;
+      else
+         jlink_tcp_start_connect();
+   }
+
    if (tcpIsServer && jlink_sock_valid(tcpListen) && !jlink_sock_valid(tcpPeer))
    {
       jlink_sock_t s = accept(tcpListen, NULL, NULL);

--- a/src/jerry/jlink_tcp.c
+++ b/src/jerry/jlink_tcp.c
@@ -164,7 +164,7 @@ int JLinkTCPOpen(int is_server, const char *host, int port)
    }
    else
    {
-      if (!host || !host[0])
+      if (!host || !host[0] || strcmp(host, "localhost") == 0)
          host = "127.0.0.1";
       sa.sin_addr.s_addr = inet_addr(host);
       if (sa.sin_addr.s_addr == INADDR_NONE)

--- a/src/jerry/jlink_tcp.h
+++ b/src/jerry/jlink_tcp.h
@@ -1,0 +1,37 @@
+/* jlink_tcp.h — nonblocking TCP endpoint for the JagLink transport.
+   Internal to jlink.c; nothing else should include this. */
+#ifndef __JLINK_TCP_H__
+#define __JLINK_TCP_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Returns 1 if this build has socket support (JLINK_HAVE_TCP). */
+int  JLinkTCPAvailable(void);
+
+/* is_server: listen on port; else connect to host:port (nonblocking —
+   the connection completes during JLinkTCPPoll).  Returns 1 on
+   successful setup, 0 on immediate failure. */
+int  JLinkTCPOpen(int is_server, const char *host, int port);
+void JLinkTCPClose(void);
+int  JLinkTCPConnected(void);
+
+/* Nonblocking send; on partial send / EAGAIN the byte parks in a small
+   pending ring flushed by JLinkTCPPoll.  Silently drops when no peer. */
+void JLinkTCPSend(uint8_t b);
+
+/* Nonblocking receive of one byte from the socket; 1 if a byte was
+   returned. */
+int  JLinkTCPRecv(uint8_t *b);
+
+/* Progress accept/connect, detect disconnect, flush pending TX. */
+void JLinkTCPPoll(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/jerry/uart.c
+++ b/src/jerry/uart.c
@@ -177,6 +177,13 @@ void UARTWriteWord(uint32_t offset, uint16_t data)
    }
 }
 
+/* Per-frame service from retro_run, after JLinkPoll has drained the
+   socket: start an RX frame for any newly arrived transport bytes. */
+void UARTPoll(void)
+{
+   UARTKickRx();
+}
+
 void UARTInit(void)
 {
    UARTReset();

--- a/src/jerry/uart.h
+++ b/src/jerry/uart.h
@@ -13,6 +13,7 @@ void UARTInit(void);
 void UARTReset(void);
 void UARTDone(void);
 void UARTSetLinkMode(int mode);   /* JLINK_MODE_* from jlink.h */
+void UARTPoll(void);              /* per frame, after JLinkPoll */
 
 uint16_t UARTReadWord(uint32_t offset);
 void UARTWriteWord(uint32_t offset, uint16_t data);

--- a/test/test_jlink_tcp.c
+++ b/test/test_jlink_tcp.c
@@ -1,0 +1,167 @@
+/* test_jlink_tcp.c — unit test for the TCP link backend.  The test acts
+   as the remote peer with its own plain sockets, so both endpoints live
+   in one process without sharing any jlink state. */
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include "src/jerry/jlink.h"
+
+static int failures = 0;
+
+#define CHECK(cond, msg) \
+    do { if (cond) printf("PASS %s\n", msg); \
+         else { printf("FAIL %s\n", msg); failures++; } } while (0)
+
+#define TEST_PORT_BASE 42371
+
+/* Poll the jlink side + give the kernel a moment, up to ~2 s. */
+static int wait_for(int (*pred)(void), int iters)
+{
+    int i;
+    for (i = 0; i < iters; i++)
+    {
+        JLinkPoll();
+        if (pred())
+            return 1;
+        usleep(10000);
+    }
+    return 0;
+}
+
+static int pred_connected(void) { return JLinkConnected(); }
+static int pred_rx_pending(void) { return JLinkRxPending() > 0; }
+
+/* ---- server-mode: jlink listens, test connects ---- */
+static void test_server_mode(void)
+{
+    int port = TEST_PORT_BASE;
+    int peer;
+    struct sockaddr_in sa;
+    uint8_t b = 0;
+    ssize_t n;
+    char buf[4];
+
+    JLinkSetTCPEndpoint(NULL, port);
+    CHECK(JLinkOpen(JLINK_MODE_TCP_SERVER) == 1, "server: open listens");
+    CHECK(!JLinkConnected(), "server: not connected before peer");
+
+    peer = socket(AF_INET, SOCK_STREAM, 0);
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family = AF_INET;
+    sa.sin_port = htons((uint16_t)port);
+    sa.sin_addr.s_addr = inet_addr("127.0.0.1");
+    CHECK(connect(peer, (struct sockaddr *)&sa, sizeof(sa)) == 0,
+          "server: test peer connects");
+
+    CHECK(wait_for(pred_connected, 200), "server: accept completes");
+
+    /* jlink -> peer */
+    JLinkSendByte(0xAA);
+    JLinkPoll();
+    n = recv(peer, buf, 1, 0);
+    CHECK(n == 1 && (uint8_t)buf[0] == 0xAA, "server: TX byte reaches peer");
+
+    /* peer -> jlink */
+    buf[0] = (char)0x55;
+    send(peer, buf, 1, 0);
+    CHECK(wait_for(pred_rx_pending, 200), "server: RX byte arrives");
+    CHECK(JLinkRecvByte(&b) == 1 && b == 0x55, "server: RX byte value");
+
+    /* disconnect detection */
+    close(peer);
+    {
+        int i, gone = 0;
+        for (i = 0; i < 200; i++)
+        {
+            JLinkPoll();
+            if (!JLinkConnected()) { gone = 1; break; }
+            usleep(10000);
+        }
+        CHECK(gone, "server: peer close detected");
+    }
+    JLinkClose();
+}
+
+/* ---- client-mode: test listens, jlink connects ---- */
+static void test_client_mode(void)
+{
+    int port = TEST_PORT_BASE + 1;
+    int lsock, peer = -1;
+    struct sockaddr_in sa;
+    uint8_t b = 0;
+    ssize_t n;
+    char buf[4];
+    int i;
+
+    lsock = socket(AF_INET, SOCK_STREAM, 0);
+    {
+        int one = 1;
+        setsockopt(lsock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    }
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family = AF_INET;
+    sa.sin_port = htons((uint16_t)port);
+    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    CHECK(bind(lsock, (struct sockaddr *)&sa, sizeof(sa)) == 0,
+          "client: test listener binds");
+    listen(lsock, 1);
+    fcntl(lsock, F_SETFL, O_NONBLOCK);
+
+    JLinkSetTCPEndpoint("127.0.0.1", port);
+    CHECK(JLinkOpen(JLINK_MODE_TCP_CLIENT) == 1, "client: open starts connect");
+
+    for (i = 0; i < 200 && peer < 0; i++)
+    {
+        JLinkPoll();
+        peer = accept(lsock, NULL, NULL);
+        if (peer < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            usleep(10000);
+    }
+    CHECK(peer >= 0, "client: jlink connected to test listener");
+    CHECK(wait_for(pred_connected, 200), "client: JLinkConnected reports up");
+
+    /* jlink -> peer */
+    JLinkSendByte(0x42);
+    JLinkPoll();
+    n = recv(peer, buf, 1, 0);
+    if (n < 0) { usleep(50000); n = recv(peer, buf, 1, 0); }
+    CHECK(n == 1 && (uint8_t)buf[0] == 0x42, "client: TX byte reaches peer");
+
+    /* peer -> jlink */
+    buf[0] = (char)0x24;
+    send(peer, buf, 1, 0);
+    CHECK(wait_for(pred_rx_pending, 200), "client: RX byte arrives");
+    CHECK(JLinkRecvByte(&b) == 1 && b == 0x24, "client: RX byte value");
+
+    close(peer);
+    close(lsock);
+    JLinkClose();
+}
+
+static void test_unconnected_send_harmless(void)
+{
+    JLinkSetTCPEndpoint(NULL, TEST_PORT_BASE + 2);
+    CHECK(JLinkOpen(JLINK_MODE_TCP_SERVER) == 1, "orphan: open ok");
+    JLinkSendByte(0x77);           /* no peer: must not crash or queue */
+    JLinkPoll();
+    CHECK(JLinkRxPending() == 0, "orphan: nothing echoes");
+    JLinkClose();
+    CHECK(JLinkMode() == JLINK_MODE_DISABLED, "orphan: close resets mode");
+}
+
+int main(void)
+{
+    test_server_mode();
+    test_client_mode();
+    test_unconnected_send_harmless();
+    printf(failures ? "FAILED (%d)\n" : "OK\n", failures);
+    return failures ? 1 : 0;
+}

--- a/test/tools/netlink_game.c
+++ b/test/tools/netlink_game.c
@@ -1,0 +1,196 @@
+/* netlink_game.c — game-level probe for the network link.
+ *
+ *   netlink_game <core> <rom> --role loopback|server|client [--port N]
+ *                [--outdir DIR] [--shot-every N] [--frames N]
+ *                [--press F:BTN[:HOLD]]...
+ *
+ * Runs a real game with the netlink active, sampling the UART registers
+ * once per frame (side-effect-free reads only: ASISTAT, ASICLK) and the
+ * transport state, logging every change so a game's link programming is
+ * visible; dumps periodic PPM screenshots for menu navigation work.
+ * Exit code: 0 if the game ever programmed the UART (ASICLK/ASICTRL
+ * write or TX observed), 2 if it never touched it, 1 on setup error.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include "../harness/harness.h"
+
+typedef void     (*jerry_ww_t)(uint32_t, uint16_t, uint32_t);
+typedef uint16_t (*jerry_rw_t)(uint32_t, uint32_t);
+typedef int      (*jlink_int_t)(void);
+
+#define MAX_W 1024
+#define MAX_H 512
+
+typedef struct {
+    /* screenshots */
+    const char *outdir;
+    unsigned shot_every;
+    uint32_t fb[MAX_W * MAX_H];
+    unsigned w, h;
+    unsigned frame_no;
+    /* uart sampling */
+    jerry_rw_t jerry_rw;
+    jlink_int_t jlink_connected;
+    jlink_int_t jlink_rx_pending;
+    uint16_t last_stat, last_clk;
+    int last_conn;
+    int uart_touched;
+    unsigned tbe_drops;      /* TBE observed low => game transmitted */
+    int realtime;            /* pace frames to ~60 fps wall clock */
+} ng_state;
+
+static void ng_write_ppm(const ng_state *st)
+{
+    char path[1024];
+    FILE *f;
+    unsigned x, y;
+    if (!st->outdir || !st->w || !st->h) return;
+    snprintf(path, sizeof(path), "%s/frame_%05u.ppm", st->outdir, st->frame_no);
+    f = fopen(path, "wb");
+    if (!f) return;
+    fprintf(f, "P6\n%u %u\n255\n", st->w, st->h);
+    for (y = 0; y < st->h; y++) {
+        for (x = 0; x < st->w; x++) {
+            uint32_t p = st->fb[y * st->w + x];
+            unsigned char rgb[3];
+            rgb[0] = (unsigned char)((p >> 16) & 0xFF);
+            rgb[1] = (unsigned char)((p >> 8) & 0xFF);
+            rgb[2] = (unsigned char)(p & 0xFF);
+            fwrite(rgb, 1, 3, f);
+        }
+    }
+    fclose(f);
+}
+
+static void ng_video_cb(void *ud, const void *data, unsigned w, unsigned h,
+                        size_t pitch)
+{
+    ng_state *st = (ng_state *)ud;
+    unsigned y;
+    const uint8_t *src = (const uint8_t *)data;
+    if (!data || w == 0 || h == 0 || w > MAX_W || h > MAX_H) return;
+    for (y = 0; y < h; y++)
+        memcpy(&st->fb[y * w], src + y * pitch, w * 4);
+    st->w = w; st->h = h;
+    if (st->outdir && st->shot_every && (st->frame_no % st->shot_every) == 0)
+        ng_write_ppm(st);
+}
+
+static bool ng_frame_cb(void *ud, unsigned frame)
+{
+    ng_state *st = (ng_state *)ud;
+    uint16_t stat = st->jerry_rw(0xF10032, 0);
+    uint16_t clk  = st->jerry_rw(0xF10034, 0);
+    int conn = st->jlink_connected ? st->jlink_connected() : 0;
+
+    st->frame_no = frame + 1;
+
+    if (stat != st->last_stat || clk != st->last_clk || conn != st->last_conn)
+    {
+        fprintf(stderr,
+                "[uart] frame %5u  ASISTAT=%04X (cfg=%02X RBF=%d TBE=%d ERR=%d)"
+                "  ASICLK=%04X  link=%d  rxq=%d\n",
+                frame, stat, stat & 0x3F, !!(stat & 0x0080),
+                !!(stat & 0x0100), !!(stat & 0x8000), clk, conn,
+                st->jlink_rx_pending ? st->jlink_rx_pending() : -1);
+        /* Any nonzero config/divider or a busy transmitter means the
+           game is driving the UART. */
+        if ((stat & 0x3F) != 0 || clk != 0)
+            st->uart_touched = 1;
+        if (!(stat & 0x0100))
+        {
+            st->tbe_drops++;
+            st->uart_touched = 1;
+        }
+        st->last_stat = stat;
+        st->last_clk = clk;
+        st->last_conn = conn;
+    }
+    if (st->realtime)
+        usleep(15000);   /* ~60 fps incl. frame cost; keeps two paired
+                            instances aligned in wall-clock time */
+    return true;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    ng_state st;
+    const char *role = "loopback";
+    const char *port = "42171";
+    char port_env[64];
+    int i;
+
+    memset(&st, 0, sizeof(st));
+    st.shot_every = 120;
+    st.last_stat = 0xFFFF;
+    st.last_clk = 0xFFFF;
+    st.last_conn = -1;
+
+    for (i = 1; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "--role") && i + 1 < argc)
+        {
+            role = argv[++i];
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+        else if (!strcmp(argv[i], "--port") && i + 1 < argc)
+        {
+            port = argv[++i];
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+        else if (!strcmp(argv[i], "--outdir") && i + 1 < argc)
+        {
+            st.outdir = argv[++i];
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+        else if (!strcmp(argv[i], "--shot-every") && i + 1 < argc)
+        {
+            st.shot_every = (unsigned)atoi(argv[++i]);
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+        else if (!strcmp(argv[i], "--realtime"))
+        {
+            st.realtime = 1;
+            argv[i] = (char *)"--quiet";
+        }
+    }
+
+    snprintf(port_env, sizeof(port_env), "VJ_NETLINK_PORT=%s", port);
+    putenv(port_env);
+    putenv((char *)"VJ_NETLINK_HOST=127.0.0.1");
+
+    cfg.frames = 1800;
+    cfg.options[0].key = "virtualjaguar_netlink";
+    cfg.options[0].value = !strcmp(role, "server") ? "tcp_server"
+                         : !strcmp(role, "client") ? "tcp_client"
+                         : "loopback";
+    cfg.num_options = 1;
+    cfg.frame_callback = ng_frame_cb;
+    cfg.frame_callback_data = &st;
+    cfg.video_callback = ng_video_cb;
+    cfg.video_callback_data = &st;
+
+    if (!harness_init_from_args(&cfg, argc, argv)) return 1;
+    if (!harness_load_rom(&cfg))                   return 1;
+
+    st.jerry_rw = (jerry_rw_t)harness_dlsym(&cfg, "JERRYReadWord");
+    st.jlink_connected = (jlink_int_t)harness_dlsym(&cfg, "JLinkConnected");
+    st.jlink_rx_pending = (jlink_int_t)harness_dlsym(&cfg, "JLinkRxPending");
+    if (!st.jerry_rw)
+    {
+        fprintf(stderr, "netlink_game: JERRY symbols missing (TEST_EXPORTS=1)\n");
+        return 1;
+    }
+
+    harness_run(&cfg);
+    harness_shutdown(&cfg);
+
+    fprintf(stderr, "[uart] summary: touched=%d tbe_drops=%u\n",
+            st.uart_touched, st.tbe_drops);
+    return st.uart_touched ? 0 : 2;
+}

--- a/test/tools/netlink_pair.c
+++ b/test/tools/netlink_pair.c
@@ -1,0 +1,169 @@
+/* netlink_pair.c — one endpoint of the two-process TCP link test.
+ *
+ *   netlink_pair <core> --role server|client [--port N]
+ *
+ * Server sends CA FE and expects BE EF; client sends BE EF and expects
+ * CA FE.  Bytes travel the full stack: JERRY registers -> UART frames
+ * -> jlink -> TCP -> peer process.  Exit 0 on success, 1 on failure.
+ * Driven by test/tools/netlink_pair_test.sh.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include "../harness/harness.h"
+
+typedef void     (*jerry_ww_t)(uint32_t, uint16_t, uint32_t);
+typedef uint16_t (*jerry_rw_t)(uint32_t, uint32_t);
+typedef int      (*jlink_conn_t)(void);
+typedef void     (*retro_run_t)(void);
+
+#define ROM_SIZE 131072
+#define MAX_WAIT_FRAMES 900   /* ~15 s at 60 fps */
+
+static const char *make_synth_rom(const char *role)
+{
+    static char path[256];
+    static uint8_t rom_buf[ROM_SIZE];
+    FILE *f;
+    const char *tmp = getenv("TMPDIR");
+    snprintf(path, sizeof(path), "%s/vj_netlink_pair_%s.j64",
+             tmp ? tmp : "/tmp", role);
+    memset(rom_buf, 0, ROM_SIZE);
+    rom_buf[0x404] = 0x00; rom_buf[0x405] = 0x80;
+    rom_buf[0x406] = 0x20; rom_buf[0x407] = 0x00;
+    rom_buf[0x2000] = 0x60; rom_buf[0x2001] = 0xFE;   /* bra.s * */
+    f = fopen(path, "wb");
+    if (!f) return NULL;
+    fwrite(rom_buf, 1, ROM_SIZE, f);
+    fclose(f);
+    return path;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    const char *role = NULL;
+    const char *port = "42171";
+    char port_env[64];
+    jerry_ww_t jerry_ww;
+    jerry_rw_t jerry_rw;
+    jlink_conn_t jlink_connected;
+    jlink_conn_t jlink_mode;
+    retro_run_t run_frame;
+    uint8_t send_bytes[2], want_bytes[2], got_bytes[2];
+    unsigned ngot = 0;
+    int i, connected = 0, sent = 0;
+
+    for (i = 1; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "--role") && i + 1 < argc)
+        {
+            role = argv[++i];
+            /* consume so harness_init doesn't see it */
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+        else if (!strcmp(argv[i], "--port") && i + 1 < argc)
+        {
+            port = argv[++i];
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+    }
+    if (!role || (strcmp(role, "server") && strcmp(role, "client")))
+    {
+        fprintf(stderr, "usage: netlink_pair <core> --role server|client [--port N]\n");
+        return 1;
+    }
+
+    if (!strcmp(role, "server"))
+    {
+        send_bytes[0] = 0xCA; send_bytes[1] = 0xFE;
+        want_bytes[0] = 0xBE; want_bytes[1] = 0xEF;
+    }
+    else
+    {
+        send_bytes[0] = 0xBE; send_bytes[1] = 0xEF;
+        want_bytes[0] = 0xCA; want_bytes[1] = 0xFE;
+    }
+
+    snprintf(port_env, sizeof(port_env), "VJ_NETLINK_PORT=%s", port);
+    putenv(port_env);
+    putenv((char *)"VJ_NETLINK_HOST=127.0.0.1");
+
+    cfg.frames = 1;
+    cfg.options[0].key = "virtualjaguar_netlink";
+    cfg.options[0].value = !strcmp(role, "server") ? "tcp_server" : "tcp_client";
+    cfg.options[1].key = "virtualjaguar_netlink_port";
+    cfg.options[1].value = port;
+    cfg.num_options = 2;
+
+    if (!harness_init_from_args(&cfg, argc, argv)) return 1;
+    if (!cfg.rom_path)
+    {
+        cfg.rom_path = make_synth_rom(role);
+        if (!cfg.rom_path) return 1;
+    }
+    if (!harness_load_rom(&cfg)) return 1;
+
+    jerry_ww = (jerry_ww_t)harness_dlsym(&cfg, "JERRYWriteWord");
+    jerry_rw = (jerry_rw_t)harness_dlsym(&cfg, "JERRYReadWord");
+    jlink_connected = (jlink_conn_t)harness_dlsym(&cfg, "JLinkConnected");
+    jlink_mode = (jlink_conn_t)harness_dlsym(&cfg, "JLinkMode");
+    run_frame = (retro_run_t)harness_dlsym(&cfg, "retro_run");
+    if (jlink_mode)
+        fprintf(stderr, "[%s] jlink mode after load = %d\n", role, jlink_mode());
+    if (!jerry_ww || !jerry_rw || !jlink_connected || !run_frame)
+    {
+        fprintf(stderr, "[%s] symbols missing — build with TEST_EXPORTS=1\n", role);
+        return 1;
+    }
+
+    /* Slow baud (~27 ms per character frame): this test only reads
+       ASIDATA at video-frame granularity, so deliveries must be spaced
+       wider than a frame or the second byte overruns (OE) exactly as
+       real hardware would.  Games service RBF from the interrupt. */
+    jerry_ww(0xF10034, 0x0FFF, 0);
+
+    for (i = 0; i < MAX_WAIT_FRAMES && ngot < 2; i++)
+    {
+        run_frame();
+        /* Headless frames run unthrottled; pace the rendezvous so the
+           frame budget spans several wall-clock seconds. */
+        if (!connected)
+            usleep(5000);
+
+        if (!connected && jlink_connected())
+        {
+            connected = 1;
+            fprintf(stderr, "[%s] link up at frame %d\n", role, i);
+        }
+        if (connected && !sent)
+        {
+            /* Two writes: shift + holding; the UART paces them out at
+               the programmed baud. */
+            jerry_ww(0xF10030, send_bytes[0], 0);
+            jerry_ww(0xF10030, send_bytes[1], 0);
+            sent = 1;
+        }
+        while (ngot < 2 && (jerry_rw(0xF10032, 0) & 0x0080))
+            got_bytes[ngot++] = (uint8_t)(jerry_rw(0xF10030, 0) & 0xFF);
+    }
+
+    harness_shutdown(&cfg);
+
+    if (!connected)
+    {
+        fprintf(stderr, "[%s] FAIL: link never came up\n", role);
+        return 1;
+    }
+    if (ngot != 2 || got_bytes[0] != want_bytes[0] || got_bytes[1] != want_bytes[1])
+    {
+        fprintf(stderr, "[%s] FAIL: got %u bytes [%02X %02X], want [%02X %02X]\n",
+                role, ngot, ngot > 0 ? got_bytes[0] : 0,
+                ngot > 1 ? got_bytes[1] : 0, want_bytes[0], want_bytes[1]);
+        return 1;
+    }
+    fprintf(stderr, "[%s] PASS: exchanged bytes correctly\n", role);
+    return 0;
+}

--- a/test/tools/netlink_pair_test.sh
+++ b/test/tools/netlink_pair_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# netlink_pair_test.sh — two-process TCP link test driver.
+# Launches a server-role and a client-role instance of the core on
+# localhost and requires both to exchange their bytes (see
+# netlink_pair.c).  Usage: netlink_pair_test.sh <core> [port]
+set -u
+
+CORE="${1:?usage: netlink_pair_test.sh <core> [port]}"
+PORT="${2:-${VJ_NETLINK_PORT:-42171}}"
+BIN="$(dirname "$0")/netlink_pair"
+
+if [ ! -x "$BIN" ]; then
+    echo "netlink_pair_test: $BIN not built" >&2
+    exit 1
+fi
+
+"$BIN" "$CORE" --role server --port "$PORT" &
+SERVER_PID=$!
+# Give the listener a moment before the client connects.
+sleep 0.3
+"$BIN" "$CORE" --role client --port "$PORT"
+CLIENT_RC=$?
+wait "$SERVER_PID"
+SERVER_RC=$?
+
+if [ "$SERVER_RC" -eq 0 ] && [ "$CLIENT_RC" -eq 0 ]; then
+    echo "netlink_pair_test: PASS (port $PORT)"
+    exit 0
+fi
+echo "netlink_pair_test: FAIL (server=$SERVER_RC client=$CLIENT_RC)" >&2
+exit 1


### PR DESCRIPTION
## Summary

Phase 2 of `docs/netlink-design.md`, stacked on #235 (retarget to `feature/netlink` once that merges).

- **TCP link backend** (`src/jerry/jlink_tcp.c`): compact nonblocking socket layer, POSIX + winsock behind one `#ifdef`, inert stub on socketless console targets. Deviation from the spec, called out in the doc: no vendored libretro-common `net_socket`/`net_compat` — that's a multi-console portability layer far larger than the ~300 lines needed here. MinGW gets `-lws2_32`; MSVC auto-links via `#pragma comment`.
- Server listens / client connects with **reconnect retry** (a refused first connect — partner not up yet — retries every ~30 frames; found by the pair test).
- Per-frame link service in `retro_run`; core option values `tcp_server`/`tcp_client` + `virtualjaguar_netlink_port` (env overrides `VJ_NETLINK_HOST` / `VJ_NETLINK_PORT`, host file `<system_dir>/vj_netlink.txt`).
- **Tests**: `test_jlink_tcp` (unit, test acts as the remote peer socket) and `netlink_pair` (two real processes exchange UART bytes over localhost TCP) — both in `make test`. `netlink_game` probe tool for game-level validation (UART sampling + screenshots + realtime pacing).

## Game validation (two instances, localhost)

- **BattleSphere Gold**: mutual link detection — both instances pass "Locating Players" into the networked Free For All options screen. Loopback control run correctly ends in "Network Failure" (a console hearing only its own echo must not find players).
- **Doom**: two-player deathmatch **enters the level on both instances** (frag-counter HUD, distinct spawns) after the ~119 kbaud JagLink handshake.

## Test plan
- [x] `make TEST_EXPORTS=1 test` green (incl. new TCP unit + two-process pair tests)
- [x] c89-lint clean; clean-tree prod build
- [x] `make benchmark` parity (3.3 ms/frame p50; link disabled by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)