### PR TITLE
fix(gpu): test effective address, not RM, in indexed load alignment

### DIFF
--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -1732,7 +1732,7 @@ INLINE static void gpu_opcode_load_r14_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[14] + (gpu_convert_zero[IMM_1] << 2);
 
-   if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
+   if ((address >= 0xF03000) && (address <= 0xF03FFF))
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);
@@ -1747,7 +1747,7 @@ INLINE static void gpu_opcode_load_r15_indexed(void)
 #ifdef GPU_CORRECT_ALIGNMENT
    uint32_t address = gpu_reg[15] + (gpu_convert_zero[IMM_1] << 2);
 
-   if ((RM >= 0xF03000) && (RM <= 0xF03FFF))
+   if ((address >= 0xF03000) && (address <= 0xF03FFF))
       RN = GPUReadLong(address & 0xFFFFFFFC, GPU);
    else
       RN = GPUReadLong(address, GPU);


### PR DESCRIPTION
## Summary

`gpu_opcode_load_r14_indexed` and `gpu_opcode_load_r15_indexed` (GPU_CORRECT_ALIGNMENT path) compute the effective address as `r14/r15 + (offset << 2)` but ran the GPU-local-RAM locality test against **`RM`** — an unrelated register value for this addressing mode. When `RM` happened to sit on the other side of the `$F03000-$F03FFF` boundary from the effective address, the masked-vs-unmasked `GPUReadLong` path was chosen wrongly.

Pre-existing bug flagged by Copilot on #260 (not introduced there). Fix is `s/RM/address/` in the two range tests.

**Scope check:** the indexed stores (`store_r14/r15_indexed`) and all four register-indexed `_ri` load/store variants already test the computed `address`; these two loads were the only instances. The DSP equivalents mask unconditionally (no range test) and do not share the bug.

## Validation

- `make TEST_EXPORTS=1 test` — exit 0, all pass (including both audio tests)
- `test/regression_test.sh` — 10/10 PASS with the patched core pixel-identical to stock (9a91f6a) baselines, incl. determinism, frameskip invariance, savestate round-trip, rewind
- `fb_ab_sweep.sh` stock-vs-patched across the full 115-title cart corpus, 1200 frames/title: **`titles=115 changed=0 unexpected=0`** — no title's rendering depended on the old path. Matches theory: divergence needs an unaligned r14/r15 base *and* an RM value straddling the local-RAM boundary; nothing in the corpus exercises that.
- `scripts/c89-lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)