### PR TITLE
fix(net): correct the JagLink traffic counters

### DIFF
--- a/src/jerry/jlink.c
+++ b/src/jerry/jlink.c
@@ -24,10 +24,17 @@ static void JLinkRingPush(uint8_t b)
 {
    uint32_t tail;
    if (jlinkCount >= JLINK_RING_SIZE)
-      return;   /* full: drop newest */
+      return;   /* full: drop newest, and don't count it as received */
    tail = (jlinkHead + jlinkCount) % JLINK_RING_SIZE;
    jlinkRing[tail] = b;
    jlinkCount++;
+   /* Counted on ARRIVAL, not on the game draining the ring.  jlinkTxTotal is
+    * incremented in JLinkSendByte(), i.e. at the transport boundary; counting
+    * RX at JLinkRecvByte() instead measured the other side of the ring, so a
+    * peer's traffic stayed invisible until the game got round to reading it
+    * and the two counters were never comparable.  (In loopback the same byte
+    * legitimately increments both: it really does go out and come back.) */
+   jlinkRxTotal++;
 }
 
 void JLinkSetTCPEndpoint(const char *host, int port)
@@ -71,6 +78,12 @@ void JLinkClose(void)
    jlinkMode = JLINK_MODE_DISABLED;
    jlinkHead = 0;
    jlinkCount = 0;
+   /* jlink.h documents these as lifetime-per-session and reset here.  Left
+    * running, they accumulate across independent sessions and across tests
+    * in one process, which makes the diagnostics read as traffic that this
+    * session never carried. */
+   jlinkTxTotal = 0;
+   jlinkRxTotal = 0;
 }
 
 int JLinkMode(void)
@@ -160,7 +173,6 @@ int JLinkRecvByte(uint8_t *b)
    *b = jlinkRing[jlinkHead];
    jlinkHead = (jlinkHead + 1) % JLINK_RING_SIZE;
    jlinkCount--;
-   jlinkRxTotal++;
    return 1;
 }
 

--- a/test/test_jlink.c
+++ b/test/test_jlink.c
@@ -67,12 +67,58 @@ static void test_state_roundtrip(void)
     JLinkClose();
 }
 
+/* jlink.h documents the traffic counters as per-session, reset by
+   JLinkClose().  They used to survive a close and accumulate across
+   sessions, which made the netlink diagnostics report traffic the current
+   session never carried. */
+static void test_counters_reset_on_close(void)
+{
+    JLinkOpen(JLINK_MODE_LOOPBACK);
+    JLinkSendByte(0x5A);
+    JLinkSendByte(0x5B);
+    CHECK(JLinkTxTotal() == 2, "tx counted while open");
+    JLinkClose();
+    CHECK(JLinkTxTotal() == 0, "close resets tx total");
+    CHECK(JLinkRxTotal() == 0, "close resets rx total");
+}
+
+/* RX is counted where the byte ARRIVES, not where the game drains the ring
+   — otherwise a peer's traffic stays invisible in the counters until the
+   game happens to read it, and tx/rx are never comparable. */
+static void test_rx_counted_on_arrival(void)
+{
+    uint8_t b = 0;
+    JLinkOpen(JLINK_MODE_LOOPBACK);
+    JLinkSendByte(0x77);
+    CHECK(JLinkRxTotal() == 1, "rx counted on arrival, before any read");
+    CHECK(JLinkRxPending() == 1, "byte still queued");
+    (void)JLinkRecvByte(&b);
+    CHECK(JLinkRxTotal() == 1, "draining the ring does not re-count it");
+    JLinkClose();
+}
+
+/* A dropped byte never entered the ring, so it must not be counted as
+   received: rx total has to stay consistent with what a reader can see. */
+static void test_dropped_bytes_not_counted(void)
+{
+    int i;
+    JLinkOpen(JLINK_MODE_LOOPBACK);
+    for (i = 0; i < 300; i++)
+        JLinkSendByte((uint8_t)i);
+    CHECK(JLinkTxTotal() == 300, "all 300 sends counted as tx");
+    CHECK(JLinkRxTotal() == 256, "only the 256 that fit counted as rx");
+    JLinkClose();
+}
+
 int main(void)
 {
     test_disabled_mode();
     test_loopback_roundtrip();
     test_overflow_drops_newest();
     test_state_roundtrip();
+    test_counters_reset_on_close();
+    test_rx_counted_on_arrival();
+    test_dropped_bytes_not_counted();
     printf(failures ? "FAILED (%d)\n" : "OK\n", failures);
     return failures ? 1 : 0;
 }

--- a/test/test_jlink_tcp.c
+++ b/test/test_jlink_tcp.c
@@ -152,11 +152,17 @@ static int hub_connect_peer(int port)
 {
     int s = socket(AF_INET, SOCK_STREAM, 0);
     struct sockaddr_in sa;
+    if (s < 0)
+        return -1;
     memset(&sa, 0, sizeof(sa));
     sa.sin_family = AF_INET;
     sa.sin_port = htons((uint16_t)port);
     sa.sin_addr.s_addr = inet_addr("127.0.0.1");
-    if (connect(s, (struct sockaddr *)&sa, sizeof(sa)) != 0) { close(s); return -1; }
+    if (connect(s, (struct sockaddr *)&sa, sizeof(sa)) != 0)
+    {
+        close(s);
+        return -1;
+    }
     return s;
 }
 


### PR DESCRIPTION
Closes out the two Copilot findings still outstanding on the netlink PRs (#240, #242).

**Scope reduced after #245 landed.** That PR fixed the netpacket TX-buffer overflow reported in the same reviews — and fixed it more thoroughly than I had, because it bounds the write *and* rejects a NULL `send_fn` in `JLinkNPStart`, closing the path at the source rather than at the queue. This PR no longer touches `jlink_netpacket.c` at all; that file is byte-identical to develop.

What's left are the two counter bugs, which #245 didn't cover.

## 1. `JLinkClose()` didn't reset the traffic counters

`jlink.h:46` documents them as *"Lifetime traffic counters (diagnostics; reset by JLinkClose)"*, but `JLinkClose()` only cleared mode/head/count. They accumulated across independent sessions and across tests sharing a process, so the netlink diagnostics reported traffic the current session never carried.

## 2. `JLinkRxTotal` measured the wrong side of the ring

`jlinkTxTotal++` sits in `JLinkSendByte()` — the transport boundary. `jlinkRxTotal++` sat in `JLinkRecvByte()` — the game draining the ring. The two counted opposite sides, so a peer's traffic stayed invisible until the game got round to reading it, and the pair was never comparable.

RX is now counted on arrival in `JLinkRingPush()`. A byte dropped because the ring was full is deliberately **not** counted, so the total stays consistent with what a reader can actually see.

Checked that nothing asserts on the old semantics before changing them — the only consumer is a diagnostic `fprintf` in `test/tools/netlink_game.c`.

Plus a `socket()` failure guard in the test helper `hub_connect_peer()`.

## Tests

Three regression tests added to `test/test_jlink.c`:

- `close resets tx total` / `close resets rx total`
- `rx counted on arrival, before any read` + `draining the ring does not re-count it`
- the drop path: 300 sends → `tx 300`, `rx 256`

`make TEST_EXPORTS=1 test` exits 0, c89-lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)