### PR TITLE
chore(info): v3.0.0 info-file refresh (description + author order)

### DIFF
--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -1,6 +1,6 @@
 # Software Information
 display_name = "Atari - Jaguar (Virtual Jaguar)"
-authors = "David Raingeard|Shamus|Joseph Mattiello"
+authors = "Joseph Mattiello|David Raingeard|Shamus"
 supported_extensions = "j64|jag|rom|abs|cof|bin|prg|cue|cdi"
 corename = "Virtual Jaguar"
 license = "GPLv3"
@@ -29,4 +29,4 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 
-description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM), and the Blitter core option can be set to 'Fast' to trade some accuracy for additional speed on lower-end hardware. Supports a high-level BIOS that lets most commercial titles boot without a real BIOS image, plus save states, SRAM, cheat codes, and RetroAchievements."
+description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. Supports Jaguar CD (CUE/BIN, CHD, CDI) with Memory Track saves, JagLink/CatBox network play over TCP or RetroArch netplay, a high-level BIOS that lets most commercial titles boot without a real BIOS image, save states, SRAM, cheat codes, and RetroAchievements. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM); the Blitter core option can be set to 'Fast' to trade some accuracy for additional speed on lower-end hardware."


### PR DESCRIPTION
Refreshes the core info file for the v3.0.0 release: description now leads with the headline features (Jaguar CD with Memory Track saves, JagLink/CatBox network play), and the authors field lists the active maintainer first (Joseph Mattiello|David Raingeard|Shamus) — original authors retained. This is the same content the post-release libretro-super PR will mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)