### PR TITLE
perf(net): sub-frame link latency (fixes slow Doom deathmatch under netplay)

### DIFF
--- a/src/jerry/jlink.c
+++ b/src/jerry/jlink.c
@@ -141,6 +141,18 @@ void JLinkPoll(void)
    }
 }
 
+void JLinkPump(void)
+{
+   if (jlinkMode == JLINK_MODE_NETPACKET)
+   {
+      JLinkNPFlush();
+      JLinkNPPumpReceive();   /* receive() feeds the ring reentrantly */
+      return;
+   }
+   /* TCP: same servicing as the per-frame poll — cheap when idle. */
+   JLinkPoll();
+}
+
 int JLinkRecvByte(uint8_t *b)
 {
    if (jlinkCount == 0)

--- a/src/jerry/jlink.h
+++ b/src/jerry/jlink.h
@@ -38,6 +38,11 @@ int  JLinkRxPending(void);
    RX ring (bounded by ring space), flush pending TX.  No-op for
    loopback/disabled. */
 void JLinkPoll(void);
+/* Mid-frame pump for latency-sensitive polling paths: fetch any bytes
+   already available from the transport RIGHT NOW (netpacket: ask the
+   frontend to deliver pending packets; TCP: drain the socket).  Called
+   by the UART when a game polls for link data; callers rate-limit. */
+void JLinkPump(void);
 /* Lifetime traffic counters (diagnostics; reset by JLinkClose). */
 uint32_t JLinkTxTotal(void);
 uint32_t JLinkRxTotal(void);

--- a/src/jerry/jlink_netpacket.c
+++ b/src/jerry/jlink_netpacket.c
@@ -12,6 +12,7 @@
 #define JLINK_NP_TXBUF_SIZE 512
 
 static retro_netpacket_send_t npSend = NULL;
+static retro_netpacket_poll_receive_t npPollReceive = NULL;
 static int npActive = 0;
 static int npPrevMode = JLINK_MODE_DISABLED;
 static uint8_t npTxBuf[JLINK_NP_TXBUF_SIZE];
@@ -21,10 +22,10 @@ void JLinkNPStart(uint16_t client_id, retro_netpacket_send_t send_fn,
                   retro_netpacket_poll_receive_t poll_receive_fn)
 {
    (void)client_id;
-   (void)poll_receive_fn;
    npPrevMode = JLinkMode();
    JLinkClose();
    npSend = send_fn;
+   npPollReceive = poll_receive_fn;
    npTxLen = 0;
    npActive = 1;
    JLinkOpen(JLINK_MODE_NETPACKET);
@@ -41,6 +42,7 @@ void JLinkNPStop(void)
 {
    npActive = 0;
    npSend = NULL;
+   npPollReceive = NULL;
    npTxLen = 0;
    JLinkClose();
    if (npPrevMode != JLINK_MODE_DISABLED
@@ -64,8 +66,20 @@ void JLinkNPQueueByte(uint8_t b)
    if (!npActive)
       return;
    npTxBuf[npTxLen++] = b;
-   if (npTxLen >= JLINK_NP_TXBUF_SIZE)
-      JLinkNPFlush();
+   /* Flush immediately: link games run request/response tic exchanges
+      and spin for the reply mid-frame.  Batching to frame boundaries
+      turned each exchange into >= 1 frame of latency (Doom deathmatch
+      ran in slow motion); per-byte reliable packets are cheap on the
+      LAN links netplay targets. */
+   JLinkNPFlush();
+}
+
+/* Pump the frontend for incoming packets mid-frame (the receive
+   callback fires reentrantly and feeds the ring). */
+void JLinkNPPumpReceive(void)
+{
+   if (npActive && npPollReceive)
+      npPollReceive();
 }
 
 void JLinkNPFlush(void)

--- a/src/jerry/jlink_netpacket.h
+++ b/src/jerry/jlink_netpacket.h
@@ -29,6 +29,7 @@ void JLinkNPPoll(void);
 int  JLinkNPActive(void);
 void JLinkNPQueueByte(uint8_t b);
 void JLinkNPFlush(void);
+void JLinkNPPumpReceive(void);
 
 #ifdef __cplusplus
 }

--- a/src/jerry/uart.c
+++ b/src/jerry/uart.c
@@ -126,6 +126,21 @@ uint16_t UARTReadWord(uint32_t offset)
          UARTKickRx();
          break;
       case 0xF10032:            /* ASISTAT */
+         /* Link games spin on this register waiting for the partner's
+            reply mid-frame.  If nothing is buffered anywhere, pump the
+            transport so a reply that is already on the network can be
+            delivered THIS frame instead of next (rate-limited: a
+            polling loop iterates every few emulated microseconds). */
+         if (!uartRxFull && !uartRxBusy && JLinkConnected()
+             && !JLinkRxPending())
+         {
+            static unsigned pumpGate = 0;
+            if ((++pumpGate & 15u) == 0)
+            {
+               JLinkPump();
+               UARTKickRx();
+            }
+         }
          v = (uint16_t)(asiCtrl & 0x003F);
          if (uartRxFull)
             v |= ASISTAT_RBF;


### PR DESCRIPTION
## Summary

Play-testing found Doom deathmatch running in slow motion under RetroArch netplay (single player fine). Root cause: Jaguar link games run lockstep tic exchanges — send input packet, spin until the partner's arrives (~100 µs on real wire). The netpacket backend batched TX until frame end and only received between frames, so every exchange cost 1–2 frames instead of microseconds.

- Netpacket TX flushes immediately per byte (`RELIABLE|FLUSH_HINT` broadcast) instead of batching to the frame boundary.
- `start()`'s `poll_receive_fn` is now stored and used: new `JLinkPump()` asks the frontend for already-arrived packets mid-frame; TCP mode pumps the socket identically.
- The UART calls the pump when a game polls ASISTAT while nothing is buffered (rate-limited to every 16th poll so tight 68K polling loops don't spam syscalls).

## Test plan
- [x] Full suite green (netpacket fake-frontend, TCP pair, hub, UART unit tests)
- [x] c89-lint clean
- [ ] Human re-test: Doom deathmatch speed under RetroArch netplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)
