### PR TITLE
fix(cd): make CD BIOS Type steer which BIOS file is used, and say so in the menu (#251 follow-up)

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -1105,12 +1105,15 @@ static bool try_load_cd_bios_file(const char *path)
  * of well-known sub-directories used by Provenance/RetroArch front-ends). */
 static bool load_external_cd_bios(void)
 {
-   /* Filenames whose content matches a specific 'CD BIOS Type' selection,
-    * plus generic names that could hold either image.  The selected type's
-    * names are searched FIRST — with both files in the system directory,
-    * picking 'Developer' must actually load the developer BIOS, not
-    * whichever name happens to sort earlier (the old single list always
-    * found retail first and silently ignored the selection). */
+   /* Filenames conventionally used for each 'CD BIOS Type', plus generic
+    * names that could hold either image.  Selection is by NAME only — the
+    * loader does not inspect the image to confirm which BIOS it actually
+    * is, so a mislabelled file is taken at its filename's word.
+    *
+    * The selected type's names are searched FIRST.  The previous code used
+    * one flat list with the retail names ahead of the developer ones, so a
+    * user with both files installed always got retail no matter what the
+    * option said. */
    static const char *retail_names[] = {
       "[BIOS] Atari Jaguar CD (World).j64",
       "[BIOS] Atari Jaguar CD (World).rom",

--- a/libretro.c
+++ b/libretro.c
@@ -1105,21 +1105,34 @@ static bool try_load_cd_bios_file(const char *path)
  * of well-known sub-directories used by Provenance/RetroArch front-ends). */
 static bool load_external_cd_bios(void)
 {
-   static const char *bios_names[] = {
+   /* Filenames whose content matches a specific 'CD BIOS Type' selection,
+    * plus generic names that could hold either image.  The selected type's
+    * names are searched FIRST — with both files in the system directory,
+    * picking 'Developer' must actually load the developer BIOS, not
+    * whichever name happens to sort earlier (the old single list always
+    * found retail first and silently ignored the selection). */
+   static const char *retail_names[] = {
+      "[BIOS] Atari Jaguar CD (World).j64",
+      "[BIOS] Atari Jaguar CD (World).rom",
+      "[BIOS] Atari Jaguar CD (World).bin",
+      NULL
+   };
+   static const char *dev_names[] = {
+      "[BIOS] Atari Jaguar Developer CD (World).j64",
+      "[BIOS] Atari Jaguar Developer CD (World).rom",
+      "[BIOS] Atari Jaguar Developer CD (World).bin",
+      NULL
+   };
+   static const char *generic_names[] = {
       "jaguarcd_bios.bin",
       "jagcd_bios.bin",
       "jaguarcd.bin",
       "jagcd.bin",
       "Jaguar CD BIOS.rom",
       "Jaguar CD BIOS.bin",
-      "[BIOS] Atari Jaguar CD (World).j64",
-      "[BIOS] Atari Jaguar CD (World).rom",
-      "[BIOS] Atari Jaguar CD (World).bin",
-      "[BIOS] Atari Jaguar Developer CD (World).j64",
-      "[BIOS] Atari Jaguar Developer CD (World).rom",
-      "[BIOS] Atari Jaguar Developer CD (World).bin",
       NULL
    };
+   const char **name_groups[3];
    static const char *sub_dirs[] = {
       "",
       "Atari - Jaguar",
@@ -1129,7 +1142,7 @@ static bool load_external_cd_bios(void)
       NULL
    };
    const char *system_dir = NULL;
-   int s, i;
+   int s, i, g;
 
    if (!environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir)
        || !system_dir)
@@ -1138,22 +1151,41 @@ static bool load_external_cd_bios(void)
       return false;
    }
 
-   LOG_INF("[CD-BIOS] Searching for CD BIOS in: %s\n", system_dir);
-
-   for (s = 0; sub_dirs[s]; s++)
+   /* Selected type first, generic names second, the other type last (a
+    * lone file of the "wrong" type still beats falling back to embedded —
+    * the user put it there on purpose). */
+   if (vjs.cdBiosType == CDBIOS_DEV)
    {
-      for (i = 0; bios_names[i]; i++)
-      {
-         char path[4096];
-         if (sub_dirs[s][0])
-            snprintf(path, sizeof(path), "%s/%s/%s",
-                     system_dir, sub_dirs[s], bios_names[i]);
-         else
-            snprintf(path, sizeof(path), "%s/%s",
-                     system_dir, bios_names[i]);
+      name_groups[0] = dev_names;
+      name_groups[2] = retail_names;
+   }
+   else
+   {
+      name_groups[0] = retail_names;
+      name_groups[2] = dev_names;
+   }
+   name_groups[1] = generic_names;
 
-         if (try_load_cd_bios_file(path))
-            return true;
+   LOG_INF("[CD-BIOS] Searching for CD BIOS in: %s (preferring %s)\n",
+           system_dir, (vjs.cdBiosType == CDBIOS_DEV) ? "developer" : "retail");
+
+   for (g = 0; g < 3; g++)
+   {
+      for (s = 0; sub_dirs[s]; s++)
+      {
+         for (i = 0; name_groups[g][i]; i++)
+         {
+            char path[4096];
+            if (sub_dirs[s][0])
+               snprintf(path, sizeof(path), "%s/%s/%s",
+                        system_dir, sub_dirs[s], name_groups[g][i]);
+            else
+               snprintf(path, sizeof(path), "%s/%s",
+                        system_dir, name_groups[g][i]);
+
+            if (try_load_cd_bios_file(path))
+               return true;
+         }
       }
    }
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -228,7 +228,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_bios",
       "BIOS (Cartridges)",
       NULL,
-      "Which BIOS a CARTRIDGE boots with. 'HLE' has the core emulate the BIOS setup and services itself, which lets most commercial titles boot faster and skips the boot animation. 'Real' runs the actual Jaguar boot ROM, which some titles require. The boot ROM is built into the core, so neither setting needs a file in the system directory and no external Jaguar BIOS is looked for. Ignored for CD content: there, 'CD Boot Mode' decides, and it turns the boot ROM on or off to match.",
+      "Which BIOS a CARTRIDGE boots with. 'HLE' has the core emulate the BIOS setup and services itself, which lets most commercial titles boot faster and skips the boot animation. 'Real' runs the actual Jaguar boot ROM, which some titles require. The boot ROM is built into the core, so neither setting needs a file — unlike the CD BIOS, the console boot ROM is never loaded from the system directory. Ignored for CD content: there, 'CD Boot Mode' decides and turns the boot ROM on or off to match.",
       NULL,
       "bios_boot",
       {
@@ -256,7 +256,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_cd_bios_type",
       "CD BIOS Type (Restart)",
       NULL,
-      "Which embedded CD BIOS the real-BIOS boot path uses. 'Retail' is the standard consumer BIOS. 'Developer' is the dev-kit BIOS, which applies less strict disc checks and can boot images the retail BIOS refuses. Both are built into the core. If a CD BIOS ROM file is present in the system directory it is used instead and this setting is ignored. Only has an effect when 'CD Boot Mode' is 'Real BIOS' or 'Auto' — the HLE boot path never runs a CD BIOS.",
+      "Which CD BIOS the real-BIOS boot path uses. 'Retail' is the standard consumer BIOS; 'Developer' is the dev-kit BIOS, which applies less strict disc checks and can boot images the retail BIOS refuses. Both are built into the core, so no files are required. CD BIOS ROM files in the system directory are preferred over the embedded images, and this selection picks which file wins when both types are present. Only has an effect when 'CD Boot Mode' is 'Real BIOS' or 'Auto' — the HLE boot path never runs a CD BIOS.",
       NULL,
       "cdrom",
       {
@@ -270,7 +270,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_cd_boot_mode",
       "CD Boot Mode (Restart)",
       NULL,
-      "How Jaguar CD discs boot. This OVERRIDES the 'BIOS (Cartridges)' setting for CD content. 'HLE' emulates the CD BIOS services directly and runs with the boot ROM off — fastest and the most broadly compatible. 'Real BIOS' runs the actual CD BIOS and forces the boot ROM on, which is more faithful but still experimental; it uses a CD BIOS ROM from the system directory if present, otherwise the embedded one selected by 'CD BIOS Type', so no files are required. 'Auto' is currently identical to 'Real BIOS'. If a real-BIOS mode is chosen but no CD BIOS can be staged, the core falls back to HLE rather than failing.",
+      "How Jaguar CD discs boot. This OVERRIDES the 'BIOS (Cartridges)' setting for CD content. 'HLE' emulates the CD BIOS services directly and runs with the console boot ROM off — fastest and the most broadly compatible. 'Real BIOS' runs an actual CD BIOS and forces the boot ROM on: more faithful, still experimental. It prefers a CD BIOS ROM file from the system directory (searched under several common names, and in Atari - Jaguar / Atari - Jaguar CD / jaguar / jaguarcd sub-folders) and otherwise uses the embedded image chosen by 'CD BIOS Type', so no files are required. 'Auto' is currently identical to 'Real BIOS'. If a real-BIOS mode is chosen but no CD BIOS can be staged at all, the core falls back to HLE rather than failing.",
       NULL,
       "cdrom",
       {


### PR DESCRIPTION
Follow-up to #257, from a maintainer question: *"I thought you could also supply your own BIOS file, the embedded one, or HLE — whatever is working the menu should reflect that."*

Auditing that turned up a real bug plus menu text that described the wrong precedence.

## The bug

#257 wired up `CD BIOS Type` so it chooses between the two **embedded** images. But `load_external_cd_bios()` searched one flat filename list, retail names first — so a user with **both** BIOS files in their system directory who picked `Developer` silently got **retail**.

Same class as the option being dead before #257, one layer up: the control looked like it worked and didn't.

Now the selected type's filenames are searched first, then the generic names (`jaguarcd.bin` etc., which could be either image), then the other type's. A lone "wrong type" file still beats the embedded image — the user put it there on purpose.

## The menu was describing the wrong precedence

Actual behaviour, verified against the code rather than assumed:

| | source | file in system dir? |
|---|---|---|
| **BIOS (Cartridges)** | console boot ROM, **embedded only** | never searched |
| **CD BIOS** | file **preferred**, embedded fallback | yes — several names, plus `Atari - Jaguar` / `Atari - Jaguar CD` / `jaguar` / `jaguarcd` sub-folders |

- `CD BIOS Type` previously claimed *"If a CD BIOS ROM file is present it is used instead and this setting is ignored"* — the opposite of what now happens, and only true before by accident of search order. It now says files are preferred and that this selection picks **which file** wins when both types are present.
- `CD Boot Mode` now states the file-preferred-then-embedded order and names the sub-folders searched.
- `BIOS (Cartridges)` now contrasts itself with the CD BIOS explicitly — the console boot ROM is embedded and is *never* loaded from the system directory. That asymmetry is exactly what was confusing.

## Testing

Both BIOS files staged in a scratch system directory:

```
type=retail                        -> [BIOS] Atari Jaguar CD (World).j64
type=dev                           -> [BIOS] Atari Jaguar Developer CD (World).j64
type=dev, only retail file present -> the retail file  (beats embedded)
type=dev, empty system dir         -> "using embedded developer CD BIOS"
```

- [x] CD BIOS corpus 35 pass / 0 fail
- [x] `make TEST_EXPORTS=1 test` exit 0 (BIOS Configuration 6/0, Option Visibility 10/0)
- [x] `bash scripts/c89-lint.sh` bare, as CI runs it — clean

Stacked conceptually on #257 (merged) and independent of #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)