### PR TITLE
fix(log): gate per-event CDDA diagnostics behind DEBUG level

### DIFF
--- a/src/cd/cdrom.c
+++ b/src/cd/cdrom.c
@@ -1059,7 +1059,7 @@ void BUTCHExec(uint32_t cycles)
             static uint32_t cddaEdgeCount = 0;
             cddaEdgeCount++;
             if (cddaEdgeCount <= 20 || (cddaEdgeCount % 5000) == 0)
-               LOG_INF("[CDDA] BUTCH IRQ edge #%u tom=%d jerryExt=%d "
+               LOG_DBG("[CDDA] BUTCH IRQ edge #%u tom=%d jerryExt=%d "
                        "fifoReady=%d dsaReady=%d butch=$%08X tick=%u%s\n",
                        cddaEdgeCount, tomEna, jerEna,
                        fifoDataReady, dsaResponseReady, butchWrite,
@@ -1611,7 +1611,7 @@ void CDROMWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
             static uint32_t cddaCmdCount = 0;
             cddaCmdCount++;
             if (cddaCmdCount <= 40 || (cddaCmdCount % 500) == 0)
-               LOG_INF("[CDDA] DSA cmd $%04X #%u tick=%u block=%u i2s=$%02X\n",
+               LOG_DBG("[CDDA] DSA cmd $%04X #%u tick=%u block=%u i2s=$%02X\n",
                        data, cddaCmdCount, diag_butchExecCalls, block,
                        cdRam[I2CNTRL + 3]);
          }
@@ -1869,7 +1869,7 @@ void CDROMWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
             static uint32_t setModeCount = 0;
             setModeCount++;
             if (setModeCount <= 40 || (setModeCount % 500) == 0)
-               LOG_INF("[CD-MODE] Set Mode $%04X #%u -> speed=%s mode=%s "
+               LOG_DBG("[CD-MODE] Set Mode $%04X #%u -> speed=%s mode=%s "
                        "rate=%lu B/s tick=%u block=%u\n",
                        data, setModeCount, why,
                        (data & 0x08) ? "data" : "audio",

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -810,7 +810,7 @@ void JaguarWriteLong(uint32_t offset, uint32_t data, uint32_t who)
     * specific but the log line is harmless elsewhere (rare false hits at
     * worst).  Remove with the rest of the CDDA-DIAG layer when resolved. */
    if (addr == 0xF1B274 && data != 0)
-      LOG_INF("[CDDA] DSP mailbox $F1B274 = %08X who=%u 68kpc=$%06X\n",
+      LOG_DBG("[CDDA] DSP mailbox $F1B274 = %08X who=%u 68kpc=$%06X\n",
               data, who, m68k_get_reg(NULL, M68K_REG_PC));
    if (addr < 0x200000)
    {

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -301,7 +301,7 @@ void DACWriteWord(uint32_t offset, uint16_t data, uint32_t who)
       /* CDDA-DIAG: SMODE master/slave switches are the CD_jeri fingerprint
        * (doc 06 p.7: slave $14 = CD data flows to the I2S port). Rare. */
       if ((*smode ^ data) & 0x01)
-         LOG_INF("[CDDA] SMODE $%04X -> $%04X (%s)\n", *smode, data,
+         LOG_DBG("[CDDA] SMODE $%04X -> $%04X (%s)\n", *smode, data,
                  (data & 0x01) ? "INTERNAL/master" : "slave: CD -> I2S");
       *smode = data;
       /* The resample ratio depends on master/slave (see DACUpdateSCLKRate) */
@@ -330,7 +330,7 @@ uint16_t DACReadWord(uint32_t offset, uint32_t who)
       static uint32_t lrxdReads = 0;
       lrxdReads++;
       if (lrxdReads <= 5 || (lrxdReads % 100000) == 0)
-         LOG_INF("[CDDA] LRXD read #%u val=$%04X who=%u\n", lrxdReads, lrxd, who);
+         LOG_DBG("[CDDA] LRXD read #%u val=$%04X who=%u\n", lrxdReads, lrxd, who);
       return lrxd;
    }
    else if (offset == RRXD + 2)

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -596,7 +596,7 @@ void DSPWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
          static uint32_t mboxWrites = 0;
          mboxWrites++;
          if (mboxWrites <= 40 || (mboxWrites % 10000) == 0)
-            LOG_INF("[CDDA] DSP mailbox write.w $%06X = $%04X who=%u 68kpc=$%06X\n",
+            LOG_DBG("[CDDA] DSP mailbox write.w $%06X = $%04X who=%u 68kpc=$%06X\n",
                     offset, data, who, m68k_get_reg(NULL, M68K_REG_PC));
          /* One-shot main-RAM snapshot at the mix-ON edge so the transient
           * music-player overlay around the writer PC can be disassembled.
@@ -616,7 +616,7 @@ void DSPWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
                {
                   fwrite(jaguarMainRAM, 1, 0x200000, f);
                   fclose(f);
-                  LOG_INF("[CDDA] snapshot: %s\n", path);
+                  LOG_DBG("[CDDA] snapshot: %s\n", path);
                }
             }
          }
@@ -669,7 +669,7 @@ void DSPWriteLong(uint32_t offset, uint32_t data, uint32_t who/*=UNKNOWN*/)
          static uint32_t mboxWritesL = 0;
          mboxWritesL++;
          if (mboxWritesL <= 40 || (mboxWritesL % 10000) == 0)
-            LOG_INF("[CDDA] DSP mailbox write $%06X = $%08X who=%u 68kpc=$%06X\n",
+            LOG_DBG("[CDDA] DSP mailbox write $%06X = $%08X who=%u 68kpc=$%06X\n",
                     offset, data, who, m68k_get_reg(NULL, M68K_REG_PC));
       }
       offset -= DSP_WORK_RAM_BASE;

--- a/src/jerry/jerry.c
+++ b/src/jerry/jerry.c
@@ -355,7 +355,7 @@ void JERRYI2SCallback(void)
          static uint32_t ssiDeliveries = 0;
          ssiDeliveries++;
          if (ssiDeliveries <= 3 || (ssiDeliveries % 220500) == 0)
-            LOG_INF("[CDDA] BUTCH->SSI delivery #%u (%us of samples)\n",
+            LOG_DBG("[CDDA] BUTCH->SSI delivery #%u (%us of samples)\n",
                     ssiDeliveries, ssiDeliveries / 44100);
          //	return GetWordFromButchSSI(offset, who);
          SetSSIWordsXmittedFromButch();
@@ -706,7 +706,7 @@ void JERRYWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
       /* CDDA-DIAG: JINTCTRL external-int enable edges gate the BUTCH ->
        * 68K IPL2 delivery (cdrom.c BUTCHExec); rare, log unconditionally. */
       if ((oldMask ^ jerryInterruptMask) & IRQ2_EXTERNAL)
-         LOG_INF("[CDDA] JINTCTRL ext-int enable %s (J_INT=$%04X who=%u 68kpc=$%06X)\n",
+         LOG_DBG("[CDDA] JINTCTRL ext-int enable %s (J_INT=$%04X who=%u 68kpc=$%06X)\n",
                  (jerryInterruptMask & IRQ2_EXTERNAL) ? "ON" : "OFF",
                  data, who, m68k_get_reg(NULL, M68K_REG_PC));
       if (oldMask != jerryInterruptMask || oldPending != jerryPendingInterrupt)

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -1371,7 +1371,7 @@ void TOMWriteByte(uint32_t offset, uint8_t data, uint32_t who)
        * cdrom.c BUTCHExec). Edges are rare; log unconditionally. */
       static uint8_t tomPrevInt1Ena = 0;
       if ((tomPrevInt1Ena ^ data) & 0x10)
-         LOG_INF("[CDDA] INT1 C_JERENA %s (INT1=$%02X who=%u 68kpc=$%06X)\n",
+         LOG_DBG("[CDDA] INT1 C_JERENA %s (INT1=$%02X who=%u 68kpc=$%06X)\n",
                  (data & 0x10) ? "ON" : "OFF", data, who,
                  m68k_get_reg(NULL, M68K_REG_PC));
       tomPrevInt1Ena = data;


### PR DESCRIPTION
User-visible log spam on iOS RetroArch: 12 per-event CD-audio diagnostics ([CDDA] LRXD/BUTCH-IRQ/DSA/SMODE/[CD-MODE]) were at RETRO_LOG_INFO, which frontends show by default. Demoted to RETRO_LOG_DEBUG per the repo's own tiering (per-call CD traces = DEBUG). One-shot boot/load/parse messages and the on-demand trace-ring/diag dumps stay INFO. No behavior change; build + c89-lint clean on all six touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)