### PR TITLE
perf(net): flush netpacket TX per UART burst (fixes Wi-Fi netplay lag)

### DIFF
--- a/src/jerry/jlink_netpacket.c
+++ b/src/jerry/jlink_netpacket.c
@@ -71,17 +71,22 @@ void JLinkNPQueueByte(uint8_t b)
    if (!npActive)
       return;
    if (npTxLen >= JLINK_NP_TXBUF_SIZE)
-      return;   /* flush unavailable: drop rather than overflow */
+   {
+      /* Full: flush to make room — dropping link bytes risks a game
+         desync.  Only drop if the flush couldn't drain (inconsistent
+         state; cannot happen for an active session). */
+      JLinkNPFlush();
+      if (npTxLen >= JLINK_NP_TXBUF_SIZE)
+         return;
+   }
    npTxBuf[npTxLen++] = b;
    /* No flush here: the UART flushes at burst end (transmit shift
       register drains with nothing queued), which keeps mid-frame tic
       exchanges sub-millisecond WITHOUT emitting one reliable packet
       per byte.  Per-byte packets were fine on localhost but caused
       visible lag over real Wi-Fi (per-packet overhead on every byte
-      of every tic).  Safety nets: buffer-full flush below, and the
+      of every tic).  Safety nets: the flush-on-full above and the
       per-frame flush in JLinkPoll/JLinkNPPoll. */
-   if (npTxLen >= JLINK_NP_TXBUF_SIZE)
-      JLinkNPFlush();
 }
 
 /* Pump the frontend for incoming packets mid-frame (the receive

--- a/src/jerry/jlink_netpacket.c
+++ b/src/jerry/jlink_netpacket.c
@@ -73,12 +73,15 @@ void JLinkNPQueueByte(uint8_t b)
    if (npTxLen >= JLINK_NP_TXBUF_SIZE)
       return;   /* flush unavailable: drop rather than overflow */
    npTxBuf[npTxLen++] = b;
-   /* Flush immediately: link games run request/response tic exchanges
-      and spin for the reply mid-frame.  Batching to frame boundaries
-      turned each exchange into >= 1 frame of latency (Doom deathmatch
-      ran in slow motion); per-byte reliable packets are cheap on the
-      LAN links netplay targets. */
-   JLinkNPFlush();
+   /* No flush here: the UART flushes at burst end (transmit shift
+      register drains with nothing queued), which keeps mid-frame tic
+      exchanges sub-millisecond WITHOUT emitting one reliable packet
+      per byte.  Per-byte packets were fine on localhost but caused
+      visible lag over real Wi-Fi (per-packet overhead on every byte
+      of every tic).  Safety nets: buffer-full flush below, and the
+      per-frame flush in JLinkPoll/JLinkNPPoll. */
+   if (npTxLen >= JLINK_NP_TXBUF_SIZE)
+      JLinkNPFlush();
 }
 
 /* Pump the frontend for incoming packets mid-frame (the receive

--- a/src/jerry/uart.c
+++ b/src/jerry/uart.c
@@ -87,6 +87,13 @@ void UARTTXCallback(void)
       if (asiCtrl & ASICTRL_TINTEN)
          UARTRaiseIRQ();
    }
+   else
+   {
+      /* Burst finished (shift drained, nothing queued): push the
+         batched transport bytes out NOW so a mid-frame tic exchange
+         gets sub-millisecond latency as one packet per burst. */
+      JLinkPump();
+   }
    UARTKickRx();
 }
 


### PR DESCRIPTION
Play-testing iOS↔macOS Doom over RetroArch netplay showed lag on Wi-Fi that localhost sessions never had. Cause: the #244 latency fix flushed every UART byte as its own RELIABLE netpacket — free on loopback, but a ~10-byte tic burst became ~10 packets per tic over the air (per-packet overhead, potential Nagle/delayed-ACK interaction on the netplay transport).

Now the UART pumps the transport at **burst end** — when the transmit shift register drains with nothing queued — so each game tic goes out as one packet with the same sub-millisecond mid-frame latency. Buffer-full and per-frame flushes remain as safety nets; TCP mode gains a prompt burst-end RX drain for free.

## Test plan
- [x] Full suite green (netpacket fake-frontend asserts both bytes of a 2-byte burst arrive in order — now as one packet)
- [x] c89-lint clean
- [ ] Human re-test: iOS↔macOS Doom netplay lag on Wi-Fi

🤖 Generated with [Claude Code](https://claude.com/claude-code)