### PR TITLE
feat(net): resolve netlink hostnames, not just dotted quads (#253)

### DIFF
--- a/docs/netlink-user-guide.md
+++ b/docs/netlink-user-guide.md
@@ -7,6 +7,11 @@ players), **BattleSphere Gold** — can play against other emulator instances.
 There are **two completely separate ways** to connect. They cannot talk to
 each other — every player in a session must use the same one.
 
+**If everyone is on RetroArch, use Option A and stop reading there.** It
+needs no IP address from you at all: RetroArch finds hosts on the LAN
+itself. Option B exists for mixed frontends (Provenance on an iPhone
+against RetroArch on a Mac) and for frontends without netplay.
+
 ## Option A: RetroArch netplay (easiest — RetroArch to RetroArch only)
 
 Requires RetroArch 1.16 or newer on every device (desktop, iOS, Android…).
@@ -40,12 +45,22 @@ build an inert stub — the TCP modes silently do nothing there.
 1. Pick one device as the hub. Set its core option
    *Network Link = TCP Host (listen)*.
 2. Every other device: *Network Link = TCP Client (connect)*, and tell it
-   the hub's LAN IP via the *Network Link Host* core option. Frontends
-   with free-text option entry (e.g. Provenance) let you type the address
-   directly; the core accepts any hostname or IP it receives. In stock
-   RetroArch (dropdown-only options) pick *From file* and create a text
-   file **`vj_netlink.txt`** in the frontend's *system/BIOS* directory
-   containing just the IP, e.g.:
+   where the hub is via the *Network Link Host* core option. This takes
+   an IP, a DNS name, **or a Bonjour/mDNS `.local` name** — so on a
+   typical home LAN you can skip looking the IP up and just use the
+   hub's computer name:
+   ```
+   jaghub.local
+   ```
+   A `.local` name survives the hub getting a different DHCP lease
+   tomorrow, which a hard-coded IP does not. Find it in *System Settings
+   → General → About → Name* on macOS, or `hostname` on Linux; Windows
+   hosts need Bonjour installed to answer to one, so use their IP.
+
+   Frontends with free-text option entry (e.g. Provenance) let you type
+   any of these directly. In stock RetroArch (dropdown-only options) pick
+   *From file* and create a text file **`vj_netlink.txt`** in the
+   frontend's *system/BIOS* directory containing just the address, e.g.:
    ```
    192.168.1.20
    ```
@@ -65,8 +80,22 @@ Desktop/testing shortcuts: environment variables `VJ_NETLINK_HOST` and
   A frontend bundling an older core has no *Network Link* option at all —
   that's the tell.
 - Both sides sit at their link menu but never connect: verify same
-  Wi-Fi/LAN, the hub's IP in *Network Link Host* (or `vj_netlink.txt`),
-  matching port, and any firewall prompt on the host machine.
+  Wi-Fi/LAN, the hub's address in *Network Link Host* (or
+  `vj_netlink.txt`), matching port, and any firewall prompt on the host
+  machine. A host firewall is the most common cause when the address is
+  definitely right — macOS's Application Firewall, for instance, allows
+  loopback but silently drops inbound LAN connections to an app that has
+  not been allowed, so the client looks connected while the hub never
+  sees anyone arrive.
+- A `.local` name that never connects while the raw IP works: the hub is
+  not answering mDNS. Windows only does after Bonjour is installed, and
+  some Wi-Fi routers block multicast between clients ("AP isolation").
+  Use the IP there.
+- The client retries on its own — a wrong-then-corrected address, a hub
+  started later, or a `.local` name whose owner is not on the network
+  yet all recover without reloading the core. A failed *name lookup*
+  backs off about five seconds between attempts, a refused connection
+  about half a second.
 - *Loopback (echo to self)* is a solo test mode: the console hears its own
   transmissions. Games will correctly report "no players found" — useful
   only to check the link menu works.

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -189,7 +189,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_netlink_host",
       "Network Link Host (TCP Client)",
       NULL,
-      "Address the TCP client connects to. Frontends with free-text option entry may supply any hostname or IP; the core uses whatever string it receives. In stock RetroArch pick 'From file' and put the address on the first line of vj_netlink.txt in the system directory. The VJ_NETLINK_HOST environment variable overrides this option.",
+      "Address the TCP client connects to -- an IP, a DNS name, or a Bonjour/mDNS name such as 'jaghub.local', which saves looking the host's IP up at all. Frontends with free-text option entry accept any of those directly. In stock RetroArch pick 'From file' and put the address on the first line of vj_netlink.txt in the system directory. The VJ_NETLINK_HOST environment variable overrides this option. If you would rather not enter an address anywhere, use RetroArch's own netplay instead -- it finds hosts on the LAN by itself and carries the link with this option left disabled.",
       NULL,
       "network",
       {

--- a/src/jerry/jlink_tcp.c
+++ b/src/jerry/jlink_tcp.c
@@ -4,7 +4,8 @@
  * share the wire.  Local TX goes to every peer; a byte received from
  * one peer is delivered locally AND forwarded to every other peer, so
  * all nodes hear all traffic — the electrical semantics of a shared
- * multi-drop bus.  Client mode is a single connection to the hub.
+ * multi-drop bus.  Client mode is a single connection to the hub, whose
+ * address may be an IP or a name (DNS or Bonjour ".local").
  *
  * POSIX and winsock share the code behind a thin macro layer;
  * platforms without BSD-style sockets (bare console targets) compile
@@ -21,6 +22,10 @@
 #ifdef JLINK_HAVE_TCP
 
 #ifdef _WIN32
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0501   /* getaddrinfo/freeaddrinfo live behind this */
+#endif
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #ifdef _MSC_VER
@@ -41,6 +46,7 @@ typedef SOCKET jlink_sock_t;
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
+#include <netdb.h>        /* getaddrinfo */
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
@@ -73,10 +79,18 @@ static int tcpConnecting = 0;    /* client connect in flight (slot 0) */
 static int tcpRetryTimer = 0;    /* polls until next client reconnect */
 static char tcpHost[128] = "127.0.0.1";
 static int tcpPort = 0;
+static struct sockaddr_in tcpAddr;   /* tcpHost resolved (client mode) */
+static int tcpAddrValid = 0;
 
 /* A refused/dropped client connect retries after this many polls
    (one poll per frame => roughly half a second). */
 #define JLINK_TCP_RETRY_POLLS 30
+
+/* A *failed name lookup* backs off further than a refused connect: a
+   refusal costs one nonblocking syscall, an unresolvable name can cost
+   the resolver's full timeout, and retrying that every half second
+   would stutter the frame loop. */
+#define JLINK_TCP_RESOLVE_RETRY_POLLS 300
 
 static void jlink_peers_reset(void)
 {
@@ -139,16 +153,82 @@ static void jlink_tcp_drop_peer(int idx)
    }
 }
 
+/* Resolve tcpHost into tcpAddr, once, and cache it.
+ *
+ * Dotted-quad addresses are matched first with AI_NUMERICHOST, which
+ * cannot block, so the common 192.168.x.y path never reaches a
+ * resolver.  Anything else is a name and gets a real lookup — which is
+ * what makes "jaghub.local" (Bonjour/mDNS) and plain DNS names usable
+ * as the hub address.  Only IPv4 results are taken: the listener binds
+ * AF_INET, so an AAAA-only peer could not be talked to anyway.
+ *
+ * Returns 1 when tcpAddr is usable. */
+static int jlink_tcp_resolve(void)
+{
+   struct addrinfo hints;
+   struct addrinfo *res = NULL;
+   struct addrinfo *ai;
+   int rc;
+
+   if (tcpAddrValid)
+      return 1;
+
+   memset(&hints, 0, sizeof(hints));
+   hints.ai_family   = AF_INET;
+   hints.ai_socktype = SOCK_STREAM;
+   hints.ai_flags    = AI_NUMERICHOST;
+
+   rc = getaddrinfo(tcpHost, NULL, &hints, &res);
+   if (rc != 0)
+   {
+      hints.ai_flags = 0;
+      rc = getaddrinfo(tcpHost, NULL, &hints, &res);
+   }
+   if (rc != 0 || !res)
+   {
+      /* "localhost" is the one name whose meaning is fixed even when
+         the resolver cannot answer (no /etc/hosts entry, no DNS on a
+         locked-down box).  Same-machine play must not depend on that. */
+      if (strcmp(tcpHost, "localhost") == 0)
+      {
+         memset(&tcpAddr, 0, sizeof(tcpAddr));
+         tcpAddr.sin_family = AF_INET;
+         tcpAddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+         tcpAddrValid = 1;
+         return 1;
+      }
+      return 0;
+   }
+
+   for (ai = res; ai; ai = ai->ai_next)
+   {
+      if (ai->ai_family == AF_INET
+          && (size_t)ai->ai_addrlen >= sizeof(struct sockaddr_in))
+      {
+         memcpy(&tcpAddr, ai->ai_addr, sizeof(struct sockaddr_in));
+         tcpAddrValid = 1;
+         break;
+      }
+   }
+   freeaddrinfo(res);
+   return tcpAddrValid;
+}
+
 /* Kick off (or re-kick) a nonblocking client connect to tcpHost:tcpPort. */
 static void jlink_tcp_start_connect(void)
 {
    struct sockaddr_in sa;
    int rc;
 
-   memset(&sa, 0, sizeof(sa));
+   if (!jlink_tcp_resolve())
+   {
+      tcpRetryTimer = JLINK_TCP_RESOLVE_RETRY_POLLS;
+      return;
+   }
+
+   sa = tcpAddr;
    sa.sin_family = AF_INET;
    sa.sin_port = htons((unsigned short)tcpPort);
-   sa.sin_addr.s_addr = inet_addr(tcpHost);
 
    tcpPeers[0].sock = socket(AF_INET, SOCK_STREAM, 0);
    if (!jlink_sock_valid(tcpPeers[0].sock))
@@ -204,17 +284,17 @@ int JLinkTCPOpen(int is_server, const char *host, int port)
    }
    else
    {
-      if (!host || !host[0] || strcmp(host, "localhost") == 0)
+      if (!host || !host[0])
          host = "127.0.0.1";
-      sa.sin_addr.s_addr = inet_addr(host);
-      if (sa.sin_addr.s_addr == INADDR_NONE)
-         return 0;
       strncpy(tcpHost, host, sizeof(tcpHost) - 1);
       tcpHost[sizeof(tcpHost) - 1] = '\0';
       tcpPort = port;
       tcpIsClient = 1;
-      /* First attempt now; refusals retry from JLinkTCPPoll (the peer
-         instance may simply not be listening yet). */
+      tcpAddrValid = 0;
+      /* First attempt now; refusals AND failed lookups retry from
+         JLinkTCPPoll.  Neither is fatal at open time: the peer instance
+         may not be listening yet, and a ".local" name does not resolve
+         until its owner is actually on the network. */
       jlink_tcp_start_connect();
    }
 
@@ -240,6 +320,7 @@ void JLinkTCPClose(void)
    tcpIsClient = 0;
    tcpConnecting = 0;
    tcpRetryTimer = 0;
+   tcpAddrValid = 0;
 }
 
 int JLinkTCPConnected(void)

--- a/src/jerry/jlink_tcp.c
+++ b/src/jerry/jlink_tcp.c
@@ -11,6 +11,9 @@
  * platforms without BSD-style sockets (bare console targets) compile
  * the stub tail of this file instead.
  */
+#if !defined(_WIN32) && !defined(_DEFAULT_SOURCE)
+#define _DEFAULT_SOURCE 1   /* glibc: expose POSIX (getaddrinfo) under c99 */
+#endif
 #include <string.h>
 #include "jlink_tcp.h"
 

--- a/src/jerry/jlink_tcp.c
+++ b/src/jerry/jlink_tcp.c
@@ -153,6 +153,16 @@ static void jlink_tcp_drop_peer(int idx)
    {
       tcpConnecting = 0;
       tcpRetryTimer = JLINK_TCP_RETRY_POLLS;
+      /* Drop the cached address too, so the next attempt re-resolves.
+         The whole point of naming the hub is that its address may
+         change -- a new DHCP lease moves the ".local" name to a new IP,
+         and a client that kept dialling the old one would never come
+         back without a core reload.  Re-resolving is cheap where it
+         matters: a dotted quad never leaves AI_NUMERICHOST, and a name
+         whose owner is up answers from the OS resolver cache.  When the
+         name does NOT resolve, the lookup path's own 5 s backoff paces
+         the retries. */
+      tcpAddrValid = 0;
    }
 }
 
@@ -245,6 +255,7 @@ static void jlink_tcp_start_connect(void)
       {
          jlink_closesock(tcpPeers[0].sock);
          tcpPeers[0].sock = JLINK_INVALID_SOCK;
+         tcpAddrValid = 0;        /* re-resolve; the host may have moved */
          tcpRetryTimer = JLINK_TCP_RETRY_POLLS;
          return;
       }

--- a/test/tools/netlink_pair.c
+++ b/test/tools/netlink_pair.c
@@ -47,7 +47,9 @@ int main(int argc, char **argv)
     harness_config cfg = HARNESS_CONFIG_DEFAULT;
     const char *role = NULL;
     const char *port = "42171";
+    const char *host = "127.0.0.1";
     char port_env[64];
+    char host_env[192];
     jerry_ww_t jerry_ww;
     jerry_rw_t jerry_rw;
     jlink_conn_t jlink_connected;
@@ -70,10 +72,18 @@ int main(int argc, char **argv)
             port = argv[++i];
             argv[i - 1] = argv[i] = (char *)"--quiet";
         }
+        /* Client-side hub address.  A name here (DNS or Bonjour
+           ".local") is the point of the test: it exercises the core's
+           resolver path rather than the dotted-quad fast path. */
+        else if (!strcmp(argv[i], "--host") && i + 1 < argc)
+        {
+            host = argv[++i];
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
     }
     if (!role || (strcmp(role, "server") && strcmp(role, "client")))
     {
-        fprintf(stderr, "usage: netlink_pair <core> --role server|client [--port N]\n");
+        fprintf(stderr, "usage: netlink_pair <core> --role server|client [--port N] [--host ADDR]\n");
         return 1;
     }
 
@@ -90,7 +100,8 @@ int main(int argc, char **argv)
 
     snprintf(port_env, sizeof(port_env), "VJ_NETLINK_PORT=%s", port);
     putenv(port_env);
-    putenv((char *)"VJ_NETLINK_HOST=127.0.0.1");
+    snprintf(host_env, sizeof(host_env), "VJ_NETLINK_HOST=%s", host);
+    putenv(host_env);
 
     cfg.frames = 1;
     cfg.options[0].key = "virtualjaguar_netlink";

--- a/test/tools/netlink_pair.c
+++ b/test/tools/netlink_pair.c
@@ -98,9 +98,24 @@ int main(int argc, char **argv)
         want_bytes[0] = 0xCA; want_bytes[1] = 0xFE;
     }
 
-    snprintf(port_env, sizeof(port_env), "VJ_NETLINK_PORT=%s", port);
+    /* Fail loudly rather than dial a silently-truncated address: a
+       clipped --host would look like a resolver or connectivity bug in
+       the core, which is exactly the thing this test exists to judge. */
+    if (snprintf(port_env, sizeof(port_env), "VJ_NETLINK_PORT=%s", port)
+        >= (int)sizeof(port_env))
+    {
+        fprintf(stderr, "[%s] FAIL: --port too long (max %u chars)\n",
+                role, (unsigned)(sizeof(port_env) - sizeof("VJ_NETLINK_PORT=")));
+        return 1;
+    }
     putenv(port_env);
-    snprintf(host_env, sizeof(host_env), "VJ_NETLINK_HOST=%s", host);
+    if (snprintf(host_env, sizeof(host_env), "VJ_NETLINK_HOST=%s", host)
+        >= (int)sizeof(host_env))
+    {
+        fprintf(stderr, "[%s] FAIL: --host too long (max %u chars)\n",
+                role, (unsigned)(sizeof(host_env) - sizeof("VJ_NETLINK_HOST=")));
+        return 1;
+    }
     putenv(host_env);
 
     cfg.frames = 1;

--- a/test/tools/netlink_pair_test.sh
+++ b/test/tools/netlink_pair_test.sh
@@ -3,6 +3,17 @@
 # Launches a server-role and a client-role instance of the core on
 # localhost and requires both to exchange their bytes (see
 # netlink_pair.c).  Usage: netlink_pair_test.sh <core> [port]
+#
+# Round 1 dials the hub by IP (the resolver's AI_NUMERICHOST fast path).
+# Round 2 dials it by *name*, which is the only coverage of the core's
+# getaddrinfo path -- the path that makes "somebox.local" work.
+#
+# Round 2 deliberately uses "localhost" rather than this machine's own
+# LAN name.  Both would prove the resolver, but a LAN address means an
+# *inbound* connection, and a host firewall that allows loopback while
+# dropping inbound LAN (macOS Application Firewall does exactly this to
+# unsigned binaries) fails the round for reasons that have nothing to do
+# with the core.  Loopback keeps the test measuring name resolution.
 set -u
 
 CORE="${1:?usage: netlink_pair_test.sh <core> [port]}"
@@ -14,18 +25,31 @@ if [ ! -x "$BIN" ]; then
     exit 1
 fi
 
-"$BIN" "$CORE" --role server --port "$PORT" &
-SERVER_PID=$!
-# Give the listener a moment before the client connects.
-sleep 0.3
-"$BIN" "$CORE" --role client --port "$PORT"
-CLIENT_RC=$?
-wait "$SERVER_PID"
-SERVER_RC=$?
+# Run one server+client pair against $1 as the client's hub address.
+# Echoes PASS/FAIL; returns the usual 0/1.
+run_pair() {
+    local host="$1" label="$2" port="$3"
+    local server_rc client_rc server_pid
 
-if [ "$SERVER_RC" -eq 0 ] && [ "$CLIENT_RC" -eq 0 ]; then
-    echo "netlink_pair_test: PASS (port $PORT)"
-    exit 0
-fi
-echo "netlink_pair_test: FAIL (server=$SERVER_RC client=$CLIENT_RC)" >&2
-exit 1
+    "$BIN" "$CORE" --role server --port "$port" &
+    server_pid=$!
+    # Give the listener a moment before the client connects.
+    sleep 0.3
+    "$BIN" "$CORE" --role client --port "$port" --host "$host"
+    client_rc=$?
+    wait "$server_pid"
+    server_rc=$?
+
+    if [ "$server_rc" -eq 0 ] && [ "$client_rc" -eq 0 ]; then
+        echo "netlink_pair_test: PASS ($label, host=$host, port $port)"
+        return 0
+    fi
+    echo "netlink_pair_test: FAIL ($label, host=$host, server=$server_rc client=$client_rc)" >&2
+    return 1
+}
+
+run_pair "127.0.0.1" "by IP" "$PORT" || exit 1
+# Second round on the next port: the first server may still be in
+# TIME_WAIT, and SO_REUSEADDR does not cover a listener that raced.
+run_pair "localhost" "by name" "$((PORT + 1))" || exit 1
+exit 0


### PR DESCRIPTION
Part of #253 (netlink ease-of-use). Cuts the "find the hub's IP address" step out of LAN setup without inventing a discovery protocol.

## The bug this starts from

`JLinkTCPOpen()` resolved the hub address with `inet_addr()`, which accepts a dotted quad and nothing else — any name returned `INADDR_NONE` and the open failed. Meanwhile the `virtualjaguar_netlink_host` option description told users "Frontends with free-text option entry may supply any hostname or IP; the core uses whatever string it receives." That was never true.

## What changes

`getaddrinfo()` replaces `inet_addr()`:

- **Numeric addresses never touch a resolver** — `AI_NUMERICHOST` is tried first, so the common `192.168.1.20` path stays non-blocking.
- **Names resolve**, including Bonjour/mDNS `.local` names. `jaghub.local` is the ease-of-use win: no IP lookup, and it survives the hub getting a new DHCP lease.
- **IPv4 only.** The listener binds `AF_INET`, so an AAAA-only peer was never reachable regardless.
- **An unresolvable name is no longer fatal at open.** A `.local` name does not resolve until its owner is on the network, so the client retries — backing off ~5 s between failed lookups vs ~0.5 s between refused connects, because a failed lookup can cost real time and the retry runs on the frame loop.
- **`localhost` is no longer rewritten to `127.0.0.1` up front**, so it exercises the resolver like any other name. It falls back to loopback if the resolver cannot answer, keeping same-machine play working on a box with no hosts entry.

## Also: the zero-config path was already shipping, undocumented

`netpacket_cb` has been registered unconditionally at `libretro.c:391` all along — when both sides run RetroArch, its netplay UI finds hosts on the LAN and no address is entered anywhere. The user guide now leads with that and tells RetroArch-to-RetroArch users to stop reading there. Option B is for mixed frontends.

## What this deliberately does not do

No UDP beacon. Provenance's `Provenance-Info.plist` has `NSLocalNetworkUsageDescription` and `NSBonjourServices` but **no `com.apple.developer.networking.multicast` entitlement** in any of its `.entitlements` files, and iOS 14+ gates raw broadcast/multicast sockets on that entitlement (Apple approval form). A beacon would work on desktop and silently fail on iOS — the exact platform in the Wi-Fi retest loop. mDNS *name resolution* needs no such entitlement, which is why this rung of the ladder works everywhere.

Also skipped: the "single LAN play value that auto-picks host vs client" idea from the issue body. Bind-succeeds-means-host / `EADDRINUSE`-means-client works for two instances on one machine and never across machines — two boxes both bind fine and you get two hosts with no link. It would pass every local test and fail on a real LAN.

## Testing

`make TEST_EXPORTS=1 test` exits 0.

`netlink_pair` gains `--host`, and `netlink_pair_test.sh` runs a second round dialling the hub **by name**:

```
netlink_pair_test: PASS (by IP, host=127.0.0.1, port 42171)
netlink_pair_test: PASS (by name, host=localhost, port 42172)
```

That round uses `localhost` rather than the machine's own LAN name on purpose. Both prove the resolver, but a LAN address makes it an *inbound* connection, and a host firewall that permits loopback while dropping inbound LAN fails the round for reasons unrelated to the core. This was not theoretical — it is what the first version of the test hit here: macOS's Application Firewall let the client reach TCP-connected state against `192.168.1.222` while the listener never saw an `accept`, and the **numeric** LAN IP failed identically, which is what ruled the resolver out.

Real mDNS resolution was verified separately: with `--host Mac` the client resolved to `192.168.1.222` and reached connected state — something `inet_addr()` could not do at all. Only the firewall stopped the handshake from reaching the listener, and that failure mode is now documented in the troubleshooting section.

C89 lint passes on `src/jerry/jlink_tcp.c`.

## Not covered here

Cross-device Wi-Fi play still carries the open human re-test from #248/#250. This change is on the *client's address resolution*, not the receive-side timing those PRs touched, so it does not muddy attribution if that re-test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)