### PR TITLE
fix(cd): Memory Track support — address map, gating, and NVM BIOS (#258)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -757,7 +757,7 @@ clean:
 		test/test_audio_dac test/test_blitter \
 		test/test_state_compat test/test_frontend_pacing \
 		test/dump_pc test/heap_search \
-		test/tools/test_memory_map test/tools/test_option_visibility test/test_memtrack test/tools/test_dsp_audio_diag \
+		test/tools/test_memory_map test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/tools/test_dsp_audio_diag \
 		test/tools/test_frame_timing
 
 # Self-contained unit tests (parser + list management + simulated
@@ -807,7 +807,7 @@ test: test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp 
 		test/test_cart_format \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap \
 		test/test_audio_dac test/test_blitter \
-		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_uart_core test/test_netlink_host \
+		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
 		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy
 	./test/test_cheat
 	./test/test_event_queue
@@ -890,6 +890,7 @@ test: test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp 
 	./test/test_audio_dac
 	./test/tools/test_memory_map ./$(TARGET)
 	./test/test_memtrack
+	./test/test_nvmbios
 	@# Option visibility is content-type dependent; the disc half runs only
 	@# when a private CD image is available (the cart half always runs).
 	@# Prefer a disc known to load (see docs/cd-boot-matrix.md); fall back to
@@ -1080,6 +1081,11 @@ test/test_audio_presence: test/test_audio_presence.c
 test/test_memtrack: test/test_memtrack.c src/core/memtrack.c src/core/memtrack.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_memtrack.c src/core/memtrack.c -lm
+
+test/test_nvmbios: test/test_nvmbios.c src/core/nvmbios.c src/core/nvmbios.h \
+		src/core/memtrack.c src/core/memtrack.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_nvmbios.c src/core/nvmbios.c src/core/memtrack.c -lm
 
 test/tools/test_memory_map: test/tools/test_memory_map.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -757,7 +757,7 @@ clean:
 		test/test_audio_dac test/test_blitter \
 		test/test_state_compat test/test_frontend_pacing \
 		test/dump_pc test/heap_search \
-		test/tools/test_memory_map test/tools/test_option_visibility test/tools/test_dsp_audio_diag \
+		test/tools/test_memory_map test/tools/test_option_visibility test/test_memtrack test/tools/test_dsp_audio_diag \
 		test/tools/test_frame_timing
 
 # Self-contained unit tests (parser + list management + simulated
@@ -807,7 +807,7 @@ test: test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp 
 		test/test_cart_format \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap \
 		test/test_audio_dac test/test_blitter \
-		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_uart_core test/test_netlink_host \
+		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_uart_core test/test_netlink_host \
 		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy
 	./test/test_cheat
 	./test/test_event_queue
@@ -889,6 +889,7 @@ test: test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp 
 	./test/test_cart_format ./$(TARGET)
 	./test/test_audio_dac
 	./test/tools/test_memory_map ./$(TARGET)
+	./test/test_memtrack
 	@# Option visibility is content-type dependent; the disc half runs only
 	@# when a private CD image is available (the cart half always runs).
 	@# Prefer a disc known to load (see docs/cd-boot-matrix.md); fall back to
@@ -1075,6 +1076,10 @@ test/test_audio_clipping: test/test_audio_clipping.c
 test/test_audio_presence: test/test_audio_presence.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_audio_presence.c -ldl -lm
+
+test/test_memtrack: test/test_memtrack.c src/core/memtrack.c src/core/memtrack.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_memtrack.c src/core/memtrack.c -lm
 
 test/tools/test_memory_map: test/tools/test_memory_map.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile.common
+++ b/Makefile.common
@@ -57,6 +57,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/jerry/joystick.c \
 	$(CORE_DIR)/src/core/settings.c \
 	$(CORE_DIR)/src/core/memtrack.c \
+	$(CORE_DIR)/src/core/nvmbios.c \
 	$(CORE_DIR)/src/core/vjag_memory.c \
 	$(CORE_DIR)/src/core/universalhdr.c \
 	$(CORE_DIR)/src/jerry/wavetable.c

--- a/docs/memory-track.md
+++ b/docs/memory-track.md
@@ -1,0 +1,134 @@
+# Memory Track (Jaguar CD save cartridge)
+
+The Memory Track is a 128 KB flash cartridge, sold separately in 1995, that
+plugs into the Jaguar's cartridge slot **while the CD unit sits on top** — the
+CD drive has its own pass-through slot. CD games use it to save settings,
+progress and high scores.
+
+Neither the Jaguar Technical Reference Manual nor the official SDK documents
+it. Everything below was reconstructed from two projects, with thanks:
+
+- **[cubanismo/skunk_mtrk](https://github.com/cubanismo/skunk_mtrk)** —
+  preserves the **original Atari NVM BIOS v1.01 68K source** (`asmnvm.s`) and
+  its February 1995 specification, *"Non Volatile Memory - Bios calls"*.
+  Released by James Jones under CC0-1.0.
+- **[MiSTer-devel/Jaguar_MiSTer](https://github.com/MiSTer-devel/Jaguar_MiSTer)** —
+  `Jaguar.sv` carries the flash detection protocol and address map in
+  comments. The only known-working open-source hardware implementation.
+
+BizHawk's Jaguar core is a Virtual Jaguar port and shares our original gaps.
+
+## Two layers
+
+Games do **not** talk to the flash chip. They call a RAM-resident BIOS module,
+which talks to the flash. Both layers have to work.
+
+### Layer 1 — the flash device
+
+| what | where |
+|---|---|
+| NVRAM data | **`$900000`–`$91FFFF`** (128 KB, plain 16-bit window) |
+| Unlock addr 1 | `$815554` (`$800000 + 4*$5555`) |
+| Unlock addr 2 | `$80AAA8` (`$800000 + 4*$2AAA`) |
+| Manufacturer ID | `$800000` → `$1F` (ATMEL) or `$01` (AMD) |
+| Device ID | `$800004` → `$D5` (AT29C010) or `$20` (AM29F010) |
+
+Unlock sequence: `$AA` → `$815554`, `$55` → `$80AAA8`, then a command to
+`$815554` — `$90` enters ID mode ("override memtrack flash in place of cart
+rom"), `$F0` undoes it, `$A0` enables writes. After the unlock write,
+`$80AAA8` reads back `$0055` (the "ROMULATOR" probe).
+
+Two things that are easy to get wrong, and that we had wrong:
+
+- **The save data is not in the `$8xxxxx` ROM window.** It is at `$900000`.
+  Mapping it over `$8xxxxx` collides with the CD BIOS.
+- **There is no MEMCON1/ROMWIDTH gating.** A plain cartridge sits at ROMWIDTH 2
+  as its *normal* width, and CD content runs at ROMWIDTH 0 — so a ROMWIDTH test
+  makes the device unreachable for discs. MiSTer gates purely on presence. The
+  device must instead claim only its own addresses so everything else still
+  reads the cartridge ROM or CD BIOS (`MTClaimsRead`/`MTClaimsWrite` in
+  `src/core/memtrack.c`).
+
+### Layer 2 — the NVM BIOS module
+
+The CD BIOS boot copies a 2 KB module from the cartridge into RAM:
+
+- **`$2400`** — magic cookie `'_NVM'` (`$5F4E564D`). This is how games detect
+  the cartridge. Vid Grid's check is at `$012B72`: `cmpi.l #'_NVM',$2400.w`.
+- **`$2404`** — dispatcher. `JSR` with an opcode and args on the stack.
+
+Opcodes: 0 Initialize, 1 Create, 2 Open, 3 Close, 4 Delete, 5 Read, 6 Write,
+7 SearchFirst, 8 SearchNext, 9 Seek, 10 Inquire. All return a 32-bit value in
+`D0`; negative means error (`ENOINIT` −1, `ENOSPC` −2, `EFILNF` −3, `EINVFN`
+−4, `ERANGE` −5, `ENFILES` −6, `EIHNDL` −7).
+
+`Initialize` must be called first and takes the application name plus a 16 KB
+scratch buffer the module may trash.
+
+#### On-cart filesystem
+
+- 512-byte blocks, 256 total. Blocks 0–7 (first 4 KB) are system.
+- Block 0 is the FAT — one byte per block: `0` free, `1` end-of-chain, `2`
+  empty file, otherwise the next block.
+- Blocks 1–7 are the directory: 199 entries × 18 bytes —
+  `startblock`(1) `numblocks`(1) `appname`(10) `filename`(6).
+- Names pack 3 characters per 16-bit word from a 40-character set
+  (`A-Z`, `0-9`, `:`, `'`, `.`, space); app names ≤ 15 chars, file names ≤ 9.
+  Anything outside the set packs as space.
+- Byte 0–1 of block 0 is a 16-bit checksum of bytes 2..511; byte 3 is the
+  used-block count.
+- A file is identified by **app name + file name**, so two games can use the
+  same file name without colliding.
+
+#### Quirks worth preserving
+
+Games were written against the shipped module, so `src/core/nvmbios.c` keeps
+its behaviour rather than an idealised version:
+
+- **A bad checksum silently reformats** the FAT and directory and reports
+  success — which is how a blank cartridge self-formats on first use.
+- **Delete always reports success.** The module recalculates the checksum
+  afterwards, clobbering `D0`, so even a missing file returns non-negative.
+- **Close does no handle validation.**
+- Only **3 file handles** exist; a 4th `Open` returns `ENFILES`.
+- `file_offset` reports `ERANGE` for offset 0 on a zero-length file (an
+  acknowledged bug in the original).
+
+## In this core
+
+| piece | file |
+|---|---|
+| Flash device + address claims | `src/core/memtrack.c` |
+| NVM BIOS module (HLE) | `src/core/nvmbios.c` |
+| Presence flag, dispatcher hook | `src/core/jaguar.c` |
+| Option, install, save wiring | `libretro.c` |
+
+Presence is CD content (or an explicitly loaded MT cart dump). The core option
+`virtualjaguar_memory_track` (default enabled) lets you emulate a console
+without the cartridge — games then warn that information cannot be saved,
+which is correct hardware behaviour.
+
+The dispatcher is hooked in the same pre-instruction callback the CD HLE jump
+table uses, and runs in **both** boot modes: the module is RAM-resident on
+hardware regardless of which CD BIOS booted the disc.
+
+Save data lives in the CD save buffer alongside the cart and CD EEPROM banks,
+so it round-trips through the frontend's `.srm`.
+
+## Tests
+
+- `test/test_memtrack.c` — flash device: address claims (including that the
+  CD BIOS at `$800000` is *not* swallowed), ID reporting, write-enable gating,
+  full 128 KB addressability without aliasing.
+- `test/test_nvmbios.c` — filesystem: round trips, app-scoped naming, handle
+  exhaustion, search, inquire accounting, every error code, and each quirk
+  above.
+
+Both run in `make test` and need no ROMs.
+
+## Status
+
+Vid Grid (USA) (Rev 1) is the first title confirmed to use it — it boots into
+its level-select with a working Save option in both boot modes. Other CD
+titles have not been individually surveyed; a title that never calls the
+module simply never sees a cartridge, which is also what happens on hardware.

--- a/exports-test.list
+++ b/exports-test.list
@@ -60,3 +60,5 @@ _BlitterCompare*
 _DAC*
 _JoystickState*
 _MTState*
+_NVMBios*
+_NVM_*

--- a/libretro.c
+++ b/libretro.c
@@ -1329,6 +1329,7 @@ bool retro_load_game(const struct retro_game_info *info)
     * if present, embedded otherwise) so ResolveBootConfig can pick the
     * right boot strategy. */
    jaguar_cd_mode            = false;
+   jaguarMemTrackInserted    = false;
    cd_image_path[0]          = '\0';
    cd_bios_loaded_externally = false;
 
@@ -1337,6 +1338,9 @@ bool retro_load_game(const struct retro_game_info *info)
                               || has_extension(info->path, "iso")))
    {
       jaguar_cd_mode = true;
+      /* Hardware has the Memory Track cart in the slot alongside the CD
+       * unit; MEMCON1 ROMWIDTH arbitrates which one answers in cart space. */
+      jaguarMemTrackInserted = true;
       strncpy(cd_image_path, info->path, sizeof(cd_image_path) - 1);
       cd_image_path[sizeof(cd_image_path) - 1] = '\0';
 
@@ -1463,6 +1467,7 @@ void retro_unload_game(void)
    retro_cheat_reset();
    CDIntfCloseImage();
    jaguar_cd_mode    = false;
+   jaguarMemTrackInserted = false;
    cd_image_path[0]  = '\0';
    /* Content type is unknown again — restore the full option list. */
    content_loaded    = false;

--- a/libretro.c
+++ b/libretro.c
@@ -102,9 +102,15 @@ extern void (*eeprom_dirty_cb)(void);
 #define EEPROM_SAVE_SIZE    128  /* 64 x 16-bit words, big-endian */
 #define CD_EEPROM_SAVE_SIZE 128  /* CD EEPROM: 64 x 16-bit words */
 #define MT_SAVE_SIZE        0x20000  /* 128K Memory Track */
-static uint8_t eeprom_save_buf[EEPROM_SAVE_SIZE + CD_EEPROM_SAVE_SIZE];
+/* CD content carries the EEPROM pair AND a Memory Track, so its save buffer
+ * is the two EEPROM banks followed by the MT NVRAM.  Keeping the EEPROMs
+ * first means the layout stays a prefix of the cart/CD-EEPROM-only one. */
+#define CD_SAVE_SIZE        (EEPROM_SAVE_SIZE + CD_EEPROM_SAVE_SIZE + MT_SAVE_SIZE)
+static uint8_t eeprom_save_buf[EEPROM_SAVE_SIZE + CD_EEPROM_SAVE_SIZE + MT_SAVE_SIZE];
+#define MT_SAVE_OFFSET      (EEPROM_SAVE_SIZE + CD_EEPROM_SAVE_SIZE)
 static void eeprom_pack_save_buf(void);
 static void eeprom_unpack_save_buf(void);
+static void mt_pack_save_buf(void);
 
 static retro_video_refresh_t video_cb;
 static retro_input_poll_t input_poll_cb;
@@ -992,7 +998,7 @@ bool retro_unserialize(const void *data, size_t size)
    buf += TOMStateLoad(buf);
    buf += CDROMStateLoad(buf, version);
    buf += JoystickStateLoad(buf);
-   buf += MTStateLoad(buf);
+   buf += MTStateLoad(buf, version);
    buf += DACStateLoad(buf, version);
    if (version >= STATE_VERSION_JERRY_UART)
       buf += UARTStateLoad(buf, version);
@@ -1324,6 +1330,7 @@ bool retro_load_game(const struct retro_game_info *info)
 
    /* Register EEPROM dirty callback so the save buffer stays in sync */
    eeprom_dirty_cb = eeprom_pack_save_buf;
+   mt_dirty_cb     = mt_pack_save_buf;
 
    /* Detect CD content (CUE/CDI/ISO) and stage a CD BIOS (external file
     * if present, embedded otherwise) so ResolveBootConfig can pick the
@@ -1489,6 +1496,7 @@ void retro_unload_game(void)
    game_height = 0;
 
    eeprom_dirty_cb = NULL;
+   mt_dirty_cb     = NULL;
    save_data_needs_unpack = false;
    memset(eeprom_save_buf, 0, sizeof(eeprom_save_buf));
 
@@ -1531,6 +1539,17 @@ static void eeprom_pack_save_buf(void)
       eeprom_save_buf[EEPROM_SAVE_SIZE + (i * 2) + 0] = cdrom_eeprom_ram[i] >> 8;
       eeprom_save_buf[EEPROM_SAVE_SIZE + (i * 2) + 1] = cdrom_eeprom_ram[i] & 0xFF;
    }
+   /* Memory Track NVRAM follows both EEPROM banks (CD content only). */
+   if (jaguar_cd_mode)
+      memcpy(eeprom_save_buf + MT_SAVE_OFFSET, mtMem, MT_SAVE_SIZE);
+}
+
+/* Mirror the Memory Track into the save buffer without repacking the EEPROMs
+ * -- MT writes are frequent enough during a save that the full pack would be
+ * wasteful, and the EEPROM banks are unaffected by them. */
+static void mt_pack_save_buf(void)
+{
+   memcpy(eeprom_save_buf + MT_SAVE_OFFSET, mtMem, MT_SAVE_SIZE);
 }
 
 /* Unpack the save buffer back into eeprom_ram[] and cdrom_eeprom_ram[].
@@ -1545,6 +1564,8 @@ static void eeprom_unpack_save_buf(void)
       cdrom_eeprom_ram[i] =
             ((uint16_t)eeprom_save_buf[EEPROM_SAVE_SIZE + (i * 2) + 0] << 8)
           |  eeprom_save_buf[EEPROM_SAVE_SIZE + (i * 2) + 1];
+   if (jaguar_cd_mode)
+      memcpy(mtMem, eeprom_save_buf + MT_SAVE_OFFSET, MT_SAVE_SIZE);
 }
 
 void *retro_get_memory_data(unsigned type)
@@ -1573,8 +1594,9 @@ size_t retro_get_memory_size(unsigned type)
       /* CD discs share the cart EEPROM with their CD-side EEPROM bank
        * (128 + 128 = 256 bytes).  Cart-only loads expose just the cart
        * EEPROM so existing per-game saves remain compatible. */
+      /* CD: cart EEPROM + CD EEPROM + Memory Track NVRAM. */
       if (jaguar_cd_mode)
-         return EEPROM_SAVE_SIZE + CD_EEPROM_SAVE_SIZE;
+         return CD_SAVE_SIZE;
       return EEPROM_SAVE_SIZE;
    }
    return 0;
@@ -1611,6 +1633,7 @@ void retro_deinit(void)
    sampleBuffer = NULL;
 
    eeprom_dirty_cb = NULL;
+   mt_dirty_cb     = NULL;
    save_data_needs_unpack = false;
    memset(eeprom_save_buf, 0, sizeof(eeprom_save_buf));
    videoWidth = 0;

--- a/libretro.c
+++ b/libretro.c
@@ -37,6 +37,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "tom.h"
 #include "eeprom.h"
 #include "memtrack.h"
+#include "nvmbios.h"
 #include "vjag_memory.h"
 #include "state.h"
 #include "log.h"
@@ -125,6 +126,8 @@ static bool save_data_needs_unpack = false;
 /* CD content state. The Tier 1 weak symbols for external_cd_bios[] and
  * cd_bios_loaded_externally are overridden by the strong definitions below. */
 static bool jaguar_cd_mode = false;
+/* Memory Track presence option (CD only); default on. */
+static bool opt_memory_track = true;
 static char cd_image_path[4096] = {0};
 bool cd_bios_loaded_externally = false;
 uint8_t external_cd_bios[0x40000];  /* 256 KB */
@@ -326,6 +329,7 @@ static bool update_option_visibility(void)
          "virtualjaguar_cd_boot_mode",
          "virtualjaguar_cd_read_speed",
          "virtualjaguar_cd_trace",
+         "virtualjaguar_memory_track",
       };
       bool show_cd_prev        = show_cd_options;
       bool show_cart_bios_prev = show_cart_bios_option;
@@ -560,6 +564,12 @@ static void check_variables(void)
       else
          vjs.hardwareTypeNTSC = true;
    }
+
+   var.key = "virtualjaguar_memory_track";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      opt_memory_track = (strcmp(var.value, "disabled") != 0);
 
    var.key = "virtualjaguar_cd_bios_type";
    var.value = NULL;
@@ -938,6 +948,7 @@ bool retro_serialize(void *data, size_t size)
    buf += CDROMStateSave(buf);
    buf += JoystickStateSave(buf);
    buf += MTStateSave(buf);
+   buf += NVMBiosStateSave(buf);
    buf += DACStateSave(buf);
    buf += UARTStateSave(buf);
 
@@ -999,6 +1010,10 @@ bool retro_unserialize(const void *data, size_t size)
    buf += CDROMStateLoad(buf, version);
    buf += JoystickStateLoad(buf);
    buf += MTStateLoad(buf, version);
+   if (version >= STATE_VERSION_MEMTRACK_OVERRIDE)
+      buf += NVMBiosStateLoad(buf);
+   else
+      NVMBiosReset();
    buf += DACStateLoad(buf, version);
    if (version >= STATE_VERSION_JERRY_UART)
       buf += UARTStateLoad(buf, version);
@@ -1345,9 +1360,10 @@ bool retro_load_game(const struct retro_game_info *info)
                               || has_extension(info->path, "iso")))
    {
       jaguar_cd_mode = true;
-      /* Hardware has the Memory Track cart in the slot alongside the CD
-       * unit; MEMCON1 ROMWIDTH arbitrates which one answers in cart space. */
-      jaguarMemTrackInserted = true;
+      /* Hardware has the Memory Track cart plugged in alongside the CD
+       * unit (user-selectable; some titles behave differently with one
+       * present). */
+      jaguarMemTrackInserted = opt_memory_track;
       strncpy(cd_image_path, info->path, sizeof(cd_image_path) - 1);
       cd_image_path[sizeof(cd_image_path) - 1] = '\0';
 
@@ -1457,6 +1473,13 @@ bool retro_load_game(const struct retro_game_info *info)
    /* Content type is now known — refresh which options apply to it. */
    content_loaded = true;
    update_option_visibility();
+
+   /* Memory Track NVM BIOS module: on hardware the CD BIOS boot installs
+    * it in RAM before the game runs; do the same after the boot strategy
+    * has set RAM up. */
+   NVMBiosReset();
+   if (jaguarMemTrackInserted)
+      NVMBiosInstall();
 
    return true;
 }
@@ -1654,6 +1677,12 @@ void retro_deinit(void)
 void retro_reset(void)
 {
    JaguarReset();
+
+   /* Console reset re-runs the CD BIOS boot on hardware, which reinstalls
+    * the Memory Track NVM module. */
+   NVMBiosReset();
+   if (jaguarMemTrackInserted)
+      NVMBiosInstall();
 
    /* Re-blank the framebuffer, or the reset presents the PREVIOUS session's
     * pixels.  TOMReset puts tomWidth back to 0, and the border-fill path in

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -299,6 +299,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "2x"
    },
    {
+      "virtualjaguar_memory_track",
+      "Memory Track (Restart)",
+      NULL,
+      "Emulate the Memory Track save cartridge alongside the CD unit, as on real hardware. CD games detect it and save settings, progress and high scores to its 128 KB NVRAM (stored in the save file). Disable to emulate a console without the cartridge — games will warn that game information cannot be saved.",
+      NULL,
+      "cdrom",
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
       "virtualjaguar_alt_inputs",
       "Enable Core Options Remapping",
       NULL,

--- a/link-test.T
+++ b/link-test.T
@@ -63,5 +63,7 @@
       DAC*;
       JoystickState*;
       MTState*;
+      NVMBios*;
+      NVM_*;
    local: *;
 };

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include <stdio.h>
 #include "jaguar.h"
 #include "log.h"  /* CDDA-DIAG */
 
@@ -32,6 +33,7 @@
 #include "joystick.h"
 #include "m68000/m68kinterface.h"
 #include "memtrack.h"
+#include "nvmbios.h"
 #include "settings.h"
 #include "tom.h"
 
@@ -324,6 +326,12 @@ void M68KInstructionHook(void)
     * jagcd_hle.c instead of executing the cart bytes.  Returns true if the
     * hook handled the call (PC/registers updated). */
    if (JaguarCDHLEHook(m68kPC))
+      return;
+
+   /* Memory Track NVM BIOS dispatcher ($2404) — active for CD content in
+    * BOTH boot modes; the module is RAM-resident on hardware, independent
+    * of which CD BIOS variant booted the disc. */
+   if (NVMBiosHook(m68kPC))
       return;
 
    /* CD boot strategy hook (cart strategy is a no-op for cart games;

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -231,10 +231,32 @@ extern uint8_t jagMemSpace[];
 
 // Internal variables
 
+/* The Memory Track answers in cart space only at MEMCON1 ROMWIDTH 2
+ * (32-bit).  Note this is NOT an MT-specific mode -- a plain cartridge sits
+ * at ROMWIDTH 2 as its normal width, which is why the CRC test below did all
+ * the real work before presence was tracked separately.
+ *
+ * What makes it safe to enable MT for CD content is measured, not designed:
+ * across the 35-disc corpus in both boot modes, CD-mode cart reads only ever
+ * occur at ROMWIDTH 0, so the MT branch is never taken and the CD BIOS stays
+ * readable at $800000.  (Same sweep found no title touching the MT interface
+ * at all -- see #258 before assuming this path is exercised.)
+ *
+ * Presence itself is either an explicitly inserted MT cart dump (a cartridge
+ * whose CRC we recognise, the historical case) or CD content, where hardware
+ * would have the MT plugged in alongside the disc. */
+#define MEMTRACK_PRESENT() \
+   (jaguarMemTrackInserted || jaguarMainROMCRC32 == 0xFDF37F47)
+
 uint32_t jaguarMainROMCRC32, jaguarROMSize, jaguarRunAddress;
 uint32_t jaguarLoadedRAMStart, jaguarLoadedRAMEnd;
 
 bool jaguarCartInserted = false;
+/* Memory Track cartridge presence.  On hardware the MT cart plugs into the
+ * cartridge slot while the CD unit sits on top, so a disc and an MT cart are
+ * present at the same time -- a combination the old CRC-only gate below could
+ * never express.  Set for CD content; see JaguarReadWord(). */
+bool jaguarMemTrackInserted = false;
 bool lowerField = false;
 
 
@@ -385,7 +407,7 @@ unsigned int m68k_read_memory_16(unsigned int address)
    else if ((address >= 0x800000) && (address <= 0xDFFEFE))
    {
       /* Memory Track reading... */
-      if (((TOMGetMEMCON1() & 0x0006) == (2 << 1)) && (jaguarMainROMCRC32 == 0xFDF37F47))
+      if (((TOMGetMEMCON1() & 0x0006) == (2 << 1)) && MEMTRACK_PRESENT())
          return MTReadWord(address);
       else
          return (jaguarMainROM[address - 0x800000] << 8)
@@ -420,7 +442,7 @@ unsigned int m68k_read_memory_32(unsigned int address)
    else if ((address >= 0x800000) && (address <= 0xDFFEFE))
    {
       // Memory Track reading...
-      if (((TOMGetMEMCON1() & 0x0006) == (2 << 1)) && (jaguarMainROMCRC32 == 0xFDF37F47))
+      if (((TOMGetMEMCON1() & 0x0006) == (2 << 1)) && MEMTRACK_PRESENT())
          return MTReadLong(address);
 
       return GET32(jaguarMainROM, address - 0x800000);
@@ -501,7 +523,7 @@ void m68k_write_memory_16(unsigned int address, unsigned int value)
    /* Memory Track device writes.... */
    else if ((address >= 0x800000) && (address <= 0x87FFFE))
    {
-      if (((TOMGetMEMCON1() & 0x0006) == (2 << 1)) && (jaguarMainROMCRC32 == 0xFDF37F47))
+      if (((TOMGetMEMCON1() & 0x0006) == (2 << 1)) && MEMTRACK_PRESENT())
          MTWriteWord(address, value);
    }
    else if ((address >= 0xDFFF00) && (address <= 0xDFFFFE))

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -231,20 +231,21 @@ extern uint8_t jagMemSpace[];
 
 // Internal variables
 
-/* The Memory Track answers in cart space only at MEMCON1 ROMWIDTH 2
- * (32-bit).  Note this is NOT an MT-specific mode -- a plain cartridge sits
- * at ROMWIDTH 2 as its normal width, which is why the CRC test below did all
- * the real work before presence was tracked separately.
+/* Memory Track presence: an explicitly inserted MT cart dump (a cartridge
+ * whose CRC we recognise) or CD content, where hardware would have the MT
+ * plugged into the cartridge slot alongside the CD unit.
  *
- * What makes it safe to enable MT for CD content is measured, not designed:
- * across the 35-disc corpus in both boot modes, CD-mode cart reads only ever
- * occur at ROMWIDTH 0, so the MT branch is never taken and the CD BIOS stays
- * readable at $800000.  (Same sweep found no title touching the MT interface
- * at all -- see #258 before assuming this path is exercised.)
+ * There is deliberately NO MEMCON1/ROMWIDTH test here.  The old code gated on
+ * ROMWIDTH == 2 on the theory that the width switch selected the MT; it does
+ * not -- a plain cartridge sits at ROMWIDTH 2 as its normal width, and CD
+ * content runs at ROMWIDTH 0, so the test only ever made the device
+ * unreachable for discs.  The MiSTer core (the working reference, see
+ * memtrack.c) gates purely on presence.
  *
- * Presence itself is either an explicitly inserted MT cart dump (a cartridge
- * whose CRC we recognise, the historical case) or CD content, where hardware
- * would have the MT plugged in alongside the disc. */
+ * Safety comes instead from MTClaimsRead/MTClaimsWrite, which restrict the
+ * part to the $900000 NVRAM window plus a couple of override-only command
+ * addresses -- everything else in cart space still reads the cartridge ROM or
+ * the CD BIOS. */
 #define MEMTRACK_PRESENT() \
    (jaguarMemTrackInserted || jaguarMainROMCRC32 == 0xFDF37F47)
 
@@ -407,7 +408,7 @@ unsigned int m68k_read_memory_16(unsigned int address)
    else if ((address >= 0x800000) && (address <= 0xDFFEFE))
    {
       /* Memory Track reading... */
-      if (((TOMGetMEMCON1() & 0x0006) == (2 << 1)) && MEMTRACK_PRESENT())
+      if (MEMTRACK_PRESENT() && MTClaimsRead(address))
          return MTReadWord(address);
       else
          return (jaguarMainROM[address - 0x800000] << 8)
@@ -442,7 +443,7 @@ unsigned int m68k_read_memory_32(unsigned int address)
    else if ((address >= 0x800000) && (address <= 0xDFFEFE))
    {
       // Memory Track reading...
-      if (((TOMGetMEMCON1() & 0x0006) == (2 << 1)) && MEMTRACK_PRESENT())
+      if (MEMTRACK_PRESENT() && MTClaimsRead(address))
          return MTReadLong(address);
 
       return GET32(jaguarMainROM, address - 0x800000);
@@ -520,10 +521,13 @@ void m68k_write_memory_16(unsigned int address, unsigned int value)
    {
       SET16(jaguarMainRAM, address, value);
    }
-   /* Memory Track device writes.... */
-   else if ((address >= 0x800000) && (address <= 0x87FFFE))
+   /* Memory Track device writes: the flash command addresses live inside the
+    * $8xxxxx ROM window, but the NVRAM itself is a separate window at
+    * $900000 -- both have to be routed here or saves silently go nowhere. */
+   else if (((address >= 0x800000) && (address <= 0x87FFFE))
+            || ((address >= MT_DATA_BASE) && (address < MT_DATA_END)))
    {
-      if (((TOMGetMEMCON1() & 0x0006) == (2 << 1)) && MEMTRACK_PRESENT())
+      if (MEMTRACK_PRESENT() && MTClaimsWrite(address))
          MTWriteWord(address, value);
    }
    else if ((address >= 0xDFFF00) && (address <= 0xDFFFFE))

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -380,7 +380,11 @@ unsigned int m68k_read_memory_8(unsigned int address)
    if ((address >= 0x000000) && (address <= 0x1FFFFF))
       return jaguarMainRAM[address];
    else if ((address >= 0x800000) && (address <= 0xDFFEFF))
+   {
+      if (MEMTRACK_PRESENT() && MTClaimsRead(address))
+         return MTReadByte(address);
       return jaguarMainROM[address - 0x800000];
+   }
    else if ((address >= 0xE00000) && (address <= 0xE3FFFF))
       return jagMemSpace[address];
    else if ((address >= 0xDFFF00) && (address <= 0xDFFFFF))
@@ -500,6 +504,14 @@ void m68k_write_memory_8(unsigned int address, unsigned int value)
    // Note that the Jaguar only has 2M of RAM, not 4!
    if ((address >= 0x000000) && (address <= 0x1FFFFF))
       jaguarMainRAM[address] = value;
+   /* Memory Track byte writes: cart space is otherwise read-only, so this
+    * branch exists purely for the device (command window + NVRAM). */
+   else if (((address >= 0x800000) && (address <= 0x87FFFF))
+            || ((address >= MT_DATA_BASE) && (address < MT_DATA_END)))
+   {
+      if (MEMTRACK_PRESENT() && MTClaimsWrite(address))
+         MTWriteByte(address, (uint8_t)value);
+   }
    else if ((address >= 0xDFFF00) && (address <= 0xDFFFFF))
       CDROMWriteByte(address, value, M68K);
    else if ((address >= 0xF00000) && (address <= 0xF0FFFF))

--- a/src/core/jaguar.h
+++ b/src/core/jaguar.h
@@ -36,6 +36,7 @@ void JaguarExecuteNew(void);
 extern int32_t jaguarCPUInExec;
 extern char * jaguarEepromsPath;
 extern bool jaguarCartInserted;
+extern bool jaguarMemTrackInserted;
 extern bool bpmActive;
 extern uint32_t bpmAddress1;
 

--- a/src/core/memtrack.c
+++ b/src/core/memtrack.c
@@ -149,6 +149,37 @@ uint16_t MTReadWord(uint32_t addr)
 }
 
 
+/* Byte accessors.  The 68K reaches the device with move.b as readily as
+ * move.w -- the original NVM BIOS's Getbyte/Putbyte are byte operations --
+ * so these must exist or byte-granular drivers silently read cart ROM and
+ * write nowhere. */
+uint8_t MTReadByte(uint32_t addr)
+{
+	uint16_t w = MTReadWord(addr & ~1u);
+	return (addr & 1) ? (uint8_t)(w & 0xFF) : (uint8_t)(w >> 8);
+}
+
+
+void MTWriteByte(uint32_t addr, uint8_t data)
+{
+	if (addr >= MT_DATA_BASE && addr < MT_DATA_END)
+	{
+		if (mtCommand == MT_WRITE_ENABLE)
+		{
+			mtMem[(addr - MT_DATA_BASE) & (MT_MEM_SIZE - 1)] = data;
+			if (mt_dirty_cb)
+				mt_dirty_cb();
+		}
+		return;
+	}
+
+	/* A byte write to a command address carries the command in the low
+	 * byte; feed the state machine the same way a word write would. */
+	if (addr == MT_CMD_UNLOCK1 || addr == MT_CMD_UNLOCK2)
+		MTWriteWord(addr & ~1u, (uint16_t)data);
+}
+
+
 uint32_t MTReadLong(uint32_t addr)
 {
 	return ((uint32_t)MTReadWord(addr) << 16) | MTReadWord(addr + 2);

--- a/src/core/memtrack.c
+++ b/src/core/memtrack.c
@@ -7,12 +7,14 @@
 // The Memory Track is just a large(-ish) EEPROM, holding 128K. We emulate the
 // Atmel part, since it seems to be easier to deal with than the AMD part. The
 // way it works is the 68K checks in its R/W functions to see if the MT is
-// inserted, and, if so, call the R/W functions here. It also checks to see if
-// the ROM width was changed to 32-bit; if not, then it reads the normal ROM in
-// the ROM space like usual.
+// inserted, and, if so, call the R/W functions here.
 //
-// The Atmel part reads/writes a single byte into a long space. So we have to
-// adjust for that when reading from/writing to the NVRAM.
+// NOTE (2026): the two claims that used to follow here -- that the part is
+// selected by switching the ROM width to 32-bit, and that it reads/writes a
+// single byte into a long space in the $8xxxxx ROM window -- were both wrong,
+// and between them made the device unreachable for CD content (see #258 and
+// the MiSTer notes below).  The ROM-width test has no hardware counterpart,
+// and the NVRAM is a plain 16-bit window at $900000.
 //
 // JLH = James Hammons <jlhamm@acm.org>
 //
@@ -26,12 +28,39 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*
+ * Address map and detection protocol corrected in 2026 against the MiSTer
+ * Atari Jaguar core (https://github.com/MiSTer-devel/Jaguar_MiSTer), which is
+ * the only open-source implementation known to work -- the Jaguar TRM and the
+ * official SDK document none of this.  Jaguar.sv carries the 68K detection
+ * routine in comments; the relevant facts, with thanks to its authors:
+ *
+ *   - Unlock:  $AA -> $815554, $55 -> $80AAA8, then a command to $815554.
+ *              $90 = ID mode ("override memtrack flash in place of cart rom"),
+ *              $F0 = undo.
+ *   - In ID mode, $800000 reads the manufacturer ID and $800004 the device ID
+ *              (ATMEL $1F / AT29C010 $D5, or AMD $01 / AM29F010 $20).
+ *   - $80AAA8 reads back $0055 after the unlock write (the "ROMULATOR" probe).
+ *   - "Actual save data is at 9XXXXXX" -- the NVRAM window is $900000, NOT the
+ *              $8xxxxx ROM window.
+ *   - MiSTer gates purely on presence (`memtrack = (forced || cd_loaded) &&
+ *              memtrak_bios_exists`); there is no MEMCON1/ROMWIDTH condition
+ *              on hardware.
+ *
+ * Everything the part does not explicitly claim must read through to the
+ * normal cart ROM / CD BIOS, or a disc-based game loses its BIOS at $800000.
+ */
+
 enum { MT_NONE, MT_PROD_ID, MT_RESET, MT_WRITE_ENABLE };
 enum { MT_IDLE, MT_PHASE1, MT_PHASE2 };
 
 uint8_t mtMem[0x20000];
 uint8_t mtCommand = MT_NONE;
 uint8_t mtState = MT_IDLE;
+/* Set once the unlock write hits $80AAA8; makes that address read back $0055
+ * (MiSTer's memtrack_override1). */
+static uint8_t mtOverride1 = 0;
+void (*mt_dirty_cb)(void) = NULL;
 static int mt_initialized = 0;
 
 // Private function prototypes
@@ -57,6 +86,7 @@ void MTReset(void)
 	 * Only reset the command state machine. */
 	mtCommand = MT_NONE;
 	mtState = MT_IDLE;
+	mtOverride1 = 0;
 }
 
 
@@ -66,69 +96,92 @@ void MTDone(void)
 }
 
 
-/*
- * This is crappy, there doesn't seem to be a word interface to the NVRAM. But
- * we'll keep this as a placeholder for now.
- */
+/* The part only answers inside its own windows.  Anything else in cart space
+ * belongs to the cartridge ROM or the CD BIOS. */
+bool MTClaimsRead(uint32_t addr)
+{
+	if (addr >= MT_DATA_BASE && addr < MT_DATA_END)
+		return true;
+	/* ID reads are valid only while the unlock sequence has selected ID
+	 * mode -- outside it, $800000/$800004 are ordinary ROM. */
+	if (mtCommand == MT_PROD_ID && (addr == MT_ID_MANUF || addr == MT_ID_DEVICE))
+		return true;
+	if (mtOverride1 && addr == MT_CMD_UNLOCK2)
+		return true;
+
+	return false;
+}
+
+
+bool MTClaimsWrite(uint32_t addr)
+{
+	if (addr >= MT_DATA_BASE && addr < MT_DATA_END)
+		return true;
+	/* Command writes are always accepted: they are how the part is woken up
+	 * in the first place, and cart ROM is not writable anyway. */
+	if (addr == MT_CMD_UNLOCK1 || addr == MT_CMD_UNLOCK2)
+		return true;
+
+	return false;
+}
+
+
 uint16_t MTReadWord(uint32_t addr)
 {
-	uint32_t value = MTReadLong(addr);
+	if (addr >= MT_DATA_BASE && addr < MT_DATA_END)
+	{
+		uint32_t off = (addr - MT_DATA_BASE) & (MT_MEM_SIZE - 2);
+		return (uint16_t)((mtMem[off] << 8) | mtMem[off + 1]);
+	}
 
-	if ((addr & 0x03) == 0)
-		value >>= 16;
-	else if ((addr & 0x03) == 2)
-		value &= 0xFFFF;
+	if (mtOverride1 && addr == MT_CMD_UNLOCK2)
+		return 0x0055;
 
-	return (uint16_t)value;
+	if (mtCommand == MT_PROD_ID)
+	{
+		if (addr == MT_ID_MANUF)
+			return 0x001F;		/* ATMEL manufacturer ID */
+		if (addr == MT_ID_DEVICE)
+			return 0x00D5;		/* AT29C010 device ID */
+	}
+
+	return 0;
 }
 
 
 uint32_t MTReadLong(uint32_t addr)
 {
-	uint32_t value = 0;
-
-	if (mtCommand == MT_PROD_ID)
-	{
-		if (addr == 0x800000)
-			value = 0x1F;
-		else if (addr == 0x800004)
-			value = 0xD5;
-	}
-	else
-	{
-		value = (uint32_t)mtMem[(addr & 0x7FFFC) >> 2];
-	}
-
-	// We do this because we're not sure how the real thing behaves; but it
-	// seems reasonable on its face to do it this way. :-P So we turn off write
-	// mode when reading the NVRAM.
-	if (mtCommand == MT_WRITE_ENABLE)
-		mtCommand = MT_NONE;
-
-	return value << 16;
+	return ((uint32_t)MTReadWord(addr) << 16) | MTReadWord(addr + 2);
 }
 
 
 void MTWriteWord(uint32_t addr, uint16_t data)
 {
-	// We don't care about writes to long offsets + 2
-	if ((addr & 0x3) == 2)
-		return;
-
-	// Write to the NVRAM if it's enabled...
-	if (mtCommand == MT_WRITE_ENABLE)
+	if (addr >= MT_DATA_BASE && addr < MT_DATA_END)
 	{
-		mtMem[(addr & 0x7FFFC) >> 2] = (uint8_t)(data & 0xFF);
+		/* Writes only land once the unlock sequence has armed the part. */
+		if (mtCommand == MT_WRITE_ENABLE)
+		{
+			uint32_t off = (addr - MT_DATA_BASE) & (MT_MEM_SIZE - 2);
+			mtMem[off]     = (uint8_t)(data >> 8);
+			mtMem[off + 1] = (uint8_t)(data & 0xFF);
+			if (mt_dirty_cb)
+				mt_dirty_cb();
+		}
 		return;
 	}
 
 	switch (addr)
 	{
-	case (0x800000 + (4 * 0x5555)):		// $815554
+	case MT_CMD_UNLOCK1:
 		MTStateMachine(0, data);
 		break;
-	case (0x800000 + (4 * 0x2AAA)):		// $80AAA8
+	case MT_CMD_UNLOCK2:
 		MTStateMachine(1, data);
+		/* MiSTer latches this so the address reads back $0055 afterwards
+		 * (the ROMULATOR probe); it is never cleared by a later command. */
+		if (data == 0x0055)
+			mtOverride1 = 1;
 		break;
 	}
 }
@@ -187,17 +240,24 @@ size_t MTStateSave(uint8_t *buf)
 	STATE_SAVE_BUF(buf, mtMem, sizeof(mtMem));
 	STATE_SAVE_VAR(buf, mtCommand);
 	STATE_SAVE_VAR(buf, mtState);
+	STATE_SAVE_VAR(buf, mtOverride1);
 
 	return (size_t)(buf - start);
 }
 
-size_t MTStateLoad(const uint8_t *buf)
+size_t MTStateLoad(const uint8_t *buf, uint32_t version)
 {
 	const uint8_t *start = buf;
 
 	STATE_LOAD_BUF(buf, mtMem, sizeof(mtMem));
 	STATE_LOAD_VAR(buf, mtCommand);
 	STATE_LOAD_VAR(buf, mtState);
+	/* Pre-v7 states have no override flag; leave it clear so the part
+	 * simply re-probes rather than reading back a stale $0055. */
+	if (version >= STATE_VERSION_MEMTRACK_OVERRIDE)
+		STATE_LOAD_VAR(buf, mtOverride1);
+	else
+		mtOverride1 = 0;
 
 	return (size_t)(buf - start);
 }

--- a/src/core/memtrack.h
+++ b/src/core/memtrack.h
@@ -7,13 +7,36 @@
 
 #include <stdint.h>
 
+#include <stdbool.h>
+
 #define MT_MEM_SIZE 0x20000
 
+/* NVRAM data window.  The save area is NOT in the $8xxxxx ROM window -- it
+ * sits at $900000, which is why an implementation that maps it over the cart
+ * ROM never works alongside a CD BIOS. */
+#define MT_DATA_BASE 0x900000
+#define MT_DATA_END  (MT_DATA_BASE + MT_MEM_SIZE)   /* $920000 */
+
+/* Flash command/ID window (inside the ROM window, override-only). */
+#define MT_CMD_UNLOCK1 0x815554        /* $800000 + 4 * $5555 */
+#define MT_CMD_UNLOCK2 0x80AAA8        /* $800000 + 4 * $2AAA */
+#define MT_ID_MANUF    0x800000
+#define MT_ID_DEVICE   0x800004
+
 extern uint8_t mtMem[MT_MEM_SIZE];
+
+/* Called after any NVRAM write so the libretro layer can keep its
+ * RETRO_MEMORY_SAVE_RAM mirror current (mirrors eeprom_dirty_cb). */
+extern void (*mt_dirty_cb)(void);
 
 void MTInit(void);
 void MTReset(void);
 void MTDone(void);
+
+/* Does the Memory Track answer for this address at all?  Everything it does
+ * not claim must fall through to the normal cart ROM / CD BIOS. */
+bool MTClaimsRead(uint32_t addr);
+bool MTClaimsWrite(uint32_t addr);
 
 uint16_t MTReadWord(uint32_t addr);
 uint32_t MTReadLong(uint32_t addr);

--- a/src/core/memtrack.h
+++ b/src/core/memtrack.h
@@ -7,7 +7,7 @@
 
 #include <stdint.h>
 
-#include <stdbool.h>
+#include <boolean.h>
 
 #define MT_MEM_SIZE 0x20000
 

--- a/src/core/memtrack.h
+++ b/src/core/memtrack.h
@@ -38,6 +38,8 @@ void MTDone(void);
 bool MTClaimsRead(uint32_t addr);
 bool MTClaimsWrite(uint32_t addr);
 
+uint8_t  MTReadByte(uint32_t addr);
+void     MTWriteByte(uint32_t addr, uint8_t data);
 uint16_t MTReadWord(uint32_t addr);
 uint32_t MTReadLong(uint32_t addr);
 void MTWriteWord(uint32_t addr, uint16_t data);

--- a/src/core/nvmbios.c
+++ b/src/core/nvmbios.c
@@ -1,0 +1,797 @@
+/*
+ * nvmbios.c — HLE of the Memory Track "NVM BIOS" module.
+ *
+ * See nvmbios.h for the big picture.  Behaviour is transcribed from the
+ * Atari NVM BIOS v1.01 68K source (asmnvm.s, preserved in
+ * https://github.com/cubanismo/skunk_mtrk with thanks to James Jones for
+ * releasing it and to the MiSTer Jaguar core for the hardware notes that
+ * led there).  Where the original has quirks, we keep them — games were
+ * written against the quirks:
+ *
+ *   - Initialize on a cart with a bad first-block checksum silently
+ *     ZEROES the FAT + directory (first 4K) and reports success.  A
+ *     freshly-blank cart therefore self-formats on first use, and 510
+ *     zero bytes sum to the stored zero checksum, so no checksum write
+ *     is needed.
+ *   - Delete always reports success: the module recalculates the
+ *     checksum after the delete attempt, clobbering D0, so even a
+ *     missing file returns non-negative.  We return 0 unconditionally.
+ *   - Close performs no handle validation.
+ *   - Empty files are represented by startblock == FAT_EMPTYFILE (2)
+ *     with 0 blocks.
+ *   - Names use a 40-character set packed 3 chars/word; characters past
+ *     the terminator (and any character not in the set) pack as index 39
+ *     (space), and unpacking preserves the trailing spaces.
+ *
+ * All filesystem access goes straight to mtMem (the same 128K image the
+ * flash device exposes at $900000), so anything the module writes is
+ * what a real Memory Track dump would hold, and mt_dirty_cb keeps the
+ * libretro save buffer current.
+ */
+
+#include "nvmbios.h"
+#include "memtrack.h"
+#include "m68000/m68kinterface.h"
+
+#include <string.h>
+
+/* Kept to direct externs (not jaguar.h) so unit tests can link this file
+ * with a stub 68K and a bare RAM array.  NOTE: jaguarMainRAM is a POINTER
+ * (see vjag_memory.h), not an array — declaring it as an array here would
+ * silently write into the data segment at the pointer variable itself. */
+extern uint8_t *jaguarMainRAM;
+extern bool jaguarMemTrackInserted;
+
+/* --------------------------------------------------------------------
+ * Module state (the original keeps this in its BSS at $2400+; ours
+ * lives host-side and is save-stated via NVMBiosStateSave/Load).
+ * -------------------------------------------------------------------- */
+
+typedef struct
+{
+   uint16_t startblock;   /* 0 = handle free/closed */
+   uint32_t offset;
+} nvm_handle;
+
+static bool     nvm_initialized = false;    /* Initialize called */
+static uint16_t nvm_appname[NVM_APPPACKSIZE];
+static nvm_handle nvm_handles[NVM_NUMFILES];
+static uint16_t nvm_search_location = 0;
+static uint16_t nvm_search_flags = 0;
+
+/* FAT entry values */
+#define FAT_FREE      0
+#define FAT_END       1
+#define FAT_EMPTYFILE 2
+
+/* NVRAM byte offsets */
+#define CHKSUM_OFFSET    0
+#define USEDSPACE_OFFSET 3
+
+/* --------------------------------------------------------------------
+ * NVRAM byte access — mtMem is the logical byte space.
+ * -------------------------------------------------------------------- */
+
+static uint8_t nv_get(uint32_t addr)
+{
+   return mtMem[addr & (MT_MEM_SIZE - 1)];
+}
+
+static void nv_put(uint32_t addr, uint8_t val)
+{
+   mtMem[addr & (MT_MEM_SIZE - 1)] = val;
+}
+
+static void nv_flush(void)
+{
+   if (mt_dirty_cb)
+      mt_dirty_cb();
+}
+
+/* 16-bit sum of bytes 2..511, the module's first-block checksum. */
+static uint16_t calc_chksum(void)
+{
+   uint32_t a;
+   uint16_t sum = 0;
+   for (a = 2; a < NVM_BLOCKSIZE; a++)
+      sum += nv_get(a);
+   return sum;
+}
+
+static void set_chksum(void)
+{
+   uint16_t sum = calc_chksum();
+   nv_put(CHKSUM_OFFSET,     (uint8_t)(sum >> 8));
+   nv_put(CHKSUM_OFFSET + 1, (uint8_t)(sum & 0xFF));
+}
+
+/* --------------------------------------------------------------------
+ * Packed names: 40-character set, 3 chars per word.
+ * -------------------------------------------------------------------- */
+
+static const char nvm_charset[40] =
+   "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:'. ";
+
+/* One character to its 5-ish-bit index (fivebit in the original). */
+static uint16_t nvm_charindex(char c)
+{
+   int i;
+   if (c >= 'a' && c <= 'z')
+      return (uint16_t)(c - 'a');
+   for (i = 0; i < 39; i++)
+      if (nvm_charset[i] == c)
+         return (uint16_t)i;
+   return 39;                       /* not in set -> space */
+}
+
+/* ascii2pack: chars past the NUL pack as space (39). */
+static void ascii2pack(const char *src, uint16_t *dst, unsigned words)
+{
+   unsigned w;
+   bool eos = false;
+   for (w = 0; w < words; w++)
+   {
+      uint16_t packed = 0;
+      unsigned k;
+      for (k = 0; k < 3; k++)
+      {
+         uint16_t idx;
+         char c = eos ? '\0' : *src;
+         if (c == '\0')
+            eos = true;
+         idx = eos ? 39 : nvm_charindex(c);
+         if (!eos)
+            src++;
+         packed = (uint16_t)(packed * 40 + idx);
+      }
+      dst[w] = packed;
+   }
+}
+
+/* pack2ascii: trailing spaces are preserved, NUL-terminated. */
+static void pack2ascii(const uint16_t *src, char *dst, unsigned words)
+{
+   unsigned w;
+   for (w = 0; w < words; w++)
+   {
+      uint16_t v = src[w];
+      dst[w * 3 + 0] = nvm_charset[(v / 1600) % 40];
+      dst[w * 3 + 1] = nvm_charset[(v / 40) % 40];
+      dst[w * 3 + 2] = nvm_charset[v % 40];
+   }
+   dst[words * 3] = '\0';
+}
+
+/* --------------------------------------------------------------------
+ * Directory entries: 18 bytes at DIROFFSET + n*18.
+ *   [0] startblock  [1] numblocks  [2..11] appname  [12..17] filename
+ * -------------------------------------------------------------------- */
+
+typedef struct
+{
+   uint8_t  startblock;
+   uint8_t  numblocks;
+   uint16_t appname[NVM_APPPACKSIZE];
+   uint16_t filename[NVM_FILEPACKSIZE];
+} nvm_dirent;
+
+static void fetch_dir(unsigned n, nvm_dirent *d)
+{
+   uint32_t a = NVM_DIROFFSET + n * NVM_DIRENTRYSIZE;
+   unsigned i;
+   d->startblock = nv_get(a + 0);
+   d->numblocks  = nv_get(a + 1);
+   for (i = 0; i < NVM_APPPACKSIZE; i++)
+      d->appname[i] = (uint16_t)((nv_get(a + 2 + i * 2) << 8)
+                                 | nv_get(a + 3 + i * 2));
+   for (i = 0; i < NVM_FILEPACKSIZE; i++)
+      d->filename[i] = (uint16_t)((nv_get(a + 12 + i * 2) << 8)
+                                  | nv_get(a + 13 + i * 2));
+}
+
+static void put_dir(unsigned n, const nvm_dirent *d)
+{
+   uint32_t a = NVM_DIROFFSET + n * NVM_DIRENTRYSIZE;
+   unsigned i;
+   nv_put(a + 0, d->startblock);
+   nv_put(a + 1, d->numblocks);
+   for (i = 0; i < NVM_APPPACKSIZE; i++)
+   {
+      nv_put(a + 2 + i * 2, (uint8_t)(d->appname[i] >> 8));
+      nv_put(a + 3 + i * 2, (uint8_t)(d->appname[i] & 0xFF));
+   }
+   for (i = 0; i < NVM_FILEPACKSIZE; i++)
+   {
+      nv_put(a + 12 + i * 2, (uint8_t)(d->filename[i] >> 8));
+      nv_put(a + 13 + i * 2, (uint8_t)(d->filename[i] & 0xFF));
+   }
+}
+
+/* --------------------------------------------------------------------
+ * FAT: one byte per block at offset 0..255 (first 8 reserved/system).
+ * -------------------------------------------------------------------- */
+
+/* AllocBlocks: returns first block, FAT_EMPTYFILE for 0 blocks, or error.
+ * Mirrors the original's order: the used-space byte is bumped before the
+ * scan; an exhausted scan (corrupt FAT) leaves it bumped and reports
+ * ERANGE, exactly as the 68K code does. */
+static int32_t alloc_blocks(unsigned nblocks)
+{
+   unsigned used, cur, prev = 0, first = 0, left;
+
+   if (nblocks == 0)
+      return FAT_EMPTYFILE;
+
+   used = nv_get(USEDSPACE_OFFSET);
+   if (used + nblocks > NVM_DATABLOCKS)
+      return NVM_ENOSPC;
+   nv_put(USEDSPACE_OFFSET, (uint8_t)(used + nblocks));
+
+   left = nblocks;
+   for (cur = NVM_FIRSTDATABLOCK; left > 0; cur++)
+   {
+      if (cur >= NVM_TOTALBLOCKS)
+         return NVM_ERANGE;         /* "this should NEVER happen" */
+      if (nv_get(cur) != FAT_FREE)
+         continue;
+      if (prev == 0)
+         first = cur;
+      else
+         nv_put(prev, (uint8_t)cur);
+      prev = cur;
+      left--;
+   }
+   nv_put(prev, FAT_END);
+   return (int32_t)first;
+}
+
+/* FreeBlocks: walk the chain, marking entries free; stops at chain end
+ * markers (<= FAT_EMPTYFILE) or when the used count hits zero. */
+static void free_blocks(unsigned startblock)
+{
+   unsigned cur = startblock;
+   unsigned used = nv_get(USEDSPACE_OFFSET);
+   while (used > 0 && cur > FAT_EMPTYFILE)
+   {
+      unsigned next = nv_get(cur);
+      nv_put(cur, FAT_FREE);
+      cur = next;
+      used--;
+   }
+   nv_put(USEDSPACE_OFFSET, (uint8_t)used);
+}
+
+/* file_offset: byte offset in a file -> logical NVRAM address, walking
+ * the FAT chain.  Quirks kept: blocks 0/1 abort with ERANGE, but a
+ * FAT_EMPTYFILE block passes through (the original's documented bug for
+ * zero-length files). */
+static int32_t file_offset(unsigned startblock, uint32_t off)
+{
+   unsigned cur = startblock;
+   if ((int32_t)off < 0)
+      return NVM_ERANGE;
+   while (off >= NVM_BLOCKSIZE)
+   {
+      if (cur < FAT_EMPTYFILE)
+         return NVM_ERANGE;
+      cur = nv_get(cur);
+      off -= NVM_BLOCKSIZE;
+   }
+   if (cur < FAT_EMPTYFILE)
+      return NVM_ERANGE;
+   return (int32_t)(cur * NVM_BLOCKSIZE + off);
+}
+
+/* FindFile: match app+file name against the directory; fills *d. */
+static int32_t find_file(const uint16_t *app, const uint16_t *file,
+                         nvm_dirent *d)
+{
+   unsigned n;
+   for (n = 0; n < NVM_NUMDIRENTRIES; n++)
+   {
+      fetch_dir(n, d);
+      if (d->startblock == 0)
+         continue;
+      if (memcmp(d->appname, app, sizeof(d->appname)) != 0)
+         continue;
+      if (memcmp(d->filename, file, sizeof(d->filename)) != 0)
+         continue;
+      return (int32_t)n;
+   }
+   return NVM_EFILNF;
+}
+
+static int32_t delete_file(const uint16_t *app, const uint16_t *file)
+{
+   nvm_dirent d;
+   int32_t n = find_file(app, file, &d);
+   if (n < 0)
+      return n;
+   nv_put(NVM_DIROFFSET + (uint32_t)n * NVM_DIRENTRYSIZE + 0, 0);
+   nv_put(NVM_DIROFFSET + (uint32_t)n * NVM_DIRENTRYSIZE + 1, 0);
+   free_blocks(d.startblock);
+   return 0;
+}
+
+static int32_t get_handle(void)
+{
+   int i;
+   for (i = 0; i < NVM_NUMFILES; i++)
+      if (nvm_handles[i].startblock == 0)
+         return i;
+   return NVM_ENFILES;
+}
+
+/* --------------------------------------------------------------------
+ * The eleven calls
+ * -------------------------------------------------------------------- */
+
+int32_t NVMInitialize(const char *appname)
+{
+   uint16_t stored;
+   ascii2pack(appname, nvm_appname, NVM_APPPACKSIZE);
+   memset(nvm_handles, 0, sizeof(nvm_handles));
+   nvm_initialized = true;
+
+   stored = (uint16_t)((nv_get(CHKSUM_OFFSET) << 8)
+                       | nv_get(CHKSUM_OFFSET + 1));
+   if (calc_chksum() != stored)
+   {
+      /* Bad checksum: zero FAT + directory (first 8 blocks).  510 zero
+       * bytes sum to the stored zero checksum, so this is consistent. */
+      uint32_t a;
+      for (a = 0; a < (uint32_t)NVM_FIRSTDATABLOCK * NVM_BLOCKSIZE; a++)
+         nv_put(a, 0);
+   }
+   nv_flush();
+   return 0;
+}
+
+int32_t NVMCreate(const char *filename, int32_t size)
+{
+   uint16_t packed[NVM_FILEPACKSIZE];
+   nvm_dirent d;
+   int32_t handle, start;
+   unsigned n, nblocks;
+
+   if (!nvm_initialized)
+      return NVM_ENOINIT;
+   handle = get_handle();
+   if (handle < 0)
+      return handle;
+   ascii2pack(filename, packed, NVM_FILEPACKSIZE);
+   delete_file(nvm_appname, packed);
+
+   for (n = 0; n < NVM_NUMDIRENTRIES; n++)
+   {
+      fetch_dir(n, &d);
+      if (d.startblock == 0)
+         break;
+   }
+   if (n == NVM_NUMDIRENTRIES)
+      return NVM_ENOSPC;
+
+   nblocks = ((uint32_t)size + NVM_BLOCKSIZE - 1) / NVM_BLOCKSIZE;
+   start = alloc_blocks(nblocks);
+   if (start < 0)
+   {
+      nv_flush();
+      return NVM_ENOSPC;
+   }
+   d.startblock = (uint8_t)start;
+   d.numblocks  = (uint8_t)nblocks;
+   memcpy(d.appname, nvm_appname, sizeof(d.appname));
+   memcpy(d.filename, packed, sizeof(d.filename));
+   put_dir(n, &d);
+   set_chksum();
+   nv_flush();
+
+   nvm_handles[handle].startblock = (uint16_t)start;
+   nvm_handles[handle].offset     = 0;
+   return handle;
+}
+
+int32_t NVMOpen(const char *filename)
+{
+   uint16_t packed[NVM_FILEPACKSIZE];
+   nvm_dirent d;
+   int32_t handle, n;
+
+   if (!nvm_initialized)
+      return NVM_ENOINIT;
+   handle = get_handle();
+   if (handle < 0)
+      return handle;
+   ascii2pack(filename, packed, NVM_FILEPACKSIZE);
+   n = find_file(nvm_appname, packed, &d);
+   if (n < 0)
+      return n;
+   nvm_handles[handle].startblock = d.startblock;
+   nvm_handles[handle].offset     = 0;
+   return handle;
+}
+
+int32_t NVMClose(int16_t handle)
+{
+   /* The original does no validation here either. */
+   unsigned h = (uint16_t)handle;
+   if (!nvm_initialized)
+      return NVM_ENOINIT;
+   if (h < NVM_NUMFILES)
+   {
+      nvm_handles[h].startblock = 0;
+      nvm_handles[h].offset     = 0;
+   }
+   return 0;
+}
+
+int32_t NVMDelete(const char *appname_or_null, const char *filename)
+{
+   uint16_t app[NVM_APPPACKSIZE];
+   uint16_t file[NVM_FILEPACKSIZE];
+
+   if (!nvm_initialized)
+      return NVM_ENOINIT;
+   ascii2pack(filename, file, NVM_FILEPACKSIZE);
+   if (appname_or_null)
+      ascii2pack(appname_or_null, app, NVM_APPPACKSIZE);
+   else
+      memcpy(app, nvm_appname, sizeof(app));
+   delete_file(app, file);
+   set_chksum();
+   nv_flush();
+   /* The module clobbers D0 recalculating the checksum, so even a
+    * missing file reports success on hardware. */
+   return 0;
+}
+
+static int32_t nvm_io(int16_t handle, uint8_t *buf, const uint8_t *src,
+                      int32_t count)
+{
+   unsigned h = (uint16_t)handle;
+   nvm_handle *fh;
+   int32_t done = 0;
+
+   if (!nvm_initialized)
+      return NVM_ENOINIT;
+   if (h >= NVM_NUMFILES || nvm_handles[h].startblock == 0)
+      return NVM_EIHNDL;
+   fh = &nvm_handles[h];
+
+   while (done < count)
+   {
+      int32_t addr = file_offset(fh->startblock, fh->offset);
+      uint32_t left, chunk, i;
+      if (addr < 0)
+         break;                       /* partial transfer, like hardware */
+      left = NVM_BLOCKSIZE - ((uint32_t)addr & (NVM_BLOCKSIZE - 1));
+      chunk = (uint32_t)(count - done);
+      if (chunk > left)
+         chunk = left;
+      for (i = 0; i < chunk; i++)
+      {
+         if (buf)
+            buf[done + i] = nv_get((uint32_t)addr + i);
+         else
+            nv_put((uint32_t)addr + i, src[done + i]);
+      }
+      fh->offset += chunk;
+      done += (int32_t)chunk;
+   }
+   if (!buf && done > 0)
+      nv_flush();
+   return done;
+}
+
+int32_t NVMReadFile(int16_t handle, uint8_t *buf, int32_t count)
+{
+   return nvm_io(handle, buf, NULL, count);
+}
+
+int32_t NVMWriteFile(int16_t handle, const uint8_t *buf, int32_t count)
+{
+   return nvm_io(handle, NULL, buf, count);
+}
+
+int32_t NVMSearchFirst(uint8_t sbuf[NVM_SEARCHBUFSIZE], int32_t flags)
+{
+   if (!nvm_initialized)
+      return NVM_ENOINIT;
+   if (flags != 0 && (flags & 0xFFFF) != 1)
+      return NVM_EINVFN;
+   nvm_search_flags    = (uint16_t)(flags & 0xFFFF);
+   nvm_search_location = 0;
+   return NVMSearchNext(sbuf);
+}
+
+int32_t NVMSearchNext(uint8_t sbuf[NVM_SEARCHBUFSIZE])
+{
+   nvm_dirent d;
+
+   if (!nvm_initialized)
+      return NVM_ENOINIT;
+   while (nvm_search_location < NVM_NUMDIRENTRIES)
+   {
+      fetch_dir(nvm_search_location++, &d);
+      if (d.startblock == 0)
+         continue;
+      if (nvm_search_flags
+          && memcmp(d.appname, nvm_appname, sizeof(d.appname)) != 0)
+         continue;
+
+      {
+         uint32_t size = (uint32_t)d.numblocks * NVM_BLOCKSIZE;
+         char name[NVM_APPNAMELEN + 1];
+         sbuf[0] = (uint8_t)(size >> 24);
+         sbuf[1] = (uint8_t)(size >> 16);
+         sbuf[2] = (uint8_t)(size >> 8);
+         sbuf[3] = (uint8_t)size;
+         pack2ascii(d.appname, name, NVM_APPPACKSIZE);
+         memcpy(sbuf + 4, name, NVM_APPNAMELEN + 1);
+         pack2ascii(d.filename, name, NVM_FILEPACKSIZE);
+         memcpy(sbuf + 4 + NVM_APPNAMELEN + 1, name, NVM_FILENAMELEN + 1);
+      }
+      return 0;
+   }
+   return NVM_EFILNF;
+}
+
+int32_t NVMSeek(int16_t handle, int32_t offset, int16_t flag)
+{
+   unsigned h = (uint16_t)handle;
+   nvm_handle *fh;
+   int32_t target, addr;
+
+   if (!nvm_initialized)
+      return NVM_ENOINIT;
+   if (h >= NVM_NUMFILES || nvm_handles[h].startblock == 0)
+      return NVM_EIHNDL;
+   fh = &nvm_handles[h];
+
+   if (flag == 1)
+      target = (int32_t)fh->offset + offset;
+   else if (flag == 0)
+      target = offset;
+   else
+      return NVM_EINVFN;
+
+   addr = file_offset(fh->startblock, (uint32_t)target);
+   if (addr < 0)
+      return addr;
+   fh->offset = (uint32_t)target;
+   return target;
+}
+
+int32_t NVMInquire(uint32_t *total, uint32_t *freebytes)
+{
+   unsigned used;
+   if (!nvm_initialized)
+      return NVM_ENOINIT;
+   used = nv_get(USEDSPACE_OFFSET);
+   *total     = (uint32_t)NVM_DATABLOCKS * NVM_BLOCKSIZE;
+   *freebytes = (uint32_t)(NVM_DATABLOCKS - used) * NVM_BLOCKSIZE;
+   return 0;
+}
+
+/* --------------------------------------------------------------------
+ * Emulator integration
+ * -------------------------------------------------------------------- */
+
+void NVMBiosInstall(void)
+{
+   /* '_NVM' cookie + RTS stub the dispatcher hook sits behind. */
+   jaguarMainRAM[NVM_COOKIE_ADDR + 0] = (uint8_t)(NVM_COOKIE_MAGIC >> 24);
+   jaguarMainRAM[NVM_COOKIE_ADDR + 1] = (uint8_t)(NVM_COOKIE_MAGIC >> 16);
+   jaguarMainRAM[NVM_COOKIE_ADDR + 2] = (uint8_t)(NVM_COOKIE_MAGIC >> 8);
+   jaguarMainRAM[NVM_COOKIE_ADDR + 3] = (uint8_t)NVM_COOKIE_MAGIC;
+   jaguarMainRAM[NVM_DISPATCH_ADDR + 0] = 0x4E;   /* RTS */
+   jaguarMainRAM[NVM_DISPATCH_ADDR + 1] = 0x75;
+}
+
+void NVMBiosReset(void)
+{
+   nvm_initialized = false;
+   memset(nvm_appname, 0, sizeof(nvm_appname));
+   memset(nvm_handles, 0, sizeof(nvm_handles));
+   nvm_search_location = 0;
+   nvm_search_flags = 0;
+}
+
+/* Read a NUL-terminated name out of emulated RAM (bounded). */
+static void read_ram_string(uint32_t addr, char *dst, unsigned max)
+{
+   unsigned i;
+   for (i = 0; i + 1 < max; i++)
+   {
+      uint8_t c = (addr + i < 0x200000) ? jaguarMainRAM[addr + i] : 0;
+      dst[i] = (char)c;
+      if (c == 0)
+         return;
+   }
+   dst[i] = '\0';
+}
+
+bool NVMBiosHook(uint32_t pc)
+{
+   uint32_t sp;
+   uint16_t opcode;
+   int32_t ret = NVM_EINVFN;
+
+   if (pc != NVM_DISPATCH_ADDR)
+      return false;
+   if (!jaguarMemTrackInserted)
+      return false;
+   /* Only dispatch while our stub is what executes here. */
+   if (((uint32_t)jaguarMainRAM[NVM_COOKIE_ADDR] << 24 |
+        (uint32_t)jaguarMainRAM[NVM_COOKIE_ADDR + 1] << 16 |
+        (uint32_t)jaguarMainRAM[NVM_COOKIE_ADDR + 2] << 8 |
+        (uint32_t)jaguarMainRAM[NVM_COOKIE_ADDR + 3]) != NVM_COOKIE_MAGIC)
+      return false;
+
+   /* Caller: JSR $2404 with args on the stack past the return address:
+    *   4(sp).w opcode, then per-op args (see the spec / asmnvm.s). */
+   sp = m68k_get_reg(NULL, M68K_REG_A7);
+   opcode = (uint16_t)m68k_read_memory_16(sp + 4);
+
+   switch (opcode)
+   {
+   case 0:  /* Initialize(appname.l, workarea.l) */
+   {
+      char app[64];
+      read_ram_string(m68k_read_memory_32(sp + 6), app, sizeof(app));
+      /* The 16K workarea is scratch the module may trash; ours doesn't. */
+      ret = NVMInitialize(app);
+      break;
+   }
+   case 1:  /* Create(filename.l, size.l) */
+   {
+      char name[64];
+      read_ram_string(m68k_read_memory_32(sp + 6), name, sizeof(name));
+      ret = NVMCreate(name, (int32_t)m68k_read_memory_32(sp + 10));
+      break;
+   }
+   case 2:  /* Open(filename.l) */
+   {
+      char name[64];
+      read_ram_string(m68k_read_memory_32(sp + 6), name, sizeof(name));
+      ret = NVMOpen(name);
+      break;
+   }
+   case 3:  /* Close(handle.w) */
+      ret = NVMClose((int16_t)m68k_read_memory_16(sp + 6));
+      break;
+   case 4:  /* Delete(appname.l or 0, filename.l) */
+   {
+      char app[64], name[64];
+      uint32_t appp = m68k_read_memory_32(sp + 6);
+      read_ram_string(m68k_read_memory_32(sp + 10), name, sizeof(name));
+      if (appp)
+         read_ram_string(appp, app, sizeof(app));
+      ret = NVMDelete(appp ? app : NULL, name);
+      break;
+   }
+   case 5:  /* Read(handle.w, buf.l, count.l) */
+   case 6:  /* Write(handle.w, buf.l, count.l) */
+   {
+      int16_t  handle = (int16_t)m68k_read_memory_16(sp + 6);
+      uint32_t bufptr = m68k_read_memory_32(sp + 8);
+      int32_t  count  = (int32_t)m68k_read_memory_32(sp + 12);
+      uint8_t  chunk[NVM_BLOCKSIZE];
+      int32_t  done = 0;
+
+      ret = 0;
+      while (done < count)
+      {
+         int32_t want = count - done;
+         int32_t got;
+         if (want > (int32_t)sizeof(chunk))
+            want = (int32_t)sizeof(chunk);
+         if (opcode == 6)
+         {
+            int32_t i;
+            for (i = 0; i < want; i++)
+               chunk[i] = (uint8_t)m68k_read_memory_8(bufptr + done + i);
+            got = NVMWriteFile(handle, chunk, want);
+         }
+         else
+         {
+            int32_t i;
+            got = NVMReadFile(handle, chunk, want);
+            for (i = 0; i < got; i++)
+               m68k_write_memory_8(bufptr + done + i, chunk[i]);
+         }
+         if (got < 0)
+         {
+            ret = got;             /* EIHNDL/ENOINIT from the first call */
+            break;
+         }
+         done += got;
+         if (got < want)
+            break;                 /* partial (end of chain), stop */
+      }
+      if (ret >= 0)
+         ret = done;
+      break;
+   }
+   case 7:  /* SearchFirst(sbuf.l, flags.l) */
+   case 8:  /* SearchNext(sbuf.l) */
+   {
+      uint32_t bufptr = m68k_read_memory_32(sp + 6);
+      uint8_t  sbuf[NVM_SEARCHBUFSIZE];
+      int32_t  i;
+      if (opcode == 7)
+         ret = NVMSearchFirst(sbuf, (int32_t)m68k_read_memory_32(sp + 10));
+      else
+         ret = NVMSearchNext(sbuf);
+      if (ret == 0)
+         for (i = 0; i < NVM_SEARCHBUFSIZE; i++)
+            m68k_write_memory_8(bufptr + i, sbuf[i]);
+      break;
+   }
+   case 9:  /* Seek(handle.w, offset.l, flag.w) */
+      ret = NVMSeek((int16_t)m68k_read_memory_16(sp + 6),
+                    (int32_t)m68k_read_memory_32(sp + 8),
+                    (int16_t)m68k_read_memory_16(sp + 12));
+      break;
+   case 10: /* Inquire(total.l, free.l) */
+   {
+      uint32_t t = 0, f = 0;
+      ret = NVMInquire(&t, &f);
+      if (ret == 0)
+      {
+         m68k_write_memory_32(m68k_read_memory_32(sp + 6), t);
+         m68k_write_memory_32(m68k_read_memory_32(sp + 10), f);
+      }
+      break;
+   }
+   default:
+      ret = nvm_initialized ? NVM_EINVFN : NVM_ENOINIT;
+      break;
+   }
+
+   m68k_set_reg(M68K_REG_D0, (uint32_t)ret);
+   return true;   /* the RTS stub at $2404 now returns to the caller */
+}
+
+/* --------------------------------------------------------------------
+ * Save states
+ * -------------------------------------------------------------------- */
+
+#include "state.h"
+
+size_t NVMBiosStateSave(uint8_t *buf)
+{
+   uint8_t *start = buf;
+   uint8_t init = nvm_initialized ? 1 : 0;
+   int i;
+
+   STATE_SAVE_VAR(buf, init);
+   STATE_SAVE_BUF(buf, nvm_appname, sizeof(nvm_appname));
+   for (i = 0; i < NVM_NUMFILES; i++)
+   {
+      STATE_SAVE_VAR(buf, nvm_handles[i].startblock);
+      STATE_SAVE_VAR(buf, nvm_handles[i].offset);
+   }
+   STATE_SAVE_VAR(buf, nvm_search_location);
+   STATE_SAVE_VAR(buf, nvm_search_flags);
+   return (size_t)(buf - start);
+}
+
+size_t NVMBiosStateLoad(const uint8_t *buf)
+{
+   const uint8_t *start = buf;
+   uint8_t init = 0;
+   int i;
+
+   STATE_LOAD_VAR(buf, init);
+   nvm_initialized = (init != 0);
+   STATE_LOAD_BUF(buf, nvm_appname, sizeof(nvm_appname));
+   for (i = 0; i < NVM_NUMFILES; i++)
+   {
+      STATE_LOAD_VAR(buf, nvm_handles[i].startblock);
+      STATE_LOAD_VAR(buf, nvm_handles[i].offset);
+   }
+   STATE_LOAD_VAR(buf, nvm_search_location);
+   STATE_LOAD_VAR(buf, nvm_search_flags);
+   return (size_t)(buf - start);
+}

--- a/src/core/nvmbios.h
+++ b/src/core/nvmbios.h
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <stdbool.h>
+#include <boolean.h>
 
 #define NVM_COOKIE_ADDR    0x2400
 #define NVM_DISPATCH_ADDR  0x2404

--- a/src/core/nvmbios.h
+++ b/src/core/nvmbios.h
@@ -1,0 +1,77 @@
+#ifndef _VIRTUALJAGUAR_NVMBIOS_H
+#define _VIRTUALJAGUAR_NVMBIOS_H
+
+/*
+ * nvmbios.h: HLE of the Memory Track "NVM BIOS" module.
+ *
+ * On hardware, the CD BIOS boot runs the Memory Track cartridge's stub,
+ * which installs a 2K module in RAM: a '_NVM' magic cookie at $2400 and a
+ * dispatcher at $2404.  Games detect the Memory Track by checking the
+ * cookie (Vid Grid: `cmpi.l #'_NVM',$2400.w` at $012B72) and use it by
+ * pushing an opcode + args and JSRing $2404 — they never touch the flash
+ * hardware themselves; the module does.
+ *
+ * We install the cookie plus an RTS stub and implement the module's eleven
+ * calls in C, operating directly on the Memory Track NVRAM image (mtMem).
+ *
+ * Semantics follow the Atari NVM BIOS v1.01 source and its specification
+ * ("Non Volatile Memory - Bios calls", Atari, Feb 1995), both preserved in
+ * https://github.com/cubanismo/skunk_mtrk — which is also where the $2400
+ * contract was documented.  See docs/memory-track.md.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#define NVM_COOKIE_ADDR    0x2400
+#define NVM_DISPATCH_ADDR  0x2404
+#define NVM_COOKIE_MAGIC   0x5F4E564Du   /* '_NVM' */
+
+/* Filesystem geometry (from nvm.h / nvm.inc, Atari NVM BIOS v1.01). */
+#define NVM_BLOCKSIZE      512
+#define NVM_TOTALBLOCKS    256
+#define NVM_FIRSTDATABLOCK 8
+#define NVM_DATABLOCKS     248
+#define NVM_NUMDIRENTRIES  199
+#define NVM_DIRENTRYSIZE   18
+#define NVM_DIROFFSET      512
+#define NVM_NUMFILES       3
+#define NVM_APPPACKSIZE    5            /* packed appname, 16-bit words */
+#define NVM_FILEPACKSIZE   3            /* packed filename, 16-bit words */
+#define NVM_APPNAMELEN     15
+#define NVM_FILENAMELEN    9
+#define NVM_SEARCHBUFSIZE  (4 + NVM_APPNAMELEN + 1 + NVM_FILENAMELEN + 1)
+
+/* Error codes (sign-extended into D0). */
+#define NVM_ENOINIT  (-1)
+#define NVM_ENOSPC   (-2)
+#define NVM_EFILNF   (-3)
+#define NVM_EINVFN   (-4)
+#define NVM_ERANGE   (-5)
+#define NVM_ENFILES  (-6)
+#define NVM_EIHNDL   (-7)
+
+/* Emulator integration */
+void NVMBiosInstall(void);        /* write cookie + RTS stub into main RAM */
+void NVMBiosReset(void);          /* forget runtime state (power-on/reset) */
+bool NVMBiosHook(uint32_t pc);    /* pre-instruction hook for $2404 */
+size_t NVMBiosStateSave(uint8_t *buf);
+size_t NVMBiosStateLoad(const uint8_t *buf);
+
+/* The eleven calls, host-pointer based so they are unit-testable without a
+ * 68K.  Return values / error codes exactly as the module's dispatcher
+ * leaves them in D0. */
+int32_t NVMInitialize(const char *appname);
+int32_t NVMCreate(const char *filename, int32_t size);
+int32_t NVMOpen(const char *filename);
+int32_t NVMClose(int16_t handle);
+int32_t NVMDelete(const char *appname_or_null, const char *filename);
+int32_t NVMReadFile(int16_t handle, uint8_t *buf, int32_t count);
+int32_t NVMWriteFile(int16_t handle, const uint8_t *buf, int32_t count);
+int32_t NVMSearchFirst(uint8_t sbuf[NVM_SEARCHBUFSIZE], int32_t flags);
+int32_t NVMSearchNext(uint8_t sbuf[NVM_SEARCHBUFSIZE]);
+int32_t NVMSeek(int16_t handle, int32_t offset, int16_t flag);
+int32_t NVMInquire(uint32_t *total, uint32_t *freebytes);
+
+#endif

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -21,7 +21,8 @@ extern "C" {
  * v4: CDROM chunk gained the DSA response queue + serial-delay counter.
  * v5: CDROM chunk gained the latched drive speed (DSA Set Mode $15nn).
  * v6: new UART chunk (JERRY async serial + jlink RX ring).
- * v7: Memory Track chunk gained the latched $80AAA8 override flag. */
+ * v7: Memory Track chunk gained the latched $80AAA8 override flag and
+ *     the NVM BIOS dispatcher state (nvmbios.c). */
 #define STATE_MAGIC     0x564A5353  /* "VJSS" */
 #define STATE_VERSION   7
 /* Oldest layout retro_unserialize still accepts.  States between
@@ -100,6 +101,8 @@ size_t JoystickStateLoad(const uint8_t *buf);
 
 size_t MTStateSave(uint8_t *buf);
 size_t MTStateLoad(const uint8_t *buf, uint32_t version);
+size_t NVMBiosStateSave(uint8_t *buf);
+size_t NVMBiosStateLoad(const uint8_t *buf);
 
 size_t DACStateSave(uint8_t *buf);
 /* stateVersion is the version read from the state header: fields added in

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -20,9 +20,10 @@ extern "C" {
 /* Save state format identifier and version.
  * v4: CDROM chunk gained the DSA response queue + serial-delay counter.
  * v5: CDROM chunk gained the latched drive speed (DSA Set Mode $15nn).
- * v6: new UART chunk (JERRY async serial + jlink RX ring). */
+ * v6: new UART chunk (JERRY async serial + jlink RX ring).
+ * v7: Memory Track chunk gained the latched $80AAA8 override flag. */
 #define STATE_MAGIC     0x564A5353  /* "VJSS" */
-#define STATE_VERSION   6
+#define STATE_VERSION   7
 /* Oldest layout retro_unserialize still accepts.  States between
  * STATE_MIN_VERSION and STATE_VERSION load by skipping the fields added
  * after them (see DACStateLoad, CDROMStateLoad); STATE_VERSION is always
@@ -41,6 +42,8 @@ extern "C" {
 #define STATE_VERSION_CDROM_DRIVE_SPEED 5
 /* First version carrying the JERRY UART + jlink chunk. */
 #define STATE_VERSION_JERRY_UART 6
+/* First version whose Memory Track block carries the $80AAA8 override flag. */
+#define STATE_VERSION_MEMTRACK_OVERRIDE 7
 
 /* Header flags */
 #define STATE_FLAG_MEMTRACK  0x01
@@ -96,7 +99,7 @@ size_t JoystickStateSave(uint8_t *buf);
 size_t JoystickStateLoad(const uint8_t *buf);
 
 size_t MTStateSave(uint8_t *buf);
-size_t MTStateLoad(const uint8_t *buf);
+size_t MTStateLoad(const uint8_t *buf, uint32_t version);
 
 size_t DACStateSave(uint8_t *buf);
 /* stateVersion is the version read from the state header: fields added in

--- a/test/test_memtrack.c
+++ b/test/test_memtrack.c
@@ -1,0 +1,133 @@
+/*
+ * test_memtrack.c — Memory Track cartridge protocol.
+ *
+ * No title we have exercises the Memory Track (see #258), so this test drives
+ * the device directly against the protocol documented by the MiSTer Atari
+ * Jaguar core (https://github.com/MiSTer-devel/Jaguar_MiSTer, Jaguar.sv) —
+ * the only known-working open-source implementation, and effectively the
+ * spec, since neither the Jaguar TRM nor the official SDK covers this part.
+ *
+ * Guards the three things that were wrong before:
+ *   1. the NVRAM window is $900000, not the $8xxxxx ROM window;
+ *   2. the device claims ONLY its own addresses, so a CD BIOS at $800000
+ *      survives;
+ *   3. unlock -> ID mode reports ATMEL AT29C010 at $800000 / $800004.
+ *
+ * Build:
+ *   cc -O2 -Wall -std=c99 $(INCFLAGS) -o test/test_memtrack \
+ *      test/test_memtrack.c src/core/memtrack.c -lm
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "memtrack.h"
+
+static int failures;
+static int checks;
+
+static void ok(const char *what, int cond)
+{
+   checks++;
+   if (cond)
+   {
+      printf("  PASS  %s\n", what);
+   }
+   else
+   {
+      printf("  FAIL  %s\n", what);
+      failures++;
+   }
+}
+
+/* The unlock sequence: $AA -> $815554, $55 -> $80AAA8, <cmd> -> $815554. */
+static void unlock(uint16_t cmd)
+{
+   MTWriteWord(MT_CMD_UNLOCK1, 0x00AA);
+   MTWriteWord(MT_CMD_UNLOCK2, 0x0055);
+   MTWriteWord(MT_CMD_UNLOCK1, cmd);
+}
+
+int main(void)
+{
+   printf("=== Memory Track ===\n");
+
+   MTInit();
+   MTReset();
+
+   /* --- 1. address claims: the device must not swallow cart/CD-BIOS space --- */
+   ok("does not claim $800000 before unlock (CD BIOS lives there)",
+      !MTClaimsRead(0x800000));
+   ok("does not claim $804000 (arbitrary cart ROM)",
+      !MTClaimsRead(0x804000));
+   ok("does not claim $880000 (above the command window)",
+      !MTClaimsRead(0x880000));
+   ok("claims the NVRAM window base $900000", MTClaimsRead(MT_DATA_BASE));
+   ok("claims the NVRAM window top  $91FFFE", MTClaimsRead(MT_DATA_END - 2));
+   ok("does not claim $920000 (past the NVRAM window)",
+      !MTClaimsRead(MT_DATA_END));
+   ok("accepts command writes at $815554", MTClaimsWrite(MT_CMD_UNLOCK1));
+   ok("accepts command writes at $80AAA8", MTClaimsWrite(MT_CMD_UNLOCK2));
+
+   /* --- 2. ID mode: ATMEL AT29C010 --- */
+   unlock(0x0090);
+   ok("ID mode claims $800000", MTClaimsRead(MT_ID_MANUF));
+   ok("manufacturer ID = $1F (ATMEL)", MTReadWord(MT_ID_MANUF) == 0x001F);
+   ok("device ID       = $D5 (AT29C010)", MTReadWord(MT_ID_DEVICE) == 0x00D5);
+
+   /* $80AAA8 reads back $0055 after the unlock write (ROMULATOR probe). */
+   ok("$80AAA8 reads back $0055", MTReadWord(MT_CMD_UNLOCK2) == 0x0055);
+
+   unlock(0x00F0);   /* undo ID mode */
+   ok("after $F0, $800000 is no longer claimed", !MTClaimsRead(MT_ID_MANUF));
+
+   /* --- 3. NVRAM read/write --- */
+   /* Writes must be ignored until the part is write-enabled. */
+   memset(mtMem, 0xFF, MT_MEM_SIZE);
+   MTWriteWord(MT_DATA_BASE, 0x1234);
+   ok("write ignored without write-enable",
+      MTReadWord(MT_DATA_BASE) == 0xFFFF);
+
+   unlock(0x00A0);   /* write enable */
+   MTWriteWord(MT_DATA_BASE, 0x1234);
+   ok("write lands after write-enable",
+      MTReadWord(MT_DATA_BASE) == 0x1234);
+   ok("stored big-endian in mtMem",
+      mtMem[0] == 0x12 && mtMem[1] == 0x34);
+
+   MTWriteWord(MT_DATA_BASE + 2, 0xABCD);
+   ok("adjacent word independent",
+      MTReadWord(MT_DATA_BASE) == 0x1234 &&
+      MTReadWord(MT_DATA_BASE + 2) == 0xABCD);
+
+   ok("long read composes two words",
+      MTReadLong(MT_DATA_BASE) == 0x1234ABCDu);
+
+   /* Top of the window is reachable — a 128K device, not a 512K stride. */
+   MTWriteWord(MT_DATA_END - 2, 0x5A5A);
+   ok("top of window writable",
+      MTReadWord(MT_DATA_END - 2) == 0x5A5A);
+   ok("top of window maps to the last mtMem bytes",
+      mtMem[MT_MEM_SIZE - 2] == 0x5A && mtMem[MT_MEM_SIZE - 1] == 0x5A);
+
+   /* The whole 128K must be addressable: the old mapping folded four
+    * addresses onto one byte, so a 128K span would have aliased. */
+   unlock(0x00A0);
+   MTWriteWord(MT_DATA_BASE + 0x10000, 0x0F0F);
+   ok("mid-window write does not alias the base",
+      MTReadWord(MT_DATA_BASE) == 0x1234 &&
+      MTReadWord(MT_DATA_BASE + 0x10000) == 0x0F0F);
+
+   /* --- 4. reset keeps contents, clears command state --- */
+   MTReset();
+   ok("soft reset preserves NVRAM contents",
+      MTReadWord(MT_DATA_BASE) == 0x1234);
+   MTWriteWord(MT_DATA_BASE, 0x9999);
+   ok("soft reset cleared write-enable",
+      MTReadWord(MT_DATA_BASE) == 0x1234);
+
+   printf("--- Memory Track: %d checks, %d failed ---\n", checks, failures);
+   return failures ? 1 : 0;
+}

--- a/test/test_memtrack.c
+++ b/test/test_memtrack.c
@@ -120,6 +120,33 @@ int main(void)
       MTReadWord(MT_DATA_BASE) == 0x1234 &&
       MTReadWord(MT_DATA_BASE + 0x10000) == 0x0F0F);
 
+   /* --- 3b. byte accessors (the 68K reaches the device with move.b too;
+    * Copilot review on #259 caught these bypassing the device entirely) --- */
+   unlock(0x00A0);
+   MTWriteByte(MT_DATA_BASE + 4, 0xDE);
+   MTWriteByte(MT_DATA_BASE + 5, 0xAD);
+   ok("byte writes land in the NVRAM window",
+      MTReadWord(MT_DATA_BASE + 4) == 0xDEAD);
+   ok("byte reads pick the right half of the word",
+      MTReadByte(MT_DATA_BASE + 4) == 0xDE
+      && MTReadByte(MT_DATA_BASE + 5) == 0xAD);
+   ok("byte write to the last NVRAM byte is in range",
+      (MTWriteByte(MT_DATA_END - 1, 0x77), mtMem[MT_MEM_SIZE - 1] == 0x77));
+
+   /* A byte write without write-enable must be ignored, like the word path. */
+   MTReset();
+   MTWriteByte(MT_DATA_BASE + 4, 0x00);
+   ok("byte write ignored without write-enable",
+      MTReadByte(MT_DATA_BASE + 4) == 0xDE);
+
+   /* Byte writes to the command window must still drive the state machine. */
+   MTWriteByte(MT_CMD_UNLOCK1, 0xAA);
+   MTWriteByte(MT_CMD_UNLOCK2, 0x55);
+   MTWriteByte(MT_CMD_UNLOCK1, 0x90);
+   ok("byte-written unlock reaches ID mode",
+      MTReadWord(MT_ID_MANUF) == 0x001F);
+   unlock(0x00F0);
+
    /* --- 4. reset keeps contents, clears command state --- */
    MTReset();
    ok("soft reset preserves NVRAM contents",

--- a/test/test_nvmbios.c
+++ b/test/test_nvmbios.c
@@ -1,0 +1,194 @@
+/*
+ * test_nvmbios.c — Memory Track NVM BIOS filesystem semantics.
+ *
+ * Drives the C implementation of the module's eleven calls directly
+ * (nvmbios.c), with the 68K stubbed out.  Covers the specified behaviour
+ * plus the quirks games depend on; see nvmbios.c's header comment and the
+ * Atari NVM BIOS v1.01 source in https://github.com/cubanismo/skunk_mtrk.
+ *
+ * Build:
+ *   cc -O2 -Wall -std=c99 $(INCFLAGS) -o test/test_nvmbios \
+ *      test/test_nvmbios.c src/core/nvmbios.c src/core/memtrack.c -lm
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "nvmbios.h"
+#include "memtrack.h"
+
+/* ---- 68K / RAM stubs so nvmbios.c links standalone ---- */
+static uint8_t ram_backing[0x200000];
+uint8_t *jaguarMainRAM = ram_backing;
+bool jaguarMemTrackInserted = true;
+unsigned int m68k_get_reg(void *c, int r) { (void)c; (void)r; return 0; }
+void m68k_set_reg(int r, unsigned int v) { (void)r; (void)v; }
+unsigned int m68k_read_memory_8(unsigned int a) { (void)a; return 0; }
+unsigned int m68k_read_memory_16(unsigned int a) { (void)a; return 0; }
+unsigned int m68k_read_memory_32(unsigned int a) { (void)a; return 0; }
+void m68k_write_memory_8(unsigned int a, unsigned int v) { (void)a; (void)v; }
+void m68k_write_memory_32(unsigned int a, unsigned int v) { (void)a; (void)v; }
+
+static int failures, checks;
+
+static void ok(const char *what, int cond)
+{
+   checks++;
+   printf("  %s  %s\n", cond ? "PASS" : "FAIL", what);
+   if (!cond)
+      failures++;
+}
+
+int main(void)
+{
+   uint8_t buf[2048];
+   uint8_t sbuf[NVM_SEARCHBUFSIZE];
+   uint32_t total = 0, freeb = 0;
+   int32_t h, h2, r;
+   int i;
+
+   printf("=== NVM BIOS (Memory Track filesystem) ===\n");
+
+   MTInit();
+   NVMBiosReset();
+
+   /* --- pre-init gating --- */
+   ok("calls before Initialize return ENOINIT",
+      NVMOpen("SAVE") == NVM_ENOINIT
+      && NVMCreate("SAVE", 100) == NVM_ENOINIT
+      && NVMInquire(&total, &freeb) == NVM_ENOINIT);
+
+   /* --- blank cart self-formats on Initialize --- */
+   memset(mtMem, 0xFF, MT_MEM_SIZE);
+   ok("Initialize on blank cart returns 0", NVMInitialize("VID GRID") == 0);
+   ok("blank cart was formatted (FAT+dir zeroed)",
+      mtMem[0] == 0 && mtMem[3] == 0 && mtMem[512] == 0);
+
+   /* --- create / write / read round trip --- */
+   h = NVMCreate("HISCORES", 1000);
+   ok("Create returns a handle", h >= 0 && h < 3);
+   for (i = 0; i < 1000; i++)
+      buf[i] = (uint8_t)(i * 7);
+   ok("Write returns count", NVMWriteFile((int16_t)h, buf, 1000) == 1000);
+   ok("Seek to 0 returns 0", NVMSeek((int16_t)h, 0, 0) == 0);
+   memset(buf, 0, sizeof(buf));
+   ok("Read returns count", NVMReadFile((int16_t)h, buf, 1000) == 1000);
+   r = 1;
+   for (i = 0; i < 1000; i++)
+      if (buf[i] != (uint8_t)(i * 7))
+         r = 0;
+   ok("data round-trips", r == 1);
+   ok("Close returns 0", NVMClose((int16_t)h) == 0);
+
+   /* --- reopen finds the file --- */
+   h = NVMOpen("HISCORES");
+   ok("Open finds the file", h >= 0);
+   memset(buf, 0, sizeof(buf));
+   ok("read after open starts at offset 0",
+      NVMReadFile((int16_t)h, buf, 4) == 4 && buf[0] == 0 && buf[1] == 7);
+   NVMClose((int16_t)h);
+
+   /* --- checksum is maintained: re-Initialize must NOT reformat --- */
+   ok("re-Initialize preserves files", NVMInitialize("VID GRID") == 0
+      && NVMOpen("HISCORES") >= 0);
+   NVMClose(0);
+
+   /* --- missing file --- */
+   ok("Open of missing file is EFILNF", NVMOpen("NOPE") == NVM_EFILNF);
+
+   /* --- create replaces an existing file of the same name --- */
+   h = NVMCreate("HISCORES", 512);
+   ok("Create over existing succeeds", h >= 0);
+   ok("size rounded to blocks: seek to 511 ok, 512 ERANGE",
+      NVMSeek((int16_t)h, 511, 0) == 511
+      && NVMSeek((int16_t)h, 512, 0) == NVM_ERANGE);
+   NVMClose((int16_t)h);
+
+   /* --- relative seek --- */
+   h = NVMOpen("HISCORES");
+   NVMSeek((int16_t)h, 100, 0);
+   ok("relative seek adds", NVMSeek((int16_t)h, 50, 1) == 150);
+   ok("bad seek flag is EINVFN", NVMSeek((int16_t)h, 0, 2) == NVM_EINVFN);
+   NVMClose((int16_t)h);
+
+   /* --- handle exhaustion: 3 handles max --- */
+   {
+      int32_t hs[3];
+      for (i = 0; i < 3; i++)
+         hs[i] = NVMOpen("HISCORES");
+      ok("three handles open", hs[0] >= 0 && hs[1] >= 0 && hs[2] >= 0);
+      ok("fourth is ENFILES", NVMOpen("HISCORES") == NVM_ENFILES);
+      for (i = 0; i < 3; i++)
+         NVMClose((int16_t)hs[i]);
+   }
+
+   /* --- bad handle --- */
+   ok("read on closed handle is EIHNDL",
+      NVMReadFile(0, buf, 4) == NVM_EIHNDL);
+
+   /* --- second app, search semantics --- */
+   NVMInitialize("OTHER APP");
+   h2 = NVMCreate("SETTINGS", 100);
+   ok("second app creates its own file", h2 >= 0);
+   NVMClose((int16_t)h2);
+   ok("open of other app's file by name fails (app-scoped)",
+      NVMOpen("HISCORES") == NVM_EFILNF);
+
+   ok("SearchFirst(all) finds a file", NVMSearchFirst(sbuf, 0) == 0);
+   ok("SearchNext finds the second", NVMSearchNext(sbuf) == 0);
+   ok("SearchNext exhausts with EFILNF", NVMSearchNext(sbuf) == NVM_EFILNF);
+   ok("SearchFirst(current app) finds exactly one",
+      NVMSearchFirst(sbuf, 1) == 0 && NVMSearchNext(sbuf) == NVM_EFILNF);
+   ok("search buffer carries app name",
+      memcmp(sbuf + 4, "OTHER APP      ", 15) == 0);
+   ok("search buffer carries file name",
+      memcmp(sbuf + 4 + 16, "SETTINGS ", 9) == 0);
+   ok("bad search flags are EINVFN", NVMSearchFirst(sbuf, 5) == NVM_EINVFN);
+
+   /* --- inquire --- */
+   NVMInquire(&total, &freeb);
+   ok("Inquire totals: 248 blocks", total == 248u * 512u);
+   /* HISCORES was re-created at 512 bytes (1 block) + SETTINGS (1 block). */
+   ok("Inquire free reflects use: 2 blocks used",
+      freeb == (248u - 2u) * 512u);
+
+   /* --- delete (cross-app, and the always-success quirk) --- */
+   ok("Delete other app's file by explicit appname",
+      NVMDelete("VID GRID", "HISCORES") == 0);
+   ok("deleted file is gone", NVMOpen("HISCORES") == NVM_EFILNF
+      /* still OTHER APP's context, so also check via search-all */
+      && (NVMSearchFirst(sbuf, 0) == 0
+          && memcmp(sbuf + 4 + 16, "SETTINGS ", 9) == 0
+          && NVMSearchNext(sbuf) == NVM_EFILNF));
+   ok("Delete of missing file still reports success (module quirk)",
+      NVMDelete(NULL, "NOPE") == 0);
+   NVMInquire(&total, &freeb);
+   ok("freed blocks return to the pool", freeb == (248u - 1u) * 512u);
+
+   /* --- ENOSPC --- */
+   ok("Create larger than the cart is ENOSPC",
+      NVMCreate("HUGE", 248 * 512) == NVM_ENOSPC);
+
+   /* --- zero-length file --- */
+   h = NVMCreate("EMPTY", 0);
+   ok("zero-length create succeeds", h >= 0);
+   NVMClose((int16_t)h);
+
+   /* --- persistence: state save/load round-trip of runtime state --- */
+   {
+      uint8_t st[128];
+      size_t n = NVMBiosStateSave(st);
+      NVMBiosReset();
+      ok("after reset, calls need Initialize again",
+         NVMOpen("SETTINGS") == NVM_ENOINIT);
+      NVMBiosStateLoad(st);
+      ok("state restore brings back the session",
+         NVMOpen("SETTINGS") >= 0);
+      ok("state block size is stable", NVMBiosStateSave(st) == n);
+   }
+
+   printf("--- NVM BIOS: %d checks, %d failed ---\n", checks, failures);
+   return failures ? 1 : 0;
+}

--- a/test/test_state_compat.c
+++ b/test/test_state_compat.c
@@ -112,6 +112,11 @@ const char *__lsan_default_suppressions(void) {
  * would not be unique. */
 #define CDROM_DSA_TAIL_SIZE           28
 
+/* Trailing Memory Track byte a v2..v6 state does not carry: the latched
+ * $80AAA8 override flag added in STATE_VERSION_MEMTRACK_OVERRIDE.  It sits at
+ * the very end of the MT block, i.e. immediately before the DAC block. */
+#define MEMTRACK_OVERRIDE_SIZE        1
+
 /* Header field offsets (see retro_serialize in libretro.c) */
 #define STATE_OFF_MAGIC    0
 #define STATE_OFF_VERSION  4
@@ -384,14 +389,22 @@ int main(int argc, char **argv)
      * block) so it still satisfies retro_unserialize's size check. */
     memcpy(state_v2, state_v3, state_size);
     {
-        /* Higher-offset cut first so the second cut's offset stays valid. */
+        /* Higher-offset cuts first so the later offsets stay valid. */
         size_t cut = dac_off + DAC_I2S_NONZEROCOUNT_OFFSET;
+        size_t cut3 = dac_off - MEMTRACK_OVERRIDE_SIZE;
         size_t cut2 = cdrom_end - CDROM_DSA_TAIL_SIZE;
         memmove(state_v2 + cut,
                 state_v2 + cut + DAC_I2S_NONZEROCOUNT_SIZE,
                 state_size - cut - DAC_I2S_NONZEROCOUNT_SIZE);
         memset(state_v2 + state_size - DAC_I2S_NONZEROCOUNT_SIZE, 0,
                DAC_I2S_NONZEROCOUNT_SIZE);
+        /* A v2..v6 Memory Track block predates the override flag (see
+         * STATE_VERSION_MEMTRACK_OVERRIDE): splice that byte out too. */
+        memmove(state_v2 + cut3,
+                state_v2 + cut3 + MEMTRACK_OVERRIDE_SIZE,
+                state_size - cut3 - MEMTRACK_OVERRIDE_SIZE);
+        memset(state_v2 + state_size - MEMTRACK_OVERRIDE_SIZE, 0,
+               MEMTRACK_OVERRIDE_SIZE);
         /* A v2/v3 CDROM block also predates the DSA queue tail (see
          * STATE_VERSION_CDROM_DSA_QUEUE): splice those bytes out too. */
         memmove(state_v2 + cut2,

--- a/test/test_state_compat.c
+++ b/test/test_state_compat.c
@@ -112,9 +112,10 @@ const char *__lsan_default_suppressions(void) {
  * would not be unique. */
 #define CDROM_DSA_TAIL_SIZE           28
 
-/* Trailing Memory Track byte a v2..v6 state does not carry: the latched
- * $80AAA8 override flag added in STATE_VERSION_MEMTRACK_OVERRIDE.  It sits at
- * the very end of the MT block, i.e. immediately before the DAC block. */
+/* Trailing v7 additions a v2..v6 state does not carry: the MT block's
+ * latched $80AAA8 override flag (1 byte) plus the entire NVM BIOS block
+ * that follows it (nvm_size, probed at runtime).  Together they sit
+ * immediately before the DAC block. */
 #define MEMTRACK_OVERRIDE_SIZE        1
 
 /* Header field offsets (see retro_serialize in libretro.c) */
@@ -205,7 +206,7 @@ int main(int argc, char **argv)
 {
     harness_config cfg = HARNESS_CONFIG_DEFAULT;
     dac_state_save_fn dac_save;
-    dac_state_save_fn cdrom_save, joy_save, mt_save;
+    dac_state_save_fn cdrom_save, joy_save, mt_save, nvm_save;
     serialize_size_fn ser_size_fn;
     serialize_fn ser;
     unserialize_fn unser;
@@ -214,7 +215,7 @@ int main(int argc, char **argv)
     uint8_t *state_v3 = NULL, *state_v2 = NULL, *scratch = NULL;
     uint8_t dac_v3[256], dac_now[256], dac_expect[256], dac_post[256];
     size_t state_size, dac_size, dac_size_now, dac_off = 0;
-    size_t cdrom_size, joy_size, mt_size, cdrom_end = 0;
+    size_t cdrom_size, joy_size, mt_size, nvm_size, cdrom_end = 0;
     size_t tail_nonzero = 0, i;
     unsigned matches;
     unsigned frame;
@@ -251,6 +252,7 @@ int main(int argc, char **argv)
     cdrom_save  = (dac_state_save_fn)harness_dlsym(&cfg, "CDROMStateSave");
     joy_save    = (dac_state_save_fn)harness_dlsym(&cfg, "JoystickStateSave");
     mt_save     = (dac_state_save_fn)harness_dlsym(&cfg, "MTStateSave");
+    nvm_save    = (dac_state_save_fn)harness_dlsym(&cfg, "NVMBiosStateSave");
     ser_size_fn = (serialize_size_fn)harness_dlsym(&cfg, "retro_serialize_size");
     ser         = (serialize_fn)harness_dlsym(&cfg, "retro_serialize");
     unser       = (unserialize_fn)harness_dlsym(&cfg, "retro_unserialize");
@@ -355,8 +357,9 @@ int main(int argc, char **argv)
      * standalone block dumps are byte-identical to what the state holds. */
     joy_size   = joy_save(scratch);
     mt_size    = mt_save(scratch);
+    nvm_size   = nvm_save(scratch);
     cdrom_size = cdrom_save(scratch);
-    cdrom_end  = dac_off - mt_size - joy_size;
+    cdrom_end  = dac_off - nvm_size - mt_size - joy_size;
     check(cdrom_end > cdrom_size && cdrom_size > CDROM_DSA_TAIL_SIZE
           && memcmp(state_v3 + cdrom_end - cdrom_size, scratch,
                     cdrom_size) == 0,
@@ -390,21 +393,21 @@ int main(int argc, char **argv)
     memcpy(state_v2, state_v3, state_size);
     {
         /* Higher-offset cuts first so the later offsets stay valid. */
+        size_t v7_tail = MEMTRACK_OVERRIDE_SIZE + nvm_size;
         size_t cut = dac_off + DAC_I2S_NONZEROCOUNT_OFFSET;
-        size_t cut3 = dac_off - MEMTRACK_OVERRIDE_SIZE;
+        size_t cut3 = dac_off - v7_tail;
         size_t cut2 = cdrom_end - CDROM_DSA_TAIL_SIZE;
         memmove(state_v2 + cut,
                 state_v2 + cut + DAC_I2S_NONZEROCOUNT_SIZE,
                 state_size - cut - DAC_I2S_NONZEROCOUNT_SIZE);
         memset(state_v2 + state_size - DAC_I2S_NONZEROCOUNT_SIZE, 0,
                DAC_I2S_NONZEROCOUNT_SIZE);
-        /* A v2..v6 Memory Track block predates the override flag (see
-         * STATE_VERSION_MEMTRACK_OVERRIDE): splice that byte out too. */
+        /* A v2..v6 state predates the MT override flag and the NVM BIOS
+         * block (see STATE_VERSION_MEMTRACK_OVERRIDE): splice both out. */
         memmove(state_v2 + cut3,
-                state_v2 + cut3 + MEMTRACK_OVERRIDE_SIZE,
-                state_size - cut3 - MEMTRACK_OVERRIDE_SIZE);
-        memset(state_v2 + state_size - MEMTRACK_OVERRIDE_SIZE, 0,
-               MEMTRACK_OVERRIDE_SIZE);
+                state_v2 + cut3 + v7_tail,
+                state_size - cut3 - v7_tail);
+        memset(state_v2 + state_size - v7_tail, 0, v7_tail);
         /* A v2/v3 CDROM block also predates the DSA queue tail (see
          * STATE_VERSION_CDROM_DSA_QUEUE): splice those bytes out too. */
         memmove(state_v2 + cut2,


### PR DESCRIPTION
Fixes #258. **Vid Grid (USA) (Rev 1) now boots into gameplay with a working Save option**, in HLE *and* real-BIOS mode — the first title confirmed to use the Memory Track.

## Credit

Neither the Jaguar TRM nor the official SDK documents any of this. Two projects made it possible:

- **[cubanismo/skunk_mtrk](https://github.com/cubanismo/skunk_mtrk)** — preserves the **original Atari NVM BIOS v1.01 68K source** (`asmnvm.s`) and its Feb 1995 specification, *"Non Volatile Memory - Bios calls"*. Released by James Jones under CC0-1.0. The filesystem here is transcribed from it.
- **[MiSTer-devel/Jaguar_MiSTer](https://github.com/MiSTer-devel/Jaguar_MiSTer)** — `Jaguar.sv` carries the flash detection protocol and address map in comments; the only known-working open-source hardware implementation.

(BizHawk's Jaguar core is a Virtual Jaguar port, so it shares our lineage and the same gap.)

## Two layers were broken

### 1. The flash device (commits 1–2)

Memory Track emulation existed but could never activate for CD content — the one configuration where hardware uses it, since the MT cart plugs into the cartridge slot while the CD unit sits on top.

- **NVRAM at the wrong address.** Mapped over the `$8xxxxx` ROM window at one byte per longword; it's actually a plain 16-bit window at **`$900000`** (*"Actual save data is at 9XXXXXX"*). The write dispatch only covered `$800000-$87FFFE`, so `$900000` writes had nowhere to land.
- **A ROMWIDTH gate with no hardware counterpart.** Gated on `MEMCON1 ROMWIDTH == 2`, on the theory the width switch selected the MT. It doesn't — a plain cartridge sits at ROMWIDTH 2 as its *normal* width, and CD content runs at ROMWIDTH 0 (measured across all 35 discs, both modes). MiSTer gates purely on presence.
- **The part claimed the entire cart window.** Now claims only what it owns via `MTClaimsRead`/`MTClaimsWrite` — the `$900000` window plus override-only command/ID addresses. That's what makes dropping the ROMWIDTH test safe: everything else still reads the CD BIOS at `$800000`.

### 2. The NVM BIOS module (commit 3) — the reason it was still invisible

Fixing the flash changed nothing observable, because **games never touch the flash directly.** A survey of all 35 discs in both boot modes found zero cart-space writes. Instead they look for a `'_NVM'` magic cookie at **`$2400`** and `JSR` a dispatcher at **`$2404`** — a 2K module the CD BIOS boot installs in RAM from the cartridge. Vid Grid's check is at `$012B72`: `cmpi.l #'_NVM',$2400.w`.

New `src/core/nvmbios.c` HLEs that module's eleven calls (Initialize, Create, Open, Close, Delete, Read, Write, SearchFirst/Next, Seek, Inquire) against the same 128K image the flash exposes at `$900000` — so what the module writes is what a real cart dump would hold. 512-byte blocks, block 0 FAT, blocks 1–7 a 199-entry directory, names packed 3 chars/word from a 40-character set, first-block checksum.

**Quirks are preserved deliberately**, because games were written against them: a bad checksum silently reformats the FAT+directory (so a blank cart self-formats on first use); Delete always reports success (the module clobbers D0 recalculating the checksum); Close does no validation; zero-length files use `FAT_EMPTYFILE`.

Hooked at `$2404` in the same pre-instruction callback the CD HLE jump table uses, active in **both** boot modes — the module is RAM-resident on hardware regardless of which CD BIOS booted the disc.

## Core option

`virtualjaguar_memory_track` (default **enabled**, CD-only, in the CD-ROM category from #257) so a console *without* the cartridge can still be emulated — some titles behave differently when one is present. Save data rides in the existing CD save buffer.

Save states go to **v7**, gated by `STATE_VERSION_MEMTRACK_OVERRIDE` so older states still load; `test_state_compat`'s v2 fixture splices out both v7 additions.

## Testing

| | result |
|---|---|
| `test/test_nvmbios` (new, 40 checks) | round trips, app-scoped naming, handle exhaustion, search, inquire accounting, `ENOSPC`/`ERANGE`/`EIHNDL`/`EFILNF`, every preserved quirk |
| `test/test_memtrack` (new, 23 checks) | address claims, ATMEL AT29C010 IDs, write-enable gating, full 128K without aliasing |
| CD HLE | 22 pass / 13 fail — disc-by-disc set **identical** to develop |
| CD BIOS | 35 pass / 0 fail |
| `make TEST_EXPORTS=1 test` | exit 0 |
| `scripts/c89-lint.sh` | clean |

Both new tests are wired into `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)