### PR TITLE
docs(test): refresh stale CDI opt-in rationale in cd_assertions.h

### DIFF
--- a/test/cd_assertions.h
+++ b/test/cd_assertions.h
@@ -75,8 +75,11 @@ static inline int cd_disc_priority(const char *ext)
 
 /* Honors VJ_TEST_CD_EXTS (comma-separated) to filter which extensions to
  * enumerate. Default is "cue" — CDI/ISO are opt-in because:
- *   CDI: parser still has at least one disc that crashes (see baldies.cdi);
- *        opt in once the parser is hardened.
+ *   CDI: V3.5 images (incl. third-party baldies.cdi) parse and boot cleanly
+ *        since the global-offset landmark scan (PR #233); the opt-in guards
+ *        the 4 known-bad CDI V2 rips (ironsoldier2, mystdemo, vidgrid,
+ *        worldtourracing) whose boot headers are damaged in the files
+ *        themselves -- see issue #269 for the pending policy decision.
  *   ISO: Jaguar boot from ISO is fundamentally degraded (no session 2 audio);
  *        useful for read-only sanity but not boot smoke. */
 static inline bool cd_ext_enabled(const char *ext)


### PR DESCRIPTION
The comment claimed baldies.cdi still crashes the CDI parser — stale since PR #233's `CDIDetectGlobalDataOffset()` landmark scan (verified 2026-08-03: baldies.cdi boots to GAME_CODE via `VJ_TEST_CD_EXTS=cdi test/test_cd_hle_boot`; 10/14 corpus passes, all V3.5). The opt-in default now guards the 4 known-bad CDI V2 rips whose boot headers are damaged in the files themselves — tracked as #269.

Comment-only; `cd_ext_enabled()` default stays "cue" (changing that default is #269's policy decision, deliberately not made here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)