### PR TITLE
fix(cd): walk HLE sync runs across sector boundaries (fixes #243)

### DIFF
--- a/src/cd/jagcd_hle.c
+++ b/src/cd/jagcd_hle.c
@@ -813,32 +813,100 @@ static void HLEHandleCDRead(void)
                continue;  /* stray match — keep searching for a real sync block */
             }
 
-            /* Sync block confirmed.  Scan forward across sector boundaries
-             * to find where the sentinel pattern ends. */
-            scanLBA = scan_base + s;
-            scanOff = j;  /* first non-sentinel byte in current sector */
-
-            /* If the sync block extends to the end of this sector, keep
-             * scanning subsequent sectors. */
-            while (scanOff >= 2352)
+            /* Sync block confirmed.  Walk the run to its end, treating
+             * the disc as a continuous byte stream.
+             *
+             * A sync run can straddle sector boundaries, and when its
+             * start is not longword-aligned the last offset a sector can
+             * test is 2348..2351 — the walk then stops with scanOff
+             * BELOW 2352 while the run continues in the next sector.
+             * The old `while (scanOff >= 2352)` continuation guard only
+             * fired on an exact boundary landing, so those runs ended
+             * early: Vid Grid (USA) (Rev 1) stopped at offset 2350 with
+             * 8 sentinel longwords still to come, prepending 32 stray
+             * 'ATRI' bytes to the payload.  Its loader compares
+             * 'HEADER ATRI!' at dest+20 (`cmpm.b` x12 at $004208) and
+             * re-issues the entire read forever when that misses. */
             {
-               scanLBA++;
-               scanOff = 0;
-               if (!CDIntfReadBlock(scanLBA, sectorBuf))
-                  break;
-               for (i = 0; i + 1 < 2352; i += 2)
+               uint8_t  nextBuf[2352];
+               bool     haveNext = false;
+               bool     readOK   = true;
+
+               scanLBA = scan_base + s;
+               scanOff = j;
+
+               while (readOK)
                {
-                  uint8_t tmp2 = sectorBuf[i];
-                  sectorBuf[i]     = sectorBuf[i + 1];
-                  sectorBuf[i + 1] = tmp2;
-               }
-               /* Advance past continuing sentinel matches */
-               while (scanOff + 3 < 2352 &&
-                      sectorBuf[scanOff]   == pat[0] && sectorBuf[scanOff+1] == pat[1] &&
-                      sectorBuf[scanOff+2] == pat[2] && sectorBuf[scanOff+3] == pat[3])
+                  uint8_t  lw[4];
+                  uint32_t k;
+
+                  /* Normalize to a sector-local offset, loading sectors
+                   * as the run crosses them. */
+                  while (scanOff >= 2352)
+                  {
+                     scanOff -= 2352;
+                     scanLBA++;
+                     haveNext = false;
+                     if (!CDIntfReadBlock(scanLBA, sectorBuf))
+                     {
+                        readOK = false;
+                        break;
+                     }
+                     for (i = 0; i + 1 < 2352; i += 2)
+                     {
+                        uint8_t t        = sectorBuf[i];
+                        sectorBuf[i]     = sectorBuf[i + 1];
+                        sectorBuf[i + 1] = t;
+                     }
+                  }
+                  if (!readOK)
+                     break;
+
+                  /* Fetch the longword at scanOff, spanning into the
+                   * following sector when fewer than 4 bytes remain. */
+                  for (k = 0; k < 4; k++)
+                  {
+                     uint32_t off = scanOff + k;
+
+                     if (off < 2352)
+                     {
+                        lw[k] = sectorBuf[off];
+                        continue;
+                     }
+                     if (!haveNext)
+                     {
+                        if (!CDIntfReadBlock(scanLBA + 1, nextBuf))
+                        {
+                           readOK = false;
+                           break;
+                        }
+                        for (i = 0; i + 1 < 2352; i += 2)
+                        {
+                           uint8_t t      = nextBuf[i];
+                           nextBuf[i]     = nextBuf[i + 1];
+                           nextBuf[i + 1] = t;
+                        }
+                        haveNext = true;
+                     }
+                     lw[k] = nextBuf[off - 2352];
+                  }
+                  if (!readOK)
+                     break;
+
+                  if (lw[0] != pat[0] || lw[1] != pat[1] ||
+                      lw[2] != pat[2] || lw[3] != pat[3])
+                     break;               /* first non-sentinel byte */
+
                   scanOff += 4;
-               if (scanOff < 2352)
-                  break;  /* found non-sentinel data in this sector */
+                  matchCount++;
+               }
+
+               /* Leave (scanLBA, scanOff) sector-local for the streamer. */
+               while (scanOff >= 2352)
+               {
+                  scanOff -= 2352;
+                  scanLBA++;
+               }
             }
             foundSentinel = true;
             HLE_LOG("CD_read: sync block (%u+ matches) ends at "


### PR DESCRIPTION
Fixes #243.

## Root cause

`Vid Grid (USA) (Rev 1)` livelocked in HLE mode, re-issuing a byte-identical `CD_read` forever. The transfer was correct — it just **started 32 bytes too early**.

`CD_read` finds the sentinel sync block, walks forward to the first non-sentinel byte, and streams from there. That walk was per-sector and only continued into the next sector when the run ended *exactly* on a boundary:

```c
while (scanOff >= 2352) { ... }
```

When the run start is not longword-aligned, the last offset a sector can test is 2348..2351 — so the inner match loop exits with `scanOff` **below** 2352 while the run continues in the next sector. The guard never fired and the walk stopped mid-run.

Rev 1 hits it precisely: the walk stopped at LBA 13168 offset 2350 with 8 sentinel longwords still to come, prepending 32 stray `ATRI` bytes:

```
$00FFE0: ATRIATRIATRIATRI ATRIATRIATRIATRI   <- 32 stray bytes
$010000: ATARI APPROVED DATA HEADER ATRI!    <- should have started at dest
```

Its loader validates the payload with a 12-byte compare at `$004208`:

```
$004208:  LEA     $0000FFF4,A0      ; dest+20
$00420E:  LEA     $00004D68,A1      ; 'HEADER ATRI!'
$004214:  MOVEQ   #11,D0
$004216:  CMPM.B  (A0)+,(A1)+
$004218:  BNE.S   $004220           ; -> ADDI.L #1,$4D64 ; BRA $004136 (reload)
$00421A:  DBRA    D0,$004216
```

With the payload shifted, the tag sat at `dest+52`, the compare missed, and it branched back to reload. The failure counter `$4D64` reached 5 (one per completed-then-rejected transfer) while the poll-loop timeout counters `$4D58`/`$4D5C` stayed 0 — the completion handshake was always fine.

The other two Vid Grid revisions ship a larger loader (`$1BD0` vs `$D88`) without that check, which is why only Rev 1 surfaced it.

## Fix

Walk the run as a continuous byte stream: normalize whole sectors as they're crossed, and fetch each candidate longword *across* the boundary when fewer than 4 bytes remain in the current sector.

## Testing

35-disc CUE/BIN corpus:

| | before | after |
|---|---|---|
| HLE | 21 pass / 14 fail | **22 pass / 13 fail** |
| BIOS | 35 pass / 0 fail | 35 pass / 0 fail |

The HLE pass/fail set diff is **exactly one line** — `Vid Grid (USA) (Rev 1)` `FAIL` → `PASS`. No other disc changed state. BIOS mode is untouched (it doesn't use this scan).

- [x] `make TEST_EXPORTS=1 test` — exit 0
- [x] `scripts/c89-lint.sh` clean
- [x] Rev 1 reaches `final_pc=$01BFF4` / `unique_pcs=56`, matching BIOS mode's `$01BF9C` / 68, and proceeds into its game-data loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)