### PR TITLE
feat(bus): symmetric DRAM self-cost timing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -795,7 +795,7 @@ else
 # rev (+ -dirty) against this before running -- a stale dylib fails loudly
 # instead of silently testing the wrong code (see scripts/build-id.sh).
 test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
-test: test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_netpacket test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 \
+test: test/test_gpu_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_netpacket test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
@@ -809,6 +809,7 @@ test: test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp 
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/test_uart_core test/test_netlink_host \
 		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy
+	./test/test_gpu_dram_timing
 	./test/test_cheat
 	./test/test_event_queue
 	./test/test_jlink
@@ -974,6 +975,9 @@ test/tools/netlink_latency: test/tools/netlink_latency.c test/harness/harness.c 
 
 test/tools/netlink_delay_proxy: test/tools/netlink_delay_proxy.c
 	$(CC) -O2 -Wall -o $@ test/tools/netlink_delay_proxy.c
+
+test/test_gpu_dram_timing: test/test_gpu_dram_timing.c src/core/bus_arbiter.c src/core/bus_arbiter.h
+	$(CC) -O2 -Wall -std=c99 -o $@ test/test_gpu_dram_timing.c src/core/bus_arbiter.c
 
 test/tools/netlink_game: test/tools/netlink_game.c test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \

--- a/Makefile
+++ b/Makefile
@@ -795,7 +795,7 @@ else
 # rev (+ -dirty) against this before running -- a stale dylib fails loudly
 # instead of silently testing the wrong code (see scripts/build-id.sh).
 test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
-test: test/test_gpu_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_netpacket test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 \
+test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_netpacket test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
@@ -809,7 +809,7 @@ test: test/test_gpu_dram_timing test/test_cheat test/test_event_queue test/test_
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/test_uart_core test/test_netlink_host \
 		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy
-	./test/test_gpu_dram_timing
+	./test/test_dram_timing
 	./test/test_cheat
 	./test/test_event_queue
 	./test/test_jlink
@@ -976,8 +976,8 @@ test/tools/netlink_latency: test/tools/netlink_latency.c test/harness/harness.c 
 test/tools/netlink_delay_proxy: test/tools/netlink_delay_proxy.c
 	$(CC) -O2 -Wall -o $@ test/tools/netlink_delay_proxy.c
 
-test/test_gpu_dram_timing: test/test_gpu_dram_timing.c src/core/bus_arbiter.c src/core/bus_arbiter.h
-	$(CC) -O2 -Wall -std=c99 -o $@ test/test_gpu_dram_timing.c src/core/bus_arbiter.c
+test/test_dram_timing: test/test_dram_timing.c src/core/bus_arbiter.c src/core/bus_arbiter.h
+	$(CC) -O2 -Wall -std=c99 -o $@ test/test_dram_timing.c src/core/bus_arbiter.c
 
 test/tools/netlink_game: test/tools/netlink_game.c test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \

--- a/Makefile.common
+++ b/Makefile.common
@@ -38,6 +38,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/cd/jagcd_bios.c \
 	$(CORE_DIR)/src/cd/jagcd_cart.c \
 	$(CORE_DIR)/src/cd/jagcd_hle.c \
+	$(CORE_DIR)/src/core/bus_arbiter.c \
 	$(CORE_DIR)/src/core/cheat.c \
 	$(CORE_DIR)/src/core/crc32.c \
 	$(CORE_DIR)/src/core/perf_counters.c \

--- a/libretro.c
+++ b/libretro.c
@@ -18,6 +18,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 
 #include "cheat.h"
 #include "crash_detect.h"
+#include "bus_arbiter.h"
 #include "file.h"
 #include "jagbios.h"
 #include "jagcdbios.h"
@@ -467,6 +468,27 @@ static void check_variables(void)
       CDTraceSetEnabled(strcmp(var.value, "enabled") == 0);
    else
       CDTraceSetEnabled(0);
+
+   /* GPU DRAM timing: enabled/disabled only.  The calibration scale is
+    * deliberately NOT a core option (manual ms/x knobs proved
+    * untunable on device) — VJ_GPU_DRAM_SCALE overrides it for
+    * headless calibration experiments until the physical cost is
+    * derived properly. */
+   var.key = "virtualjaguar_gpu_dram_timing";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      busArbiter.enabled = (strcmp(var.value, "enabled") == 0);
+   else
+      busArbiter.enabled = 0;
+   {
+      const char *scale_env = getenv("VJ_GPU_DRAM_SCALE");
+      int dram_scale = (scale_env && scale_env[0]) ? atoi(scale_env) : 1;
+      if (dram_scale < 1)
+         dram_scale = 1;
+      if (dram_scale > 16)
+         dram_scale = 16;
+      busArbiter.contention_scale = (uint8_t)dram_scale;
+   }
 
    var.key = "virtualjaguar_netlink";
    var.value = NULL;

--- a/libretro.c
+++ b/libretro.c
@@ -469,19 +469,19 @@ static void check_variables(void)
    else
       CDTraceSetEnabled(0);
 
-   /* GPU DRAM timing: enabled/disabled only.  The calibration scale is
-    * deliberately NOT a core option (manual ms/x knobs proved
-    * untunable on device) — VJ_GPU_DRAM_SCALE overrides it for
-    * headless calibration experiments until the physical cost is
-    * derived properly. */
-   var.key = "virtualjaguar_gpu_dram_timing";
+   /* DRAM timing: enabled/disabled only, covering BOTH halves of the
+    * symmetric self-cost model (GPU stalls in gpu.c, 68K wait-states
+    * in jaguar.c).  The calibration scale is deliberately NOT a core
+    * option (manual knobs proved untunable on device) — VJ_DRAM_SCALE
+    * overrides it for headless calibration experiments only. */
+   var.key = "virtualjaguar_dram_timing";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       busArbiter.enabled = (strcmp(var.value, "enabled") == 0);
    else
       busArbiter.enabled = 0;
    {
-      const char *scale_env = getenv("VJ_GPU_DRAM_SCALE");
+      const char *scale_env = getenv("VJ_DRAM_SCALE");
       int dram_scale = (scale_env && scale_env[0]) ? atoi(scale_env) : 1;
       if (dram_scale < 1)
          dram_scale = 1;

--- a/libretro.c
+++ b/libretro.c
@@ -908,6 +908,9 @@ bool retro_serialize(void *data, size_t size)
    buf += DACStateSave(buf);
    buf += UARTStateSave(buf);
 
+   /* v7: 68K DRAM self-cost carry (bus arbiter). */
+   STATE_SAVE_VAR(buf, busArbiter.m68k_sysclk_carry);
+
    written = (size_t)(buf - start);
    if (written > STATE_SIZE)
       return false;
@@ -969,6 +972,18 @@ bool retro_unserialize(const void *data, size_t size)
    buf += DACStateLoad(buf, version);
    if (version >= STATE_VERSION_JERRY_UART)
       buf += UARTStateLoad(buf, version);
+
+   if (version >= STATE_VERSION_BUS_ARBITER)
+   {
+      STATE_LOAD_VAR(buf, busArbiter.m68k_sysclk_carry);
+   }
+   else
+   {
+      busArbiter.m68k_sysclk_carry = 0;
+   }
+   /* tomRam8 was restored raw above; recompute the DRAM timing that
+    * bus_arbiter derives from MEMCON1 so it matches the loaded state. */
+   bus_arbiter_update_memcon(TOMGetMEMCON1());
 
    JaguarApplyHLEBIOSState();
 

--- a/libretro.c
+++ b/libretro.c
@@ -480,6 +480,11 @@ static void check_variables(void)
       busArbiter.enabled = (strcmp(var.value, "enabled") == 0);
    else
       busArbiter.enabled = 0;
+   /* No charging happens while disabled, so a carry left over from a
+    * runtime toggle (or an older savestate) must not leak into the
+    * first charged access when the option is re-enabled. */
+   if (!busArbiter.enabled)
+      busArbiter.m68k_sysclk_carry = 0;
    {
       const char *scale_env = getenv("VJ_DRAM_SCALE");
       int dram_scale = (scale_env && scale_env[0]) ? atoi(scale_env) : 1;

--- a/libretro.c
+++ b/libretro.c
@@ -1535,6 +1535,11 @@ void retro_init(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_INPUT_BITMASKS, NULL))
       libretro_supports_bitmasks = true;
 
+   /* Reset all bus-arbiter state (iOS cannot dlclose cores, so statics
+    * persist across loads).  Must run before check_variables() applies
+    * the core option — retro_load_game calls that after retro_init. */
+   bus_arbiter_init();
+
    CrashDetectInit();
 }
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -121,10 +121,10 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "enabled"
    },
    {
-      "virtualjaguar_gpu_dram_timing",
-      "GPU Memory Timing (Experimental)",
+      "virtualjaguar_dram_timing",
+      "DRAM Timing (Experimental)",
       NULL,
-      "Charge the GPU realistic DRAM access time for loads/stores that leave its local RAM, pacing GPU-rendered games (Doom-class) closer to real hardware. Affects only the GPU's own speed — no other processor is slowed. Experimental: the exact cost model is still being calibrated; leave disabled unless a game visibly runs too fast.",
+      "Charge the GPU and 68000 realistic DRAM access time for memory accesses that leave their local buses, pacing games that rely on hardware timing (Doom-class) closer to real hardware. Symmetric: each processor pays only its own access costs, so relative CPU/GPU timing is preserved. Experimental: the cost model is still being calibrated; leave disabled unless a game visibly runs too fast.",
       NULL,
       NULL,
       {

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -121,6 +121,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "enabled"
    },
    {
+      "virtualjaguar_gpu_dram_timing",
+      "GPU Memory Timing (Experimental)",
+      NULL,
+      "Charge the GPU realistic DRAM access time for loads/stores that leave its local RAM, pacing GPU-rendered games (Doom-class) closer to real hardware. Affects only the GPU's own speed — no other processor is slowed. Experimental: the exact cost model is still being calibrated; leave disabled unless a game visibly runs too fast.",
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "virtualjaguar_netlink",
       "Network Link (JagLink / CatBox)",
       NULL,

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -71,11 +71,28 @@ uint32_t bus_arbiter_dram_cost(uint32_t addr)
 uint32_t bus_arbiter_charge_access(int master, uint32_t addr)
 {
     uint32_t cost;
-    (void)master;
     cost = bus_arbiter_dram_cost(addr);
     if (cost == 0)
-        return 0;
+    {
+        /* GPU/DSP local RAM: internal bus for the owning RISC (free),
+         * but an I/O-bus transaction for the 68K. */
+        if (master != BM_CPU)
+            return 0;
+        cost = 2;
+    }
     if (busArbiter.contention_scale > 1)
         cost *= busArbiter.contention_scale;
     return cost;
+}
+
+uint32_t bus_arbiter_m68k_access(uint32_t addr, uint32_t naccesses)
+{
+    uint32_t sysclks, cycles;
+    sysclks = bus_arbiter_charge_access(BM_CPU, addr) * naccesses;
+    if (sysclks == 0)
+        return 0;
+    busArbiter.m68k_sysclk_carry += sysclks;
+    cycles = busArbiter.m68k_sysclk_carry >> 1;
+    busArbiter.m68k_sysclk_carry &= 1;
+    return cycles;
 }

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -87,11 +87,17 @@ uint32_t bus_arbiter_dram_cost(uint32_t addr)
     if (addr >= 0x800000 && addr < 0xE00000)
         return busArbiter.rom_clocks;
 
+    /* Bootstrap ROM bank ($E00000-$E3FFFF): same ROMSPEED-derived
+     * timing as the cartridge bank (JTRM: both ROM banks share width
+     * and speed). */
+    if (addr >= 0xE00000 && addr <= 0xE3FFFF)
+        return busArbiter.rom_clocks;
+
     /* TOM/JERRY registers: I/O bus. */
     if (addr >= 0xF00000)
         return IO_BUS_CLOCKS_ESTIMATE;
 
-    /* Default for other addresses (0x200000-0x7FFFFF, 0xE00000-0xEFFFFF):
+    /* Default for other addresses (0x200000-0x7FFFFF, 0xE40000-0xEFFFFF):
      * treat as DRAM-equivalent, same approximation as main DRAM above. */
     return DRAM_PAGE_CYCLE + busArbiter.dram_row_miss;
 }

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -11,18 +11,41 @@
 
 struct BusArbiter busArbiter;
 
-/* DRAMSPEED field (MEMCON1 bits 5-6) -> base DRAM clocks per access.
- * JTRM: 00=2, 01=3, 10=4, 11=5 system clocks. */
-static const uint8_t dramspeed_table[4] = { 2, 3, 4, 5 };
+/* DRAMSPEED field (MEMCON1 bits 5-6) -> row-change (page miss) overhead,
+ * in system clocks (precharge + RAS-to-CAS from the JTRM MEMCON1 table):
+ *   DRAMSPEED  precharge  RAS-to-CAS  refresh  row-miss overhead
+ *       0          4          3          5           7
+ *       1          4          3          4           7
+ *       2          3          2          4           5
+ *       3          2          1          3           3
+ * Page-mode (page hit) cycle time is always 2 clocks, fixed -- that is
+ * DRAM_PAGE_CYCLE below, independent of DRAMSPEED. */
+static const uint8_t dram_row_miss_table[4] = { 7, 7, 5, 3 };
 
-/* RAS precharge penalty for page miss (row activation + precharge). */
-#define PAGE_MISS_PENALTY 4
+/* Fixed page-mode (page hit) cycle time, per JTRM: "The page mode cycle
+ * time is always two clock cycles." */
+#define DRAM_PAGE_CYCLE 2
+
+/* ROMSPEED field (MEMCON1 bits 3-4) -> ROM cycle time in system clocks,
+ * per JTRM: 0=10, 1=8, 2=6, 3=5.  FASTROM (bit 7) overrides to 2 clocks
+ * ("for test purposes only"). */
+static const uint8_t rom_speed_table[4] = { 10, 8, 6, 5 };
+#define ROM_FASTROM_CLOCKS 2
+
+/* 68K access to GPU/DSP local RAM (an I/O-bus transaction for the 68K,
+ * free for the owning RISC's internal bus) and to TOM/JERRY registers.
+ * Estimate only: no JTRM figure was found for 68K/RISC-local-RAM access
+ * cost.  IOSPEED (MEMCON1 bits 11-12) governs EXTERNAL peripherals, a
+ * different bus, so it does not source this number. */
+#define IO_BUS_CLOCKS_ESTIMATE 2
 
 void bus_arbiter_init(void)
 {
     memset(&busArbiter, 0, sizeof(busArbiter));
-    busArbiter.dram_base_clocks = 5;
-    busArbiter.dram_miss_penalty = PAGE_MISS_PENALTY;
+    /* Match reset MEMCON1 = 0x1861: DRAMSPEED=3 -> row_miss 3,
+     * ROMSPEED=0, FASTROM=0 -> rom_clocks 10. */
+    busArbiter.dram_row_miss = 3;
+    busArbiter.rom_clocks = 10;
     /* Default OFF: timing modeling is experimental and must be a
      * zero-behavior-change opt-in.  check_variables() enables it when
      * the virtualjaguar_dram_timing core option is set. */
@@ -33,8 +56,12 @@ void bus_arbiter_init(void)
 void bus_arbiter_update_memcon(uint16_t memcon1)
 {
     uint8_t dramspeed;
+    uint8_t romspeed;
     dramspeed = (memcon1 >> 5) & 0x03;
-    busArbiter.dram_base_clocks = dramspeed_table[dramspeed];
+    romspeed = (memcon1 >> 3) & 0x03;
+    busArbiter.dram_row_miss = dram_row_miss_table[dramspeed];
+    busArbiter.rom_clocks = (memcon1 & 0x80) ? ROM_FASTROM_CLOCKS
+                                              : rom_speed_table[romspeed];
 }
 
 uint32_t bus_arbiter_dram_cost(uint32_t addr)
@@ -52,20 +79,21 @@ uint32_t bus_arbiter_dram_cost(uint32_t addr)
      * would get page hits, but without tracking row state, the miss
      * cost is a reasonable average for scattered GPU access patterns. */
     if (addr < 0x200000)
-        return busArbiter.dram_base_clocks + busArbiter.dram_miss_penalty;
+        return DRAM_PAGE_CYCLE + busArbiter.dram_row_miss;
 
-    /* Cartridge ROM (0x800000-0xDFFFFF): similar cost to DRAM.
-     * ROMSPEED from MEMCON1 bits 3-4 controls this, but games rarely
-     * access ROM from GPU at runtime. Use DRAM base cost. */
+    /* Cartridge ROM (0x800000-0xDFFFFF): ROMSPEED-derived cost from
+     * MEMCON1 bits 3-4 (FASTROM override on bit 7).  ROM is the
+     * hottest path here — 68K instruction fetches run out of it. */
     if (addr >= 0x800000 && addr < 0xE00000)
-        return busArbiter.dram_base_clocks;
+        return busArbiter.rom_clocks;
 
-    /* TOM/JERRY registers: ~2 system clocks (I/O bus). */
+    /* TOM/JERRY registers: I/O bus. */
     if (addr >= 0xF00000)
-        return 2;
+        return IO_BUS_CLOCKS_ESTIMATE;
 
-    /* Default for other addresses */
-    return busArbiter.dram_base_clocks;
+    /* Default for other addresses (0x200000-0x7FFFFF, 0xE00000-0xEFFFFF):
+     * treat as DRAM-equivalent, same approximation as main DRAM above. */
+    return DRAM_PAGE_CYCLE + busArbiter.dram_row_miss;
 }
 
 uint32_t bus_arbiter_charge_access(int master, uint32_t addr)
@@ -78,7 +106,7 @@ uint32_t bus_arbiter_charge_access(int master, uint32_t addr)
          * but an I/O-bus transaction for the 68K. */
         if (master != BM_CPU)
             return 0;
-        cost = 2;
+        cost = IO_BUS_CLOCKS_ESTIMATE;
     }
     if (busArbiter.contention_scale > 1)
         cost *= busArbiter.contention_scale;

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -1,0 +1,81 @@
+/*
+ * bus_arbiter.c — GPU external-memory access timing.
+ *
+ * See bus_arbiter.h for scope and history.
+ *
+ * MiSTer reference: rtl/Rework/arb.v, mem.v, gateway.v
+ */
+
+#include "bus_arbiter.h"
+#include <string.h>
+
+struct BusArbiter busArbiter;
+
+/* DRAMSPEED field (MEMCON1 bits 5-6) -> base DRAM clocks per access.
+ * JTRM: 00=2, 01=3, 10=4, 11=5 system clocks. */
+static const uint8_t dramspeed_table[4] = { 2, 3, 4, 5 };
+
+/* RAS precharge penalty for page miss (row activation + precharge). */
+#define PAGE_MISS_PENALTY 4
+
+void bus_arbiter_init(void)
+{
+    memset(&busArbiter, 0, sizeof(busArbiter));
+    busArbiter.dram_base_clocks = 5;
+    busArbiter.dram_miss_penalty = PAGE_MISS_PENALTY;
+    /* Default OFF: timing modeling is experimental and must be a
+     * zero-behavior-change opt-in.  check_variables() enables it when
+     * the virtualjaguar_gpu_dram_timing core option is set. */
+    busArbiter.enabled = 0;
+    busArbiter.contention_scale = 1;
+}
+
+void bus_arbiter_update_memcon(uint16_t memcon1)
+{
+    uint8_t dramspeed;
+    dramspeed = (memcon1 >> 5) & 0x03;
+    busArbiter.dram_base_clocks = dramspeed_table[dramspeed];
+}
+
+uint32_t bus_arbiter_dram_cost(uint32_t addr)
+{
+    /* GPU local RAM: 0xF03000-0xF03FFF — no bus transaction */
+    if (addr >= 0xF03000 && addr <= 0xF03FFF)
+        return 0;
+
+    /* DSP local RAM: 0xF1B000-0xF1CFFF — no bus transaction */
+    if (addr >= 0xF1B000 && addr <= 0xF1CFFF)
+        return 0;
+
+    /* Main DRAM (0x000000-0x1FFFFF): full DRAM access cost.
+     * Use page-miss cost as the average — sequential access patterns
+     * would get page hits, but without tracking row state, the miss
+     * cost is a reasonable average for scattered GPU access patterns. */
+    if (addr < 0x200000)
+        return busArbiter.dram_base_clocks + busArbiter.dram_miss_penalty;
+
+    /* Cartridge ROM (0x800000-0xDFFFFF): similar cost to DRAM.
+     * ROMSPEED from MEMCON1 bits 3-4 controls this, but games rarely
+     * access ROM from GPU at runtime. Use DRAM base cost. */
+    if (addr >= 0x800000 && addr < 0xE00000)
+        return busArbiter.dram_base_clocks;
+
+    /* TOM/JERRY registers: ~2 system clocks (I/O bus). */
+    if (addr >= 0xF00000)
+        return 2;
+
+    /* Default for other addresses */
+    return busArbiter.dram_base_clocks;
+}
+
+uint32_t bus_arbiter_charge_access(int master, uint32_t addr)
+{
+    uint32_t cost;
+    (void)master;
+    cost = bus_arbiter_dram_cost(addr);
+    if (cost == 0)
+        return 0;
+    if (busArbiter.contention_scale > 1)
+        cost *= busArbiter.contention_scale;
+    return cost;
+}

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -25,7 +25,7 @@ void bus_arbiter_init(void)
     busArbiter.dram_miss_penalty = PAGE_MISS_PENALTY;
     /* Default OFF: timing modeling is experimental and must be a
      * zero-behavior-change opt-in.  check_variables() enables it when
-     * the virtualjaguar_gpu_dram_timing core option is set. */
+     * the virtualjaguar_dram_timing core option is set. */
     busArbiter.enabled = 0;
     busArbiter.contention_scale = 1;
 }

--- a/src/core/bus_arbiter.h
+++ b/src/core/bus_arbiter.h
@@ -10,7 +10,13 @@
  * local GPU RAM pays a DRAM access cost in system clocks, derived from
  * MEMCON1, charged to the GPU's OWN cycle budget in gpu.c; the 68K's
  * bus cycles pay their own DRAM cost via bus_arbiter_m68k_access().
- * Neither half can slow any other processor.
+ * Neither half can slow any other processor: costs are only ever
+ * charged to the owning master's own cycle budget.  The 68K's
+ * consumed time IS visible to time-based cross-processor sync points
+ * (GPUSyncToM68K in gpu.c, keyed off m68k_cycles_run()) — that
+ * coupling reads elapsed 68K time, not raw instruction count, so
+ * DRAM wait-states folded into remainingCycles are exactly what it
+ * should see.  That is the intended semantics, not a leak.
  *
  * The file keeps its name so the remaining #169 work (OP bus stealing,
  * blitter busy-time, 68K arbitration done right) can grow back around

--- a/src/core/bus_arbiter.h
+++ b/src/core/bus_arbiter.h
@@ -47,7 +47,7 @@ struct BusArbiter {
     uint8_t enabled;
 
     /* Calibration multiplier applied to charged cycles.  NOT a user
-     * option: settable only via the VJ_GPU_DRAM_SCALE env var while the
+     * option: settable only via the VJ_DRAM_SCALE env var while the
      * correct physical cost (OP occupancy, load latency, master
      * handoff) is being pinned down against measured game pace. */
     uint8_t contention_scale;

--- a/src/core/bus_arbiter.h
+++ b/src/core/bus_arbiter.h
@@ -1,0 +1,73 @@
+/*
+ * bus_arbiter.h — GPU external-memory access timing (DRAM latency).
+ *
+ * Extracted from the full bus-arbiter experiment (PR #169) after device
+ * testing showed its cross-processor half was harmful: deducting
+ * GPU/blitter bus traffic from the 68K's cycle budget slowed innocent
+ * 68K-paced work (real-BIOS boot logo animation, BIOS load) and made
+ * pacing bursty (penalty applied in per-timeslice chunks).  What
+ * survives here is the principled half: a GPU LOAD/STORE that leaves
+ * local GPU RAM pays a DRAM access cost in system clocks, derived from
+ * MEMCON1, charged to the GPU's OWN cycle budget in gpu.c.  It cannot
+ * slow any other processor.
+ *
+ * The file keeps its name so the remaining #169 work (OP bus stealing,
+ * blitter busy-time, 68K arbitration done right) can grow back around
+ * it.
+ *
+ * MEMCON1 default on Jaguar: 0x1861
+ *   Bits 5-6 (DRAMSPEED): 0b11 = 5 system clocks per DRAM access
+ *   Page miss adds ~4 clocks for RAS precharge + row activation
+ */
+#ifndef BUS_ARBITER_H
+#define BUS_ARBITER_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Bus masters (subset — only the GPU charges today; the enum survives
+ * so future arbitration work keeps stable identities). */
+enum BusMaster {
+    BM_GPU = 0,
+    BM_COUNT
+};
+
+struct BusArbiter {
+    /* DRAM timing derived from MEMCON1 DRAMSPEED field.
+     * Page hit = base access time; page miss adds RAS precharge. */
+    uint8_t dram_base_clocks;
+    uint8_t dram_miss_penalty;
+
+    /* Feature toggle (from core option). */
+    uint8_t enabled;
+
+    /* Calibration multiplier applied to charged cycles.  NOT a user
+     * option: settable only via the VJ_GPU_DRAM_SCALE env var while the
+     * correct physical cost (OP occupancy, load latency, master
+     * handoff) is being pinned down against measured game pace. */
+    uint8_t contention_scale;
+};
+
+extern struct BusArbiter busArbiter;
+
+void bus_arbiter_init(void);
+
+/* Called when MEMCON1 is written to recompute DRAM timing. */
+void bus_arbiter_update_memcon(uint16_t memcon1);
+
+/* Return DRAM access cost in system clocks for a given address.
+ * Local GPU/DSP RAM returns 0 (no bus transaction). */
+uint32_t bus_arbiter_dram_cost(uint32_t addr);
+
+/* Cost (in system clocks, scaled) the master pays for one access to
+ * `addr`.  0 for local RAM. */
+uint32_t bus_arbiter_charge_access(int master, uint32_t addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BUS_ARBITER_H */

--- a/src/core/bus_arbiter.h
+++ b/src/core/bus_arbiter.h
@@ -23,8 +23,16 @@
  * it.
  *
  * MEMCON1 default on Jaguar: 0x1861
- *   Bits 5-6 (DRAMSPEED): 0b11 = 5 system clocks per DRAM access
- *   Page miss adds ~4 clocks for RAS precharge + row activation
+ *   Bits 3-4 (ROMSPEED): 0b00 = 10 system clocks per ROM access
+ *     (JTRM: 0=10, 1=8, 2=6, 3=5; bit 7 FASTROM overrides to 2, test-only)
+ *   Bits 5-6 (DRAMSPEED): 0b11 -> row-change (page miss) overhead of
+ *     3 system clocks (precharge 2 + RAS-to-CAS 1, from the JTRM
+ *     MEMCON1 table).  Page-mode (page hit) cycle time is always 2
+ *     clocks, fixed, regardless of DRAMSPEED.  Full row-miss overhead
+ *     table indexed by DRAMSPEED: { 7, 7, 5, 3 }.
+ *   This model uses the row-miss cost as an average DRAM access cost
+ *   (2 + row-miss) since GPU/68K access patterns are not tracked for
+ *   page-hit/page-miss state — see bus_arbiter_dram_cost().
  */
 #ifndef BUS_ARBITER_H
 #define BUS_ARBITER_H
@@ -44,10 +52,18 @@ enum BusMaster {
 };
 
 struct BusArbiter {
-    /* DRAM timing derived from MEMCON1 DRAMSPEED field.
-     * Page hit = base access time; page miss adds RAS precharge. */
-    uint8_t dram_base_clocks;
-    uint8_t dram_miss_penalty;
+    /* DRAM row-change (page miss) overhead in system clocks, derived
+     * from MEMCON1 DRAMSPEED (bits 5-6).  Page-mode (page hit) cycle
+     * time is a fixed 2 clocks and is not stored here (DRAM_PAGE_CYCLE
+     * in bus_arbiter.c).  NOT serialized: recomputed from MEMCON1 via
+     * bus_arbiter_update_memcon() on savestate load. */
+    uint8_t dram_row_miss;
+
+    /* Cartridge ROM cycle time in system clocks, derived from MEMCON1
+     * ROMSPEED (bits 3-4), overridden by FASTROM (bit 7).  NOT
+     * serialized: recomputed from MEMCON1 via bus_arbiter_update_memcon()
+     * on savestate load. */
+    uint8_t rom_clocks;
 
     /* Feature toggle (from core option). */
     uint8_t enabled;

--- a/src/core/bus_arbiter.h
+++ b/src/core/bus_arbiter.h
@@ -1,5 +1,5 @@
 /*
- * bus_arbiter.h — GPU external-memory access timing (DRAM latency).
+ * bus_arbiter.h — GPU and 68K self-cost access timing (DRAM latency).
  *
  * Extracted from the full bus-arbiter experiment (PR #169) after device
  * testing showed its cross-processor half was harmful: deducting
@@ -8,8 +8,9 @@
  * pacing bursty (penalty applied in per-timeslice chunks).  What
  * survives here is the principled half: a GPU LOAD/STORE that leaves
  * local GPU RAM pays a DRAM access cost in system clocks, derived from
- * MEMCON1, charged to the GPU's OWN cycle budget in gpu.c.  It cannot
- * slow any other processor.
+ * MEMCON1, charged to the GPU's OWN cycle budget in gpu.c; the 68K's
+ * bus cycles pay their own DRAM cost via bus_arbiter_m68k_access().
+ * Neither half can slow any other processor.
  *
  * The file keeps its name so the remaining #169 work (OP bus stealing,
  * blitter busy-time, 68K arbitration done right) can grow back around
@@ -28,10 +29,11 @@
 extern "C" {
 #endif
 
-/* Bus masters (subset — only the GPU charges today; the enum survives
- * so future arbitration work keeps stable identities). */
+/* Bus masters.  Locality is per-master: an address that is free for
+ * one master (its own local RAM) is a bus transaction for another. */
 enum BusMaster {
     BM_GPU = 0,
+    BM_CPU,
     BM_COUNT
 };
 
@@ -49,6 +51,10 @@ struct BusArbiter {
      * correct physical cost (OP occupancy, load latency, master
      * handoff) is being pinned down against measured game pace. */
     uint8_t contention_scale;
+
+    /* 68K self-cost carry: system clocks not yet converted to a whole
+     * 68K cycle (68K runs at system/2, so 0 or 1).  Savestate field. */
+    uint32_t m68k_sysclk_carry;
 };
 
 extern struct BusArbiter busArbiter;
@@ -65,6 +71,13 @@ uint32_t bus_arbiter_dram_cost(uint32_t addr);
 /* Cost (in system clocks, scaled) the master pays for one access to
  * `addr`.  0 for local RAM. */
 uint32_t bus_arbiter_charge_access(int master, uint32_t addr);
+
+/* 68K self-cost: whole 68K cycles to charge for `naccesses` 16-bit
+ * bus cycles at `addr` (a longword access passes 2).  Converts system
+ * clocks to 68K cycles (system/2), carrying the odd clock in
+ * busArbiter.m68k_sysclk_carry.  Does not check busArbiter.enabled —
+ * call sites gate, same as the GPU half. */
+uint32_t bus_arbiter_m68k_access(uint32_t addr, uint32_t naccesses);
 
 #ifdef __cplusplus
 }

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -31,6 +31,8 @@
 #include "jerry.h"
 #include "joystick.h"
 #include "m68000/m68kinterface.h"
+#include "m68000/cpudefs.h"   /* regs.remainingCycles — 68K DRAM self-cost */
+#include "bus_arbiter.h"
 #include "memtrack.h"
 #include "settings.h"
 #include "tom.h"
@@ -334,6 +336,19 @@ int irq_ack_handler(int level)
    return M68K_INT_ACK_AUTOVECTOR;
 }
 
+/* 68K DRAM self-cost (symmetric timing model): every 68K bus cycle
+ * that reaches shared memory pays its DRAM/I-O access time out of the
+ * 68K's own cycle budget.  naccesses = number of 16-bit bus cycles
+ * (a longword = 2).  m68kBusNoCharge exempts disassembler reads so
+ * debug output cannot perturb timing. */
+static int m68kBusNoCharge = 0;
+
+#define M68K_BUS_CHARGE(addr, naccesses) \
+   do { \
+      if (busArbiter.enabled && !m68kBusNoCharge) \
+         regs.remainingCycles -= (int32_t)bus_arbiter_m68k_access((addr), (naccesses)); \
+   } while (0)
+
 unsigned int m68k_read_memory_8(unsigned int address)
 {
 #ifdef ALPINE_FUNCTIONS
@@ -344,6 +359,7 @@ unsigned int m68k_read_memory_8(unsigned int address)
 
    // Musashi does this automagically for you, UAE core does not :-P
    address &= 0x00FFFFFF;
+   M68K_BUS_CHARGE(address, 1);
 
    // Note that the Jaguar only has 2M of RAM, not 4!
    if ((address >= 0x000000) && (address <= 0x1FFFFF))
@@ -378,6 +394,7 @@ unsigned int m68k_read_memory_16(unsigned int address)
 
    // Musashi does this automagically for you, UAE core does not :-P
    address &= 0x00FFFFFF;
+   M68K_BUS_CHARGE(address, 1);
 
    // Note that the Jaguar only has 2M of RAM, not 4!
    if ((address >= 0x000000) && (address <= 0x1FFFFE))
@@ -416,16 +433,21 @@ unsigned int m68k_read_memory_32(unsigned int address)
    address &= 0x00FFFFFF;
 
    if (address <= 0x1FFFFC)
+   {
+      M68K_BUS_CHARGE(address, 2);
       return GET32(jaguarMainRAM, address);
+   }
    else if ((address >= 0x800000) && (address <= 0xDFFEFE))
    {
       // Memory Track reading...
+      M68K_BUS_CHARGE(address, 2);
       if (((TOMGetMEMCON1() & 0x0006) == (2 << 1)) && (jaguarMainROMCRC32 == 0xFDF37F47))
          return MTReadLong(address);
 
       return GET32(jaguarMainROM, address - 0x800000);
    }
 
+   /* Fallthrough recurses into _16 twice — charged there, not here. */
    return (m68k_read_memory_16(address) << 16) | m68k_read_memory_16(address + 2);
 }
 
@@ -465,6 +487,7 @@ void m68k_write_memory_8(unsigned int address, unsigned int value)
 
    // Musashi does this automagically for you, UAE core does not :-P
    address &= 0x00FFFFFF;
+   M68K_BUS_CHARGE(address, 1);
 
    // Note that the Jaguar only has 2M of RAM, not 4!
    if ((address >= 0x000000) && (address <= 0x1FFFFF))
@@ -492,6 +515,7 @@ void m68k_write_memory_16(unsigned int address, unsigned int value)
 
    // Musashi does this automagically for you, UAE core does not :-P
    address &= 0x00FFFFFF;
+   M68K_BUS_CHARGE(address, 1);
 
    // Note that the Jaguar only has 2M of RAM, not 4!
    if ((address >= 0x000000) && (address <= 0x1FFFFE))
@@ -532,6 +556,7 @@ void m68k_write_memory_32(unsigned int address, unsigned int value)
 
    if (address <= 0x1FFFFC)
    {
+      M68K_BUS_CHARGE(address, 2);
       SET32(jaguarMainRAM, address, value);
       return;
    }
@@ -547,19 +572,31 @@ void m68k_write_memory_32(unsigned int address, unsigned int value)
 
 unsigned int m68k_read_disassembler_8(unsigned int address)
 {
-   return m68k_read_memory_8(address);
+   unsigned int v;
+   m68kBusNoCharge++;
+   v = m68k_read_memory_8(address);
+   m68kBusNoCharge--;
+   return v;
 }
 
 
 unsigned int m68k_read_disassembler_16(unsigned int address)
 {
-   return m68k_read_memory_16(address);
+   unsigned int v;
+   m68kBusNoCharge++;
+   v = m68k_read_memory_16(address);
+   m68kBusNoCharge--;
+   return v;
 }
 
 
 unsigned int m68k_read_disassembler_32(unsigned int address)
 {
-   return m68k_read_memory_32(address);
+   unsigned int v;
+   m68kBusNoCharge++;
+   v = m68k_read_memory_32(address);
+   m68kBusNoCharge--;
+   return v;
 }
 
 uint8_t JaguarReadByte(uint32_t offset, uint32_t who)

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -338,7 +338,7 @@ int irq_ack_handler(int level)
 
 /* 68K DRAM self-cost (symmetric timing model): every 68K bus cycle
  * that leaves the CPU (shared DRAM, and GPU/DSP local RAM, which also
- * costs the 68K 2 clocks) pays its DRAM/I-O access time out of the
+ * costs the 68K 2 system clocks) pays its DRAM/I-O access time out of the
  * 68K's own cycle budget.  naccesses = number of 16-bit bus cycles
  * (a longword = 2).  m68kBusNoCharge exempts disassembler reads so
  * debug output cannot perturb timing.

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -337,10 +337,16 @@ int irq_ack_handler(int level)
 }
 
 /* 68K DRAM self-cost (symmetric timing model): every 68K bus cycle
- * that reaches shared memory pays its DRAM/I-O access time out of the
+ * that leaves the CPU (shared DRAM, and GPU/DSP local RAM, which also
+ * costs the 68K 2 clocks) pays its DRAM/I-O access time out of the
  * 68K's own cycle budget.  naccesses = number of 16-bit bus cycles
  * (a longword = 2).  m68kBusNoCharge exempts disassembler reads so
- * debug output cannot perturb timing. */
+ * debug output cannot perturb timing.
+ *
+ * Side effect, intended: remainingCycles now measures time including
+ * wait-states, so m68k_cycles_run()-based coupling (GPUSyncToM68K)
+ * sees the 68K's consumed bus time, not just retired-instruction
+ * cycles. */
 static int m68kBusNoCharge = 0;
 
 #define M68K_BUS_CHARGE(addr, naccesses) \

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -20,9 +20,10 @@ extern "C" {
 /* Save state format identifier and version.
  * v4: CDROM chunk gained the DSA response queue + serial-delay counter.
  * v5: CDROM chunk gained the latched drive speed (DSA Set Mode $15nn).
- * v6: new UART chunk (JERRY async serial + jlink RX ring). */
+ * v6: new UART chunk (JERRY async serial + jlink RX ring).
+ * v7: bus-arbiter 68K self-cost carry (symmetric DRAM timing). */
 #define STATE_MAGIC     0x564A5353  /* "VJSS" */
-#define STATE_VERSION   6
+#define STATE_VERSION   7
 /* Oldest layout retro_unserialize still accepts.  States between
  * STATE_MIN_VERSION and STATE_VERSION load by skipping the fields added
  * after them (see DACStateLoad, CDROMStateLoad); STATE_VERSION is always
@@ -41,6 +42,8 @@ extern "C" {
 #define STATE_VERSION_CDROM_DRIVE_SPEED 5
 /* First version carrying the JERRY UART + jlink chunk. */
 #define STATE_VERSION_JERRY_UART 6
+/* v7 adds the bus-arbiter 68K carry (symmetric DRAM self-cost). */
+#define STATE_VERSION_BUS_ARBITER 7
 
 /* Header flags */
 #define STATE_FLAG_MEMTRACK  0x01

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>								// For memset
+#include "bus_arbiter.h"
 #include "log.h"
 #include "dsp.h"
 #include "jaguar.h"
@@ -38,6 +39,21 @@
 
 // Seems alignment in loads & stores was off...
 #define GPU_CORRECT_ALIGNMENT
+
+/* Bus contention: accumulates stall cycles for GPU external memory
+ * accesses within a single instruction.  Reset before each opcode
+ * in GPUExec(), then added to cycle cost after the opcode completes.
+ * Units: system clocks (same as bus_arbiter charges). */
+static uint32_t gpu_bus_stall;
+
+/* Charge an external memory access and accumulate the stall.
+ * addr is the target address — GPU local RAM (0xF03000-0xF03FFF)
+ * costs nothing; external addresses cost DRAM access time. */
+#define GPU_EXT_ACCESS(addr) \
+   do { \
+      if (busArbiter.enabled) \
+         gpu_bus_stall += bus_arbiter_charge_access(BM_GPU, (addr)); \
+   } while (0)
 
 #define GPU_TRACE_DEBUG 0
 #if GPU_TRACE_DEBUG
@@ -1006,16 +1022,14 @@ void GPUExec(int32_t cycles)
       //$E400 -> 1110 01 -> $39 -> 57
       //GPU #1
       gpu_pc += 2;
+      gpu_bus_stall = 0;
 #if 0
       gpu_opcode[index]();
 #else
        executeOpcode(index);
 #endif
-      // BIOS hacking
-      //GPU: [00F03548] jr      nz,00F03560 (0xd561) (RM=00F03114, RN=00000004) ->     --> JR: Branch taken.
-      //GPU: [00F0354C] jump    nz,(r29) (0xd3a1) (RM=00F03314, RN=00000004) -> (RM=00F03314, RN=00000004)
 
-      cycles -= gpu_opcode_cycles[index];
+      cycles -= gpu_opcode_cycles[index] + (int32_t)gpu_bus_stall;
 
       /* Single-step barrier (G_CTRL SINGLE_STEP, bit 3): a running RISC core
        * that has just set SINGLE_STEP has entered single-step mode and stops
@@ -1476,12 +1490,17 @@ INLINE static void gpu_opcode_store_r14_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2), RN, GPU);
+   {
+      uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1491,12 +1510,17 @@ INLINE static void gpu_opcode_store_r15_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2), RN, GPU);
+   {
+      uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1506,12 +1530,17 @@ INLINE static void gpu_opcode_load_r14_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[14] + RM, GPU);
+   {
+      uint32_t address = gpu_reg[14] + RM;
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 
@@ -1521,12 +1550,17 @@ INLINE static void gpu_opcode_load_r15_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[15] + RM, GPU);
+   {
+      uint32_t address = gpu_reg[15] + RM;
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 
@@ -1536,12 +1570,17 @@ INLINE static void gpu_opcode_store_r14_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[14] + RM, RN, GPU);
+   {
+      uint32_t address = gpu_reg[14] + RM;
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1551,12 +1590,17 @@ INLINE static void gpu_opcode_store_r15_ri(void)
 #ifdef GPU_CORRECT_ALIGNMENT_STORE
    uint32_t address = gpu_reg[15] + RM;
 
+   GPU_EXT_ACCESS(address);
    if (address >= 0xF03000 && address <= 0xF03FFF)
       GPUWriteLong(address & 0xFFFFFFFC, RN, GPU);
    else
       GPUWriteLong(address, RN, GPU);
 #else
-   GPUWriteLong(gpu_reg[15] + RM, RN, GPU);
+   {
+      uint32_t address = gpu_reg[15] + RM;
+      GPU_EXT_ACCESS(address);
+      GPUWriteLong(address, RN, GPU);
+   }
 #endif
 }
 
@@ -1579,12 +1623,13 @@ INLINE static void gpu_opcode_pack(void)
 
 INLINE static void gpu_opcode_storeb(void)
 {
-   //Is this right???
-   // Would appear to be so...!
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM, RN & 0xFF, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       JaguarWriteByte(RM, RN, GPU);
+   }
 }
 
 
@@ -1594,12 +1639,18 @@ INLINE static void gpu_opcode_storew(void)
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM & 0xFFFFFFFE, RN & 0xFFFF, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       JaguarWriteWord(RM, RN, GPU);
+   }
 #else
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM, RN & 0xFFFF, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       JaguarWriteWord(RM, RN, GPU);
+   }
 #endif
 }
 
@@ -1610,8 +1661,12 @@ INLINE static void gpu_opcode_store(void)
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       GPUWriteLong(RM & 0xFFFFFFFC, RN, GPU);
    else
+   {
+      GPU_EXT_ACCESS(RM);
       GPUWriteLong(RM, RN, GPU);
+   }
 #else
+   GPU_EXT_ACCESS(RM);
    GPUWriteLong(RM, RN, GPU);
 #endif
 }
@@ -1640,6 +1695,8 @@ INLINE static void gpu_opcode_store(void)
  * which needs its own before/after evidence rather than riding along here. */
 INLINE static void gpu_opcode_storep(void)
 {
+   GPU_EXT_ACCESS(RM);
+   GPU_EXT_ACCESS(RM + 4);
    GPUWriteLong((RM & 0xFFFFFFF8) + 0, gpu_hidata, GPU);
    GPUWriteLong((RM & 0xFFFFFFF8) + 4, RN, GPU);
 }
@@ -1663,7 +1720,10 @@ INLINE static void gpu_opcode_loadb(void)
       RN = GPUReadLong(RM & 0xFFFFFFFC, GPU);
    }
    else
+   {
+      GPU_EXT_ACCESS(RM);
       RN = JaguarReadByte(RM, GPU);
+   }
 }
 
 
@@ -1676,7 +1736,10 @@ INLINE static void gpu_opcode_loadw(void)
       RN = GPUReadLong(RM & 0xFFFFFFFC, GPU);
    }
    else
+   {
+      GPU_EXT_ACCESS(RM);
       RN = JaguarReadWord(RM, GPU);
+   }
 }
 
 
@@ -1700,8 +1763,10 @@ INLINE static void gpu_opcode_loadw(void)
 INLINE static void gpu_opcode_load(void)
 {
 #ifdef GPU_CORRECT_ALIGNMENT
+   GPU_EXT_ACCESS(RM);
    RN = GPUReadLong(RM & 0xFFFFFFFC, GPU);
 #else
+   GPU_EXT_ACCESS(RM);
    RN = GPUReadLong(RM, GPU);
 #endif
 }
@@ -1717,10 +1782,14 @@ INLINE static void gpu_opcode_loadp(void)
    }
    else
    {
+      GPU_EXT_ACCESS(RM);
+      GPU_EXT_ACCESS(RM + 4);
       gpu_hidata = GPUReadLong(RM + 0, GPU);
       RN		   = GPUReadLong(RM + 4, GPU);
    }
 #else
+   GPU_EXT_ACCESS(RM);
+   GPU_EXT_ACCESS(RM + 4);
    gpu_hidata = GPUReadLong(RM + 0, GPU);
    RN		   = GPUReadLong(RM + 4, GPU);
 #endif
@@ -1732,12 +1801,17 @@ INLINE static void gpu_opcode_load_r14_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2), GPU);
+   {
+      uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 
@@ -1747,12 +1821,17 @@ INLINE static void gpu_opcode_load_r15_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
 
+   GPU_EXT_ACCESS(address);
    if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
 #else
-   RN = GPUReadLong(gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2), GPU);
+   {
+      uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
+      GPU_EXT_ACCESS(address);
+      RN = GPUReadLong(address, GPU);
+   }
 #endif
 }
 

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -1695,8 +1695,9 @@ INLINE static void gpu_opcode_store(void)
  * which needs its own before/after evidence rather than riding along here. */
 INLINE static void gpu_opcode_storep(void)
 {
+   /* One 64-bit phrase = one bus transaction (JTRM: "the memory
+    * controller makes it all look 64 bits wide"), not two 32-bit ones. */
    GPU_EXT_ACCESS(RM);
-   GPU_EXT_ACCESS(RM + 4);
    GPUWriteLong((RM & 0xFFFFFFF8) + 0, gpu_hidata, GPU);
    GPUWriteLong((RM & 0xFFFFFFF8) + 4, RN, GPU);
 }
@@ -1782,14 +1783,14 @@ INLINE static void gpu_opcode_loadp(void)
    }
    else
    {
+      /* One 64-bit phrase = one bus transaction, not two. */
       GPU_EXT_ACCESS(RM);
-      GPU_EXT_ACCESS(RM + 4);
       gpu_hidata = GPUReadLong(RM + 0, GPU);
       RN		   = GPUReadLong(RM + 4, GPU);
    }
 #else
+   /* One 64-bit phrase = one bus transaction, not two. */
    GPU_EXT_ACCESS(RM);
-   GPU_EXT_ACCESS(RM + 4);
    gpu_hidata = GPUReadLong(RM + 0, GPU);
    RN		   = GPUReadLong(RM + 4, GPU);
 #endif

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -1391,6 +1391,12 @@ void TOMWriteByte(uint32_t offset, uint8_t data, uint32_t who)
       return;
    }
    tomRam8[offset] = data;
+
+   /* MEMCON1 can be written a byte at a time; keep the bus arbiter's
+    * MEMCON1-derived DRAM/ROM timing in sync (word writes hook in
+    * TOMWriteWord). */
+   if (offset == MEMCON1 || offset == MEMCON1 + 1)
+      bus_arbiter_update_memcon(TOMGetMEMCON1());
 }
 
 // TOM word access (write)

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -257,6 +257,7 @@
 
 #include <string.h>								// For memset()
 #include "blitter.h"
+#include "bus_arbiter.h"
 #include "event.h"
 #include "gpu.h"
 #include "jaguar.h"
@@ -1140,6 +1141,7 @@ void TOMReset(void)
    {
       SET16(tomRam8, MEMCON1, 0x1861);
       SET16(tomRam8, MEMCON2, 0x35CC);
+      bus_arbiter_update_memcon(0x1861);
       SET16(tomRam8, HP, 844);			// Horizontal Period (1-based; HP=845)
       SET16(tomRam8, HBB, 1713);		// Horizontal Blank Begin
       SET16(tomRam8, HBE, 125);			// Horizontal Blank End
@@ -1166,6 +1168,7 @@ void TOMReset(void)
    {
       SET16(tomRam8, MEMCON1, 0x1861);
       SET16(tomRam8, MEMCON2, 0x35CC);
+      bus_arbiter_update_memcon(0x1861);
       SET16(tomRam8, HP, 850);			// Horizontal Period
       SET16(tomRam8, HBB, 1711);		// Horizontal Blank Begin
       SET16(tomRam8, HBE, 158);			// Horizontal Blank End
@@ -1460,6 +1463,9 @@ void TOMWriteWord(uint32_t offset, uint16_t data, uint32_t who)
    // Fix a lockup bug... :-P
    TOMWriteByte(0xF00000 | offset, data >> 8, who);
    TOMWriteByte(0xF00000 | (offset+1), data & 0xFF, who);
+
+   if (offset == MEMCON1)
+      bus_arbiter_update_memcon(data);
 
    // detect screen resolution changes
    //This may go away in the future, if we do the virtualized screen thing...

--- a/test/test_dram_timing.c
+++ b/test/test_dram_timing.c
@@ -33,8 +33,14 @@ int main(void)
     bus_arbiter_init();
     check(busArbiter.enabled == 0, "init: disabled by default");
     bus_arbiter_update_memcon(0x1861);   /* power-on default */
-    check(busArbiter.dram_base_clocks == 5,
-          "MEMCON1 0x1861 -> DRAMSPEED 0b11 -> 5 clocks");
+    check(busArbiter.dram_row_miss == 3 && busArbiter.rom_clocks == 10,
+          "MEMCON1 0x1861 -> DRAMSPEED 0b11 row_miss=3, ROMSPEED 0b00 rom_clocks=10");
+
+    /* FASTROM (bit 7) overrides ROMSPEED to 2 clocks. Check it, then
+     * restore power-on timing so it doesn't affect what follows. */
+    bus_arbiter_update_memcon(0x1861 | 0x80);
+    check(busArbiter.rom_clocks == 2, "FASTROM overrides rom_clocks to 2");
+    bus_arbiter_update_memcon(0x1861);
 
     busArbiter.enabled = 1;
     busArbiter.contention_scale = 1;
@@ -45,13 +51,14 @@ int main(void)
     check(bus_arbiter_charge_access(BM_GPU, 0x00F1B000) == 0,
           "DSP local RAM costs 0");
 
-    /* Main DRAM costs base + page-miss average (5 + 4 at defaults). */
+    /* Main DRAM costs page cycle + row-miss overhead (2 + 3 at defaults,
+     * per JTRM MEMCON1 DRAMSPEED=0b11 -> precharge 2, RAS-to-CAS 1). */
     ext1 = bus_arbiter_charge_access(BM_GPU, 0x00080000);
-    check(ext1 == 9, "main DRAM access costs base+miss (9 clocks)");
+    check(ext1 == 5, "main DRAM access costs page+row-miss (5 clocks)");
 
-    /* Cart ROM and I/O cost less than DRAM-with-miss but not zero. */
-    check(bus_arbiter_charge_access(BM_GPU, 0x00800000) == 5,
-          "cart ROM access costs base clocks");
+    /* Cart ROM is ROMSPEED-derived (bits 3-4 = 0 at reset -> 10 clocks). */
+    check(bus_arbiter_charge_access(BM_GPU, 0x00800000) == 10,
+          "cart ROM access costs ROMSPEED clocks (10 at reset)");
     check(bus_arbiter_charge_access(BM_GPU, 0x00F00050) == 2,
           "TOM/JERRY register access costs 2 clocks");
 
@@ -61,10 +68,10 @@ int main(void)
     check(scaled == ext1 * 8, "scale 8x multiplies the DRAM cost by 8");
 
     /* Slower DRAMSPEED settings track MEMCON1. */
-    bus_arbiter_update_memcon(0x0000);   /* DRAMSPEED 0b00 = 2 clocks */
+    bus_arbiter_update_memcon(0x0000);   /* DRAMSPEED 0b00 -> row-miss 7 */
     busArbiter.contention_scale = 1;
-    check(bus_arbiter_charge_access(BM_GPU, 0x00080000) == 6,
-          "DRAMSPEED 0b00 -> 2+4 clocks");
+    check(bus_arbiter_charge_access(BM_GPU, 0x00080000) == 9,
+          "DRAMSPEED 0b00 -> 2+7 clocks");
 
     /* ---- 68K half (symmetric self-cost) ---- */
 
@@ -73,30 +80,32 @@ int main(void)
     busArbiter.contention_scale = 1;
 
     /* GPU/DSP local RAM is free only for the owning RISC.  For the 68K
-     * it is an I/O-bus transaction (~2 system clocks). */
+     * it is modeled as an I/O-bus transaction: IO_BUS_CLOCKS_ESTIMATE
+     * (2, unsourced -- no JTRM figure found for 68K access to RISC
+     * local RAM; this is a model assertion, not a hardware fact). */
     check(bus_arbiter_charge_access(BM_CPU, 0x00F03000) == 2,
-          "68K access to GPU local RAM costs 2 clocks (not free)");
+          "68K access to GPU local RAM charged IO_BUS_CLOCKS_ESTIMATE (2, unsourced)");
     check(bus_arbiter_charge_access(BM_CPU, 0x00F1B000) == 2,
-          "68K access to DSP local RAM costs 2 clocks (not free)");
+          "68K access to DSP local RAM charged IO_BUS_CLOCKS_ESTIMATE (2, unsourced)");
     check(bus_arbiter_charge_access(BM_GPU, 0x00F03000) == 0,
           "GPU access to GPU local RAM still free");
 
     /* bus_arbiter_m68k_access converts system clocks to 68K cycles
      * (68K runs at system/2) with a carry for the odd clock.
-     * DRAM cost at 0x1861 = 9 sysclks: 4 cycles carry 1, then 5. */
+     * DRAM cost at 0x1861 = 5 sysclks: 2 cycles carry 1, then 3. */
     busArbiter.m68k_sysclk_carry = 0;
-    check(bus_arbiter_m68k_access(0x00080000, 1) == 4,
-          "9 sysclks -> 4 68K cycles, carry 1");
+    check(bus_arbiter_m68k_access(0x00080000, 1) == 2,
+          "5 sysclks -> 2 68K cycles, carry 1");
     check(busArbiter.m68k_sysclk_carry == 1,
           "odd system clock carried");
-    check(bus_arbiter_m68k_access(0x00080000, 1) == 5,
-          "carry+9 sysclks -> 5 68K cycles, carry 0");
+    check(bus_arbiter_m68k_access(0x00080000, 1) == 3,
+          "carry+5 sysclks -> 3 68K cycles, carry 0");
     check(busArbiter.m68k_sysclk_carry == 0,
           "carry drained");
 
     /* A longword is two 16-bit bus cycles. */
-    check(bus_arbiter_m68k_access(0x00080000, 2) == 9,
-          "2 accesses = 18 sysclks -> 9 68K cycles");
+    check(bus_arbiter_m68k_access(0x00080000, 2) == 5,
+          "2 accesses = 10 sysclks -> 5 68K cycles");
 
     /* I/O access: 2 sysclks -> 1 cycle, no carry. */
     check(bus_arbiter_m68k_access(0x00F00050, 1) == 1,

--- a/test/test_dram_timing.c
+++ b/test/test_dram_timing.c
@@ -1,4 +1,4 @@
-/* test_gpu_dram_timing.c — unit test for the GPU DRAM-timing charge
+/* test_dram_timing.c — unit test for the symmetric DRAM self-cost timing
  * (the GPU self-stall extracted from the full bus arbiter, PR #169).
  *
  * The model: a GPU LOAD/STORE that leaves local GPU RAM pays a DRAM
@@ -62,6 +62,44 @@ int main(void)
     busArbiter.contention_scale = 1;
     check(bus_arbiter_charge_access(BM_GPU, 0x00080000) == 6,
           "DRAMSPEED 0b00 -> 2+4 clocks");
+
+    /* ---- 68K half (symmetric self-cost) ---- */
+
+    /* Restore power-on timing for the 68K checks. */
+    bus_arbiter_update_memcon(0x1861);
+    busArbiter.contention_scale = 1;
+
+    /* GPU/DSP local RAM is free only for the owning RISC.  For the 68K
+     * it is an I/O-bus transaction (~2 system clocks). */
+    check(bus_arbiter_charge_access(BM_CPU, 0x00F03000) == 2,
+          "68K access to GPU local RAM costs 2 clocks (not free)");
+    check(bus_arbiter_charge_access(BM_CPU, 0x00F1B000) == 2,
+          "68K access to DSP local RAM costs 2 clocks (not free)");
+    check(bus_arbiter_charge_access(BM_GPU, 0x00F03000) == 0,
+          "GPU access to GPU local RAM still free");
+
+    /* bus_arbiter_m68k_access converts system clocks to 68K cycles
+     * (68K runs at system/2) with a carry for the odd clock.
+     * DRAM cost at 0x1861 = 9 sysclks: 4 cycles carry 1, then 5. */
+    busArbiter.m68k_sysclk_carry = 0;
+    check(bus_arbiter_m68k_access(0x00080000, 1) == 4,
+          "9 sysclks -> 4 68K cycles, carry 1");
+    check(busArbiter.m68k_sysclk_carry == 1,
+          "odd system clock carried");
+    check(bus_arbiter_m68k_access(0x00080000, 1) == 5,
+          "carry+9 sysclks -> 5 68K cycles, carry 0");
+    check(busArbiter.m68k_sysclk_carry == 0,
+          "carry drained");
+
+    /* A longword is two 16-bit bus cycles. */
+    check(bus_arbiter_m68k_access(0x00080000, 2) == 9,
+          "2 accesses = 18 sysclks -> 9 68K cycles");
+
+    /* I/O access: 2 sysclks -> 1 cycle, no carry. */
+    check(bus_arbiter_m68k_access(0x00F00050, 1) == 1,
+          "I/O 2 sysclks -> 1 68K cycle");
+    check(busArbiter.m68k_sysclk_carry == 0,
+          "no carry from even cost");
 
     printf("%s: %d failure(s)\n", fails ? "FAIL" : "PASS", fails);
     return fails ? 1 : 0;

--- a/test/test_dram_timing.c
+++ b/test/test_dram_timing.c
@@ -59,6 +59,8 @@ int main(void)
     /* Cart ROM is ROMSPEED-derived (bits 3-4 = 0 at reset -> 10 clocks). */
     check(bus_arbiter_charge_access(BM_GPU, 0x00800000) == 10,
           "cart ROM access costs ROMSPEED clocks (10 at reset)");
+    check(bus_arbiter_charge_access(BM_GPU, 0x00E00000) == 10,
+          "bootstrap ROM bank uses ROMSPEED timing");
     check(bus_arbiter_charge_access(BM_GPU, 0x00F00050) == 2,
           "TOM/JERRY register access costs 2 clocks");
 

--- a/test/test_dram_timing.c
+++ b/test/test_dram_timing.c
@@ -1,13 +1,16 @@
 /* test_dram_timing.c — unit test for the symmetric DRAM self-cost timing
- * (the GPU self-stall extracted from the full bus arbiter, PR #169).
+ * (the GPU self-stall and 68K self-cost extracted from the full bus arbiter, PR #169).
  *
- * The model: a GPU LOAD/STORE that leaves local GPU RAM pays a DRAM
- * access cost in system clocks (base + page-miss from MEMCON1),
- * multiplied by the configurable scale.  Local GPU RAM costs nothing.
- * Disabled costs nothing anywhere.  There is NO cross-processor
- * penalty: the 68K/blitter halves of the arbiter were measured to slow
- * innocent 68K-paced work (real-BIOS boot logo animation) and are
- * deliberately not part of this.
+ * The model: each master (GPU, 68K) pays DRAM access cost for its own
+ * memory accesses — a LOAD/STORE that leaves local RAM pays system
+ * clocks (base + page-miss from MEMCON1), multiplied by scale.  Local
+ * RISC RAM is free only for the owning processor (internal bus); the
+ * 68K accessing RISC local RAM incurs an I/O-bus transaction (~2
+ * clocks).  The 68K-side cost is carried across calls to handle the
+ * 68K's half-system-clock rate.  Disabled costs nothing anywhere.
+ * There is NO cross-processor penalty: charging the 68K for GPU/blitter
+ * bus traffic was measured to slow innocent 68K-paced work (real-BIOS
+ * boot logo animation) and is deliberately not implemented.
  *
  * Links bus_arbiter.c directly (like test_jlink does jlink.c).
  */

--- a/test/test_gpu_dram_timing.c
+++ b/test/test_gpu_dram_timing.c
@@ -1,0 +1,68 @@
+/* test_gpu_dram_timing.c — unit test for the GPU DRAM-timing charge
+ * (the GPU self-stall extracted from the full bus arbiter, PR #169).
+ *
+ * The model: a GPU LOAD/STORE that leaves local GPU RAM pays a DRAM
+ * access cost in system clocks (base + page-miss from MEMCON1),
+ * multiplied by the configurable scale.  Local GPU RAM costs nothing.
+ * Disabled costs nothing anywhere.  There is NO cross-processor
+ * penalty: the 68K/blitter halves of the arbiter were measured to slow
+ * innocent 68K-paced work (real-BIOS boot logo animation) and are
+ * deliberately not part of this.
+ *
+ * Links bus_arbiter.c directly (like test_jlink does jlink.c).
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include "../src/core/bus_arbiter.h"
+
+static int fails = 0;
+
+static void check(int cond, const char *what)
+{
+    printf("%s %s\n", cond ? "PASS" : "FAIL", what);
+    if (!cond) fails++;
+}
+
+int main(void)
+{
+    uint32_t ext1, scaled;
+
+    bus_arbiter_init();
+    check(busArbiter.enabled == 0, "init: disabled by default");
+    bus_arbiter_update_memcon(0x1861);   /* power-on default */
+    check(busArbiter.dram_base_clocks == 5,
+          "MEMCON1 0x1861 -> DRAMSPEED 0b11 -> 5 clocks");
+
+    busArbiter.enabled = 1;
+    busArbiter.contention_scale = 1;
+
+    /* Local GPU/DSP RAM are on internal buses: no DRAM transaction. */
+    check(bus_arbiter_charge_access(BM_GPU, 0x00F03000) == 0,
+          "GPU local RAM costs 0");
+    check(bus_arbiter_charge_access(BM_GPU, 0x00F1B000) == 0,
+          "DSP local RAM costs 0");
+
+    /* Main DRAM costs base + page-miss average (5 + 4 at defaults). */
+    ext1 = bus_arbiter_charge_access(BM_GPU, 0x00080000);
+    check(ext1 == 9, "main DRAM access costs base+miss (9 clocks)");
+
+    /* Cart ROM and I/O cost less than DRAM-with-miss but not zero. */
+    check(bus_arbiter_charge_access(BM_GPU, 0x00800000) == 5,
+          "cart ROM access costs base clocks");
+    check(bus_arbiter_charge_access(BM_GPU, 0x00F00050) == 2,
+          "TOM/JERRY register access costs 2 clocks");
+
+    /* Calibration scale multiplies the charge. */
+    busArbiter.contention_scale = 8;
+    scaled = bus_arbiter_charge_access(BM_GPU, 0x00080000);
+    check(scaled == ext1 * 8, "scale 8x multiplies the DRAM cost by 8");
+
+    /* Slower DRAMSPEED settings track MEMCON1. */
+    bus_arbiter_update_memcon(0x0000);   /* DRAMSPEED 0b00 = 2 clocks */
+    busArbiter.contention_scale = 1;
+    check(bus_arbiter_charge_access(BM_GPU, 0x00080000) == 6,
+          "DRAMSPEED 0b00 -> 2+4 clocks");
+
+    printf("%s: %d failure(s)\n", fails ? "FAIL" : "PASS", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## What

Symmetric DRAM self-cost timing: each bus master now pays its own DRAM access
latency out of its own cycle budget. The GPU half already existed (908848b,
#169); this branch adds the 68K half (instruction fetches included, charged
in the UAE memory callbacks) and puts both under one option,
`virtualjaguar_dram_timing` (`enabled`/`disabled`, **default `disabled`**,
experimental). There are no user-facing tuning knobs — `VJ_DRAM_SCALE` is a
dev-only env var for calibration testing, not a shipped setting.

Two bugs are fixed along the way:

- **Latent bug:** `bus_arbiter_init()` was never called from `retro_init`, so
  the page-miss penalty was silently `0` at runtime regardless of the option
  state.
- **Cost-oracle bug:** the original GPU-half commit (908848b) shipped a
  DRAMSPEED table that was inverted against the JTRM MEMCON1 spec. Corrected
  (6644e3f) to: page-mode cycle fixed at 2 clocks, DRAMSPEED programs
  row-miss overhead `{7, 7, 5, 3}` (5 sysclks for main DRAM at reset), and
  cart ROM cost is ROMSPEED-derived (`{10, 8, 6, 5}`, `FASTROM` override = 2
  clocks, both ROM banks) instead of reusing the DRAM base cost.

## Why symmetric (the wedge story)

GPU-only stalling (the original #169 shape) is a dead end: at scale >= 4x it
wedges Doom permanently on the title card. Root cause, found with
`cd_wedge_probe` + disassembly of both processors: the GPU ends up idle and
healthy, parked in its dispatcher loop (`$F0308A`-`$F0309E`) polling an empty
mailbox, while the 68K loops forever through corrupted BSP/renderer data.
Doom's dispatcher protocol has no completion interlock between the two
processors — it depends on a specific relative pace. When a GPU command
crosses a frame boundary under GPU-only slowdown, a boundary it never crosses
on real hardware, the full-speed 68K races ahead and corrupts shared state.

(This corrects 908848b's commit message, which guessed at a "latent emulation
race" — it wasn't a race, it was two processors falling out of their implicit
timing contract.)

The old full arbiter (#169) got the wedge-avoidance right by accident — its
cross-processor half slowed both sides together — but it also slowed innocent
68K work with no DRAM contention involved (the real-BIOS boot logo got
visibly slower), and its per-timeslice chunking made the pacing bursty rather
than smooth. That was device-tested and rejected. This branch keeps only the
principled part: each master pays *its own* DRAM cost, nothing more.

## Evidence

All numbers below are from the corrected-oracle re-run at `6644e3f`
(`docs/superpowers/plans/2026-08-01-validation-results.md`, "Corrected oracle
(6644e3f)" section — the earlier Steps 2-3 tables in that document predate
the oracle fix and are marked superseded there).

**No-wedge, decisive:** 10/10 `cd_wedge_probe` invocations against Doom
(`--frames 3000/3100 --arm 60 --freeze-frames 900`) report `ran clean` at
off, scale 1, scale 4, and scale 8 — zero `pc_escape`, `gpu_wedge`,
`dsp_wedge`, or `cd_seek_wedge`. The old GPU-only model wedged Doom
permanently at scale >= 4; the symmetric model does not.

**Pace, monotonic and directionally correct** (gametic counter `$04080C`,
median of clean 300-frame windows):

| mode | tics/s | % of 30 Hz cap |
|---|---|---|
| off | 29.97 | 100.0% |
| scale 1 (ships) | 29.77 | 99.3% |
| scale 2 | 29.17 | 97.3% |
| scale 4 | 28.07 | 93.7% |
| scale 8 | 19.58 | 65.3% |

**Off-mode benchmark (Tasks 1-5 only, i.e. excluding the oracle-fix commits):
+0.06% min-avg** vs the branch base — effectively free. (See "Honest
findings" below for the separate, real anomaly introduced by the oracle-fix
commit itself.)

**Positive control:** RAM state genuinely diverges between scales rather than
the deduction being a no-op — e.g. the scale-4 run shows 110,703 bytes of RAM
churn in the window where the attract loop transitions between demos,
confirming the 68K-side charge is actually landing on execution, not just
changing a counter that's never read.

**Acid suite:** verdicts are byte-identical to the branch base and to
develop (140/140 matching PASS/FAIL/SKIP lines); the 3 flagged "regressions"
(`unaligned_word`, `op_gpu_int_object`, `pit_countdown_rate`, all NOT-RUN or
pre-existing FAIL) are present equally on all three builds and are not
attributable to this branch.

**CD spot-check:** Primal Rage and Hover Strike both `ran clean` with the
option enabled (`cd_wedge_probe --frames 1800 --arm 60 --freeze-frames 900`);
CD pacing is unaffected at scale 1.

## Honest findings

1. **Calibration gap.** At the shipping scale (1), the corrected physics-
   derived DRAM cost moves Doom's pace by under 1% (99.3% of cap vs 100.0%
   off). Pure DRAM latency, charged correctly per the JTRM, cannot pace
   Doom's real-hardware speed — the unmodelled bus masters (deterministic
   DRAM refresh, Object Processor line-buffer fetches, blitter traffic, DSP
   DMA) carry essentially all of the missing contention. The next
   physics-derived, knob-free candidate is deterministic refresh +
   OP-fetch overhead derived from video timing — a documented follow-up,
   deliberately not tuned around in this PR.

2. **Off-mode benchmark regression, isolated to the oracle-fix commit.** The
   `yarc.j64` benchmark ROM shows +4.1% min-p50 (default-disabled path) after
   the oracle-fix commit (6644e3f), even though that commit only *removes* a
   guarded branch from `gpu_opcode_loadp`/`gpu_opcode_storep` (never-taken in
   off-mode) and `gpu.o`'s `__text` shrank by 108 bytes. Root-caused to code
   layout, not added work: forcing `-falign-functions=64` on `gpu.c` on both
   sides collapses the gap to +0.4% (noise), and reverting just the
   `gpu.c` hunk on top of the fix restores baseline performance exactly.
   It's workload-specific — `yarc.j64` is phrase-traffic-heavy and sensitive
   to GPU-interpreter layout; Doom itself shows only +0.48%. Accepted with
   this rationale; not a reason to revert the JTRM correctness fix, and
   hand-tuning layout to chase a benchmark-ROM-specific artifact is not
   recommended.

3. **Known model deviations** (documented, not hidden): page-hit vs.
   page-miss DRAM state is averaged rather than tracked per-row; a longword
   access is modelled as two independent misses; no OP, refresh, blitter, or
   DSP-DMA bus masters are modelled; `IO_BUS_CLOCKS_ESTIMATE` (2 sysclks for
   68K -> RISC-local-RAM and TOM/JERRY I/O register accesses) is an
   unsourced estimate — no JTRM figure exists for it.

4. **Acid's timing test doesn't exercise this model.**
   `tests/timing/pit_countdown_rate.jag` is NOT-RUN on every build tested
   here, including develop (pre-existing harness/boot-stub issue, being
   fixed separately) — so the acid sweep provides no evidence either way for
   the timing model; the pace evidence in this PR rests on Steps 2-3 of the
   validation doc, not on acid.

## Savestates

Bumps `STATE_VERSION` 6 -> 7 to persist the new 68K-side DRAM-cost carry
field and to reapply MEMCON1-derived timing on load. States saved at
versions 2-6 still load (forward-compatible loader). States written by this
build are **not** loadable by released cores (forward-incompatible in that
direction, as always with a version bump).

Coordination note (resolved): develop's Memory Track work (#259) also bumped
to `STATE_VERSION 7`; the merge from develop folds both field sets under the
single shared v7 (`STATE_VERSION_MEMTRACK_OVERRIDE` + `STATE_VERSION_BUS_ARBITER`),
per the one-bump-per-release policy. Next release is expected to be 3.x.

## Post-review updates

- Copilot review handled: MEMCON1 byte-write hook + stale-carry clear
  (ac4e8c3); the RM-vs-address indexed-load finding is pre-existing on
  develop and tracked separately.
- Merged develop back in (b0f94fc): core-options overhaul (the option now
  lives in a new **Timing** category), Memory Track HLE, CD BIOS type.
- **Device findings (iPhone, option enabled, scale 1):** Doom's auto-demo
  pace looks right but **sound effects stutter in the demo** (stutter is
  absent with the option off — enabled-mode issue, under investigation);
  in-game audio is fine but monsters still visibly too fast, confirming
  the headless finding that DRAM latency alone moves the tic rate <1%.
  Both belong to the documented follow-up (OP/refresh bus-occupancy
  modeling), not blockers for this default-off option.

## Supersedes

Supersedes #169. Not closing it here — that happens manually once this PR is
merged, per the project's post-merge checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

