### PR TITLE
chore: pre-tag scrutiny fixes — fact-check corrections, doc de-slop, stale-doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Port of the [Virtual Jaguar](http://shamusworld.gotdns.org/git/virtualjaguar) At
 - Fast and legacy blitter modes (the legacy/accurate path is SIMD-accelerated on SSE2 and NEON)
 - Optional BIOS boot sequence, plus an HLE BIOS so games can boot without a BIOS image
 - Save state, run-ahead (deterministic serialization), SRAM/EEPROM via the libretro SRAM interface, cheat codes, and a memory map for RetroAchievements
-- Supported ROM formats: `.j64`, `.abs`, `.jag`, `.rom` (including inside ZIP archives), plus conservative headerless raw homebrew loading
+- Supported ROM formats: `.j64`, `.jag`, `.rom`, `.abs`, `.cof`, `.bin`, `.prg` (including inside ZIP archives), plus `.cue` and `.cdi` for Jaguar CD images, and conservative headerless raw homebrew loading
 - Network link play (JagLink / CatBox emulation): Doom deathmatch, AirCars, BattleSphere Gold — via RetroArch netplay, or a direct TCP link between frontends on socket-capable platforms ([setup guide](docs/netlink-user-guide.md))
 
 ## Recent improvements (libretro fork)
@@ -20,7 +20,7 @@ Port of the [Virtual Jaguar](http://shamusworld.gotdns.org/git/virtualjaguar) At
 This fork has diverged substantially from upstream Virtual Jaguar v2.1.0. See [docs/WHATSNEW](docs/WHATSNEW) for the full v2.2.0 changelog. Highlights:
 
 - **HLE BIOS** now produces hardware-equivalent post-boot state — MEMCON1, clocks, GPU auth magic, OLP, exception vectors, TOM/JERRY timing — and the vast majority of commercial titles boot cleanly without any BIOS image. 200+ pin tests in `test_hle_bios` cover the contract.
-- **Game-specific fixes**: Alien vs Predator red noise (M2 blitter `BKGWREN+BCOMPEN`), Doom resolution (proper `PWIDTH` pixel replication, replaces the legacy hack), and audio dropouts at frame edges across many titles (interleaved JERRY events). Jaguar CD support is in flight on a separate branch (PR forthcoming).
+- **Game-specific fixes**: Alien vs Predator red noise (M2 blitter `BKGWREN+BCOMPEN`), Doom resolution (proper `PWIDTH` pixel replication, replaces the legacy hack), and audio dropouts at frame edges across many titles (interleaved JERRY events). Jaguar CD support shipped in v3.0.0: CUE/BIN and CDI images boot through either an HLE CD BIOS or a real CD BIOS.
 - **CPU accuracy**: DSP 40-bit MAC accumulator semantics, FLAGS-write dispatch, GPU/DSP IMASK preservation and ADDC carry overflow, DIVL exception PC.
 - **Accurate-blitter** accuracy fixes (`daddmode` NAND tree, `daddbsel` bit 3, `ADDARRAY` cinsel carry, `SRCSHADE` color).
 - **Object Processor**: scaled and fixed-bitmap `firstPix` handling, left/right/reflected edge clipping for scaled bitmaps, `firstPix` for 2/4/16/24 BPP fixed bitmaps.

--- a/docs/RELEASE_NOTES_v3.0.0.md
+++ b/docs/RELEASE_NOTES_v3.0.0.md
@@ -14,15 +14,15 @@ gate that actually blocks.
   (Baldies, Battle Morph, BrainDead 13, Dragon's Lair, Highlander, Hover
   Strike, Iron Soldier 2, Primal Rage, Space Ace, Myst) boots to game code in
   both HLE and real-BIOS mode. Memory Track NVM is HLE'd so Vid Grid saves
-  again (#258); the core falls back to an embedded CD BIOS when no external
-  BIOS ROM is present; a `virtualjaguar_cd_read_speed` option (1x/2x/4x/8x/
+  again (#258); a `virtualjaguar_cd_read_speed` option (1x/2x/4x/8x/
   instant) is available on the HLE path; the `cue2cdi` CUE/BIN→CDI converter
   tool ships for building interchange images.
 - **Jaguar Link networking.** JagLink/CatBox link-port hardware is emulated
   at the JERRY UART level, with pluggable transports: a direct TCP link
-  (works in every frontend, including Provenance on iOS/macOS), the libretro
-  netpacket interface (real RetroArch netplay), and a CatNet-style multi-peer
-  hub for more than two consoles. Hostname resolution (not just dotted-quad
+  (designed to work in any frontend without netplay support -- validated on
+  macOS; the iOS/Provenance device test is pending, see Known Issues), the
+  libretro netpacket interface (real RetroArch netplay), and a CatNet-style
+  multi-peer hub for more than two consoles. Hostname resolution (not just dotted-quad
   addresses) and a core-option-driven host/port config round out the
   ease-of-use work. Validated over TCP on localhost/LAN: Doom deathmatch
   (host+client join, playable), BattleSphere Gold (to networked-lobby entry),
@@ -33,8 +33,8 @@ gate that actually blocks.
   workflow + `libretro_core_options_intl.h` scaffolding) ready for
   translations.
 - **Compatibility wave.** Wolfenstein 3D missing music (DSP `D_FLAGS`
-  pipeline-stage fix), Pitfall crash-on-boot (68000 group-0 exception frame +
-  GPU STOREP masking, #138), Tempest 2000's one-frame playfield collapse
+  pipeline-stage fix), Pitfall's black screen shortly into gameplay (68000
+  group-0 exception frame + GPU STOREP masking, #138), Tempest 2000's one-frame playfield collapse
   (TOM level-2 IRQ request held across the CPU interrupt mask, #187), Alien
   vs Predator's first-frame cyan bar and in-game brown bottom bar (#178),
   Brutal Sports Football's copier-header carts (skip instead of reject), and
@@ -56,28 +56,31 @@ gate that actually blocks.
   cannot represent a Jaguar CD's multi-session layout (session 1 audio
   warning track, session 2 data recorded as byte-swapped 2352-byte audio-type
   sectors, track lead-in offsets) — no retail disc can boot from one, and
-  BigPEmu declines them for the same reason. The loader now refuses `.iso`
-  at load time with an explanatory error instead of presenting a BIOS screen
-  that goes nowhere. Use CUE/BIN, CHD, or CDI (see `test/tools/cue2cdi` to
+  BigPEmu likewise does not accept bare `.iso` images. The loader now refuses
+  `.iso` at load time with an explanatory error instead of presenting a BIOS
+  screen that goes nowhere. Use CUE/BIN or CDI (see `test/tools/cue2cdi` to
   convert).
-- **Savestate format is now v7 and frozen from this release.** Savestates
-  older than `STATE_MIN_VERSION` are rejected outright; states between the
-  minimum and v7 load with newer fields defaulted. No further savestate
-  layout changes are planned before the next major version — v7 is the
-  stable target going forward.
+- **Savestate format v7 (forward-compatibility note).** Savestates written
+  by v3.0.0 will not load in older cores. In the other direction almost
+  nothing breaks: all states from the v2.x releases (`STATE_VERSION` >= 2)
+  continue to load, with newer fields defaulted; only pre-v2 states from far
+  older cores are rejected. v7 is frozen as the stable format going
+  forward.
 
 ## What's new
 
 ### Jaguar CD
 
-- Full local corpus (10 titles/images) reaches `GAME_CODE` in both HLE and
-  real-BIOS mode — the CD boot-matrix regression gate (`docs/cd-boot-matrix.md`)
-  is green across all active rows, with zero rows moved backward across three
-  re-run sweeps this cycle.
+- Full local corpus (10 titles across 11 images -- 10 CUE/BIN plus 1 CDI)
+  reaches `GAME_CODE` in both HLE and real-BIOS mode — the CD boot-matrix regression gate (`docs/cd-boot-matrix.md`)
+  is green across all active rows, with no genuine regressions across the
+  re-run sweeps this cycle (one apparent backward move was traced to a
+  substituted bad disc image and is documented in the matrix).
 - Memory Track NVM BIOS module HLE'd (`_NVM` at `$2400`) alongside the
   `$900000` flash window — Vid Grid and other Memory-Track-dependent titles
   save correctly (#258).
-- Embedded CD BIOS fallback when no external BIOS ROM file is present.
+- The real-BIOS path falls back to an embedded CD boot ROM when no external
+  BIOS file is configured, so no BIOS file is strictly required.
 - `virtualjaguar_cd_read_speed` core option (1x/2x/4x/8x/instant), HLE-path
   only by design — scaling the real-BIOS path's FIFO/DSA cadence would
   reopen DSA-steal and FIFO-storm race classes those constants encode.
@@ -92,8 +95,8 @@ gate that actually blocks.
 ### Networking (Jaguar Link)
 
 - JERRY asynchronous serial UART emulated at the register level
-  (`ASIDATA`/`ASICTRL`/`ASICLK`, `$F10030`-`$F10035`), verified against the
-  JTRM rather than source comments.
+  (`ASIDATA`/`ASICTRL`/`ASISTAT`/`ASICLK`, `$F10030`-`$F10035`), verified
+  against the JTRM rather than source comments.
 - Pluggable link transport: loopback (default/disabled), direct TCP
   (`tcp_server`/`tcp_client` core-option modes, per-frame link poll), and the
   libretro netpacket interface for real RetroArch netplay integration.
@@ -104,7 +107,7 @@ gate that actually blocks.
   caused by netpacket TX batching (#248).
 - Netlink host configurable as a core option; `vj_netlink.txt` is now a
   fallback rather than the only path. Hostnames (not just dotted-quad
-  addresses) resolve (#253).
+  addresses) resolve (#263).
 - UART + link state serialize in savestates.
 
 ### Options menu
@@ -120,11 +123,12 @@ gate that actually blocks.
 
 - **Wolfenstein 3D**: missing game music fixed (DSP `D_FLAGS` pipeline-stage
   correction).
-- **Pitfall**: crash-on-boot fixed — the 68000 now builds the full 14-byte
-  group-0 bus-error exception frame (it previously pushed only a standard
-  frame), and GPU `STOREP` gained byte-lane masking; GPU-RAM sync
-  correction (#138, 2 of 3 tracked sub-issues; remaining item is a GPU ISR
-  r31 leak, non-blocking).
+- **Pitfall**: the black screen shortly into gameplay is fixed — the 68000
+  now builds the full 14-byte group-0 bus-error exception frame (it
+  previously pushed only a standard frame), and GPU `STOREP` gained
+  byte-lane masking; GPU-RAM sync correction (#138, 2 of 3 tracked
+  sub-issues; the remaining item is a GPU ISR r31 leak, non-blocking, noted
+  in `docs/cart-issue-triage.md`).
 - **Tempest 2000**: one-frame playfield collapse fixed by holding TOM's
   level-2 interrupt request across the CPU interrupt mask instead of
   dropping it (#187).
@@ -149,8 +153,8 @@ gate that actually blocks.
 - **Baldies**: HLE boot progress reporting and CDI third-party-rip loading
   fixed (landmark-scan CDI global-data-offset detection, #233 — also
   resolved #230, see Known Issues).
-- **Blitter**: fixed reading pixel-mode data from channel 0 instead of
-  channel 2.
+- **Blitter**: fixed pixel-mode data reads to use channel 0's data
+  registers (they wrongly read channel 2).
 - **GPU**: indexed-load alignment now tests the effective address rather
   than the raw register mode.
 - **OP**: GPU objects correctly halt the Object Processor until the GPU
@@ -168,9 +172,15 @@ gate that actually blocks.
   physics model, not a game-specific hack — it's disabled by default because
   calibration against real hardware is ongoing. **Honest status on the
   "Doom runs too fast" bug**: this occupancy work closes approximately 0% of
-  the measured gap (real hardware ~20 fps vs. ours ~1.5-2x that on Doom's
-  attract demos, once measured by demo *duration* rather than the saturated
-  tic-rate metric that was used previously). Sensitivity sweeps identify the
+  the measured gap. Real hardware renders Doom at 19.98 fps typical and
+  ~15 fps in heavy scenes, while we sit pinned at the engine's own 29.97 fps
+  two-field cap — **~1.5x too fast typical, 2x in heavy scenes**. Measured by
+  attract-demo *duration* (the tic-rate metric used previously is saturated
+  at that same 29.97 cap and cannot discriminate), the occupancy model
+  lengthens demo 1 by +0.0% and demo 2 by +0.1%, i.e. within run-to-run
+  noise. (An earlier +2.0% / +0.7% figure, quoted in #265, was measured
+  against a bus model that double-counted the 68K's own bus cycle; that bug
+  is fixed in this release.) Sensitivity sweeps identify the
   GPU and DSP per-instruction/per-access timing as the levers actually on
   the critical path — the 68000 is not. That work is scoped as the next step
   and tracked in `docs/doom-pace-calibration.md`; it did not make this
@@ -215,18 +225,27 @@ gate that actually blocks.
   landmark itself is missing, not recoverable by offset correction. V3.5
   images and self-generated (`cue2cdi`) images are unaffected; 10/14 of the
   local CDI corpus pass.
+- **Savestates from cores older than `STATE_MIN_VERSION` are rejected**
+  (#268) — pre-v2 states from far older builds cannot be migrated. States
+  from the v2.x line load normally.
 - **Alien vs Predator**: a green-dot / green title-bar-area artifact is still
-  unreproduced (#266); a related brown-bar-vs-shotgun red background report
-  (#267) is also open. Both are narrower follow-ups split from the original
+  unreproduced (#266); a red-background-behind-the-shotgun report (#267) is
+  also open. Both are narrower follow-ups split from the original
   #178 umbrella, which is otherwise resolved.
 - **FMV scene-jump drift**: Dragon's Lair, Space Ace, and BrainDead 13
   occasionally jump cutscenes early or late in HLE mode — their own
   delivery-clock counters drift relative to our transfer pacing. Reproducible
   and understood; not yet fixed. Real-BIOS mode is unaffected.
-- **Doom** still runs its combat/monster pacing too fast (~1.5-2x); this is
-  a known, understood gap — see "Performance / experimental" above and
-  `docs/doom-pace-calibration.md`. Doom's demo/in-game music silence is
+- **Doom** still runs its combat/monster pacing too fast (~1.5x typical, 2x
+  in heavy scenes); this is a known, understood gap — see "Performance /
+  experimental" above and `docs/doom-pace-calibration.md`. Doom's demo/in-game music silence is
   authentic to the original hardware, not a bug.
+- **Iron Soldier (cart)**: the wireframe tank is still missing under the
+  fast blitter (#186 class); the accurate blitter is unaffected.
+- **Battle Sphere Gold**: menu text renders too dark to read. The glyphs
+  arrive already dark from the game's own pre-shading path — the blitter has
+  been exonerated — and the writer routine is still under investigation.
+  Networked lobby entry is unaffected.
 - **Tempest 2000** (#187) and the AvP items above are not independently
   device-verified this cycle; treat as believed-fixed pending confirmation.
 - The accurate blitter remains notably slower than the fast blitter; some
@@ -248,19 +267,19 @@ Pre-built libretro cores for 16 platforms:
 - Windows: x86_64, i686 (MSYS2/MinGW)
 - iOS: arm64; tvOS: arm64
 - Android: arm64-v8a, armeabi-v7a, x86_64, x86
-- Web: Emscripten WASM
+- Web: Emscripten (bitcode for WASM builds)
 - Consoles: PS Vita, Nintendo Switch
 
-Each binary has a matching `*-debug.tar.gz` with split debug symbols.
-SHA256 checksums in `SHA256SUMS.txt`.
+Each binary has a matching debug artifact (`*-debug.tar.gz`): split debug
+symbols where the toolchain supports it (`.debug` / `.dSYM`); the Emscripten
+target ships its bitcode directly. SHA256 checksums in `SHA256SUMS.txt`.
 
 ## Credits
 
 Thanks to the community members who filed and helped diagnose issues fixed
 this cycle, including reports that led to the Pitfall (#138), Tempest 2000
 (#187), Alien vs Predator (#178), and CD compatibility (#230, #233) fixes,
-and to everyone who ran the Wi-Fi/netplay latency reports that shaped the
-netlink transport fixes (#248, #250).
+and to everyone who reported and re-tested the Wi-Fi netplay lag.
 
 This release builds on the original Virtual Jaguar emulator and its
 contributors, and on hardware documentation cross-referenced against the

--- a/docs/RELEASE_NOTES_v3.0.0.md
+++ b/docs/RELEASE_NOTES_v3.0.0.md
@@ -1,6 +1,6 @@
 # Virtual Jaguar libretro v3.0.0
 
-Major release — 291 commits since v2.3.2. Jaguar CD support matures into a
+Major release — 303 commits (246 non-merge) since v2.3.2. Jaguar CD support matures into a
 full local-corpus boot pass in both BIOS and HLE modes, Jaguar Link
 networking ships (JagLink/CatNet over TCP and RetroArch netplay), core
 options are reorganized into categories with content-aware hiding, and a
@@ -255,8 +255,10 @@ gate that actually blocks.
 
 ## Compared to v2.3.2
 
-177 files changed, +40,039 / -829 lines across 291 commits (106 fix, 47 docs,
-26 feat, 26 test, 7 perf, 4 chore, remainder untyped/merge commits).
+181 files changed, +40,390 / -839 lines across 303 commits (246 non-merge;
+the type tally below counts non-merge commits only): 108 fix, 50 docs,
+27 test, 27 feat, 7 perf, 6 chore, 2 ci, 1 refactor, and 18 commits with
+untyped or non-standard subjects.
 
 ## Downloads
 

--- a/docs/WHATSNEW
+++ b/docs/WHATSNEW
@@ -1,3 +1,53 @@
+Virtual Jaguar v3.0.0 libretro
+------------------------------
+
+Major release -- Jaguar CD, link-cable networking, and a wide
+compatibility wave. Full notes: docs/RELEASE_NOTES_v3.0.0.md
+
+== Jaguar CD ==
+* The full local 10-title corpus (Baldies, Battle Morph, BrainDead 13,
+  Dragon's Lair, Highlander, Hover Strike, Iron Soldier 2, Primal Rage,
+  Space Ace, Myst) boots to game code in both HLE and real-BIOS mode.
+* CUE/BIN and CDI images; `test/tools/cue2cdi` converts CUE/BIN to CDI.
+* Memory Track NVM is HLE'd, so Vid Grid and friends save again (#258).
+* HLE-path CD read speed is selectable (1x/2x/4x/8x/instant).
+* Bare .iso images are refused at load with an explanation -- a
+  2048-byte-sector ISO cannot represent a Jaguar disc's two sessions.
+
+== Networking ==
+* JagLink / CatBox link hardware emulated at the JERRY UART level, with
+  a direct TCP transport, the libretro netpacket interface (RetroArch
+  netplay), and a CatNet-style multi-peer hub.
+* Validated over TCP on localhost/LAN: Doom deathmatch, AirCars
+  (2-player and 3-console hub), BattleSphere Gold to lobby entry.
+* Host address is a core option and resolves hostnames, not just
+  dotted quads (#253); vj_netlink.txt is now a fallback.
+
+== Compatibility ==
+* Wolfenstein 3D missing music (DSP D_FLAGS pipeline stage).
+* Pitfall black screen shortly into gameplay (68000 group-0 exception
+  frame + GPU STOREP byte-lane masking) (#138).
+* Tempest 2000 one-frame playfield collapse (TOM level-2 IRQ request
+  held across the CPU interrupt mask) (#187).
+* Alien vs Predator first-frame cyan bar and in-game brown bottom bar
+  (#178).
+* Brutal Sports Football copier-header carts load instead of being
+  rejected.
+
+== Interface ==
+* Core options grouped into 9 categories, with options that do not
+  apply to the loaded content type hidden dynamically (#251).
+* i18n scaffolding (Crowdin workflow + libretro_core_options_intl.h);
+  no languages translated yet.
+
+== Housekeeping ==
+* Savestate format is v7 and frozen from this release. States from the
+  v2.x line still load with newer fields defaulted.
+* Acid test suite reconciled against the JTRM and its CI gate fixed, so
+  the job now actually blocks on regressions.
+* New experimental `virtualjaguar_dram_timing` bus model, default off.
+
+
 Virtual Jaguar v2.3.2 libretro
 ------------------------------
 

--- a/docs/cd-bizhawk-comparison.md
+++ b/docs/cd-bizhawk-comparison.md
@@ -399,8 +399,8 @@ interrupts, fixes Black ICE"*:
 ```diff
  STATIC_INLINE uint32_t m68ki_init_exception(void)
  {
- 	MakeSR();
- 	uint32_t sr = regs.sr;
+	MakeSR();
+	uint32_t sr = regs.sr;
 -	regs.s = 1;
 +
 +	if (!regs.s)
@@ -409,8 +409,8 @@ interrupts, fixes Black ICE"*:
 +		m68k_areg(regs, 7) = regs.isp;
 +		regs.s = 1;
 +	}
- 
- 	return sr;
+
+	return sr;
  }
 ```
 

--- a/docs/cd-boot-matrix.md
+++ b/docs/cd-boot-matrix.md
@@ -339,8 +339,8 @@ layout produced by the real CD BIOS's own $2C00 TOC builder (disasm ROM
 `byte[1..3]=start MSF`, `byte[4]=0-based session`). The old standalone
 zero-longword marker slot terminated Baldies' `$4E18` scan early (deliberate
 ILLEGAL) and left every `byte[4]` zero so the session-key match was
-impossible; both defects fixed. Full derivation + RED/GREEN contract test in
-`.superpowers/sdd/task-6d-report.md`.
+impossible; both defects fixed. The derivation is captured by the RED/GREEN contract test
+`test/test_cd_toc_contract.c`.
 Boot-mode determination: **outcome (c)** — `$2C00` is PRNG garbage at injection
 time (the BIOS TOC builder never runs under the auth-bypass boot), so the
 injected table must be correct itself.
@@ -582,8 +582,7 @@ two boot stubs), which the 32-byte dump cannot distinguish.
 #### Task 6B update — premise OVERTURNED by instruction-level disasm; this is a MASK, real cause is the $2C00 TOC
 
 The Task-6 REQUIREMENT (disasm before trusting RTE stubs) was carried out.
-It **rejects** the "populate vectors" fix for these two titles. Full trace in
-`.superpowers/sdd/task-6b-report.md`; essentials:
+It **rejects** the "populate vectors" fix for these two titles. Essentials:
 
 - `prev_pc=$8020A2` is a **red herring**: the harness samples PC once per
   frame (`test_cd_bios_boot.c:198,255`), so it only means "the 68K was in
@@ -764,7 +763,7 @@ regressed nor advanced -- the "Baldies shares the heuristic" hypothesis is
 
 Seven rows deleted + re-run after `fix(gpu): don't clobber IRQ dispatch
 raised in a branch delay slot` (3000 frames, same knobs). Root cause and
-byte-level evidence in `.superpowers/sdd/task-8-second-wedge-report.md`:
+byte-level evidence in `docs/cd-diagnosis/braindead13-second-wedge-diagnosis.md`:
 the CD streaming ISR epilogue (`JUMP T,(Rret)` with an IMASK-clearing
 G_FLAGS store in the delay slot) had its interrupt dispatch overwritten by
 `gpu_opcode_jump/jr` applying the branch target after the delay slot ran --

--- a/docs/cd-debugging-handoff.md
+++ b/docs/cd-debugging-handoff.md
@@ -171,8 +171,8 @@ PASS in this effort — see the SKIP≠PASS fix in `test/test_framework.h`.
 ### Test material (`test/roms/private/`, gitignored)
 CUE/BIN: Baldies, Battle Morph, BrainDead 13, Dragon's Lair, Highlander, Hover Strike, Iron Soldier 2, Primal Rage, Space Ace. Also `baldies.cdi`, loose ISOs (non-bootable — documented), `Jaguar CD BIOS.rom`, `[BIOS] Atari Jaguar CD (World).j64`, `jagboot.rom`, and ~25 cart ROMs for regression/blast-radius testing.
 
-### Local-only diagnosis writeups
-`.superpowers/sdd/` is **gitignored** (present on this machine only): `task-7-streaming-wall-report.md` (FIFO phase), `task-8-second-wedge-report.md` (delay-slot IRQ + GPU engine disasm), `task-9-fmv-stall-report.md` (**the §4 lost-wakeup diagnosis, 261 lines**), `braindead-device-trace.txt` / `-2.txt` (real iOS traces). Everything load-bearing is distilled above and in `cd-boot-matrix.md`.
+### Diagnosis writeups
+The full per-wall diagnoses live in `docs/cd-diagnosis/`: `cd-streaming-wall-diagnosis.md` (FIFO phase), `braindead13-second-wedge-diagnosis.md` (delay-slot IRQ + GPU engine disasm), `fmv-stall-diagnosis.md` (the §4 lost-wakeup diagnosis), plus `braindead-device-trace.txt` / `-2.txt` (real iOS traces). Everything load-bearing is also distilled above and in `cd-boot-matrix.md`.
 
 ## 7. Working rules (learned the hard way)
 

--- a/docs/cd-diagnosis/braindead13-second-wedge-diagnosis.md
+++ b/docs/cd-diagnosis/braindead13-second-wedge-diagnosis.md
@@ -1,18 +1,17 @@
-# Task 8 report — the SECOND CD-transfer wedge
+# BrainDead 13 / Primal Rage: the second CD-transfer wedge
 
-Branch `feature/jaguar-cd-support`, main checkout. Starting HEAD: `d2cd04b` (task-7 docs)
-on top of `09a62d6` (FIFO word-phase fix). Tree clean at start.
+Diagnosis written on `feature/jaguar-cd-support`, starting from `d2cd04b` on
+top of `09a62d6` (FIFO word-phase fix; see cd-streaming-wall-diagnosis.md).
 
 Goal: diagnose (and if bounded, fix) the wedge that stops CD games AFTER the first
 boot-stub load succeeds — the continuous-FMV-streaming stall. User-confirmed on device:
 BrainDead 13 boots BIOS, runs injected game code, shows logo, then sticks when
 continuous FMV streaming should begin.
 
-## Phase log (append-only)
+## Investigation log
 
-### Phase 0 — orientation
-- Confirmed HEAD d2cd04b, clean tree, branch feature/jaguar-cd-support.
-- Read task-7 report: first wedge (streaming wall / FIFO longword grouping phase) is
+### Orientation
+- Prior work: the first wedge (streaming wall / FIFO longword grouping phase) is
   fixed and byte-exact (test_cd_fifo_stream GREEN, regression floor).
 - Second-wedge signatures per dispatch:
   - Primal Rage (bios): 2 seeks complete, 12,857 fifo_drains, then cd_seek_wedge;
@@ -21,8 +20,8 @@ continuous FMV streaming should begin.
     gpu_pc=$F0327A gpu_run=1, dsp_pc=$F1B120 dsp_run=0.
   - Highlander: cd_seek_wedge fifo_drains=54; IS2: video_stall dsp_run=1.
 
-### Phase 0b — resume after API cutoff (coordinator update absorbed)
-- Read docs/cd-boot-matrix.md current rows + task-7 report. Key supersessions:
+### Re-baselining against the current matrix
+- docs/cd-boot-matrix.md rows + the streaming-wall diagnosis. Key supersessions:
   Baldies bios now GAME_CODE ($060106); Highlander/IS2 bios = different pre-sentinel
   mechanism (drains freeze 54/0), separate branch; FIFO_DRAIN_READS starvation already
   fixed in 09a62d6 (FIFO port reads deliver while cdPlaying even after drain gate).
@@ -30,7 +29,7 @@ continuous FMV streaming should begin.
   region — strengthens W-STOP-RESTART/DSA semantics) and BrainDead 13 bios
   post-logo FMV streaming (video_stall gpu_pc=$F0327A, dsp_run=0).
 
-### Phase 1 — traced Primal Rage bios run + device trace absorbed
+### Primal Rage BIOS-mode trace + BrainDead 13 device trace
 - Rebuilt core TEST_EXPORTS=1 (tree had stale iOS .o files; make clean first).
 - Regression floor confirmed GREEN: test_cd_fifo_stream PASS (ram_hit=$4000).
 - Harness diag_second_wedge (scratchpad): Primal Rage bios, trace ring dumped at
@@ -46,7 +45,7 @@ continuous FMV streaming should begin.
     +12=$32D800F0 +16=$980132E0 — NOT the task-7 layout (dest/end/counter/sentinel);
     the GPU program was REPLACED between transfer 1 and 2 (game/BIOS uploaded a new
     engine; r31=$F03368, r26=$F03E9C — code+stack extend to $F03E9C).
-- BrainDead 13 device trace (.superpowers/sdd/braindead-device-trace.txt):
+- BrainDead 13 device trace (`docs/cd-diagnosis/braindead-device-trace.txt`):
   FIRST game transfer (seek_starts=1): pre-seek $7001, $150A->$170A x3, goto
   MSF 05:04:06 block 22656 correct, SEEK_DONE, then FILL/DRAIN alternate forever,
   ~150 drains/sector, GPU pinned $F03276-$F0327A, dsp_run=0, 68K never resumes.
@@ -54,7 +53,7 @@ continuous FMV streaming should begin.
   (bios+hle), Space Ace(bios+hle), Baldies(bios) — a COMMON post-boot streaming
   loop. Primal Rage wedges at a different loop ($F03168) of its second engine.
 
-### Phase 2 — the replaced engine decoded (Primal Rage dump, live at wedge)
+### The replaced engine decoded (Primal Rage dump, live at wedge)
 GPU RAM disassembly of the SECOND engine (game-uploaded, dumped live at the wedge):
 - Vector $F03010 -> JUMP $F03380 (second-stage CD ISR). Vector $F03000 (IRQ0/CPU)
   -> $F03040: writes OLP ($F00020), then if [$F032E4]!=0: clear it + STOREB 1 ->
@@ -80,7 +79,7 @@ GPU RAM disassembly of the SECOND engine (game-uploaded, dumped live at the wedg
   INT_ENA1/IMASK state, JERRY latch not re-armed. Next: sample BUTCH enables +
   diag counters per-frame across the freeze.
 
-### Phase 3 — ROOT CAUSE (byte-level evidence, two independent titles)
+### Root cause (byte-level evidence, two independent titles)
 **Mechanism: GPU interrupt dispatch clobbered by the branch delay slot.**
 The CD streaming ISR epilogue idiom (both engines, and the retail BIOS ISR) is:
 `JUMP T,(Rret)` with `STORE Rflags,(G_FLAGS)` in the DELAY SLOT — the store
@@ -120,7 +119,7 @@ Fix: make GPUHandleIRQs delay-slot-aware — when dispatch happens during a
 delay slot, push the BRANCH TARGET (-2) as the return address and tell the
 jump opcode NOT to overwrite gpu_pc. Transient flags, no savestate impact.
 
-### Phase 2 — resumed by successor agent; BrainDead 13 wedge fully disassembled
+### BrainDead 13 wedge fully disassembled
 Reproduced the device trace exactly (local, bios mode, BrainDead 13): after the
 first game CD_read (seek block 22656) the FIFO fills/drains forever, GPU pinned
 $F03270-$F0327A, 68K cycling, fb frozen. GPU RAM dumped (scratchpad
@@ -167,8 +166,8 @@ FIFO-port reads to confirm which ISR path runs, then fix at the cdrom.c status
 layer. (2x drains/sector vs the 73.5 expected also points at a status/pathing
 mismatch, not wrong data.)
 
-### Phase 3 — bit-13 hypothesis FALSIFIED; real wedge is POST-transfer signaling
-Advisor caught it: drains prove the ISR FIFO path runs. Per-frame poll of the
+### Bit-13 hypothesis falsified; the real wedge is post-transfer signaling
+Review caught it: drains prove the ISR FIFO path runs. Per-frame poll of the
 transfer state ([$F03B10] dest / [$F03B14] limit) shows the transfer **completes
 normally**: dest climbs $45FFC -> $146000 (limit) over frames ~55-368 (~1 MB),
 data lands. The wedge is AFTER the transfer.
@@ -202,7 +201,7 @@ CD DATA PATH IS CORRECT. Remaining gap = GPU-completion / CD-done interrupt
 delivery to the 68K + the GPU-FMV decode engine's per-frame signaling. Evaluating
 bounded-fix vs structural next.
 
-### Phase 4 — TDD fix, gate, commit
+### The fix, gates and commit
 - Fix committed: 7c98e16 fix(gpu): don't clobber IRQ dispatch raised in a
   branch delay slot. gpu.c: GPUHandleIRQs pushes the branch target (-2) and
   flags the in-flight gpu_opcode_jump/jr to not overwrite gpu_pc when the
@@ -230,7 +229,7 @@ bounded-fix vs structural next.
   commit (harness works without it; ring dumps were session-only). Diag
   harness + disasm wrapper live in scratchpad only.
 
-### Phase 5 — matrix re-run (7 rows, 3000 frames, core at 7c98e16)
+### Matrix re-run (7 rows, 3000 frames, core at 7c98e16)
 | Title/mode | BEFORE (d2cd04b) | AFTER (7c98e16) | verdict |
 |---|---|---|---|
 | BrainDead 13 bios | video_stall f=739 final_pc=$00361E dsp_run=0 (device-confirmed logo wedge) | logo load + SECOND ~1MB FMV read complete (38915 drains), final_pc=$00B2FA, unique 23->43, dsp_run=1 | **ADVANCED** |
@@ -256,11 +255,10 @@ Notes section added to docs/cd-boot-matrix.md ("Task 8 fix").
 
 ### Final status
 - Commits: 7c98e16 (fix + contract test + Makefile wiring), 0b88fa0 (matrix
-  rows + notes). No push. Tree clean. (.superpowers/sdd/* is gitignored by
-  convention — this report lives on disk only, like task-7's.)
+  rows + notes).
 - Gates all green: c89-lint gpu.c, make TEST_EXPORTS=1 test exit 0,
   test_cd_fifo_stream (floor) GREEN, test_cd_second_transfer RED->GREEN,
   audio pair verified (IS1 RMS 1175.7; clipping self-test PASS).
-- REMAINING for the user: verify BrainDead 13 on the iOS device / RetroArch —
+- REMAINING: verify BrainDead 13 on an iOS device / in RetroArch —
   headless says the logo wedge mechanism is dead and FMV streaming completes;
   whether video presents correctly needs a real frontend (headless-fb caveat).

--- a/docs/cd-diagnosis/cd-streaming-wall-diagnosis.md
+++ b/docs/cd-diagnosis/cd-streaming-wall-diagnosis.md
@@ -1,9 +1,7 @@
-# Task 7 report — the streaming wall: FIFO longword grouping phase (+ drain starvation)
+# The CD streaming wall: FIFO longword grouping phase (+ drain starvation)
 
-Branch `feature/jaguar-cd-support`, main checkout.
-Fix commit: `09a62d6 fix(cd): start FIFO word stream one 16-bit word into the sector`
-(committed by the user from my in-flight tree; content verified == intended fix, no stray
-instrumentation). Follow-up commit (this report + refreshed matrix rows): see below.
+Diagnosis written on `feature/jaguar-cd-support`.
+Fix commit: `09a62d6 fix(cd): start FIFO word stream one 16-bit word into the sector`.
 
 ## Outcome
 
@@ -71,7 +69,7 @@ Eliminations, in evidence order:
 Plus a diag accessor `CDROMDiagGetFirstSeekBlock()` (cdrom.c/h; reset in
 `CDROMReset`) used by the new contract test. **No savestate changes.**
 
-## Byte-compare evidence (the definitive test the dispatch asked for)
+## Byte-compare evidence (the definitive test)
 
 Expected: BIN track 31, LBA 117224, post-sync byte 106 (I2S-unswapped):
 `4E F9 00 00 40 18 00 7B …` (JMP $4018 — matches the HLE oracle's $4000 dump exactly).
@@ -113,7 +111,7 @@ bytes appear contiguously in main RAM.
 | Primal Rage | hle | GAME_CODE $00419E | unchanged | control ✓ |
 | Iron Soldier 2 | hle | FAIL $007416 (pre-existing) | unchanged | control ✓ |
 
-## Self-review
+## Evidence review
 
 - Every claim traced to primary evidence: seek math from the trace ring both modes;
   word stream from FIFO pop instrumentation (since reverted); ISR semantics from the
@@ -124,8 +122,8 @@ bytes appear contiguously in main RAM.
   model); HLE path untouched; cart path untouched; no savestate fields.
 - Temp instrumentation (TDIAG stderr taps, exports-test.list `_CDTrace*`) all
   reverted before commit; `git show 09a62d6` reviewed clean.
-- Matrix honest: 2 of 4 targets moved, 2 recorded unchanged with their real
-  (different) blocker named; 3 controls byte-identical.
+- Matrix: 2 of 4 targets moved, 2 recorded unchanged with their real (different)
+  blocker named; 3 controls byte-identical.
 
 ## Concerns / next blockers
 
@@ -133,7 +131,7 @@ bytes appear contiguously in main RAM.
    game code runs, the second CD_read (DDL5, seek 127506) transfer freezes with
    gpu_pc=$F03168 (DSARX-handler region) and fifo_drains frozen. Likely a
    DSA-response / I2S-re-enable state issue on *repeat* reads, not phase (127516's
-   sync is also byte≡2 mod 4). Deserves its own task.
+   sync is also byte≡2 mod 4). Deserves its own investigation.
 2. **Highlander / IS2 (bios)** stall *before* any sentinel scan (drains freeze at
    54/0, gpu_pc $F0307E/$F03068) — a different engine or an earlier handshake;
    unaffected by this fix, needs separate diagnosis.

--- a/docs/cd-diagnosis/dlair-error-screen-diagnosis.md
+++ b/docs/cd-diagnosis/dlair-error-screen-diagnosis.md
@@ -31,8 +31,8 @@ Repro: `make cd-visual CD_VISUAL_DISC="<DL cue>" CD_VISUAL_FLAGS="--frames
 
 ## Evidence chain
 
-- Probe: `scratchpad/dlair_wedge.c` (session scratchpad; PC_BAND_LO/HI env,
-  dumps GPU RAM + 2MB main RAM + CD trace at end). Run to `--frames 2820`.
+- Probe: a local `dlair_wedge.c` harness (PC_BAND_LO/HI env, dumps GPU RAM +
+  2MB main RAM + CD trace at end). Run to `--frames 2820`.
 - The failing load: game seeks MSF 3:40:52 → block 16402 → track-3 file
   sector 1309 (layout: T1 3245 sectors, +11400 inter-session gap, T2 448,
   T3 starts at LBA 15093, INDEX 01 at +149 where the byte-swapped
@@ -146,7 +146,7 @@ Supporting instrument for any of these: a control-events-only trace mode
 covers a whole retry cycle; fills/drains currently flood 16K-deep rings in
 ~2 cycles.
 
-## Tooling added this session
+## Tooling added alongside this diagnosis
 
 - CD trace ring `I2S_CTRL` event (data-enable edges) — in `f74ce09`.
 - `VJ_HARNESS_LOG_INFO=1` lets INFO logs (CDTraceDump etc.) through the
@@ -155,6 +155,6 @@ covers a whole retry cycle; fills/drains currently flood 16K-deep rings in
   it; ring dumps only surface via the cd_seek_wedge watchdog. Consider
   adding `_CDTrace*` to the export list.
 - Deep-ring diagnosis builds: temporarily set `CD_TRACE_SIZE` to 8192/16384
-  in cdrom.c (default 256), build, copy dylib to scratchpad, `git checkout`
+  in cdrom.c (default 256), build, copy the dylib aside, `git checkout`
   the file. Never rebuild in-tree while `cd_boot_matrix.sh` is running —
   the build-identity guard kills every subsequent matrix row.

--- a/docs/cd-diagnosis/fmv-corruption-diagnosis.md
+++ b/docs/cd-diagnosis/fmv-corruption-diagnosis.md
@@ -22,8 +22,8 @@ RAM dumper at the live FMV moment (frame ~916, first >26%-nonblack frame).
    → the pixel VALUES in the framebuffer are wrong.
 
 2. **CD data path / byte order — ruled out.**
-   The ~1 MB compressed FMV stream lands at `$46000..$146000` (task-8 dest
-   telemetry). Probes at +0x0/+0x10000/+0x40000/+0x80000/+0xC0000 all match
+   The ~1 MB compressed FMV stream lands at `$46000..$146000` (dest telemetry
+   from braindead13-second-wedge-diagnosis.md). Probes at +0x0/+0x10000/+0x40000/+0x80000/+0xC0000 all match
    Track 4 of the BIN **word-swapped** — and so does the *executing* 68K
    engine code at `$A000`/`$B2DC` (probed vs Track 3). Since that code runs
    correctly, "swapped vs BIN" is the CORRECT in-RAM byte order (the disc is
@@ -50,12 +50,13 @@ and the input data is bit-correct. Pre-fix cores never reached FMV playback
 pre-fix baseline build), so the corruption was previously unreachable, not
 absent.
 
-## Next steps (fresh session)
+## Next steps
 
 1. Dump GPU RAM at the live FMV moment and disassemble the decode loop
    (`python3 test/tools/disasm_gpu_isr.py`; handler entry `$F034EC`, cmd=3
-   dispatch per task-8). Inventory the arithmetic ops used (SAT8/SAT16/
-   SATS? MULT/IMULT/IMACN/RESMAC? MMULT? SH/SHA?) — then unit-test those
+   dispatch, per braindead13-second-wedge-diagnosis.md). Inventory the
+   arithmetic ops used (SAT8/SAT16/SATS? MULT/IMULT/IMACN/RESMAC? MMULT?
+   SH/SHA?) — then unit-test those
    gpu.c opcodes against the JTRM semantics (`docs/jtrm-gpu-dsp.md`).
    Suspects: saturation ops and multiply-accumulate edge cases (the DSP
    needed a 40-bit MAC fix once — `test_dsp_mac40`; the GPU may have an

--- a/docs/cd-diagnosis/fmv-stall-diagnosis.md
+++ b/docs/cd-diagnosis/fmv-stall-diagnosis.md
@@ -1,11 +1,11 @@
-# Task 9 report — the THIRD wall: FMV streaming "stops" mid-playback (BrainDead 13)
+# BrainDead 13: FMV streaming "stops" mid-playback
 
-Branch `feature/jaguar-cd-support`, base `0b88fa0`. Append-only phase log.
+Diagnosis written on `feature/jaguar-cd-support`, base `0b88fa0`.
 
-## Phase 0 — orientation + hypothesis triage (before any code)
+## Orientation and hypothesis triage (before any code)
 
-Read: `braindead-device-trace-2.txt`, `task-8-second-wedge-report.md` (Phases 2/3/4/5),
-`task-7-streaming-wall-report.md`, `src/cd/cdrom.c` BUTCHExec (lines 574-703).
+Inputs: `braindead-device-trace-2.txt`, `braindead13-second-wedge-diagnosis.md`,
+`cd-streaming-wall-diagnosis.md`, `src/cd/cdrom.c` BUTCHExec (lines 574-703).
 
 ### Hypothesis A (continuous streaming not modeled) — REJECTED before testing
 
@@ -18,7 +18,7 @@ Rejected on evidence already in hand, not on a new experiment:
 - Task-8 loose-end #1 already names why drains stop: the game's GPU ISR **clears
   BUTCH bit 0** when `dest >= end` (transfer done). Drains stopping is the
   *completion signal*, not starvation.
-- Task-8 Phase 3 polled the transfer state per-frame: `[$F03B10]` dest climbs
+- The second-wedge diagnosis polled the transfer state per-frame: `[$F03B10]` dest climbs
   `$45FFC -> $146000` (= limit) over frames ~55-368. The transfer **finishes**.
 
 The device trace's "expects data to keep arriving" reading is the trace author's
@@ -26,8 +26,8 @@ inference; the disassembly + dest-pointer telemetry outrank it.
 
 ### Hypothesis B (engine waits on a different signal) — ADOPTED
 
-The dispatch asked to distinguish A/B by disassembling `$F03270-$F0327A`.
-**Task 8 already did this disasm** (report lines 129-138) and it answers B:
+A and B are distinguished by disassembling `$F03270-$F0327A`.
+**The second-wedge diagnosis already did this disassembly** (`braindead13-second-wedge-diagnosis.md`) and it answers B:
 
 ```
 $F03260 movei #$F03A50,r31                            ; set stack
@@ -39,16 +39,16 @@ $F03276 load (r0),r1; or r1,r1; jr z,$F03270          ; wait *($F039DC)!=0
 This polls a **RAM mailbox ($F039DC in GPU RAM), not a FIFO/BUTCH status word**
 -> hypothesis **B**, decisively. The GPU streaming engine is a healthy idle waiter.
 
-### Correction to task-8's sign-off (important)
+### Correction to the second-wedge sign-off (important)
 
-Task 8 closed BrainDead 13 as "next wait is the game's frame-kick mailbox
+That diagnosis closed BrainDead 13 as "next wait is the game's frame-kick mailbox
 (**headless-fb class**)" — i.e. presumed a headless presentation artifact.
 **The device trace falsifies that**: the same wait is a real black-screen wall on
 real iOS hardware. This aftermath is a genuine blocker, not a harness artifact.
 
-### The named gap (what Phase 1 must resolve)
+### The named gap (what the reproduction must resolve)
 
-Task-8 Phase 3 established the post-transfer wedge shape:
+The second-wedge diagnosis established the post-transfer wedge shape:
 - 68K: `$00B2F0 move.l #1,(a1)` (a1=$F039DC, command GPU) -> `$00B2F6 stop #$2000`
   -> `$00B2FA tst.b ($0072CC)` -> `beq.s $00B2F6`. Device trace `final_pc=$00B2FA`
   confirms this exact loop on hardware.
@@ -71,16 +71,16 @@ BUTCH bit 0, and the game's ISR clears bit 0 at completion — if bit 0 is clear
 the wedge, the pending path cannot deliver anyway and cdrom.c is the wrong layer.
 **Do not pre-write the conditional-IRQ2 fix.** Disasm #1 decides.
 
-(Advisor consulted at this checkpoint; concurred A is dead, B is the mechanism,
-and that the layer must be named by disasm #1 before any code.)
+(Checkpoint review concurred: A is dead, B is the mechanism, and the layer must
+be named by disasm #1 before any code is written.)
 
-## Phase 1 — reproduced headlessly + the two missing disasms (EVIDENCE)
+## Reproduced headlessly + the two missing disassemblies (evidence)
 
-Harness: `scratchpad/diag_fmv.c` (BIOS mode via `virtualjaguar_cd_boot_mode=bios`).
+Harness: a local `diag_fmv.c` probe (BIOS mode via `virtualjaguar_cd_boot_mode=bios`).
 **Repro is exact vs the device trace**: `starts=2 dones=2 drains=38915`, GPU pinned
 $F03270-$F0327A, `68k_pc=$00B2FA` for **300/300** frames post-wedge.
 
-### Harness gotcha (cost a cycle; recorded so the next agent doesn't repeat it)
+### Harness gotcha (recorded to avoid repeating it)
 `jaguarMainRAM` is a **`uint8_t *` pointer**, not an array (`src/core/vjag_memory.c:45`).
 `dlsym` returns `&pointer` -> raw indexing reads ARM64 pointer bytes as "RAM"
 (the bogus "vector table" `94 F1 DC 05 01 00 00 00 ...` was literally consecutive
@@ -90,9 +90,9 @@ Also `M68K_REG_PC` = **16**, not 0 (D0..D7=0-7, A0..A7=8-15).
 ### Hypothesis A — REFUTED by direct measurement
 `[$F03B10]` cd dest = **$0014603C** >= `[$F03B14]` limit = **$00146000**.
 The ~1 MB FMV transfer **ran to completion**. Drains stop because the work is done.
-Not starvation. A is dead, as predicted in Phase 0.
+Not starvation. A is dead, as the triage above predicted.
 
-### The 68K wedge site, decoded from the RAM dump (confirms task-8 byte-for-byte)
+### The 68K wedge site, decoded from the RAM dump (confirms the second-wedge diagnosis byte-for-byte)
 ```
 $00B2DC 41F9 000072CC   lea     $000072CC,a0
 $00B2E2 4250            clr.w   (a0)              ; done flag := 0
@@ -142,11 +142,12 @@ byte is `tomRam8[$E1]`:
 
     RAW tomRam8[$E1] = $02  ->  VIDENA=0 GPUENA=1 OPENA=0 PITENA=0 JERENA=0
 
-**The game enables ONLY the GPU interrupt.** So VBLANK/PIT cannot wake it — task-8's
-"the 68K wakes from STOP every frame (VBLANK)" is **false**; video int pends 60x/60
-frames and is masked off every time. The ONLY wake source is the GPU's CPUINT.
-=> This is **not** the `cdrom.c` IRQ2-suppression layer. The advisor's trap is avoided:
-the m68k IRQ2 suppression (`cdrom.c:679-699`) is irrelevant here (JERENA=0 anyway).
+**The game enables ONLY the GPU interrupt.** So VBLANK/PIT cannot wake it — the
+earlier assumption that "the 68K wakes from STOP every frame (VBLANK)" is **false**;
+the video int pends 60x/60 frames and is masked off every time. The ONLY wake source
+is the GPU's CPUINT.
+=> This is **not** the `cdrom.c` IRQ2-suppression layer: the m68k IRQ2 suppression
+(`cdrom.c:679-699`) is irrelevant here (JERENA=0 anyway).
 
 ### IRQ-chain counters at the wedge (temporary core instrumentation, to be reverted)
 ```
@@ -170,7 +171,7 @@ halted waiting for a signal **that already came and went**. This is a lost-wakeu
 **race**, not a missing feature. Next: pin down the ordering (why the one CPUINT
 landed while `stopped=0`), which names the layer.
 
-## Phase 2 — MECHANISM NAMED: lost wakeup on `stop #$2000` (GPU CPUINT consumed pre-STOP)
+## Mechanism named: lost wakeup on `stop #$2000` (GPU CPUINT consumed pre-STOP)
 
 ### The level-2 IRQ handler (DISASM #2) — it is the done-flag writer
 `irq_ack_handler()` (`src/core/jaguar.c:315-334`) returns **64** for level 2
@@ -198,7 +199,7 @@ $0072CC — the **68K IRQ handler** does. Only 3 refs to $000072CC exist in main
 1. 68K `clr.w ($0072CC)`  2. 68K `move.l #1,($F039DC)` (command GPU)
 3. 68K `stop #$2000` (halt)  4. GPU decodes -> `store #3,(G_CTRL)` = GPUGO|CPUINT
 5. 68K wakes -> level-2 IRQ -> $00A12A sets flag=$FFFF, acks, `rte`
-6. 68K resumes past `stop` -> `tst.b` = $FF -> exits. 
+6. 68K resumes past `stop` -> `tst.b` = $FF -> exits.
 On real silicon steps 4-5 CANNOT precede step 3: `move.l`->`stop` is ~6 cycles,
 the GPU decode is thousands.
 
@@ -224,12 +225,12 @@ This is a **lost-wakeup race created by execution-interleaving granularity**, no
 missing CD/BUTCH feature and not FIFO starvation. `m68k_execute` returns immediately
 when `regs.stopped` (m68kinterface.c:124-130), so nothing re-examines the condition.
 
-Verdict on the dispatch's hypotheses: **A refuted** (transfer completes),
+Verdict on the three hypotheses: **A refuted** (transfer completes),
 **B confirmed and now fully mechanised**, **C not implicated** (data is correct and
 complete; drain rate is a red herring — the transfer finished byte-correct).
 
 ---
-## BLAST-RADIUS ANALYSIS (controller, post-diagnosis — gates any fix)
+## Blast-radius analysis (post-diagnosis; gates any fix)
 
 The `stop #$2000`-wait idiom is NOT CD-only. Static scan of the local cart library
 (STOP #$2000 = opcode 4E72 2000):

--- a/docs/cd-diagnosis/primal-rage-cdda-diagnosis.md
+++ b/docs/cd-diagnosis/primal-rage-cdda-diagnosis.md
@@ -101,9 +101,9 @@ audio cues).
    Disassemble the 68K around the storm's Goto sender (BIOS service band;
    the caller retries every ~430 ticks).
 
-## Tooling notes for whoever continues
+## Tooling notes
 
-- DSP RAM dump + disassembler: scratchpad `dlair_wedge.c` probe dumps
+- DSP RAM dump + disassembler: the local `dlair_wedge.c` probe dumps
   `dspram.bin`/`gpuram.bin`/`mainram.bin`; the throwaway RISC disassembler
   used in this diagnosis is a ~40-line python (opcode table order = gpu.c
   `gpu_opcode[64]`; MOVEI imm is low-word-first).

--- a/docs/cd-known-issues.md
+++ b/docs/cd-known-issues.md
@@ -87,7 +87,7 @@ from structured noise at the right level.
   which survive an ISO rip. No retail game can ever start from one
   (BigPEmu declines ISOs for the same reason), so the loader refuses
   `.iso` outright with an explanatory error instead of raising false
-  hopes with a BIOS screen that goes nowhere. Use CUE/BIN, CHD, or CDI.
+  hopes with a BIOS screen that goes nowhere. Use CUE/BIN or CDI.
 - **CD read speeds above 2x on the real-BIOS path**: the
   `virtualjaguar_cd_read_speed` option is HLE-only by design; scaling the
   BIOS path's FIFO/DSA cadence re-opens the DSA-steal and FIFO-storm race

--- a/docs/doom-pace-calibration.md
+++ b/docs/doom-pace-calibration.md
@@ -709,9 +709,9 @@ model will legitimately render it faster than 20 fps.
 Guard against overshoot in both directions: demo 1 longer than ~45 s, or a
 gameplay mode of gap-4, means the engine is now slower than silicon.
 
-### Open cross-check to hand to the user
+### Open cross-check for a hardware owner
 
-Neither captured clip contains the attract demo, and the user's device
+Neither captured clip contains the attract demo, and the reported device
 impression was that the *demo* pace looks right while in-game monsters are too
 fast. Under §1.4 the demo's apparent speed is also proportional to render rate,
 so if silicon runs the demo at 20 fps it should look 1.5x fast to us too. One

--- a/docs/netlink-design.md
+++ b/docs/netlink-design.md
@@ -8,7 +8,7 @@ latency fix, PR #244). Known limitations: internet play is best-effort
 lobby, sustained dogfight play unverified; AirCars under *netpacket* netplay
 untested (its interrupt-driven RX does not hit the ASISTAT pump path — TCP
 mode fully validated); iOS/Provenance TCP mode not yet device-tested.
-**Branch:** `claude/jaguar-networking-support-0c8a86` (off `libretro/develop`)
+**Merged:** PR #250 / #263 lineage.
 
 ## Overview
 
@@ -149,8 +149,8 @@ Backends selected by core option:
 
 ### 4. Testing
 
-ROM corpus: `/Users/jmattiello/Workspace/Provenance/jaguar-roms-private`
-(symlinked at `test/roms/private`; discover with `find -L`).
+ROM corpus: the private ROM tree symlinked at `test/roms/private` (see
+CLAUDE.md; discover with `find -L`).
 
 1. **Unit (phase 1):** harness-based (`test/harness/`) loopback test driving
    the real registers via `harness_dlsym` — write ASIDATA, poll ASISTAT for

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -19,7 +19,7 @@ PRs targeting `master` directly trigger a friendly comment from `.github/workflo
 1. Cut `release/X.Y.Z` from `develop`.  Bump `CORE_BASE_VERSION` in `Makefile` (or use the `Bump Version & Release` workflow).  Update `docs/RELEASE_NOTES_vX.Y.Z.md`.  Open a PR from `release/X.Y.Z` → `master`.
 2. Merge into `master`.
 3. `git tag vX.Y.Z && git push libretro vX.Y.Z` (or via GitHub UI).
-4. Watch [Actions](https://github.com/libretro/virtualjaguar-libretro/actions) — `release.yml` builds 14 platforms, generates `SHA256SUMS.txt`, and publishes the release with `docs/RELEASE_NOTES_vX.Y.Z.md` as the body.
+4. Watch [Actions](https://github.com/libretro/virtualjaguar-libretro/actions) — `release.yml` builds 16 platforms (14 in the build matrix, plus Vita and Switch in their own jobs), generates `SHA256SUMS.txt`, and publishes the release with `docs/RELEASE_NOTES_vX.Y.Z.md` as the body.
 5. **Back-merge `master` → `develop`** so the version bump and any release-branch fixes are in `develop`: `git checkout develop && git merge master && git push libretro develop`.
 6. After the tag publishes, send a small PR to [libretro/libretro-super](https://github.com/libretro/libretro-super) updating `dist/info/virtualjaguar_libretro.info` to match `dist/info/virtualjaguar_libretro.info` from this repo at the tag.
 
@@ -54,7 +54,7 @@ The push triggers `.github/workflows/release.yml` which runs only on `v*` tags.
 
 ### 3. What `release.yml` does on tag push
 
-For each of 14 target platforms (Linux x86_64/aarch64/i686, macOS arm64/x86_64, Windows x86_64/i686, Emscripten WASM, Android arm64-v8a/armeabi-v7a/x86_64/x86, iOS arm64, tvOS arm64), in parallel:
+For each of the 14 matrix platforms (Linux x86_64/aarch64/i686, macOS arm64/x86_64, Windows x86_64/i686, Emscripten WASM, Android arm64-v8a/armeabi-v7a/x86_64/x86, iOS arm64, tvOS arm64), in parallel — PS Vita and Switch build in separate jobs, for 16 targets in total:
 
 1. Build the core with `RELEASE_DEBUG_INFO=1` so the optimized binary keeps `-g` symbols.
 2. Extract split debug info into a `<platform>-debug.tar.gz` archive (`objcopy --only-keep-debug` for ELF, `dsymutil` for Mach-O).

--- a/libretro.c
+++ b/libretro.c
@@ -58,8 +58,8 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
  *   cof           : COFF binaries (also routes through JST_ABS_TYPE1)
  *   bin, prg      : conservative headerless raw-homebrew with valid
  *                   68k bootstrap (JST_RAW_BINARY)
- * Add `cdi`, `cue`, `iso`, and `chd` here when CD-image support
- * lands on a future PR. */
+ *   cue, cdi      : Jaguar CD images (CUE/BIN and CDI).  Bare `iso`
+ *                   images are not bootable -- see docs/cd-known-issues.md. */
 #define JAGUAR_VALID_EXTENSIONS "j64|jag|rom|abs|cof|bin|prg|cue|cdi"
 
 /* Framebuffer allocation, in pixels.  Sized for the widest / tallest video

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -248,7 +248,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_bios",
       "BIOS (Cartridges)",
       NULL,
-      "Which BIOS a CARTRIDGE boots with. 'HLE' has the core emulate the BIOS setup and services itself, which lets most commercial titles boot faster and skips the boot animation. 'Real' runs the actual Jaguar boot ROM, which some titles require. The boot ROM is built into the core, so neither setting needs a file — unlike the CD BIOS, the console boot ROM is never loaded from the system directory. Ignored for CD content: there, 'CD Boot Mode' decides and turns the boot ROM on or off to match.",
+      "Which BIOS a CARTRIDGE boots with. 'HLE' has the core emulate the BIOS setup and services itself, which lets most commercial titles boot faster and skips the boot animation. 'Real' runs the actual Jaguar boot ROM, which some titles require. The boot ROM is built into the core, so neither setting needs a file -- unlike the CD BIOS, the console boot ROM is never loaded from the system directory. Ignored for CD content: there, 'CD Boot Mode' decides and turns the boot ROM on or off to match.",
       NULL,
       "bios_boot",
       {
@@ -276,7 +276,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_cd_bios_type",
       "CD BIOS Type (Restart)",
       NULL,
-      "Which CD BIOS the real-BIOS boot path uses. 'Retail' is the standard consumer BIOS; 'Developer' is the dev-kit BIOS, which applies less strict disc checks and can boot images the retail BIOS refuses. Both are built into the core, so no files are required. CD BIOS ROM files in the system directory are preferred over the embedded images, and this selection picks which file wins when both types are present. Only has an effect when 'CD Boot Mode' is 'Real BIOS' or 'Auto' — the HLE boot path never runs a CD BIOS.",
+      "Which CD BIOS the real-BIOS boot path uses. 'Retail' is the standard consumer BIOS; 'Developer' is the dev-kit BIOS, which applies less strict disc checks and can boot images the retail BIOS refuses. Both are built into the core, so no files are required. CD BIOS ROM files in the system directory are preferred over the embedded images, and this selection picks which file wins when both types are present. Only has an effect when 'CD Boot Mode' is 'Real BIOS' or 'Auto' -- the HLE boot path never runs a CD BIOS.",
       NULL,
       "cdrom",
       {
@@ -290,7 +290,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_cd_boot_mode",
       "CD Boot Mode (Restart)",
       NULL,
-      "How Jaguar CD discs boot. This OVERRIDES the 'BIOS (Cartridges)' setting for CD content. 'HLE' emulates the CD BIOS services directly and runs with the console boot ROM off — fastest and the most broadly compatible. 'Real BIOS' runs an actual CD BIOS and forces the boot ROM on: more faithful, still experimental. It prefers a CD BIOS ROM file from the system directory (searched under several common names, and in Atari - Jaguar / Atari - Jaguar CD / jaguar / jaguarcd sub-folders) and otherwise uses the embedded image chosen by 'CD BIOS Type', so no files are required. 'Auto' is currently identical to 'Real BIOS'. If a real-BIOS mode is chosen but no CD BIOS can be staged at all, the core falls back to HLE rather than failing.",
+      "How Jaguar CD discs boot. This OVERRIDES the 'BIOS (Cartridges)' setting for CD content. 'HLE' emulates the CD BIOS services directly and runs with the console boot ROM off -- fastest and the most broadly compatible. 'Real BIOS' runs an actual CD BIOS and forces the boot ROM on: more faithful, still experimental. It prefers a CD BIOS ROM file from the system directory (searched under several common names, and in Atari - Jaguar / Atari - Jaguar CD / jaguar / jaguarcd sub-folders) and otherwise uses the embedded image chosen by 'CD BIOS Type', so no files are required. 'Auto' is currently identical to 'Real BIOS'. If a real-BIOS mode is chosen but no CD BIOS can be staged at all, the core falls back to HLE rather than failing.",
       NULL,
       "cdrom",
       {
@@ -322,7 +322,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_memory_track",
       "Memory Track (Restart)",
       NULL,
-      "Emulate the Memory Track save cartridge alongside the CD unit, as on real hardware. CD games detect it and save settings, progress and high scores to its 128 KB NVRAM (stored in the save file). Disable to emulate a console without the cartridge — games will warn that game information cannot be saved.",
+      "Emulate the Memory Track save cartridge alongside the CD unit, as on real hardware. CD games detect it and save settings, progress and high scores to its 128 KB NVRAM (stored in the save file). Disable to emulate a console without the cartridge -- games will warn that game information cannot be saved.",
       NULL,
       "cdrom",
       {

--- a/src/cd/cdintf.c
+++ b/src/cd/cdintf.c
@@ -956,7 +956,7 @@ bool CDIntfOpenImage(const char *path)
    if (ext && strcasecmp(ext + 1, "iso") == 0)
    {
       LOG_ERR("[CD-ISO] bare .iso images cannot represent a Jaguar CD "
-              "(no session/track layout) -- use CUE/BIN, CHD, or CDI\n");
+              "(no session/track layout) -- use CUE/BIN or CDI\n");
       return false;
    }
 

--- a/src/cd/cdrom.c
+++ b/src/cd/cdrom.c
@@ -442,7 +442,7 @@ static uint16_t DSAQueuePop(void)
 
 /* --- CD trace ring: records DSA traffic + seek/FIFO state transitions ---
  *
- * Diagnostic-only instrumentation for Task 5's boot-hang triage (see
+ * Diagnostic-only instrumentation for CD boot-hang triage (see
  * docs/cd-boot-matrix.md).  Never touches savestates -- all of this is
  * reset to empty on CDROMReset() the same as the other diag_* counters,
  * never serialized.
@@ -923,7 +923,7 @@ void BUTCHExec(uint32_t cycles)
             }
          }
 
-         CD_LOG("BUTCHExec: seek complete block=%u (MSF %02u:%02u:%02u) — queued $0100, FIFO+playback active\n",
+         CD_LOG("BUTCHExec: seek complete block=%u (MSF %02u:%02u:%02u) -- queued $0100, FIFO+playback active\n",
                 block, min, sec, frm);
       }
    }
@@ -943,7 +943,7 @@ void BUTCHExec(uint32_t cycles)
          fifoDataReady = true;
          fifoReadCount = 0;
          CDTracePush(CD_TRACE_FIFO_FILL, 0, block);
-         CD_LOG("BUTCHExec: FIFO half-full — ready for GPU ISR\n");
+         CD_LOG("BUTCHExec: FIFO half-full -- ready for GPU ISR\n");
       }
       else if (fifoFillDelay == 0 && cdPlaying && (!i2sDataEnabled || !FIFOFeedAllowed()))
       {
@@ -1196,7 +1196,7 @@ uint16_t CDROMReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
          cdPlaying = true;
          if (FIFOFeedAllowed())
             fifoDataReady = true;
-         CD_LOG("Play Title response consumed — playback and FIFO now active\n");
+         CD_LOG("Play Title response consumed -- playback and FIFO now active\n");
       }
       else if ((cdCmd & 0xFF00) == 0x0200)			// Stop CD
       {
@@ -1266,7 +1266,7 @@ TOC: 2 10 00  b 00:00:00 00 54:26:17   <-- Track #11
             fifoDataReady = true;
             fifoReadCount = 0;
          }
-         CD_LOG("Seek response $0100 consumed (direct) — cdPlaying=true\n");
+         CD_LOG("Seek response $0100 consumed (direct) -- cdPlaying=true\n");
       }
       else if ((cdCmd & 0xFF00) == 0x1400)		// Read "full" session TOC
       {
@@ -1474,7 +1474,7 @@ TOC: 2 10 00  b 00:00:00 00 54:26:17   <-- Track #11
       static uint32_t subReads = 0;
       subReads++;
       if (subReads <= 40 || (subReads % 10000) == 0)
-         LOG_INF("[SUBCODE] read %s+%u -> $%04X who=%u 68kpc=$%06X\n",
+         LOG_DBG("[SUBCODE] read %s+%u -> $%04X who=%u 68kpc=$%06X\n",
                  (offset >= SB_TIME) ? "SB_TIME" :
                  (offset >= SUBDATB) ? "SUBDATB" :
                  (offset >= SUBDATA) ? "SUBDATA" : "SBCNTRL",
@@ -1534,7 +1534,7 @@ void CDROMWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
       {
          static uint16_t prevSubEna = 0;
          if ((prevSubEna ^ data) & 0x0C)
-            LOG_INF("[SUBCODE] BUTCH int enables $%02X -> $%02X (frame=%d match=%d) who=%u 68kpc=$%06X\n",
+            LOG_DBG("[SUBCODE] BUTCH int enables $%02X -> $%02X (frame=%d match=%d) who=%u 68kpc=$%06X\n",
                     prevSubEna & 0x7F, data & 0x7F,
                     (data >> 2) & 1, (data >> 3) & 1, who,
                     m68k_get_reg(NULL, M68K_REG_PC));
@@ -1567,7 +1567,7 @@ void CDROMWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
       static uint32_t subWrites = 0;
       subWrites++;
       if (subWrites <= 40 || (subWrites % 10000) == 0)
-         LOG_INF("[SUBCODE] write %s+%u = $%04X who=%u 68kpc=$%06X\n",
+         LOG_DBG("[SUBCODE] write %s+%u = $%04X who=%u 68kpc=$%06X\n",
                  (offset >= SB_TIME) ? "SB_TIME" :
                  (offset >= SUBDATB) ? "SUBDATB" :
                  (offset >= SUBDATA) ? "SUBDATA" : "SBCNTRL",
@@ -1599,8 +1599,9 @@ void CDROMWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
    if (offset == DS_DATA)
    {
       CD_LOG("DS_DATA write: cmd=0x%04X\n", data);
-      /* CDDA-DIAG: audio-flow commands, rare -- log unconditionally so
-       * device RetroArch logs show the play sequence without a wedge dump.
+      /* CDDA-DIAG: audio-flow commands, rare -- log the first 40 and
+       * then every 500th so device RetroArch logs show the play sequence
+       * without a wedge dump, while a stuck game cannot flood the log.
        * $01 Play / $02 Stop / $04 Pause / $05 Unpause? / $15 Set Mode /
        * $51 Mute-Unmute / $70 Set DAC Mode. */
       {

--- a/src/cd/cdrom.h
+++ b/src/cd/cdrom.h
@@ -45,7 +45,7 @@ void CDROMDiagGetCounters(uint32_t *butchExec,
                           uint32_t *globalDisabled,
                           uint32_t *hleBytes);
 
-/* --- CD trace ring (Task 4 instrumentation, see cdrom.c) ---
+/* --- CD trace ring (diagnostic instrumentation, see cdrom.c) ---
  * Diagnostic only; never touches savestates. */
 
 /* Enable/disable the trace ring. Called from libretro.c's check_variables()

--- a/src/cd/jagcd_bios.c
+++ b/src/cd/jagcd_bios.c
@@ -81,7 +81,7 @@ static bool bios_instruction_hook(uint32_t m68kPC)
 
                 if (loadAddr != 0x080000)
                 {
-                    LOG_INF("[CD-BOOTSTUB] Boot stub loads at $%06X, not $080000 — "
+                    LOG_INF("[CD-BOOTSTUB] Boot stub loads at $%06X, not $080000 -- "
                             "installing trampoline at $080000\n", loadAddr);
                     /* JMP loadAddr (4EF9 xxxx xxxx) */
                     jaguarMainRAM[0x080000] = 0x4E;

--- a/src/cd/jagcd_hle.c
+++ b/src/cd/jagcd_hle.c
@@ -395,7 +395,7 @@ static uint32_t HLERawStreamAlignOffset(uint32_t startLBA, uint32_t destAddr,
             uint32_t relOff = s * 2352 + i;   /* run start in the stream */
             uint32_t mis    = (destAddr + relOff) & 3;
             HLE_LOG("align scan: %s run (%u) at LBA %u off %u "
-                    "(stream off %u, dest misalign %u) — shift %u\n",
+                    "(stream off %u, dest misalign %u) -- shift %u\n",
                     what, run, startLBA + s, i, relOff, mis,
                     (mis == 2) ? 2u : 0u);
             return (mis == 2) ? 2u : 0u;
@@ -471,7 +471,7 @@ static uint32_t HLERawStreamAlignOffset(uint32_t startLBA, uint32_t destAddr,
                uint32_t relOff = s2 * 2352 + i;
                uint32_t mis    = (destAddr + relOff) & 3;
                HLE_LOG("align scan: %s run (%u) at LBA %u off %u "
-                       "(stream off %u, dest misalign %u) — shift %u\n",
+                       "(stream off %u, dest misalign %u) -- shift %u\n",
                        what, run, startLBA + s2, i, relOff, mis,
                        (mis == 2) ? 2u : 0u);
                return (mis == 2) ? 2u : 0u;
@@ -544,7 +544,7 @@ static void HLEHandleCDRead(void)
     * stale or garbage values in re-seek mode) and stomp memory. */
    if (reseekOnly)
    {
-      HLE_LOG("CD_read: re-seek only (D0 bit31 set, D0=$%08X) — "
+      HLE_LOG("CD_read: re-seek only (D0 bit31 set, D0=$%08X) -- "
               "skipping data transfer\n", d0);
       /* A just-seek repositions the drive and leaves it playing — this is
        * the documented CDDA-play API ("call CD_read with the Just Seek bit
@@ -581,7 +581,7 @@ static void HLEHandleCDRead(void)
    if (hleStream.active && d0 == hleStream.sigD0 && d1 == hleStream.sigD1 &&
        a0 == hleStream.sigA0 && a1 == hleStream.sigA1)
    {
-      HLE_LOG("CD_read: identical re-issue while streaming ($%06X/$%06X done) — "
+      HLE_LOG("CD_read: identical re-issue while streaming ($%06X/$%06X done) -- "
               "keeping in-flight transfer\n",
               hleStream.written, hleStream.total);
       return;
@@ -601,14 +601,14 @@ static void HLEHandleCDRead(void)
            min, sec, frm, lba, destAddr, a1, byteCount);
 
    /* HLE_READ trace event: carries the requested LBA (in the `block`
-    * field) so Task 5's wrong-LBA hypothesis can be checked against the
+    * field) so the wrong-LBA hypothesis can be checked against the
     * HLE path too, not just the real-BIOS/BUTCHExec path. No-op when the
     * trace ring is disabled (CDTracePush's off-mode short-circuit). */
    CDTraceHLERead(lba, (uint16_t)(byteCount > 0xFFFF ? 0xFFFF : byteCount));
 
    if (destAddr == 0 || destAddr >= 0x200000)
    {
-      HLE_LOG("CD_read: invalid dest=$%06X — skipping\n", destAddr);
+      HLE_LOG("CD_read: invalid dest=$%06X -- skipping\n", destAddr);
       hle_read_pending = false;
       return;
    }
@@ -696,7 +696,7 @@ static void HLEHandleCDRead(void)
          uint32_t gameData = CDIntfGetSession2GameDataLBA();
          if (gameData > 0)
          {
-            HLE_LOG("CD_read: LBA %u outside session-2 range [%u..%u) — "
+            HLE_LOG("CD_read: LBA %u outside session-2 range [%u..%u) -- "
                     "redirecting to game data LBA %u\n",
                     lba, s2first, discTotal, gameData);
             startLBA = gameData;
@@ -728,7 +728,7 @@ static void HLEHandleCDRead(void)
       scanOff = HLERawStreamAlignOffset(startLBA, destAddr, d1,
                                         d1 != a1 && (d1 >> 16) != 0);
       HLE_LOG("CD_read: non-match ISR mode ($3072=$%02X, D1=$%08X A1=$%06X) "
-              "— streaming raw from LBA %u offset %u\n",
+              "-- streaming raw from LBA %u offset %u\n",
               jaguarMainRAM[0x3072], d1, a1, startLBA, scanOff);
       foundSentinel = true;  /* short-circuit the scan loop */
       phase_starts[0] = startLBA;
@@ -748,7 +748,7 @@ static void HLEHandleCDRead(void)
     * mastered sync run — Myst's movie/JSND loads, handled above.) */
    if ((d1 >> 16) == 0)
    {
-      HLE_LOG("CD_read: D1=$%08X is a counter/ID — skipping sentinel scan, "
+      HLE_LOG("CD_read: D1=$%08X is a counter/ID -- skipping sentinel scan, "
               "streaming raw from LBA %u\n", d1, startLBA);
       scanLBA = startLBA;
       scanOff = 0;
@@ -928,7 +928,7 @@ static void HLEHandleCDRead(void)
           * proceed past its poll loop; whatever code runs at the zeroed
           * destination (ORI.B #0,D0 = NOP-like) generates enough PC
           * diversity for the smoke test to pass. */
-         HLE_LOG("CD_read: sentinel NOT found after redirect — "
+         HLE_LOG("CD_read: sentinel NOT found after redirect -- "
                  "zeroing dest $%06X-$%06X and signalling completion\n",
                  destAddr, destAddr + byteCount - 1);
          for (i = 0; i < ((byteCount + 3u) & ~3u) &&
@@ -945,7 +945,7 @@ static void HLEHandleCDRead(void)
       scanLBA = startLBA;
       scanOff = HLERawStreamAlignOffset(startLBA, destAddr, d1,
                                         d1 != a1 && (d1 >> 16) != 0);
-      HLE_LOG("CD_read: sentinel NOT found — reading raw from LBA %u "
+      HLE_LOG("CD_read: sentinel NOT found -- reading raw from LBA %u "
               "offset %u\n", startLBA, scanOff);
    }
 
@@ -1174,7 +1174,7 @@ static void HLEStreamFinish(void)
     * data area (CD_poll) alone, matching the real GPU CD ISR — see the
     * $F1B4C8 note at the top of this file. */
 
-   HLE_LOG("CD_read: transfer complete — %u bytes (%u sectors) "
+   HLE_LOG("CD_read: transfer complete -- %u bytes (%u sectors) "
            "to $%06X-$%06X\n",
            byteCount, (byteCount + 2351) / 2352, destAddr,
            hle_read_end_addr - 1);
@@ -1577,7 +1577,7 @@ bool JaguarCDHLEBoot(void)
 
    if (!CDIntfIsImageLoaded())
    {
-      LOG_ERR("[CD-HLE] No disc image loaded — HLE boot aborted\n");
+      LOG_ERR("[CD-HLE] No disc image loaded -- HLE boot aborted\n");
       HLEParkOnHalt();
       return false;
    }
@@ -1671,7 +1671,7 @@ bool JaguarCDHLEBoot(void)
 
    hle_active = true;
 
-   LOG_INF("[CD-HLE] Boot complete — PC=$%06X SP=$%06X\n",
+   LOG_INF("[CD-HLE] Boot complete -- PC=$%06X SP=$%06X\n",
            loadAddr, 0x200000);
    return true;
 }
@@ -1794,7 +1794,7 @@ static bool hle_strategy_boot(const struct retro_game_info *info)
 
    if (!JaguarCDHLEBoot())
    {
-      LOG_ERR("[CD-HLE] HLE boot failed — falling back to diagnostic screen\n");
+      LOG_ERR("[CD-HLE] HLE boot failed -- falling back to diagnostic screen\n");
       return false;
    }
 

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -78,7 +78,7 @@ void bus_arbiter_update_memcon(uint16_t memcon1)
     busArbiter.dram_refresh_clks = dram_refresh_table[dramspeed];
 }
 
-uint32_t bus_arbiter_dram_cost(uint32_t addr)
+static uint32_t bus_arbiter_dram_cost(uint32_t addr)
 {
     /* GPU local RAM: 0xF03000-0xF03FFF — no bus transaction */
     if (addr >= 0xF03000 && addr <= 0xF03FFF)

--- a/src/core/bus_arbiter.h
+++ b/src/core/bus_arbiter.h
@@ -32,7 +32,8 @@
  *     table indexed by DRAMSPEED: { 7, 7, 5, 3 }.
  *   This model uses the row-miss cost as an average DRAM access cost
  *   (2 + row-miss) since GPU/68K access patterns are not tracked for
- *   page-hit/page-miss state — see bus_arbiter_dram_cost().
+ *   page-hit/page-miss state -- see the DRAM cost model in
+ *   bus_arbiter.c.
  */
 #ifndef BUS_ARBITER_H
 #define BUS_ARBITER_H
@@ -125,10 +126,6 @@ uint32_t bus_arbiter_op_take(void);
  * MEMCON2 REFRATE, carrying the sub-period remainder.  Scaled by
  * contention_scale. */
 uint32_t bus_arbiter_refresh_clocks(uint32_t elapsed_sysclks);
-
-/* Return DRAM access cost in system clocks for a given address.
- * Local GPU/DSP RAM returns 0 (no bus transaction). */
-uint32_t bus_arbiter_dram_cost(uint32_t addr);
 
 /* Cost (in system clocks, scaled) the master pays for one access to
  * `addr`.  0 for local RAM. */

--- a/src/core/crash_detect.c
+++ b/src/core/crash_detect.c
@@ -271,8 +271,8 @@ void CrashDetectFrameTick(const uint32_t *fb, unsigned w, unsigned h)
     * evaluate this at all.
     *
     * Deliberately broader than "SEEK_START without SEEK_DONE": comparing
-    * fifoDrains instead of seekDones catches both failure shapes Task 5
-    * needs to tell apart -- (a) the seek-completion response never
+    * fifoDrains instead of seekDones catches both CD seek-wedge shapes
+    * that need telling apart -- (a) the seek-completion response never
     * arrives (seekDones stays behind seekStarts, so fifoDrains obviously
     * never advances either), and (b) the seek completes fine but the
     * FIFO continuation dies afterward (seekDones catches up, fifoDrains

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -30,7 +30,7 @@ void ResolveBootConfig(struct BootConfig *cfg,
    {
       cfg->showBootROM = userWantsBIOS;
       cfg->strategy    = &cd_boot_strategy_cart;
-      LOG_INF("[BOOT] Cart game — showBootROM=%d\n", cfg->showBootROM);
+      LOG_INF("[BOOT] Cart game -- showBootROM=%d\n", cfg->showBootROM);
       return;
    }
 
@@ -48,7 +48,7 @@ void ResolveBootConfig(struct BootConfig *cfg,
          cfg->showBootROM = true;
          cfg->strategy    = &cd_boot_strategy_bios;
          if (!userWantsBIOS)
-            LOG_INF("[BOOT] CD game, mode=BIOS — boot ROM forced on "
+            LOG_INF("[BOOT] CD game, mode=BIOS -- boot ROM forced on "
                     "(required by real CD BIOS path)\n");
          LOG_INF("[BOOT] CD game, mode=BIOS (BIOS image staged)\n");
       }
@@ -56,7 +56,7 @@ void ResolveBootConfig(struct BootConfig *cfg,
       {
          cfg->showBootROM = false;
          cfg->strategy    = &cd_boot_strategy_hle;
-         LOG_WRN("[BOOT] CD game, mode=BIOS but no BIOS file found — "
+         LOG_WRN("[BOOT] CD game, mode=BIOS but no BIOS file found -- "
                  "falling back to HLE\n");
       }
       break;
@@ -68,15 +68,15 @@ void ResolveBootConfig(struct BootConfig *cfg,
          cfg->showBootROM = true;
          cfg->strategy    = &cd_boot_strategy_bios;
          if (!userWantsBIOS)
-            LOG_INF("[BOOT] CD game, mode=AUTO — boot ROM forced on "
+            LOG_INF("[BOOT] CD game, mode=AUTO -- boot ROM forced on "
                     "(required by real CD BIOS path)\n");
-         LOG_INF("[BOOT] CD game, mode=AUTO — using real BIOS\n");
+         LOG_INF("[BOOT] CD game, mode=AUTO -- using real BIOS\n");
       }
       else
       {
          cfg->showBootROM = false;
          cfg->strategy    = &cd_boot_strategy_hle;
-         LOG_INF("[BOOT] CD game, mode=AUTO — no BIOS, using HLE\n");
+         LOG_INF("[BOOT] CD game, mode=AUTO -- no BIOS, using HLE\n");
       }
       break;
    }

--- a/test/mister_ground_truth.h
+++ b/test/mister_ground_truth.h
@@ -1,7 +1,7 @@
 /*
- * mister_ground_truth.h — Expected hardware values extracted from MiSTer FPGA RTL.
+ * mister_ground_truth.h -- Expected hardware values extracted from MiSTer FPGA RTL.
  *
- * Source: /private/tmp/Jaguar_MiSTer/rtl/
+ * Source: MiSTer-devel/Jaguar_MiSTer repository, rtl/
  * These constants define the correct behavior according to real hardware
  * as implemented in the MiSTer Jaguar FPGA core.
  */

--- a/test/test_blitter.c
+++ b/test/test_blitter.c
@@ -335,7 +335,7 @@ int main(int argc, char *argv[])
     RUN_TEST(blit_dstd_write_read);
 
     /* Operations — fill hangs in headless (blitter never returns from B_CMD write) */
-    SKIP_TEST(blit_fill_operation, "hangs in headless — blitter execution never completes");
+    SKIP_TEST(blit_fill_operation, "hangs in headless -- blitter execution never completes");
 
     /* Intensity/Z registers */
     RUN_TEST(blit_iinc_write_read);

--- a/test/test_cd_boot.c
+++ b/test/test_cd_boot.c
@@ -803,7 +803,7 @@ int main(int argc, char *argv[])
       printf("  $DFFF12 (I2CNTRL)        = $%04X\n", p_CDROMReadWord(0xDFFF12, 0));
    }
    else
-      printf("  (CDROMReadWord not available — cannot read BUTCH/CD registers)\n");
+      printf("  (CDROMReadWord not available -- cannot read BUTCH/CD registers)\n");
 
    if (p_JERRYReadWord)
    {

--- a/test/test_cd_fifo_stream.c
+++ b/test/test_cd_fifo_stream.c
@@ -1,7 +1,7 @@
 /*
- * test_cd_fifo_stream.c -- CD FIFO stream delivery contract test (Task 7).
+ * test_cd_fifo_stream.c -- CD FIFO stream delivery contract test.
  *
- * Closes the gap the Task 6D report named: the TOC contract test proves the
+ * Closes the gap left by test_cd_toc_contract.c: that test proves the
  * injected table matches CDIntf, but NOT that a seek delivers the right disc
  * BYTES to RAM.  This test does the end-to-end byte-compare:
  *

--- a/test/test_cd_hle_idempotent.c
+++ b/test/test_cd_hle_idempotent.c
@@ -1,7 +1,7 @@
 /*
  * test_cd_hle_idempotent.c -- HLE CD_read idempotency regression test.
  *
- * Encodes the contract established in Task 6C: the BIOS CD_read service is a
+ * Encodes the CD_read idempotency contract: the BIOS CD_read service is a
  * discrete, self-contained read.  D0 (packed MSF) fully specifies the source
  * position; when a boot stub / game re-issues a byte-identical CD_read (same
  * D0/D1/A0/A1), real hardware re-seeks to the SAME position and reproduces the

--- a/test/test_cd_second_transfer.c
+++ b/test/test_cd_second_transfer.c
@@ -1,5 +1,5 @@
 /*
- * test_cd_second_transfer.c -- CD second-transfer liveness contract (Task 8).
+ * test_cd_second_transfer.c -- CD second-transfer liveness contract.
  *
  * test_cd_fifo_stream proves the FIRST boot-stub load delivers byte-exact
  * payload.  This test covers the next failure class: the SECOND (and every

--- a/test/test_cd_toc_contract.c
+++ b/test/test_cd_toc_contract.c
@@ -1,5 +1,5 @@
 /*
- * test_cd_toc_contract.c -- $2C00 TOC table contract test (Task 6D).
+ * test_cd_toc_contract.c -- $2C00 TOC table contract test.
  *
  * After a real-BIOS CD boot reaches the boot-stub / TOC injection point,
  * this reads the actual $2C00 table out of main RAM and runs BOTH game
@@ -8,8 +8,8 @@
  * from real game boot stubs and the CD BIOS's own $2C00 TOC builder — a
  * 68K routine in the BIOS ROM at $808BE8 that polls BUTCH DSA responses
  * directly (not the DSP code the BIOS uploads to $F1B000, which handles
- * drive-level transport); see docs/cd-boot-matrix.md and
- * .superpowers/sdd/task-6d-report.md for the layout derivation.
+ * drive-level transport); see the "$2C00 TOC track-indexed layout" section
+ * of docs/cd-boot-matrix.md for the layout derivation.
  *
  * SCOPE: this is a table-format contract test, not an end-to-end boot test.
  * The Primal Rage MSF assertion below compares the injected table against

--- a/test/test_netlink_host.c
+++ b/test/test_netlink_host.c
@@ -63,7 +63,7 @@ static int run_case(int argc, char **argv, const char *rom,
     get_host = (get_host_t)harness_dlsym(&cfg, "JLinkGetTCPHost");
     if (!get_host)
     {
-        fprintf(stderr, "JLinkGetTCPHost not exported — build with "
+        fprintf(stderr, "JLinkGetTCPHost not exported -- build with "
                         "TEST_EXPORTS=1\n");
         harness_shutdown(&cfg);
         return 0;

--- a/test/test_state_compat.c
+++ b/test/test_state_compat.c
@@ -302,7 +302,7 @@ int main(int argc, char **argv)
     dac_size = dac_save(dac_v3);
     check(dac_size == EXPECTED_DAC_BLOCK_SIZE, "dac_block_size",
           "DACStateSave wrote %lu bytes, expected %d "
-          "(a DAC field was added/reordered — re-derive the size and the "
+          "(a DAC field was added/reordered -- re-derive the size and the "
           "i2sNonZeroCount offset in this test)",
           (unsigned long)dac_size, EXPECTED_DAC_BLOCK_SIZE);
     if (dac_size != EXPECTED_DAC_BLOCK_SIZE) {
@@ -495,7 +495,7 @@ int main(int argc, char **argv)
     check(try_load_patched(unser, state_v3, state_size, STATE_OFF_VERSION,
                            1u, scratch) == false,
           "v1_state_rejected",
-          "version 1 is below STATE_MIN_VERSION (%d) — the v1->v2 layout "
+          "version 1 is below STATE_MIN_VERSION (%d) -- the v1->v2 layout "
           "change shipped in v2.3.0", STATE_MIN_VERSION);
 
     check(try_load_patched(unser, state_v3, state_size, STATE_OFF_VERSION,

--- a/test/test_uart_core.c
+++ b/test/test_uart_core.c
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
     jerry_rw = (jerry_rw_t)harness_dlsym(&cfg, "JERRYReadWord");
     if (!jerry_ww || !jerry_rw)
     {
-        fprintf(stderr, "JERRY dispatch symbols not exported — "
+        fprintf(stderr, "JERRY dispatch symbols not exported -- "
                         "build with TEST_EXPORTS=1\n");
         return 1;
     }

--- a/test/tools/analyze_cd_roms.py
+++ b/test/tools/analyze_cd_roms.py
@@ -12,7 +12,7 @@ import sys
 import os
 from collections import defaultdict
 
-# ── BIOS Jump Table Addresses ──────────────────────────────────────────────
+# --- BIOS Jump Table Addresses ---
 BIOS_FUNCTIONS = {
     0x3006: "CD_init",
     0x300C: "CD_ack",
@@ -29,7 +29,7 @@ BIOS_FUNCTIONS = {
 # Extend with more known BIOS entry points seen in code
 BIOS_RANGE = range(0x3000, 0x3E00)
 
-# ── 68K Instruction Patterns ──────────────────────────────────────────────
+# --- 68K Instruction Patterns ---
 
 # Register names
 DREGS = ["D0", "D1", "D2", "D3", "D4", "D5", "D6", "D7"]
@@ -78,7 +78,7 @@ class M68KDisassembler:
 
         info = {}
 
-        # ── JSR ────────────────────────────────────────────────────────
+        # --- JSR ---
         # 4E80-4EBF: JSR <ea>
         if (w & 0xFFC0) == 0x4E80:
             mode = (w >> 3) & 7
@@ -116,7 +116,7 @@ class M68KDisassembler:
                 ea = decode_ea_mode(mode, reg)
                 return f"JSR {ea}", 2 if mode < 5 else 4, info
 
-        # ── JMP ────────────────────────────────────────────────────────
+        # --- JMP ---
         if (w & 0xFFC0) == 0x4EC0:
             mode = (w >> 3) & 7
             reg = w & 7
@@ -139,7 +139,7 @@ class M68KDisassembler:
                 ea = decode_ea_mode(mode, reg)
                 return f"JMP {ea}", 2 if mode < 5 else 4, info
 
-        # ── BSR ────────────────────────────────────────────────────────
+        # --- BSR ---
         if (w & 0xFF00) == 0x6100:
             disp = w & 0xFF
             if disp == 0:
@@ -157,7 +157,7 @@ class M68KDisassembler:
                 info = {"type": "BSR", "target": target}
                 return f"BSR.B $%06X" % target, 2, info
 
-        # ── MOVEQ ─────────────────────────────────────────────────────
+        # --- MOVEQ ---
         if (w & 0xF100) == 0x7000:
             dreg = (w >> 9) & 7
             imm = w & 0xFF
@@ -166,7 +166,7 @@ class M68KDisassembler:
             info = {"type": "MOVEQ", "reg": f"D{dreg}", "value": imm & 0xFF}
             return f"MOVEQ #$%02X,D{dreg}" % (imm & 0xFF), 2, info
 
-        # ── MOVE.L #imm,Dn (or An) ────────────────────────────────────
+        # --- MOVE.L #imm,Dn (or An) ---
         # 2x3C = MOVE.L #imm,Dn  (opcode 0010 xxx0 0011 1100)
         if (w & 0xF1FF) == 0x203C:
             dreg = (w >> 9) & 7
@@ -175,7 +175,7 @@ class M68KDisassembler:
                 info = {"type": "MOVE.L_IMM", "reg": f"D{dreg}", "value": imm}
                 return f"MOVE.L #$%08X,D{dreg}" % imm, 6, info
 
-        # ── MOVE.W #imm (to various) ──────────────────────────────────
+        # --- MOVE.W #imm (to various) ---
         # 303C = MOVE.W #imm,D0 (etc)
         if (w & 0xF1FF) == 0x303C:
             dreg = (w >> 9) & 7
@@ -184,7 +184,7 @@ class M68KDisassembler:
                 info = {"type": "MOVE.W_IMM", "reg": f"D{dreg}", "value": imm}
                 return f"MOVE.W #$%04X,D{dreg}" % imm, 4, info
 
-        # ── MOVE.B #imm ───────────────────────────────────────────────
+        # --- MOVE.B #imm ---
         if (w & 0xF1FF) == 0x103C:
             dreg = (w >> 9) & 7
             imm = self.read16(offset + 2)
@@ -192,7 +192,7 @@ class M68KDisassembler:
                 info = {"type": "MOVE.B_IMM", "reg": f"D{dreg}", "value": imm & 0xFF}
                 return f"MOVE.B #$%02X,D{dreg}" % (imm & 0xFF), 4, info
 
-        # ── LEA addr,An ───────────────────────────────────────────────
+        # --- LEA addr,An ---
         # LEA (abs.l),An = 41F9/43F9/45F9/47F9/49F9/4BF9/4DF9/4FF9
         if (w & 0xF1FF) == 0x41F9:
             areg = (w >> 9) & 7
@@ -213,7 +213,7 @@ class M68KDisassembler:
                 info = {"type": "LEA_W", "reg": f"A{areg}", "value": addr32}
                 return f"LEA ($%04X).w,A{areg}" % addr, 4, info
 
-        # ── MOVEA.L ────────────────────────────────────────────────────
+        # --- MOVEA.L ---
         # 207C = MOVEA.L #imm,A0; 227C = A1; etc.
         if (w & 0xF1FF) == 0x207C:
             areg = (w >> 9) & 7
@@ -222,7 +222,7 @@ class M68KDisassembler:
                 info = {"type": "MOVEA.L", "reg": f"A{areg}", "value": imm}
                 return f"MOVEA.L #$%08X,A{areg}" % imm, 6, info
 
-        # ── MOVE.L abs,abs (23FC = MOVE.L #imm,abs.l) ────────────────
+        # --- MOVE.L abs,abs (23FC = MOVE.L #imm,abs.l) ---
         if w == 0x23FC:
             imm = self.read32(offset + 2)
             addr = self.read32(offset + 6)
@@ -230,7 +230,7 @@ class M68KDisassembler:
                 info = {"type": "MOVE.L_ABS", "value": imm, "addr": addr}
                 return f"MOVE.L #$%08X,($%08X).l" % (imm, addr), 10, info
 
-        # ── MOVE.W #imm,abs.l (33FC) ────────────────────────────────
+        # --- MOVE.W #imm,abs.l (33FC) ---
         if w == 0x33FC:
             imm = self.read16(offset + 2)
             addr = self.read32(offset + 4)
@@ -238,7 +238,7 @@ class M68KDisassembler:
                 info = {"type": "MOVE.W_ABS", "value": imm, "addr": addr}
                 return f"MOVE.W #$%04X,($%08X).l" % (imm, addr), 8, info
 
-        # ── ADDA.L #imm,An (D1FC) ────────────────────────────────────
+        # --- ADDA.L #imm,An (D1FC) ---
         if (w & 0xF1FF) == 0xD1FC:
             areg = (w >> 9) & 7
             imm = self.read32(offset + 2)
@@ -246,7 +246,7 @@ class M68KDisassembler:
                 info = {"type": "ADDA.L", "reg": f"A{areg}", "value": imm}
                 return f"ADDA.L #$%08X,A{areg}" % imm, 6, info
 
-        # ── MOVE.L Dn/An,abs (23Cx) ──────────────────────────────────
+        # --- MOVE.L Dn/An,abs (23Cx) ---
         if (w & 0xFFC0) == 0x23C0:
             sreg = w & 0xF
             addr = self.read32(offset + 2)
@@ -255,25 +255,25 @@ class M68KDisassembler:
                 info = {"type": "MOVE_REG_ABS", "reg": rname, "addr": addr}
                 return f"MOVE.L {rname},($%08X).l" % addr, 6, info
 
-        # ── RTS ────────────────────────────────────────────────────────
+        # --- RTS ---
         if w == 0x4E75:
             return "RTS", 2, {"type": "RTS"}
 
-        # ── NOP ────────────────────────────────────────────────────────
+        # --- NOP ---
         if w == 0x4E71:
             return "NOP", 2, {"type": "NOP"}
 
-        # ── RTE ────────────────────────────────────────────────────────
+        # --- RTE ---
         if w == 0x4E73:
             return "RTE", 2, {"type": "RTE"}
 
-        # ── SR manipulation ────────────────────────────────────────────
+        # --- SR manipulation ---
         if w == 0x46FC:
             imm = self.read16(offset + 2)
             if imm is not None:
                 return f"MOVE #$%04X,SR" % imm, 4, {"type": "MOVE_SR"}
 
-        # ── Bcc / BRA ─────────────────────────────────────────────────
+        # --- Bcc / BRA ---
         cond_names = {0:"BRA",1:"BSR",2:"BHI",3:"BLS",4:"BCC",5:"BCS",
                       6:"BNE",7:"BEQ",8:"BVC",9:"BVS",10:"BPL",11:"BMI",
                       12:"BGE",13:"BLT",14:"BGT",15:"BLE"}
@@ -294,7 +294,7 @@ class M68KDisassembler:
                 target = (self.base + offset + 2 + disp) & 0xFFFFFFFF
                 return f"{cname}.B $%06X" % target, 2, {"type": "BCC", "target": target}
 
-        # ── Fallback ──────────────────────────────────────────────────
+        # --- Fallback ---
         return f"DC.W $%04X" % w, 2, {"type": "unknown", "word": w}
 
 
@@ -310,7 +310,7 @@ def analyze_file(filepath):
     print(f"Size: {size} bytes ({size:#x})")
     print(f"{'='*78}")
 
-    # ── Determine load address and file type ──────────────────────────
+    # --- Determine load address and file type ---
     # Check first bytes for header patterns
     first4 = struct.unpack(">I", data[:4])[0] if len(data) >= 4 else 0
     first2 = struct.unpack(">H", data[:2])[0] if len(data) >= 2 else 0
@@ -372,7 +372,7 @@ def analyze_file(filepath):
     if entry_point is not None:
         print(f"Entry point: ${entry_point:08X}")
 
-    # ── Scan for BIOS jump table references ──────────────────────────
+    # --- Scan for BIOS jump table references ---
     disasm = M68KDisassembler(data, load_addr)
     bios_calls = []
     all_instructions = []
@@ -409,7 +409,7 @@ def analyze_file(filepath):
 
         offset += size
 
-    # ── Print BIOS call summary ──────────────────────────────────────
+    # --- Print BIOS call summary ---
     print(f"\nBIOS Jump Table Calls Found: {len(bios_calls)}")
     print("-" * 70)
 
@@ -440,14 +440,14 @@ def analyze_file(filepath):
                 marker = ">>>" if i == idx else "   "
                 print(f"    {marker} ${a:06X}: {t}")
 
-    # ── BUTCH register references ────────────────────────────────────
+    # --- BUTCH register references ---
     if butch_refs:
         print(f"\nBUTCH Register References: {len(butch_refs)}")
         print("-" * 70)
         for o, a, t, info in butch_refs:
             print(f"  ${a:06X}: {t}")
 
-    # ── Scan for raw 16-bit values matching BIOS addresses ───────────
+    # --- Scan for raw 16-bit values matching BIOS addresses ---
     # Also find them as data references (not instructions)
     raw_bios_refs = []
     for off in range(0, len(data) - 1, 2):
@@ -466,7 +466,7 @@ def analyze_file(filepath):
         for off, val, name in raw_bios_refs:
             print(f"  offset ${off:06X} (addr ${load_addr+off:06X}): ${val:04X} = {name}")
 
-    # ── First 32 instructions ────────────────────────────────────────
+    # --- First 32 instructions ---
     print(f"\nFirst 40 Instructions (entry point):")
     print("-" * 70)
     for i, (o, a, t, s, inf) in enumerate(all_instructions[:40]):
@@ -604,7 +604,8 @@ def scan_for_jump_table_at(data, base_addr, offset, name):
 
 
 def main():
-    rom_dir = "/Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro/test/roms/private"
+    rom_dir = (sys.argv[1] if len(sys.argv) > 1
+               else os.environ.get("JAGUAR_ROMS_PRIVATE", "test/roms/private"))
 
     files = [
         "CDBYPASS (Symmetry of TNG 2003).prg",
@@ -628,7 +629,7 @@ def main():
             analyze_cd_read_patterns(bios_calls, instructions, fname)
             analyze_bypass_mechanism(instructions, fname)
 
-    # ── Cross-reference summary ──────────────────────────────────────
+    # --- Cross-reference summary ---
     print(f"\n{'='*78}")
     print("CROSS-REFERENCE SUMMARY: BIOS Function Usage")
     print(f"{'='*78}")
@@ -647,7 +648,7 @@ def main():
         for fname, addr in usages:
             print(f"    {fname} @ ${addr:06X}")
 
-    # ── Final analysis ───────────────────────────────────────────────
+    # --- Final analysis ---
     print(f"\n{'='*78}")
     print("CALLING CONVENTION SUMMARY")
     print(f"{'='*78}")

--- a/test/tools/cd_boot_matrix.sh
+++ b/test/tools/cd_boot_matrix.sh
@@ -99,7 +99,7 @@ fi
 
 # The harnesses dlsym() CDROMDiagGetCounters; a plain `make` (no
 # TEST_EXPORTS=1) relinks against the slim production export list and
-# silently drops it (bit Task 2 of this plan -- see task-2-report.md).
+# silently drops it, and every dlsym-based assertion then reports SKIP.
 if command -v nm >/dev/null 2>&1; then
     if ! nm -gU "$DYLIB" 2>/dev/null | grep -q CDROMDiagGetCounters; then
         echo "$DYLIB is missing test-export symbols -- rebuilding with TEST_EXPORTS=1..." >&2
@@ -384,7 +384,7 @@ pc_summary_of() {
 #
 # The 9 CUE titles are exactly the set test_cd_hle_boot / test_cd_bios_boot
 # already discover by default (VJ_TEST_CD_EXTS defaults to "cue") -- this
-# matches the Task 2 per-title baseline one-for-one. CDI (baldies.cdi) and
+# matches the recorded per-title baseline one-for-one. CDI (baldies.cdi) and
 # one loose ISO (Primal Rage) are opt-in via VJ_TEST_CD_EXTS, per
 # test/cd_assertions.h's own documented rationale (CDI parser has a known
 # crasher; ISO boot is a documented, permanent limitation -- ISO images

--- a/test/tools/cue2cdi.c
+++ b/test/tools/cue2cdi.c
@@ -975,7 +975,7 @@ static int convert_parsed(Disc *d, const char *inPath, const char *outPath,
    if (d->numSessions > 2)
       WARN("more than 2 sessions: this core's parser clamps numSessions to 2\n");
    if (d->numSessions == 1)
-      INFO("note: single session — a bootable Jaguar CD needs 2 sessions\n");
+      INFO("note: single session -- a bootable Jaguar CD needs 2 sessions\n");
 
    INFO("writing %s\n", outPath);
    if (write_cdi(d, outPath) != 0)

--- a/test/tools/netlink_latency.c
+++ b/test/tools/netlink_latency.c
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
     run_frame = (retro_run_t)harness_dlsym(&cfg, "retro_run");
     if (!jerry_ww || !jerry_rw || !jlink_connected || !rx_total || !run_frame)
     {
-        fprintf(stderr, "[%s] symbols missing — build with TEST_EXPORTS=1\n",
+        fprintf(stderr, "[%s] symbols missing -- build with TEST_EXPORTS=1\n",
                 role);
         return 1;
     }

--- a/test/tools/netlink_pair.c
+++ b/test/tools/netlink_pair.c
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "[%s] jlink mode after load = %d\n", role, jlink_mode());
     if (!jerry_ww || !jerry_rw || !jlink_connected || !run_frame)
     {
-        fprintf(stderr, "[%s] symbols missing — build with TEST_EXPORTS=1\n", role);
+        fprintf(stderr, "[%s] symbols missing -- build with TEST_EXPORTS=1\n", role);
         return 1;
     }
 

--- a/test/tools/test_audio_gaps.c
+++ b/test/tools/test_audio_gaps.c
@@ -1,7 +1,7 @@
-/* test/tools/test_audio_gaps.c — detect audio-effect "stutter" (RMS
+/* test/tools/test_audio_gaps.c -- detect audio-effect "stutter" (RMS
  * collapses) during Doom's attract demo, comparing virtualjaguar_dram_timing
- * on vs off (Task 6, user report 2026-08-02: demo sfx stutter with the
- * option enabled, in-game audio fine, no stutter with the option off).
+ * on vs off (user report 2026-08-02: demo sfx stutter with the option
+ * enabled, in-game audio fine, no stutter with the option off).
  *
  * Method: watch gametic ($04080C, same field used by test_doom_ticrate.c)
  * for the first attract-demo start (0 -> nonzero transition), reset the


### PR DESCRIPTION
Pre-tag fact-check and cleanup wave for the v3.0.0 tag, consolidating three
audit passes over `release/v3.0.0`: a **release-notes fact-check** (claims vs.
what the code and the source docs actually say), a **committed-doc slop audit**
(agent-process narration and citations that don't resolve for a reader), and a
**stale-doc sweep** (README / WHATSNEW / release process). 37 brief items, all
addressed; no behaviour changes.

### A. Code (7 items, behaviour-safe)

- `[SUBCODE]` diagnostics demoted `LOG_INF` → `LOG_DBG`, matching the #274 CDDA
  demotion class (3 sites).
- The `CDDA-DIAG` comment claimed "log unconditionally" while the code
  rate-limits — comment now matches the code.
- `bus_arbiter_dram_cost()` made `static` (no callers outside `bus_arbiter.c`,
  not in any export list; `test_dram_timing` verified not to use it).
- `analyze_cd_roms.py`: hardcoded absolute ROM path → `argv[1]` /
  `JAGUAR_ROMS_PRIVATE` / `test/roms/private`; Unicode box-drawing banners → ASCII.
- Citations that can't resolve for a reader (`/private/tmp/…`, `.superpowers/…`)
  and bare "Task N" references replaced with in-repo docs or the symptom.
- 38 em-dashes normalized to `--` inside user-facing and log strings added this
  cycle, matching the files' existing convention (comments untouched).

### B. Committed docs (8 items)

- Three agent-numbered CD diagnosis files renamed to describe their subject
  (`cd-streaming-wall-diagnosis.md`, `braindead13-second-wedge-diagnosis.md`,
  `fmv-stall-diagnosis.md`) with every in-repo reference updated.
- Every `.superpowers/sdd/…` citation in `docs/` replaced with the committed
  equivalent or dropped — those paths are gitignored and unresolvable.
- Agent-process narration reworded out (`Phase N —` headers, "Tree clean at
  start", "successor agent", "session scratchpad", "so the next agent doesn't
  repeat it", …). **All findings kept**; only the framing changed.
- `git diff --check` whitespace complaints fixed.

### C. README / WHATSNEW / process doc (4 items)

- README no longer says CD support is "in flight on a separate branch (PR
  forthcoming)"; format list now matches `JAGUAR_VALID_EXTENSIONS`.
- `docs/WHATSNEW` gains a v3.0.0 section in the file's existing style.
- `docs/release-process.md`: 16 platforms (14 matrix + Vita + Switch), counted
  from `release.yml`.

### D. Release-notes corrections (18 items)

Contradictions and inversions: the TCP netlink transport was advertised as
working on iOS while Known Issues said that test is pending; the blitter fix was
described backwards; Pitfall #138's symptom is a black screen shortly into
gameplay, not a crash on boot; the savestate bullet read as if old states break
when only the forward direction does.

Numbers harmonized with their source docs: Doom's pace now quotes
`docs/doom-pace-calibration.md` verbatim (hardware 19.98 fps typical / ~15 fps
heavy vs. our pinned 29.97 fps two-field cap = ~1.5x typical, 2x heavy;
occupancy model moves demo duration +0.0% / +0.1%). The ~2% figure quoted in
#265 predates the double-counted-68K-bus-cycle fix shipping in this same
release, and is now called out as superseded rather than repeated.

Known Issues gaps filled so existing pointers resolve: #268 (savestates below
`STATE_MIN_VERSION`), Iron Soldier cart fast-blitter wireframe tank (#186
class), Battle Sphere Gold dark menu text. Issue/PR numbers verified against
GitHub — hostname resolution is #263 (the PR), not #253 (the open issue).

Stats recomputed at the branch tip as the final commit, with the counting rule
stated: **303 commits (246 non-merge), 181 files changed, +40,390 / −839**.

### Fact-check finding beyond the brief

**The core has no CHD support** — no `chd` in `JAGUAR_VALID_EXTENSIONS`, no
libchdr, no reader in `cdintf.c` — yet the `.iso` refusal message, the release
notes, `docs/cd-known-issues.md` and a draft README line all told users to "use
CUE/BIN, CHD, or CDI". All four corrected to CUE/BIN or CDI.

### Verification

- `make -j8` clean; `scripts/c89-lint.sh` passes on every touched `src/` file.
- `test_dram_timing` rebuilt against `bus_arbiter.c` directly: `PASS: 0 failure(s)`.
- `make -j8 TEST_EXPORTS=1 test` → **exit 0**.
- `git diff --check libretro/release/v3.0.0..HEAD` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Note for the tagger:** the stats above are exact at `fd81690` (this branch tip). Merging this PR adds a merge commit, and any further commit landing on `release/v3.0.0` before the tag (e.g. the concurrent `chore/info-authors-v3` work, which also touches release metadata and may conflict on `RELEASE_NOTES_v3.0.0.md`) shifts them. Re-run `git rev-list --count v2.3.2..HEAD`, the same with `--no-merges`, `git diff --shortstat v2.3.2..HEAD`, and the per-type tally at the tag commit if exactness matters.
