### PR TITLE
fix(net): harden netpacket edge cases from Copilot review of #241

### DIFF
--- a/src/jerry/jlink_netpacket.c
+++ b/src/jerry/jlink_netpacket.c
@@ -22,6 +22,11 @@ void JLinkNPStart(uint16_t client_id, retro_netpacket_send_t send_fn,
                   retro_netpacket_poll_receive_t poll_receive_fn)
 {
    (void)client_id;
+   /* The libretro contract guarantees a valid send_fn, but a NULL here
+      would otherwise leave the link claiming to be connected while
+      JLinkNPFlush can never drain the TX buffer. */
+   if (!send_fn)
+      return;
    npPrevMode = JLinkMode();
    JLinkClose();
    npSend = send_fn;
@@ -65,6 +70,8 @@ void JLinkNPQueueByte(uint8_t b)
 {
    if (!npActive)
       return;
+   if (npTxLen >= JLINK_NP_TXBUF_SIZE)
+      return;   /* flush unavailable: drop rather than overflow */
    npTxBuf[npTxLen++] = b;
    /* Flush immediately: link games run request/response tic exchanges
       and spin for the reply mid-frame.  Batching to frame boundaries

--- a/test/tools/netlink_ra_matrix.sh
+++ b/test/tools/netlink_ra_matrix.sh
@@ -39,9 +39,13 @@ cleanup() {
     if [ "$KEEP" != "1" ]; then
         [ -n "$HOST_PID" ] && kill "$HOST_PID" 2>/dev/null
         [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null
+        wait "$HOST_PID" "$CLIENT_PID" 2>/dev/null
     fi
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+# On signals: clean up, drop the EXIT trap (avoid double cleanup), and
+# actually stop the script instead of continuing the run.
+trap 'cleanup; trap - EXIT; exit 130' INT TERM
 APPEND="$WORK/append.cfg"
 cat > "$APPEND" <<EOF
 config_save_on_exit = "false"

--- a/test/tools/netlink_ra_matrix.sh
+++ b/test/tools/netlink_ra_matrix.sh
@@ -32,6 +32,16 @@ fi
 
 WORK="${TMPDIR:-/tmp}/vj_ra_matrix.$$"
 mkdir -p "$WORK"
+
+HOST_PID=""
+CLIENT_PID=""
+cleanup() {
+    if [ "$KEEP" != "1" ]; then
+        [ -n "$HOST_PID" ] && kill "$HOST_PID" 2>/dev/null
+        [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null
+    fi
+}
+trap cleanup EXIT INT TERM
 APPEND="$WORK/append.cfg"
 cat > "$APPEND" <<EOF
 config_save_on_exit = "false"


### PR DESCRIPTION
Addresses the three Copilot review comments left on #241 (closed with its content merged via #242) — all validated as legitimate:

1. `JLinkNPStart` now rejects a NULL `send_fn`. The libretro contract guarantees validity, but a NULL would have left the link claiming connected with a TX buffer that can never drain.
2. `JLinkNPQueueByte` bounds-checks before writing — with an undrainable buffer the two issues chained into a real out-of-bounds write; bytes now drop instead.
3. `netlink_ra_matrix.sh` gets an EXIT/INT/TERM cleanup trap so early exits don't strand RetroArch instances (KEEP=1 still leaves them for manual play).

Full suite green; c89-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)