### PR TITLE
docs: verification and ticket plan for every open issue

### DIFF
--- a/docs/open-issue-handoff.md
+++ b/docs/open-issue-handoff.md
@@ -329,6 +329,17 @@ run that changed nothing. Belongs upstream.
 `options_intl[]` is replaced with `&options_xx`. That is upstream behaviour, and
 referencing the symbol before the header defines it would not compile.
 
+**Risk note (dependabot bumps already on `develop`):** PRs #278–#281 all merged
+before any live Crowdin run. #278 is the non-routine one —
+`ad-m/github-push-action` **0.8.0 → 1.3.0** (major), the action that pushes
+regenerated translations in
+`.github/workflows/crowdin_translation_sync.yml`. The other three
+(`setup-python` 4→7, `checkout` 4→7, `setup-java` 4→5) land in the same
+workflows. Until step 4 above succeeds once, a sync failure is ambiguous
+between "bump broke it" and "was never set up". Check the push-action
+changelog for breaking input changes (`github_token`, `branch`) when
+triaging the first live failure.
+
 ---
 
 ## 7. #254 — Standalone SDL frontend
@@ -349,31 +360,26 @@ body are overwritten. Do not open tickets against it.
 
 ---
 
-## 9. Open dependabot PRs — #278, #279, #280, #281
+## 9. Dependabot bumps — merged (history)
 
-Routine CI bumps, but **#278 is not routine**: it bumps
-`ad-m/github-push-action` **0.8.0 → 1.3.0**, a major version, and that action is
-what pushes the regenerated translations in
-`.github/workflows/crowdin_translation_sync.yml`. Check its changelog for
-breaking input changes before merging; the workflow passes `github_token` and
-`branch`. The other three (`setup-python` 4→7, `checkout` 4→7, `setup-java` 4→5)
-are used by the same workflows and are lower risk, but all four touch the
-Crowdin pipeline that has never had a successful live run — so a failure after
-merging will be ambiguous between "bump broke it" and "was never set up".
-Prefer merging these **after** the org-side Crowdin setup has had one green run.
+PRs #278, #279, #280, and #281 all merged to `develop` (#278 as `6249339`;
+#279–#281 as `c4edff9` / `791d292` / `f1e84d8`). There is no open dependabot
+work left. The untested major bump of `ad-m/github-push-action` is now a risk
+note under §6 (#252), not a ticket.
 
 ---
 
 ## Suggested ticket breakdown
 
-Ordered by value-per-effort, not by issue number.
+Ordered by value-per-effort, not by issue number. Cheap-model task files for
+items 1–4 and 6 live under `docs/tasks/`.
 
 | # | Ticket | Depends on | Size |
 |---|---|---|---|
 | 1 | Savestate header inspector CLI (#268) | — | XS |
 | 2 | #268 maintainer decision + document | 1 | XS |
 | 3 | #269 warn-and-refuse + known-bad-dump table + corpus message assertion | — | S |
-| 4 | Scripted-input fixture reaching AvP shotgun (#267 unlock) | — | S–M |
+| 4 | Scripted-input fixture reaching AvP in-game (#267 unlock) | — | S–M |
 | 5 | #267 re-confirm on nightly; isolate B_CMD if it reproduces | 4 | M |
 | 6 | Overscan column-band digest in A/B sweep tooling (#266) | — | S |
 | 7 | #266: request nightly capture; write-side instrumentation if confirmed | 6 | M |
@@ -381,13 +387,12 @@ Ordered by value-per-effort, not by issue number.
 | 9 | VLM: single-session audio-disc support, gated | 8 | L |
 | 10 | `supports_no_game` + CD BIOS standalone boot | 9 | M |
 | 11 | Disk control (audio-CD swap in VLM only) | 10 | M |
-| 12 | Review dependabot #278 major bump | Crowdin green run | XS |
-| 13 | #254 SDL frontend phase 1 | — | L |
+| 12 | #254 SDL frontend phase 1 | — | L |
 
 Items 1–3 are closeable quickly and clear the tracker. Items 4 and 6 are
 infrastructure that make two stuck visual bugs tractable and stay useful
 afterwards — do them before the bugs they unlock. Items 8–11 are the VLM chain
-and are strictly sequential. Item 13 is independent of everything else.
+and are strictly sequential. Item 12 is independent of everything else.
 
 ### What NOT to do
 

--- a/docs/open-issue-handoff.md
+++ b/docs/open-issue-handoff.md
@@ -1,0 +1,400 @@
+# Open-issue handoff — verification, tooling and ticket plan
+
+Written 2026-08-03 against `develop`. Audience: an agent or engineer who will
+break this into work tickets and execute them. Every claim here is either
+verified (marked so) or explicitly flagged as unconfirmed — do not promote an
+unconfirmed item to fact without re-measuring.
+
+**Read `CLAUDE.md` first.** It is not optional context; it carries the C89
+rules, the branch policy, the private-ROM-tree warning, and the test-ABI
+mechanics that every ticket below depends on.
+
+---
+
+## 0. Cross-cutting rules that will bite you
+
+These have each cost real debugging time in this repo. Internalise them before
+opening any ticket.
+
+1. **Headless ≠ what RetroArch shows.** The harness does not read the same
+   composited framebuffer RetroArch presents. A visual artefact can be real and
+   still be invisible headlessly (`CLAUDE.md`, "Headless framebuffer caveat").
+   *"Not reproduced headlessly" is never proof a visual bug is fixed.* This
+   directly governs #266.
+2. **Verify the binary you are testing.** `make` can skip a rebuild when file
+   mtimes are second-identical. Always:
+   `VJ_EXPECT_BUILD=$(./scripts/build-id.sh) ./test/tools/<harness> ...`
+3. **Test ABI switching.** `make` links the production-slim ABI; `make test`
+   needs `TEST_EXPORTS=1` for harnesses to `dlsym` internals.
+4. **Branch from `libretro/develop`**, never local `develop`, never `master`.
+5. **Never relax a test threshold to make a PR green.** If a real fix
+   legitimately changes a measured value, that is a deliberate, called-out
+   baseline update — not a side effect.
+6. **Never `git clean -xfd`.** `test/roms/private` is a symlink to an
+   irreplaceable ROM tree outside the repo. Use `find -L` to traverse it.
+7. **Set `DEVELOPER_DIR=/Library/Developer/CommandLineTools`** on macOS host
+   builds, or every invocation raises an App Management prompt.
+8. **A stale-object trap exists**: if another session cross-built for iOS in
+   this tree, `make` fails with *"building for 'macOS', but linking in object
+   file built for 'iOS'"*. Fix is `make clean`, not investigation.
+
+### Tooling inventory (all already exist — do not rebuild these)
+
+| Tool | Use |
+|---|---|
+| `test/harness/harness.h` | Shared dlopen/init/run harness. Common CLI: `--json --frames N --option K=V --press FRAME:BUTTON[:HOLD]`. **Scripted input is how you reach in-game states headlessly.** |
+| `test/tools/cd_visual_verify` | Per-second motion timeline, non-black coverage, audio RMS, periodic PPM screenshots. `sips -s format png` to read them. |
+| `test/tools/test_blitter_compare` | Fast-vs-accurate per-blit diff. `--frame-window F L`, `--cmd-filter MASK VAL`, `--load-state`. Isolated the Iron Soldier wireframe bug. |
+| `test/tools/cd_wedge_probe` | Frozen-framebuffer detector; dumps 68K regs, pcQueue, CD trace, RAM. Exits 42 when caught. |
+| `test/regression_test.sh` | Screenshot regression vs `test/baselines/` (baselines are local, not committed). |
+| `test/tools/cd_boot_matrix.sh` | Per-title CD boot-stage matrix, both modes. **22 rows, all `GAME_CODE` — this is the CD regression gate.** |
+| `test/test_cd_hle_boot` + `VJ_TEST_CD_EXTS=cdi` | Corpus sweep across disc images. |
+| `src/core/crash_detect.c` | Runtime watchdog: `gpu_pc_escape`, `dsp_pc_escape`, `gpu_wedge`, `dsp_wedge`, `video_stall`, `cd_seek_wedge`. Add new signatures here rather than sprinkling one-off logs. |
+| `VJ_CD_TRACE=1` | CD trace ring (DSA TX/RX, seek, FIFO). `VJ_HARNESS_LOG_INFO=1` / `VJ_HARNESS_LOG_DEBUG=1` to surface it. |
+
+---
+
+## 1. #266 — AvP green dot / green right-edge (x ≥ 320 overscan)
+
+**Status: reported, pixel-verified once, then twice NOT reproduced. Root cause open.**
+
+### What is established
+
+- BIOS off, both blitters, frame 1500: a single `#00FC38` pixel at exactly
+  `(324, 32)`.
+- BIOS on, both blitters: textured `#00FC38` at `x = 323..325`, `y ≈ 0..240`.
+- Both hit ranges are at **x ≥ 320**. AvP's framebuffer is 326 columns; emulated
+  active video is 320. Columns 320–325 are an overscan/border strip that a
+  frontend may crop or show.
+- Present in v2.1.0 (`48096c1`) — **not a regression**.
+- The old "line buffer not cleared because AvP doesn't set BGEN" theory is
+  **superseded**: BGEN *is* set for AvP with `BG=0x0000`.
+- Two later full sweeps on develop found no green pixels anywhere in the border
+  rows. In one of those passes the headless title screen also lacked the black
+  letterbox the reporter sees — itself evidence of a capture/composition
+  mismatch rather than of a fix.
+
+### The decisive question
+
+Is anything actually written into columns 320–325, or is the artefact produced
+downstream in presentation/composition? The two sweeps point at the latter, but
+the headless read path is exactly the thing that cannot answer it.
+
+### Verification plan
+
+1. **Get a current-nightly RetroArch capture with overscan cropping explicitly
+   disabled.** This is the gating input; without it the ticket cannot progress.
+   If the artefact is gone on a nightly, close it.
+2. If still present: instrument the write side, not the read side. Determine
+   whether TOM/OP/blitter ever writes `x ≥ 320` for AvP, by adding a temporary
+   counter over the overscan columns rather than by screenshotting.
+3. Compare what the core hands to `video_cb` against what RetroArch composites —
+   the delta *is* the bug if step 2 shows clean writes.
+
+### Automation worth building
+
+Extend the A/B framebuffer digest tooling to emit a **separate digest for
+columns 320–325**, corpus-wide. Overscan content is currently invisible to every
+existing check; a per-column-band digest turns "did anything change in the
+border strip" into a one-line regression assertion, and it generalises past AvP.
+
+### Acceptance criteria
+
+Either (a) a nightly capture shows the artefact gone → close with evidence, or
+(b) the write-side instrumentation names the component that fills x ≥ 320, and a
+fix is gated so that no other title's overscan digest changes.
+
+### Traps
+
+Do not "fix" this by blanking columns 320–325 unconditionally. That would hide
+the symptom, and if some title legitimately renders there it becomes a new bug
+with no signature.
+
+---
+
+## 2. #267 — AvP red background behind shotgun (accurate blitter)
+
+**Status: never reproduced headlessly. May already be fixed.**
+
+### What is established
+
+- Symptom requires **Fast Blitter OFF** and a specific in-game weapon state.
+- The reporter's guess that #166 is responsible was checked: #166 gated a
+  phrase-mode `dstd` read on `!bkgwren` at `src/tom/blitter.c:2993`. An audit
+  found the only other unconditional `dstd` read (`blitter.c:2872`, inside
+  `if (dread)`) cannot fire under AvP's `!dsten && bkgwren` combination — so
+  the guard *should* cover the case as understood. That makes **"it is a
+  different blit type"** (SRCSHADE / Gouraud / other inhibit mask) the stronger
+  lead.
+- On current develop, fast vs accurate are **byte-identical across a full
+  900-frame AvP timeline**. The paths agree far more than when this was filed.
+
+### Verification plan (strictly ordered — step 1 is the whole unlock)
+
+1. **Build an input script that reaches the shotgun.** Use
+   `--press FRAME:BUTTON[:HOLD]` to navigate menus into gameplay and select the
+   weapon. Until this exists, nothing else in this ticket can run. Treat this as
+   its own ticket — it is reusable infrastructure, not overhead.
+2. Re-confirm on a current nightly, accurate blitter, at that moment. If the
+   byte-identical result holds through the shotgun draw, close as fixed by
+   unrelated blitter work — with the frame window quoted as evidence.
+3. If it reproduces: `test/tools/test_blitter_compare` with `--frame-window`
+   around the draw and `--cmd-filter` to narrow to the offending B_CMD. This is
+   the exact technique that isolated the Iron Soldier wireframe-tank bug.
+4. From the isolated command, determine the blit type and which inhibit mask is
+   wrong.
+
+### Automation worth building
+
+The step-1 input fixture. Bank it as a named scripted-input fixture other AvP
+tickets (#266) can reuse, and add the resulting frame to the screenshot
+regression corpus so a future regression is caught without manual play.
+
+### Acceptance criteria
+
+Either a quoted byte-identical comparison through the shotgun draw (close), or
+an identified B_CMD plus a fix that leaves `test_blitter_compare` at zero
+divergent blits corpus-wide.
+
+---
+
+## 3. #268 — AvP savestates rejected (below STATE_MIN_VERSION)
+
+**Status: not a bug. Needs a maintainer decision, plus one cheap tool.**
+
+### What is established
+
+- `src/core/state.h`: `STATE_VERSION = 7` (what this build writes),
+  `STATE_MIN_VERSION = 2` (oldest it will load). `retro_unserialize()` refuses
+  anything outside that window and returns false silently.
+- A Battle Sphere Gold state loaded on the same build — so this is version
+  gating, not a general savestate bug and not AvP-specific.
+- **Unconfirmed:** the actual header version in the reporter's two files was
+  never measured; the files were not available. Do not assert they are "v1".
+
+### Decision required (this is the ticket)
+
+- **Recommended:** leave as-is, document that states from sufficiently old
+  Virtual Jaguar versions do not carry forward, close as expected behaviour.
+- Alternative: add a best-effort legacy loader below `STATE_MIN_VERSION`. Only
+  worth it if there is real appetite — the format gap is old and the v3.0.0
+  freeze at v7 means the window is now stable rather than drifting.
+
+### Automation worth building (small, high leverage)
+
+A savestate header inspector: read the first 8 bytes, print magic (`"VJSS"`) and
+the version field. Turns "what version is this file" from an unanswerable
+support question into a one-line answer, for this and every future report. Ask
+the reporter for those 8 bytes either way.
+
+### Acceptance criteria
+
+A documented, deliberate call recorded on the issue — not an implicit one — plus
+the inspector merged if the team wants triage support.
+
+---
+
+## 4. #269 — CDI V2 rips with truncated/absent boot headers
+
+**Status: root-caused. Needs a product decision, not more investigation.**
+
+### What is established
+
+Of 14 local CDI images, 4 fail `retro_load_game` — all CDI V2 rips:
+
+- **ironsoldier2, mystdemo, vidgrid** — the boot-header region is **zero-filled
+  in the file itself**. No offset math can recover data that is not present.
+  These are bad dumps.
+- **worldtourracing** — carries a **partial 22-of-32-byte** boot magic. Making
+  it boot requires the boot stub to tolerate a truncated match.
+
+The CDI walk itself is correct; this is not an offset bug. (Verified previously:
+the V2 rips are `zeros(N) + content`, N = 112/76.)
+
+### Decision required
+
+- **Recommended: warn and refuse**, with a message that names the dump problem
+  explicitly ("boot header is zero-filled — this image is a bad dump, not an
+  unsupported format") and a known-bad-dump table so users stop re-filing it.
+- Alternative: tolerate truncated magic for the worldtourracing class. **This
+  carries real false-positive risk** — a 22-byte prefix match against
+  decoy-prone data is a weak predicate, and a wrong accept boots garbage rather
+  than failing cleanly.
+
+### Verification plan
+
+`VJ_TEST_CD_EXTS=cdi test/test_cd_hle_boot` over the corpus (this is how the
+four were found). Whatever is implemented, assert the *message* in that sweep,
+not just the pass/fail.
+
+### Acceptance criteria
+
+All 14 CDI images produce either a successful boot or a specific, actionable
+diagnostic naming the dump defect. Zero regressions in the 22-row boot matrix.
+
+---
+
+## 5. VLM / audio-CD support — **no ticket exists yet; open one**
+
+**Status: investigated this session. Verified findings below.**
+
+### What is established (all verified)
+
+- The **Virtual Light Machine ships inside the CD BIOS we already compile in**.
+  `src/bios/jagcdbios.c` and `jagdevcdbios.c` are both 262144 bytes and contain
+  `Virtual Light Machine v0.9 / (c) 1994 Virtual Light Company Ltd. / Jaguar
+  CD-ROM version / FFT code by ib2 / Grafix code by Yak`. No BIOS file needed.
+- Booting a synthetic single-session audio CD with
+  `virtualjaguar_cd_boot_mode=bios` runs the real BIOS — logo + starfield
+  animate for 90 s — but **never hands off to the VLM**.
+- Trace shows only **two** DSA commands ever sent: `$7001` (Set DAC Mode) and
+  `$150A` (Set Mode = double speed + **data**), then nothing. No TOC read
+  (`$03xx`), no seek (`$10/$11/$12`). Button presses change nothing.
+- So the BIOS stalls **before** its "is this a data disc?" decision.
+- HLE rejects the disc outright: `[CD-BOOTSTUB] Early exit: loaded=1
+  numSessions=1`, then "unsupported or invalid content format".
+- Root cause is **disc shape**: the CD stack is built for 2-session game discs;
+  `cdintf.c` gates on `numSessions >= 2` (≈ lines 427, 445, 1164).
+
+### Two corrections to natural assumptions
+
+- **"Add an option to always boot the BIOS" is not the fix** — that option
+  already exists (`CD Boot Mode = Real BIOS`) and is exactly what was tested.
+- **Every Jaguar CD track is `TRACK AUDIO / FLAGS DCP`, including data tracks.**
+  Game discs and music CDs are indistinguishable by track type; the BIOS
+  separates them by the `ATARI APPROVED DATA HEADER` magic in session 2.
+
+### Verification plan
+
+1. Find what the BIOS polls after `$150A` and why it never advances. Trace the
+   68K PC in the stall loop and identify the register/response it waits on.
+2. Serve a single-session all-audio disc convincingly: TOC plus CDDA.
+3. Success = the VLM appears and reacts to the audio.
+
+### Repro
+
+```bash
+# synthesize a music CD: two audio tone tracks, one session, no ATRI header
+./test/tools/cd_visual_verify <core> musiccd.cue \
+  --option virtualjaguar_cd_boot_mode=bios \
+  --frames 5400 --outdir DIR --shot-every 1800
+# add VJ_CD_TRACE=1 VJ_HARNESS_LOG_DEBUG=1 to see the DSA traffic
+```
+
+### Traps
+
+- The VLM is BIOS code — it can **only** work in real-BIOS mode. HLE will never
+  produce it. Do not scope an HLE path.
+- Gate any change strictly on **1 session AND no ATRI header** so game discs
+  take byte-identical paths. `cdintf.c`/`cdrom.c` are the code that took the
+  longest to stabilise for game boot.
+- **Regression gate: the 22-row CD boot matrix must stay all `GAME_CODE`.**
+
+### Follow-on this unlocks
+
+`supports_no_game` (currently `"false"`; `libretro.c` has `if (!info) return
+false;`) would let the CD BIOS boot with no disc. That is also the only context
+in which libretro **disk control** becomes meaningful — swapping audio CDs while
+the VLM runs. Note `disk_control = "false"` in the `.info` file is *correct
+today*: the CD BIOS jump table (18 entries, `jagcd_hle.c:60-77`) has no
+disc-status call and the reverse-engineered DSA set has no lid/status opcode, so
+a game cannot be told a disc changed. Enabling disk control without that would
+let a frontend swap the image under a running game — a corruption path, not a
+feature.
+
+---
+
+## 6. #252 — Crowdin: in-repo work merged, org-side work remains
+
+The pipeline landed (PR #264). **Nothing further is a code ticket**; four steps
+need libretro org access:
+
+1. Obtain a Crowdin access token for this repo (Crowdin project managers, or the
+   `retroarch-translations` Discord channel).
+2. Add it as the Actions secret **`CROWDIN_API_KEY`**.
+3. Run **Crowdin Translations Initial Setup** manually, once, then delete or
+   disable it — re-running can overwrite newer Crowdin-side translations.
+4. Run **Crowdin Translation Sync** manually once to confirm it can push to
+   `develop`.
+
+Until step 2, both workflows fail fast on the empty-key guard by design.
+
+**Known residual gap** (documented in `docs/core-option-translations.md`): the
+vendored `intl/` scripts call `subprocess.run()` without `check=True`, so a
+token that is present but *rejected*, or a Crowdin outage, still yields a green
+run that changed nothing. Belongs upstream.
+
+**Per-language enablement is manual and expected:** the generator writes only
+`libretro_core_options_intl.h`; each language stays inert until its `NULL` in
+`options_intl[]` is replaced with `&options_xx`. That is upstream behaviour, and
+referencing the symbol before the header defines it would not compile.
+
+---
+
+## 7. #254 — Standalone SDL frontend
+
+Parked feature, no investigation needed. The useful framing for whoever scopes
+it: **`test/harness/` is already most of a frontend** — it implements the
+libretro callbacks headlessly. Phase 1 (CLI: `vjag game.j64 [--fullscreen]
+[--bios real] [--netlink client:HOST]`, SDL window, audio, gamepad) is mostly
+wiring that harness to SDL rather than new emulator work. Evaluate SDL2 vs SDL3
+at implementation time.
+
+---
+
+## 8. #236 — Nightly builds
+
+Informational, auto-updated by CI on every nightly. **No work.** Edits to the
+body are overwritten. Do not open tickets against it.
+
+---
+
+## 9. Open dependabot PRs — #278, #279, #280, #281
+
+Routine CI bumps, but **#278 is not routine**: it bumps
+`ad-m/github-push-action` **0.8.0 → 1.3.0**, a major version, and that action is
+what pushes the regenerated translations in
+`.github/workflows/crowdin_translation_sync.yml`. Check its changelog for
+breaking input changes before merging; the workflow passes `github_token` and
+`branch`. The other three (`setup-python` 4→7, `checkout` 4→7, `setup-java` 4→5)
+are used by the same workflows and are lower risk, but all four touch the
+Crowdin pipeline that has never had a successful live run — so a failure after
+merging will be ambiguous between "bump broke it" and "was never set up".
+Prefer merging these **after** the org-side Crowdin setup has had one green run.
+
+---
+
+## Suggested ticket breakdown
+
+Ordered by value-per-effort, not by issue number.
+
+| # | Ticket | Depends on | Size |
+|---|---|---|---|
+| 1 | Savestate header inspector CLI (#268) | — | XS |
+| 2 | #268 maintainer decision + document | 1 | XS |
+| 3 | #269 warn-and-refuse + known-bad-dump table + corpus message assertion | — | S |
+| 4 | Scripted-input fixture reaching AvP shotgun (#267 unlock) | — | S–M |
+| 5 | #267 re-confirm on nightly; isolate B_CMD if it reproduces | 4 | M |
+| 6 | Overscan column-band digest in A/B sweep tooling (#266) | — | S |
+| 7 | #266: request nightly capture; write-side instrumentation if confirmed | 6 | M |
+| 8 | VLM: trace the post-`$150A` stall (investigation only, no code) | — | M |
+| 9 | VLM: single-session audio-disc support, gated | 8 | L |
+| 10 | `supports_no_game` + CD BIOS standalone boot | 9 | M |
+| 11 | Disk control (audio-CD swap in VLM only) | 10 | M |
+| 12 | Review dependabot #278 major bump | Crowdin green run | XS |
+| 13 | #254 SDL frontend phase 1 | — | L |
+
+Items 1–3 are closeable quickly and clear the tracker. Items 4 and 6 are
+infrastructure that make two stuck visual bugs tractable and stay useful
+afterwards — do them before the bugs they unlock. Items 8–11 are the VLM chain
+and are strictly sequential. Item 13 is independent of everything else.
+
+### What NOT to do
+
+- Do not close #266 or #267 on headless evidence alone. Both are visual bugs in
+  a code path where the harness is known not to see what RetroArch shows.
+- Do not implement disk control before the VLM chain — there is nothing for it
+  to control, and it would be actively harmful on game discs.
+- Do not touch `cdintf.c` session logic without running the 22-row boot matrix.
+- Do not edit vendored `intl/` scripts for style; they are a clean upstream copy
+  and the two existing divergences are documented deliberately.

--- a/docs/tasks/00-handoff-dependabot-stale.md
+++ b/docs/tasks/00-handoff-dependabot-stale.md
@@ -1,0 +1,135 @@
+# T0 — Correct handoff §9 (dependabot bumps are merged)
+
+## Environment (do this first, exactly)
+
+```bash
+cd /Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+git fetch libretro
+# PR #282 is already open on this branch — do NOT create a new branch.
+git checkout docs/open-issue-handoff
+git merge --ff-only libretro/develop || true
+[ -e test/roms/private ] || ln -sfn "${JAGUAR_ROMS_PRIVATE:?set me}" test/roms/private
+```
+
+## Hard rules (violating any of these fails the task)
+
+- NEVER run `git clean -xfd` or any recursive delete at repo root.
+- C89 only: all declarations at top of block, no `for (int i…)`, no
+  designated initializers. Run `bash scripts/c89-lint.sh <file>` before commit.
+- Branch from `libretro/develop`. Never `master`. Never stack on another task.
+- Never relax a test threshold to make something pass.
+- Touch ONLY the files in "Files you may touch". If the fix seems to need
+  another file, STOP and report.
+
+## Goal (one sentence)
+
+Update `docs/open-issue-handoff.md` so §9 records that dependabot PRs
+#278–#281 already merged, move the untested `ad-m/github-push-action`
+major-bump risk into §6 (#252), and drop table row 12 ("Review dependabot
+#278").
+
+## Files you may touch (explicit allowlist)
+
+- `docs/open-issue-handoff.md`
+
+## Steps (numbered, copy-pasteable commands)
+
+1. Confirm you are on the PR #282 branch:
+
+   ```bash
+   git branch --show-current   # must print: docs/open-issue-handoff
+   gh pr view 282 --json number,headRefName,state
+   ```
+
+2. Confirm the bumps are merged on `libretro/develop` (do not re-merge them):
+
+   ```bash
+   git log --oneline libretro/develop | head -20
+   # Expect commits mentioning ad-m/github-push-action, setup-python,
+   # checkout, setup-java (hashes around 6249339 / c4edff9 / 791d292 / f1e84d8).
+   ```
+
+3. Edit `docs/open-issue-handoff.md`:
+
+   **§6 (#252)** — after the per-language enablement paragraph, add a
+   **Risk note** that:
+   - states PRs #278–#281 all merged before any live Crowdin run;
+   - names #278 as the non-routine bump (`ad-m/github-push-action` 0.8.0 → 1.3.0);
+   - notes the other three (`setup-python` 4→7, `checkout` 4→7, `setup-java` 4→5);
+   - says a sync failure is ambiguous until §6 step 4 has one green run.
+
+   **§9** — replace the entire "Open dependabot PRs — #278, #279, #280, #281"
+   section with a short **merged (history)** section that records the four
+   merges and points the risk note at §6. No open-work language.
+
+   **Suggested ticket breakdown table** — delete the row
+   `| 12 | Review dependabot #278 major bump | Crowdin green run | XS |`
+   and renumber `#254 SDL frontend` to row 12. Update the prose under the
+   table ("Item 13" → "Item 12"). Optionally note that cheap-model task
+   files for items 1–4 and 6 live under `docs/tasks/`.
+
+4. Do not invent new tickets. Do not close any GitHub issues.
+
+## Acceptance gate (literal command + expected exit code / expected output)
+
+```bash
+# Gate A: #279/#280/#281 appear only in the merged-history / risk-note lines,
+# never as "open dependabot PRs" work.
+rg -n '#279|#280|#281' docs/open-issue-handoff.md
+```
+
+Expected: matches only inside the §6 risk note and/or the §9 merged-history
+paragraph. Zero matches that say the PRs are still open.
+
+```bash
+# Gate B: table row 12 must NOT be the dependabot review ticket.
+rg -n 'Review dependabot #278' docs/open-issue-handoff.md; echo exit:$?
+```
+
+Expected: no matches, exit 1 from `rg` (not found).
+
+```bash
+# Gate C: section 9 title reflects merged state.
+rg -n '^## 9\.' docs/open-issue-handoff.md
+```
+
+Expected: a title containing `merged` or `history`, not `Open dependabot PRs`.
+
+## STOP conditions (abort triggers — report, do not improvise)
+
+- You are not on `docs/open-issue-handoff` / PR #282 cannot be found.
+- `docs/open-issue-handoff.md` already has the §9 merged-history rewrite and
+  Gates A–C pass — then make no further edits; report "already done".
+- Any change would require editing a file outside the allowlist.
+
+## Deliverable (exact commit message, PR title, PR body, issue comment text)
+
+**Commit message:**
+
+```
+docs: mark dependabot #278-#281 merged; move push-action risk to #252
+```
+
+**PR:** this lands on existing PR #282 (`docs: verification and ticket plan
+for every open issue`). Push to the same branch:
+
+```bash
+git add docs/open-issue-handoff.md
+git commit -m "$(cat <<'EOF'
+docs: mark dependabot #278-#281 merged; move push-action risk to #252
+
+EOF
+)"
+git push libretro HEAD:docs/open-issue-handoff
+```
+
+**PR comment** (post on #282):
+
+```
+Updated §9: #278–#281 are merged history, not open work. Untested
+ad-m/github-push-action major bump is now a risk note under §6 (#252).
+Dropped table row "Review dependabot #278".
+```
+
+**Do not close any issue.**

--- a/docs/tasks/01-vjss-info.md
+++ b/docs/tasks/01-vjss-info.md
@@ -1,0 +1,268 @@
+# T1 — Savestate header inspector (`vjss_info`)
+
+## Environment (do this first, exactly)
+
+```bash
+cd /Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+git fetch libretro
+git checkout -b tools/vjss-info libretro/develop
+[ -e test/roms/private ] || ln -sfn "${JAGUAR_ROMS_PRIVATE:?set me}" test/roms/private
+```
+
+## Hard rules (violating any of these fails the task)
+
+- NEVER run `git clean -xfd` or any recursive delete at repo root.
+- C89 only: all declarations at top of block, no `for (int i…)`, no
+  designated initializers. Run `bash scripts/c89-lint.sh <file>` before commit.
+- Branch from `libretro/develop`. Never `master`. Never stack on another task.
+- Never relax a test threshold to make something pass.
+- Touch ONLY the files in "Files you may touch". If the fix seems to need
+  another file, STOP and report.
+
+## Goal (one sentence)
+
+Add `test/tools/vjss_info.c` that reads the first 16 bytes of a Virtual Jaguar
+savestate, prints magic/version/flags/reserved, detects host byte order, and
+prints a loadability verdict against `STATE_VERSION` / `STATE_MIN_VERSION`.
+
+## Files you may touch (explicit allowlist)
+
+- `test/tools/vjss_info.c`  (**create**)
+- `test/tools/README-vjss-info.md`  (**create**, optional one-screen usage note)
+
+Do **not** edit `src/core/state.h`, `libretro.c`, or any shipped core code.
+
+## Critical fact (read before writing a single line)
+
+`STATE_SAVE_VAR` in `src/core/state.h` is a plain `memcpy` of a host
+`uint32_t`. Headers are **host-endian**, not big-endian and not a literal
+ASCII `"VJSS"` string on disk.
+
+On a little-endian host the on-disk magic `0x564A5353` ("VJSS" as a
+big-endian fourcc value stored as a native `uint32_t`) appears as bytes:
+
+```
+53 53 4A 56
+```
+
+A naive `memcmp(buf, "VJSS", 4)` reports every valid little-endian state as
+corrupt. Your tool MUST:
+
+1. Read 16 bytes (magic, version, flags, reserved — four `uint32_t`s).
+2. Interpret them as little-endian AND as big-endian.
+3. Report which interpretation yields `magic == 0x564A5353`.
+4. Use that endianness for version/flags/reserved.
+5. Print a verdict:
+   - `loadable` if `STATE_MIN_VERSION (2) <= version <= STATE_VERSION (7)`
+   - `too_old` if `version < 2`
+   - `too_new` if `version > 7`
+   - `bad_magic` if neither endianness matches
+
+Constants (do not hardcode differently):
+
+```c
+/* from src/core/state.h — copy the numeric values, do not #include state.h
+ * into a standalone tool unless you also pull its dependencies cleanly.
+ * Prefer duplicating the three numbers with a comment citing state.h. */
+#define VJSS_MAGIC        0x564A5353u  /* "VJSS" */
+#define VJSS_VERSION      7u
+#define VJSS_MIN_VERSION  2u
+```
+
+## Steps (numbered, copy-pasteable commands)
+
+1. Create `test/tools/vjss_info.c` as a standalone C89 program (no libretro
+   link required). CLI:
+
+   ```
+   vjss_info <statefile>
+   ```
+
+   Required stdout (one line or a short block — keep it machine-grepable):
+
+   ```
+   magic=0x564A5353 endian=le version=7 flags=0x00000000 reserved=0x00000000 verdict=loadable
+   ```
+
+   Use `endian=le` or `endian=be`. Exit codes:
+   - `0` — file opened and magic matched (any verdict including too_old/too_new)
+   - `1` — I/O error or bad_magic
+   - `2` — usage error
+
+2. Build the tool:
+
+   ```bash
+   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+     cc -O2 -Wall -std=c89 -o test/tools/vjss_info test/tools/vjss_info.c
+   ```
+
+3. Build a known-good current-version state for the gate. Prefer a tiny
+   throwaway dump (do **not** commit the dump helper or the `.state` file):
+
+   ```bash
+   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+     make -j"$(getconf _NPROCESSORS_ONLN)" TEST_EXPORTS=1
+
+   # Dump first 16+ bytes via a one-shot Python helper (not committed):
+   python3 <<'PY'
+   import ctypes, sys
+   core = ctypes.CDLL("./virtualjaguar_libretro.dylib")
+   # Minimal libretro dance is painful in Python; instead use test_state_compat
+   # which already serializes — OR write /tmp/vjss_dump.c as below.
+   print("use /tmp/vjss_dump.c recipe in step 3b", file=sys.stderr)
+   sys.exit(0)
+   PY
+   ```
+
+   **Step 3b (recommended dump recipe)** — write `/tmp/vjss_dump.c` (NOT in
+   the repo), build it against the harness, dump a state from `test/roms/yarc.j64`:
+
+   ```bash
+   cat > /tmp/vjss_dump.c <<'EOF'
+   #include <stdio.h>
+   #include <stdlib.h>
+   #include <stdint.h>
+   #include <string.h>
+   #include "test/harness/harness.h"
+   int main(int argc, char **argv) {
+       harness_config cfg = HARNESS_CONFIG_DEFAULT;
+       size_t (*ser_size)(void);
+       bool (*ser)(void *, size_t);
+       void *buf;
+       size_t n;
+       FILE *f;
+       cfg.frames = 30;
+       if (!harness_init_from_args(&cfg, argc, argv)) return 1;
+       if (!harness_load_rom(&cfg)) return 1;
+       harness_run(&cfg);
+       ser_size = (size_t (*)(void))harness_dlsym(&cfg, "retro_serialize_size");
+       ser = (bool (*)(void *, size_t))harness_dlsym(&cfg, "retro_serialize");
+       if (!ser_size || !ser) { fprintf(stderr, "missing serialize\n"); return 1; }
+       n = ser_size();
+       buf = malloc(n);
+       if (!buf || !ser(buf, n)) return 1;
+       f = fopen("/tmp/vjss_yarc.state", "wb");
+       if (!f) return 1;
+       fwrite(buf, 1, n, f);
+       fclose(f);
+       printf("wrote /tmp/vjss_yarc.state bytes=%zu\n", n);
+       harness_shutdown(&cfg);
+       free(buf);
+       return 0;
+   }
+   EOF
+
+   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+     cc -O2 -Wall -std=c99 \
+       -I. -I./libretro-common/include \
+       -o /tmp/vjss_dump /tmp/vjss_dump.c test/harness/harness.c -ldl -lm
+
+   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
+     /tmp/vjss_dump ./virtualjaguar_libretro.dylib test/roms/yarc.j64 --frames 30 --quiet
+   ```
+
+4. Run the inspector on that state:
+
+   ```bash
+   ./test/tools/vjss_info /tmp/vjss_yarc.state
+   ```
+
+5. Lint:
+
+   ```bash
+   bash scripts/c89-lint.sh test/tools/vjss_info.c
+   ```
+
+## Acceptance gate (literal command + expected exit code / expected output)
+
+```bash
+bash scripts/c89-lint.sh test/tools/vjss_info.c
+# exit 0
+
+./test/tools/vjss_info /tmp/vjss_yarc.state
+# stdout MUST contain: version=7
+# stdout MUST contain: verdict=loadable
+# stdout MUST contain: endian=le   (on Apple Silicon / Intel Mac)
+# exit 0
+
+# Negative check: truncating magic must fail
+dd if=/tmp/vjss_yarc.state of=/tmp/vjss_bad.state bs=16 count=1 2>/dev/null
+printf '\x00\x00\x00\x00' | dd of=/tmp/vjss_bad.state bs=1 seek=0 conv=notrunc 2>/dev/null
+./test/tools/vjss_info /tmp/vjss_bad.state; echo exit:$?
+# stdout MUST contain: verdict=bad_magic
+# exit MUST be 1
+```
+
+## STOP conditions (abort triggers — report, do not improvise)
+
+- You believe the header is big-endian on disk "because Jaguar is big-endian"
+  — wrong; STOP and re-read the Critical fact above.
+- Building `/tmp/vjss_dump` fails because of missing symbols — rebuild with
+  `make TEST_EXPORTS=1`. If still failing after `make clean && make TEST_EXPORTS=1`,
+  STOP and report.
+- You are tempted to change `STATE_MIN_VERSION` or add a legacy loader — that
+  is T2 / a maintainer decision, not this task.
+- `test/roms/yarc.j64` is missing — STOP and report; do not download ROMs
+  from the internet into the tree.
+
+## Deliverable (exact commit message, PR title, PR body, issue comment text)
+
+**Commit message:**
+
+```
+test(tools): add vjss_info savestate header inspector
+```
+
+**PR title:**
+
+```
+test(tools): add vjss_info savestate header inspector
+```
+
+**PR body template:**
+
+```markdown
+## Summary
+- Standalone CLI that prints VJSS magic/version/flags and a loadability verdict.
+- Handles host-endian `STATE_SAVE_VAR` layout (tries LE and BE).
+
+Closes nothing. Supports triage for #268.
+
+## Acceptance gate transcript
+$ bash scripts/c89-lint.sh test/tools/vjss_info.c
+<paste>
+$ ./test/tools/vjss_info /tmp/vjss_yarc.state
+<paste>
+```
+
+**Push + PR:**
+
+```bash
+git add test/tools/vjss_info.c
+git status   # only allowlisted files
+git commit -m "$(cat <<'EOF'
+test(tools): add vjss_info savestate header inspector
+
+EOF
+)"
+git push -u libretro HEAD
+gh pr create --base develop --title "test(tools): add vjss_info savestate header inspector" --body-file - <<'EOF'
+## Summary
+- Standalone CLI that prints VJSS magic/version/flags and a loadability verdict.
+- Handles host-endian `STATE_SAVE_VAR` layout (tries LE and BE).
+
+Supports triage for #268.
+
+## Acceptance gate transcript
+(paste here)
+EOF
+```
+
+**Issue comment on #268** (after PR exists):
+
+```
+Added a header inspector in PR <N>: `./test/tools/vjss_info your.state`
+Please paste its one-line output for the two rejected files so we can see
+the on-disk version field. Do not close this issue from that PR.
+```

--- a/docs/tasks/02-savestate-decision.md
+++ b/docs/tasks/02-savestate-decision.md
@@ -1,0 +1,187 @@
+# T2 — #268 maintainer decision + docs (does NOT close the issue)
+
+## Environment (do this first, exactly)
+
+```bash
+cd /Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+git fetch libretro
+git checkout -b docs/savestate-min-version libretro/develop
+[ -e test/roms/private ] || ln -sfn "${JAGUAR_ROMS_PRIVATE:?set me}" test/roms/private
+```
+
+## Hard rules (violating any of these fails the task)
+
+- NEVER run `git clean -xfd` or any recursive delete at repo root.
+- C89 only: all declarations at top of block, no `for (int i…)`, no
+  designated initializers. Run `bash scripts/c89-lint.sh <file>` before commit.
+- Branch from `libretro/develop`. Never `master`. Never stack on another task.
+- Never relax a test threshold to make something pass.
+- Touch ONLY the files in "Files you may touch". If the fix seems to need
+  another file, STOP and report.
+
+## Goal (one sentence)
+
+Record a deliberate decision that states below `STATE_MIN_VERSION` (2) are
+rejected by design, document how to inspect a file with `vjss_info`, and post
+that decision on GitHub issue #268 — **without closing the issue**.
+
+## Depends on
+
+T1 (`vjss_info`) must already be merged to `libretro/develop`, OR your branch
+must contain `test/tools/vjss_info.c` (cherry-pick / merge T1 first).
+
+```bash
+test -f test/tools/vjss_info.c || {
+  echo "STOP: T1 not present — merge/cherry-pick tools/vjss-info first"
+  exit 1
+}
+```
+
+## Files you may touch (explicit allowlist)
+
+- `docs/savestate-compat.md`  (**create**)
+- Optionally one cross-link line in `docs/open-issue-handoff.md` §3 pointing
+  at `docs/savestate-compat.md` (only if that file exists on your branch)
+
+Do **not** change `STATE_MIN_VERSION`, `STATE_VERSION`, or any loader code.
+
+## Decision to document (do not invent a different policy)
+
+**Recommended / required for this task:** leave gating as-is.
+
+- Current core writes `STATE_VERSION = 7`.
+- Current core loads only `2 <= version <= 7`.
+- Rejection of older states is **expected behaviour**, not an AvP-specific bug.
+- A Battle Sphere Gold state loading on the same build already proved the
+  loader works; the reporter's files were never measured (do not claim they
+  are "v1").
+- A best-effort legacy loader below `STATE_MIN_VERSION` is explicitly **out of
+  scope** for this task.
+
+## Steps (numbered, copy-pasteable commands)
+
+1. Create `docs/savestate-compat.md` with at least:
+
+   - Title + date
+   - Table of `STATE_VERSION` / `STATE_MIN_VERSION` values (cite
+     `src/core/state.h`)
+   - The deliberate decision paragraph above
+   - How to inspect a file:
+
+     ```bash
+     ./test/tools/vjss_info path/to/file.state
+     ```
+
+   - Note that RetroArch `.state` files are raw `retro_serialize()` payloads
+     for this core (no extra wrapper), so `vjss_info` can read them directly
+     on the first 16 bytes
+   - Link to issue #268 as the tracker for user-facing reports
+
+2. Build `vjss_info` if the binary is missing:
+
+   ```bash
+   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+     cc -O2 -Wall -std=c89 -o test/tools/vjss_info test/tools/vjss_info.c
+   ```
+
+3. Post the issue comment (see Deliverable). **Do not** run
+   `gh issue close 268`.
+
+## Acceptance gate (literal command + expected exit code / expected output)
+
+```bash
+test -f docs/savestate-compat.md && echo OK_FILE
+rg -n 'STATE_MIN_VERSION|vjss_info|deliberate|expected behaviour|expected behavior' docs/savestate-compat.md
+# Must hit deliberate/expected + vjss_info + STATE_MIN_VERSION
+
+# Must NOT have closed the issue
+gh issue view 268 --json state -q .state
+# Expected: OPEN
+```
+
+## STOP conditions (abort triggers — report, do not improvise)
+
+- T1 / `test/tools/vjss_info.c` is absent — STOP.
+- You are about to lower `STATE_MIN_VERSION` or write a legacy loader — STOP.
+- You are about to close #268 — STOP. Maintainer closes after reading the
+  comment and any reporter follow-up.
+- Reporter's two files appear in the tree — do not commit them; run
+  `vjss_info` locally and paste output into the issue comment only.
+
+## Deliverable (exact commit message, PR title, PR body, issue comment text)
+
+**Commit message:**
+
+```
+docs: record savestate STATE_MIN_VERSION policy for #268
+```
+
+**PR title:**
+
+```
+docs: record savestate STATE_MIN_VERSION policy for #268
+```
+
+**PR body template:**
+
+```markdown
+## Summary
+- Documents that rejecting states below STATE_MIN_VERSION (2) is deliberate.
+- Points reporters at `vjss_info` for header triage.
+- Does **not** close #268.
+
+## Acceptance gate transcript
+$ gh issue view 268 --json state -q .state
+OPEN
+$ rg -n 'STATE_MIN_VERSION|vjss_info' docs/savestate-compat.md
+<paste>
+```
+
+**Push + PR:**
+
+```bash
+git add docs/savestate-compat.md
+git commit -m "$(cat <<'EOF'
+docs: record savestate STATE_MIN_VERSION policy for #268
+
+EOF
+)"
+git push -u libretro HEAD
+gh pr create --base develop --title "docs: record savestate STATE_MIN_VERSION policy for #268" --body-file - <<'EOF'
+## Summary
+- Documents that rejecting states below STATE_MIN_VERSION (2) is deliberate.
+- Points reporters at `vjss_info` for header triage.
+- Does **not** close #268.
+
+## Acceptance gate transcript
+(paste here)
+EOF
+```
+
+**Issue comment on #268** (required; copy-paste):
+
+```markdown
+## Decision (documented in docs/savestate-compat.md, PR <N>)
+
+This is savestate **version gating working as designed**, not an AvP-specific
+loader bug.
+
+- Current cores write `STATE_VERSION = 7` and load only
+  `STATE_MIN_VERSION (2) … STATE_VERSION (7)`.
+- Older Virtual Jaguar states below that window are refused by
+  `retro_unserialize()` (returns false).
+- We are **not** adding a best-effort legacy loader in this pass.
+
+### Please run this on the two rejected files
+
+```bash
+./test/tools/vjss_info /path/to/file.state
+```
+
+Paste the one-line output (magic/version/verdict) for each file. That turns
+"what version is this" into a measurable fact.
+
+Leaving the issue **open** until that output lands (or a maintainer
+explicitly closes as expected behaviour).
+```

--- a/docs/tasks/03-cdi-bad-dump-diag.md
+++ b/docs/tasks/03-cdi-bad-dump-diag.md
@@ -1,0 +1,216 @@
+# T3 — #269 CDI bad-dump diagnostics (warn-and-refuse, no behaviour change)
+
+## Environment (do this first, exactly)
+
+```bash
+cd /Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+git fetch libretro
+git checkout -b fix/cdi-bad-dump-diag libretro/develop
+[ -e test/roms/private ] || ln -sfn "${JAGUAR_ROMS_PRIVATE:?set me}" test/roms/private
+```
+
+## Hard rules (violating any of these fails the task)
+
+- NEVER run `git clean -xfd` or any recursive delete at repo root.
+- C89 only: all declarations at top of block, no `for (int i…)`, no
+  designated initializers. Run `bash scripts/c89-lint.sh <file>` before commit.
+- Branch from `libretro/develop`. Never `master`. Never stack on another task.
+- Never relax a test threshold to make something pass.
+- Touch ONLY the files in "Files you may touch". If the fix seems to need
+  another file, STOP and report.
+
+## Goal (one sentence)
+
+When `CDIntfExtractBootStub` rejects a disc for magic mismatch, log **why**
+(zero-filled header vs partial N/32 match vs other), document the four known
+bad CDI V2 dumps, and keep refuse-as-refuse — **do not** tolerate truncated
+magic to force a boot.
+
+## Files you may touch (explicit allowlist)
+
+- `src/cd/cdintf.c`  (only the magic-mismatch diagnostics path around the
+  `memcmp(swapped + 0x42, MAGIC, sizeof(MAGIC))` check — today ~line 1441)
+- `docs/cd-known-issues.md`  (add a "Known bad CDI dumps" section)
+
+Do **not** edit `src/cd/cdrom.c`, HLE boot stub injection in `jaguar.c`,
+session-count gates, or `intl/`.
+
+## What is established (do not re-investigate)
+
+Of 14 local CDI images, 4 fail load — all CDI V2:
+
+| Image (local names) | Defect |
+|---|---|
+| ironsoldier2, mystdemo, vidgrid | boot-header region **zero-filled in the file** |
+| worldtourracing | **partial 22/32** boot magic |
+
+The CDI walk/offset math is correct. Missing data cannot be invented.
+
+**Product decision for this task (already chosen):** warn and refuse, with an
+actionable message. Do **not** implement truncated-magic acceptance.
+
+## Steps (numbered, copy-pasteable commands)
+
+1. Locate the magic check:
+
+   ```bash
+   rg -n 'Magic mismatch at \+0x42' src/cd/cdintf.c
+   ```
+
+2. Replace the single generic `LOG_ERR` on mismatch with C89-legal code that:
+
+   a. Counts how many of the 32 magic bytes at `swapped + 0x42` match
+      `MAGIC[i]`.
+   b. Detects all-zero: every byte in that 32-byte window is `0x00`.
+   c. Logs exactly one of:
+
+      - **All zero:**
+        `[CD-BOOTSTUB] Boot header region is zero-filled at +0x42 — this image is an incomplete / bad rip, not an unsupported format`
+      - **Partial (1..31 matches):**
+        `[CD-BOOTSTUB] Magic mismatch at +0x42 of session-2 track BIN (matched N/32 bytes)`
+        where `N` is the match count (worldtourracing should show `22/32`).
+      - **Zero matches but not all-zero:**
+        keep a clear generic mismatch line (may reuse the old text plus
+        `(matched 0/32 bytes)`).
+
+   d. Still `return false;` in every branch. **No boot on mismatch.**
+
+   Declarations stay at the top of the enclosing block (C89).
+
+3. Add a section to `docs/cd-known-issues.md` titled **Known bad CDI dumps**
+   listing the four titles above, stating warn-and-refuse is intentional, and
+   pointing at the new log lines. Do not claim a core "fix" for missing data.
+
+4. Lint + build:
+
+   ```bash
+   bash scripts/c89-lint.sh src/cd/cdintf.c
+   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+     make -j"$(getconf _NPROCESSORS_ONLN)" TEST_EXPORTS=1
+   ```
+
+5. Run the CDI corpus sweep (private ROM tree required):
+
+   ```bash
+   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+     make test/test_cd_hle_boot
+   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
+     VJ_TEST_CD_EXTS=cdi ./test/test_cd_hle_boot 2>&1 | tee /tmp/cdi_hle_boot.log
+   ```
+
+6. Confirm messages (adjust filenames if your corpus uses different basename
+   spellings — match on the log text, not a hardcoded path):
+
+   ```bash
+   rg -n 'zero-filled|matched 22/32|incomplete / bad rip' /tmp/cdi_hle_boot.log
+   ```
+
+7. Regression gate — boot matrix must stay all `GAME_CODE` (do not skip):
+
+   ```bash
+   # Use the project's usual invocation; keep the run bounded if the script
+   # supports CD_MATRIX_* knobs. Resume is OK if OUT already has same-build rows.
+   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
+     bash test/tools/cd_boot_matrix.sh
+   ```
+
+   If a full matrix is too long for the session, run at least one known-good
+   CUE title through `test/test_cd_hle_boot` without `VJ_TEST_CD_EXTS=cdi` and
+   state clearly in the PR that the matrix must be finished before merge —
+   but prefer finishing the matrix.
+
+## Acceptance gate (literal command + expected exit code / expected output)
+
+```bash
+bash scripts/c89-lint.sh src/cd/cdintf.c
+# exit 0
+
+# After VJ_TEST_CD_EXTS=cdi ./test/test_cd_hle_boot:
+rg -c 'zero-filled' /tmp/cdi_hle_boot.log
+# Expected: >= 3  (ironsoldier2, mystdemo, vidgrid)
+
+rg -n 'matched 22/32' /tmp/cdi_hle_boot.log
+# Expected: at least one hit (worldtourracing)
+
+# Behaviour unchanged: those four still fail to become GAME_CODE / still
+# fail load. Count successful CDI loads must remain 10 of 14 (or whatever
+# the pre-change baseline was — do not increase by "fixing" dumps).
+```
+
+## STOP conditions (abort triggers — report, do not improvise)
+
+- You are about to accept a 22/32 magic match and boot worldtourracing — STOP.
+  That is the rejected alternative in the handoff doc (false-positive risk).
+- `test/roms/private` is missing or has fewer than 14 `.cdi` files — STOP and
+  report; do not download dumps.
+- Magic check site has moved and you cannot find `memcmp(swapped + 0x42` —
+  STOP and report the new locus; do not rewrite the whole extractor.
+- Boot matrix loses any `GAME_CODE` row — revert and STOP.
+- Stale iOS objects break the macOS link — `make clean` once, then rebuild.
+  If still broken, STOP.
+
+## Deliverable (exact commit message, PR title, PR body, issue comment text)
+
+**Commit message:**
+
+```
+fix(cd): diagnose zero-filled / partial CDI boot headers (#269)
+```
+
+**PR title:**
+
+```
+fix(cd): diagnose zero-filled / partial CDI boot headers (#269)
+```
+
+**PR body template:**
+
+```markdown
+## Summary
+- Distinguish zero-filled vs partial ATARI magic mismatches in CDIntfExtractBootStub.
+- Document known-bad CDI V2 dumps.
+- Refuse stays refuse — no truncated-magic boot path.
+
+Addresses #269 (does not claim the bad dumps become playable).
+
+## Acceptance gate transcript
+$ bash scripts/c89-lint.sh src/cd/cdintf.c
+<paste>
+$ rg -n 'zero-filled|matched 22/32' /tmp/cdi_hle_boot.log
+<paste>
+```
+
+**Push + PR:**
+
+```bash
+git add src/cd/cdintf.c docs/cd-known-issues.md
+git commit -m "$(cat <<'EOF'
+fix(cd): diagnose zero-filled / partial CDI boot headers (#269)
+
+EOF
+)"
+git push -u libretro HEAD
+gh pr create --base develop --title "fix(cd): diagnose zero-filled / partial CDI boot headers (#269)" --body-file - <<'EOF'
+## Summary
+- Distinguish zero-filled vs partial ATARI magic mismatches in CDIntfExtractBootStub.
+- Document known-bad CDI V2 dumps.
+- Refuse stays refuse.
+
+Addresses #269.
+
+## Acceptance gate transcript
+(paste here)
+EOF
+```
+
+**Issue comment on #269:**
+
+```markdown
+PR <N> implements warn-and-refuse diagnostics:
+- zero-filled +0x42 → explicit bad-rip message
+- partial match → `matched N/32 bytes` (worldtourracing = 22/32)
+- known-bad table in docs/cd-known-issues.md
+
+No truncated-magic acceptance (false-positive risk). Bad dumps remain unloadable.
+```

--- a/docs/tasks/04-overscan-band-digest.md
+++ b/docs/tasks/04-overscan-band-digest.md
@@ -1,0 +1,253 @@
+# T4 — Overscan column-band digest (`VJFBDIG3`) for #266 tooling
+
+## Environment (do this first, exactly)
+
+```bash
+cd /Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+git fetch libretro
+git checkout -b tools/overscan-band-digest libretro/develop
+[ -e test/roms/private ] || ln -sfn "${JAGUAR_ROMS_PRIVATE:?set me}" test/roms/private
+```
+
+## Hard rules (violating any of these fails the task)
+
+- NEVER run `git clean -xfd` or any recursive delete at repo root.
+- C89 only: all declarations at top of block, no `for (int i…)`, no
+  designated initializers. Run `bash scripts/c89-lint.sh <file>` before commit.
+- Branch from `libretro/develop`. Never `master`. Never stack on another task.
+- Never relax a test threshold to make something pass.
+- Touch ONLY the files in "Files you may touch". If the fix seems to need
+  another file, STOP and report.
+
+## Goal (one sentence)
+
+Extend `fb_row_digest` / `fb_row_diff.py` so each frame also records a digest
+of columns `320 .. width-1` (the overscan/border strip), bumping the file
+magic from `VJFBDIG2` to `VJFBDIG3`.
+
+## Files you may touch (explicit allowlist)
+
+- `test/tools/fb_row_digest.c`
+- `test/tools/fb_row_diff.py`
+- `test/tools/fb_ab_sweep.sh`  (only if needed for a one-line comment or
+  magic-related flag; prefer not to change behaviour)
+
+Do **not** edit `src/tom/tom.c`, OP, blitter, or blank columns 320–325 in the
+core. This task is tooling only.
+
+## Critical facts
+
+1. AvP presents wider than 320. `game_width` comes from
+   `TOMGetVideoModeWidth()` (up to 652). Columns 320–325 are **inside** the
+   buffer the harness already hashes; they are just folded into the whole-row
+   hash today.
+2. Active area for the band digest is columns `x >= 320`. If `width <= 320`,
+   band width is 0 and band fields are zeros / sentinel.
+3. `fb_ab_sweep.sh` uses `find "$ROMS_ROOT"` **without** `-L`. Passing the
+   `test/roms/private` **symlink** finds nothing. Always pass the resolved
+   path, e.g. `"$(cd test/roms/private && pwd -P)"` or
+   `$JAGUAR_ROMS_PRIVATE`.
+
+## Format change (implement exactly)
+
+Bump magic: `VJFBDIG2` → `VJFBDIG3`.
+
+Per-frame record today (`VJFBDIG2`):
+
+```
+uint32 width, height, frame_hash, written_extent
+uint32 row_hash[height]
+```
+
+Per-frame record for `VJFBDIG3` (append after `row_hash[height]`):
+
+```
+uint32 band_x0          /* always 320, or 0 if width <= 320 */
+uint32 band_width       /* max(0, width - 320) */
+uint32 band_hash        /* FNV-1a over all pixels in columns [band_x0, width) for every row; 0 if band_width==0 */
+uint32 band_nonblack    /* count of pixels in the band with RGB != 0; 0 if band_width==0 */
+uint32 band_first_x     /* first non-black x in band, or 0xFFFFFFFF if none */
+uint32 band_first_y     /* first non-black y in band, or 0xFFFFFFFF if none */
+```
+
+Use the same little-endian `put_u32` path as existing fields. Reuse the
+existing FNV-1a helper.
+
+`fb_row_diff.py` must:
+
+- Accept `VJFBDIG3` (and may reject `VJFBDIG2` with a clear error, **or**
+  accept both — pick one and document it in a comment at the magic constant).
+- Prefer: require matching magic on both inputs; if either is v2, exit 2 with
+  `need VJFBDIG3`.
+- When comparing v3 files, if geometry/audio/row rules pass, also report
+  `band_changed_frames=N` and fail (exit 1) if the patched band_hash differs
+  on any frame **unless** you add an explicit `--ignore-band` flag defaulting
+  to off. For this task, **failing on band_hash mismatch is correct** when
+  the rest of the A/B rules would have passed — but if that breaks the
+  existing brown-bar allow rule unexpectedly, STOP and report rather than
+  inventing a new allow rule.
+
+Minimal acceptable `fb_row_diff.py` behaviour for merge:
+
+- Parse v3.
+- Print per-run summary including max `band_nonblack` and whether any frame
+  had `band_nonblack > 0`.
+- Keep the existing brown-bar classification for row hashes.
+
+## Steps (numbered, copy-pasteable commands)
+
+1. Read `test/tools/fb_row_digest.c` and `test/tools/fb_row_diff.py` end to end.
+
+2. Implement the v3 fields in `on_video()` in `fb_row_digest.c`. Keep C89
+   style consistent with the file (the file already uses C99-ish build flags
+   in its header comment — match the file's existing declaration style; still
+   run `c89-lint` and fix what it flags if the script covers this path).
+
+   Note: `scripts/c89-lint.sh` may skip or flag this file — if the lint script
+   skips it, still avoid mid-block declarations in new code you add.
+
+3. Update `fb_row_diff.py` magic + parser.
+
+4. Rebuild tools + core:
+
+   ```bash
+   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+     make -j"$(getconf _NPROCESSORS_ONLN)" TEST_EXPORTS=1
+
+   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+     cc -O2 -Wall -std=c99 \
+       -I. -I./libretro-common/include \
+       -o test/tools/fb_row_digest test/tools/fb_row_digest.c \
+       test/harness/harness.c -ldl -lm
+   ```
+
+5. Gate run — AvP (wide) vs yarc (typically 320):
+
+   ```bash
+   AVP='test/roms/private/ROMS/Alien vs Predator (1994).jag'
+   test -f "$AVP" || AVP="$(find -L test/roms/private -iname 'Alien vs Predator (1994).jag' | head -1)"
+
+   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
+     ./test/tools/fb_row_digest ./virtualjaguar_libretro.dylib "$AVP" \
+       --frames 120 --out /tmp/avp_dig3.bin --quiet
+
+   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
+     ./test/tools/fb_row_digest ./virtualjaguar_libretro.dylib test/roms/yarc.j64 \
+       --frames 120 --out /tmp/yarc_dig3.bin --quiet
+
+   # Inspect with Python one-liner (not committed):
+   python3 <<'PY'
+   import struct, sys
+   def peek(path):
+       b = open(path,'rb').read(16)
+       assert b[:8] == b'VJFBDIG3', b[:8]
+       nv, na = struct.unpack_from('<2I', b, 8)
+       # first frame header after 16-byte file hdr
+       f = open(path,'rb'); f.seek(16)
+       w,h,fh,ext = struct.unpack('<4I', f.read(16))
+       f.read(4*h)  # row hashes
+       band = struct.unpack('<6I', f.read(24))
+       print(path, 'frames', nv, 'w', w, 'band', band)
+   peek('/tmp/avp_dig3.bin')
+   peek('/tmp/yarc_dig3.bin')
+   PY
+   ```
+
+## Acceptance gate (literal command + expected exit code / expected output)
+
+```bash
+# Magic
+dd if=/tmp/avp_dig3.bin bs=8 count=1 2>/dev/null | od -An -tc
+# Must show V J F B D I G 3
+
+python3 <<'PY'
+import struct
+def band(path):
+    f=open(path,'rb'); assert f.read(8)==b'VJFBDIG3'
+    nv,na=struct.unpack('<2I', f.read(8))
+    w,h,fh,ext=struct.unpack('<4I', f.read(16))
+    f.read(4*h)
+    return struct.unpack('<6I', f.read(24)) + (w,)
+bx0,bw,bh,bnb,fx,fy,w = band('/tmp/avp_dig3.bin')
+assert w > 320, w
+assert bx0 == 320 and bw == w-320, (bx0,bw,w)
+print('AVP_OK', w, bw)
+bx0,bw,bh,bnb,fx,fy,w = band('/tmp/yarc_dig3.bin')
+assert bw == 0 or w <= 320, (w,bw)
+print('YARC_OK', w, bw)
+PY
+# exit 0
+
+python3 test/tools/fb_row_diff.py /tmp/yarc_dig3.bin /tmp/yarc_dig3.bin --label yarc
+# exit 0 (identical)
+```
+
+## STOP conditions (abort triggers — report, do not improvise)
+
+- AvP dump shows `width <= 320` for all frames — the overscan strip is not
+  reachable via this path on current develop; STOP and report (do not blank
+  columns in the core to "create" a band).
+- You are about to "fix" #266 by clearing columns 320–325 in TOM/OP — STOP.
+  Tooling only.
+- Tempted to keep writing `VJFBDIG2` with a side-car file — STOP; bump magic.
+- `fb_row_diff.py` changes would require redesigning the brown-bar allow rule
+  — implement parse + report first; if classification conflicts, STOP with
+  notes rather than silently weakening the allow rule.
+
+## Deliverable (exact commit message, PR title, PR body, issue comment text)
+
+**Commit message:**
+
+```
+test(tools): add VJFBDIG3 overscan column-band digest (#266)
+```
+
+**PR title:**
+
+```
+test(tools): add VJFBDIG3 overscan column-band digest (#266)
+```
+
+**PR body template:**
+
+```markdown
+## Summary
+- fb_row_digest emits per-frame digest for columns x>=320 (VJFBDIG3).
+- fb_row_diff.py reads the new record.
+- Tooling only — does not claim #266 fixed.
+
+## Acceptance gate transcript
+$ python3 … (AVP_OK / YARC_OK)
+<paste>
+```
+
+**Push + PR:**
+
+```bash
+git add test/tools/fb_row_digest.c test/tools/fb_row_diff.py
+git commit -m "$(cat <<'EOF'
+test(tools): add VJFBDIG3 overscan column-band digest (#266)
+
+EOF
+)"
+git push -u libretro HEAD
+gh pr create --base develop --title "test(tools): add VJFBDIG3 overscan column-band digest (#266)" --body-file - <<'EOF'
+## Summary
+- fb_row_digest emits per-frame digest for columns x>=320 (VJFBDIG3).
+- fb_row_diff.py reads the new record.
+- Tooling only — does not claim #266 fixed. Do not close #266.
+
+## Acceptance gate transcript
+(paste here)
+EOF
+```
+
+**Issue comment on #266:**
+
+```markdown
+PR <N> adds an overscan column-band digest (VJFBDIG3) so columns x≥320 are
+visible to A/B sweeps. This does **not** close the bug — headless still is
+not RetroArch's compositor (see CLAUDE.md caveat). Next: nightly capture
+with overscan crop disabled, then write-side instrumentation if still present.
+```

--- a/docs/tasks/05-avp-input-fixture.md
+++ b/docs/tasks/05-avp-input-fixture.md
@@ -140,12 +140,13 @@ VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
 Define pass in `run_avp_fixture.sh` (exit 0) iff the `cd_visual_verify`
 timeline shows **all** of:
 
-1. At least one window in the **last 300 frames** with `moving_frames` ≥ 30%
-   of that window (or the tool's equivalent "motion" metric > 0.5% change on
-   ≥18 frames of a 60-frame window).
-2. Peak `nonblack` (or max non-black coverage) in that late window ≥ **5000**
-   pixels (avoids "stuck on black / bios logo only").
-3. Process exit 0 from the verifier wrapper.
+1. Across windows covering the **last 300 frames**,
+   `sum(moving_frames) ≥ 40` (AvP first-person tops out ~12/60 per window
+   under `cd_visual_verify`'s 0.5%-change detector — a per-window 30% bar
+   is unreachable in-game).
+2. Peak `nonblack` in those late windows ≥ **5000** pixels.
+3. Process exit 0 from the verifier wrapper (`run_avp_fixture.sh` encodes
+   this gate).
 
 If `cd_visual_verify` stdout format makes scripting awkward, parse it in the
 wrapper with `awk`/`rg` and exit 1 on failure — do not weaken thresholds.

--- a/docs/tasks/05-avp-input-fixture.md
+++ b/docs/tasks/05-avp-input-fixture.md
@@ -1,0 +1,228 @@
+# T5 — AvP scripted-input fixture (reach sustained in-game motion)
+
+## Environment (do this first, exactly)
+
+```bash
+cd /Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+git fetch libretro
+git checkout -b test/avp-input-fixture libretro/develop
+[ -e test/roms/private ] || ln -sfn "${JAGUAR_ROMS_PRIVATE:?set me}" test/roms/private
+```
+
+## Hard rules (violating any of these fails the task)
+
+- NEVER run `git clean -xfd` or any recursive delete at repo root.
+- C89 only: all declarations at top of block, no `for (int i…)`, no
+  designated initializers. Run `bash scripts/c89-lint.sh <file>` before commit.
+- Branch from `libretro/develop`. Never `master`. Never stack on another task.
+- Never relax a test threshold to make something pass.
+- Touch ONLY the files in "Files you may touch". If the fix seems to need
+  another file, STOP and report.
+
+## Goal (one sentence)
+
+Commit a replayable harness `--press` script that drives Alien vs Predator
+from boot into **sustained in-game motion**, banked for reuse by #266 / #267.
+
+## Scope boundary (read twice)
+
+**In scope:** reach a state with ongoing gameplay motion (player can move;
+framebuffer keeps changing for ≥300 frames).
+
+**Out of scope for this task:** selecting the shotgun, proving the red
+background bug, proving the green overscan bug, closing #266 or #267.
+Weapon-select is a follow-on for a strong model after this fixture exists.
+
+## Files you may touch (explicit allowlist)
+
+- `test/fixtures/avp_reach_gameplay.press`  (**create** — plain text)
+- `test/fixtures/README.md`  (**create** or append — how to invoke)
+- `test/tools/run_avp_fixture.sh`  (**create** — thin wrapper that expands the
+  press file into `cd_visual_verify` / harness args)
+
+Do **not** edit blitter, TOM, OP, or core options defaults.
+
+## Press file format
+
+One event per line, comments with `#`:
+
+```
+# frame:button[:hold]
+700:b:8
+720:option:6
+```
+
+Buttons (from `test/harness/harness.c`):  
+`up down left right a b c pause option 0 1 2 3 4 5 6`
+
+Jaguar mapping reminder: A/B/C = `a`/`b`/`c`, Pause = `pause`, Option = `option`.
+
+Wrapper must turn the file into repeated `--press` flags.
+
+## ROM path
+
+```bash
+AVP='test/roms/private/ROMS/Alien vs Predator (1994).jag'
+test -f "$AVP" || AVP="$(find -L test/roms/private -iname 'Alien vs Predator (1994).jag' | head -1)"
+echo "AVP=$AVP"
+test -f "$AVP" || { echo "STOP: AvP ROM missing"; exit 1; }
+```
+
+Use BIOS off unless you discover menus require BIOS on — if you switch, record
+it in the fixture README as a required `--option`.
+
+## Steps (numbered, copy-pasteable commands)
+
+1. Build core + `cd_visual_verify`:
+
+   ```bash
+   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+     make -j"$(getconf _NPROCESSORS_ONLN)" TEST_EXPORTS=1
+
+   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+     cc -O2 -Wall -std=c99 \
+       -I. -I./libretro-common/include \
+       -o test/tools/cd_visual_verify test/tools/cd_visual_verify.c \
+       test/harness/harness.c -ldl -lm
+   ```
+
+2. Create `test/fixtures/avp_reach_gameplay.press` and
+   `test/tools/run_avp_fixture.sh`.
+
+   Suggested wrapper behaviour:
+
+   ```bash
+   # run_avp_fixture.sh <core> [extra harness args...]
+   # expands fixtures/avp_reach_gameplay.press into --press args
+   # invokes cd_visual_verify with --frames high enough to cover the script
+   # writes shots under /tmp/avp_fixture_$$ 
+   ```
+
+3. Iterate the press script. Strategy that usually works for Jaguar title
+   menus: wait through boot/attract, press `b` or `a` to start, use
+   `option` / d-pad as needed, then hold `up`/`right` periodically in-game.
+
+   Capture smoke evidence:
+
+   ```bash
+   OUT=/tmp/avp_fixture_try1
+   mkdir -p "$OUT"
+   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
+     bash test/tools/run_avp_fixture.sh ./virtualjaguar_libretro.dylib \
+       --outdir "$OUT" --shot-every 300
+   # Read the timeline printed by cd_visual_verify.
+   # Convert a late PPM if useful:
+   #   sips -s format png "$OUT"/frame_*.ppm --out "$OUT"
+   ```
+
+4. You get **three candidate attempts**. After the third failure against the
+   acceptance gate, STOP (see STOP conditions).
+
+5. When the gate passes twice in a row, commit the fixture + wrapper + README.
+
+## Acceptance gate (literal command + expected exit code / expected output)
+
+Mechanical — not "looks like AvP to a human":
+
+```bash
+# Run 1
+VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
+  bash test/tools/run_avp_fixture.sh ./virtualjaguar_libretro.dylib \
+    --outdir /tmp/avp_fix1 --shot-every 0 2>&1 | tee /tmp/avp_fix1.log
+
+# Run 2 (must also pass — reproducibility)
+VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
+  bash test/tools/run_avp_fixture.sh ./virtualjaguar_libretro.dylib \
+    --outdir /tmp/avp_fix2 --shot-every 0 2>&1 | tee /tmp/avp_fix2.log
+```
+
+Define pass in `run_avp_fixture.sh` (exit 0) iff the `cd_visual_verify`
+timeline shows **all** of:
+
+1. At least one window in the **last 300 frames** with `moving_frames` ≥ 30%
+   of that window (or the tool's equivalent "motion" metric > 0.5% change on
+   ≥18 frames of a 60-frame window).
+2. Peak `nonblack` (or max non-black coverage) in that late window ≥ **5000**
+   pixels (avoids "stuck on black / bios logo only").
+3. Process exit 0 from the verifier wrapper.
+
+If `cd_visual_verify` stdout format makes scripting awkward, parse it in the
+wrapper with `awk`/`rg` and exit 1 on failure — do not weaken thresholds.
+
+**Explicit non-goals for the gate:** shotgun on screen, red background absent,
+green pixels absent. Do not close #267.
+
+## STOP conditions (abort triggers — report, do not improvise)
+
+- **Three failed candidate scripts** against the gate — STOP and report the
+  three press files + timelines. Do not invent a fourth without maintainer
+  input.
+- Headless shows motion but you cannot tell if it is the menu attract loop —
+  if nonblack+motion pass, that is enough for this task; do not chase
+  weapon-select.
+- Tempted to commit a save state instead of a press script — STOP unless the
+  press path is impossible; savestates are a different ticket (#268 world).
+- Tempted to declare #267 fixed because fast==accurate on the fixture window —
+  that is a strong-model follow-on; mention it in the PR, do not close #267.
+- AvP ROM missing — STOP.
+
+## Deliverable (exact commit message, PR title, PR body, issue comment text)
+
+**Commit message:**
+
+```
+test(fixtures): AvP scripted input to sustained gameplay (#267 unlock)
+```
+
+**PR title:**
+
+```
+test(fixtures): AvP scripted input to sustained gameplay (#267 unlock)
+```
+
+**PR body template:**
+
+```markdown
+## Summary
+- Adds `test/fixtures/avp_reach_gameplay.press` + runner.
+- Gate: late-window motion + non-black coverage, two consecutive runs.
+- Does **not** reach shotgun / does not close #267.
+
+## Acceptance gate transcript
+$ bash test/tools/run_avp_fixture.sh …
+<paste run1 and run2>
+```
+
+**Push + PR:**
+
+```bash
+git add test/fixtures/avp_reach_gameplay.press test/fixtures/README.md \
+        test/tools/run_avp_fixture.sh
+git commit -m "$(cat <<'EOF'
+test(fixtures): AvP scripted input to sustained gameplay (#267 unlock)
+
+EOF
+)"
+git push -u libretro HEAD
+gh pr create --base develop --title "test(fixtures): AvP scripted input to sustained gameplay (#267 unlock)" --body-file - <<'EOF'
+## Summary
+- Adds AvP press fixture + runner for sustained in-game motion.
+- Unlock for #267 / reusable by #266. Does not close either issue.
+
+## Acceptance gate transcript
+(paste here)
+EOF
+```
+
+**Issue comment on #267:**
+
+```markdown
+PR <N> banks a scripted-input fixture that reaches sustained AvP gameplay
+headlessly (`test/fixtures/avp_reach_gameplay.press`).
+
+Still **not** closing: shotgun / red-background confirmation needs a strong
+model + RetroArch check. Headless ≠ composited output (CLAUDE.md caveat).
+Next: extend the press script to weapon-select, then `test_blitter_compare`
+with `--frame-window` if the bug still reproduces on a nightly.
+```

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,0 +1,81 @@
+# Cheap-model task files
+
+Self-contained prompts for weak models in fresh sessions. Each file inlines
+its own environment block, hard rules, allowlist, steps, acceptance gate,
+STOP conditions, and PR/issue deliverable text. Do not rely on shared
+context across sessions.
+
+Source of truth for the open-issue picture: [`docs/open-issue-handoff.md`](../open-issue-handoff.md).
+Read [`CLAUDE.md`](../../CLAUDE.md) before any code change.
+
+## Execution protocol
+
+1. **One task per session.** One branch per task. One PR per task.
+2. Branch fresh from `libretro/develop` every time — never stack on another
+   task branch. (Exception: T0 lands on the already-open `docs/open-issue-handoff` / PR #282.)
+3. Paste the entire task file into the session. Do not summarise it first.
+4. A PR without a pasted acceptance-gate transcript in the body is incomplete.
+5. If any STOP condition fires, stop and report. Do not improvise.
+
+## Order
+
+| File | Ticket | Depends | Parallel? |
+|---|---|---|---|
+| [00-handoff-dependabot-stale.md](00-handoff-dependabot-stale.md) | Handoff doc §9 | — | yes (on PR #282 branch) |
+| [01-vjss-info.md](01-vjss-info.md) | #268 tooling | — | yes |
+| [02-savestate-decision.md](02-savestate-decision.md) | #268 decision | T1 merged | after 01 |
+| [03-cdi-bad-dump-diag.md](03-cdi-bad-dump-diag.md) | #269 | — | yes |
+| [04-overscan-band-digest.md](04-overscan-band-digest.md) | #266 tooling | — | yes |
+| [05-avp-input-fixture.md](05-avp-input-fixture.md) | #267 unlock | — | yes |
+
+T0, T1, T3, T4, T5 may run in parallel. T2 waits on T1.
+
+## What is NOT here
+
+Judgment-heavy work stays with a strong model / maintainer:
+
+- #266 write-side instrumentation and RetroArch nightly capture
+- #267 root-cause after the fixture exists
+- VLM / audio-CD chain
+- #254 SDL frontend
+- Closing #266 or #267 on headless evidence alone (forbidden)
+
+## Shared preamble (every task file inlines this)
+
+The blocks below are copied verbatim into each task file so a session that
+only receives one file still has them.
+
+### Environment
+
+```bash
+cd /Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+git fetch libretro
+# then: git checkout -b <BRANCH> libretro/develop   (see each task)
+[ -e test/roms/private ] || ln -sfn "${JAGUAR_ROMS_PRIVATE:?set me}" test/roms/private
+```
+
+### Hard rules
+
+- NEVER run `git clean -xfd` or any recursive delete at repo root.
+- C89 only for C: all declarations at top of block, no `for (int i…)`, no
+  designated initializers, no VLAs. Prefer `/* */` comments.
+  Run `bash scripts/c89-lint.sh <file>` before commit on every touched `.c`.
+- Branch from `libretro/develop`. Never `master`. Never stack on another task.
+- Never relax a test threshold to make something pass.
+- Touch ONLY the files in that task's "Files you may touch". If the fix
+  seems to need another file, STOP and report.
+- Prefix host builds with `DEVELOPER_DIR=/Library/Developer/CommandLineTools`.
+- After edits: `VJ_EXPECT_BUILD=$(./scripts/build-id.sh)` when running harnesses.
+- If `make` fails with *"building for 'macOS', but linking in object file
+  built for 'iOS'"*, run `make clean` and rebuild — do not investigate.
+
+### PR evidence requirement
+
+Every PR body MUST end with:
+
+```
+## Acceptance gate transcript
+$ <exact command from the task>
+<paste stdout/stderr and exit code>
+```


### PR DESCRIPTION
A handoff document for whoever picks up the tracker next — `docs/open-issue-handoff.md`.

Covers every open issue (#266, #267, #268, #269, #252, #254, #236), the four open dependabot PRs, and the VLM/audio-CD work that has no ticket yet. For each: **what is actually established vs merely reported**, the decisive question, a concrete verification plan with commands, what is worth automating, acceptance criteria, and the traps.

It is written to be executed from, not read once — the intent is that it can be broken straight into work tickets.

## Findings recorded here that would otherwise need re-deriving

- **The VLM already ships in the core.** `src/bios/jagcdbios.c` and `jagdevcdbios.c` are both 262144 bytes and carry the `Virtual Light Machine v0.9 … FFT code by ib2 / Grafix code by Yak` banner. No BIOS file needed.
- **But it is unreachable.** A single-session audio CD in real-BIOS mode runs the BIOS (logo animates 90 s) and sends exactly two DSA commands — `$7001` Set DAC Mode and `$150A` Set Mode (double speed + *data*) — then nothing. No TOC read, no seek, input ignored. It stalls *before* the "is this a data disc?" decision. Root cause is disc shape: the CD stack gates on `numSessions >= 2`.
- **"Add an option to always boot the BIOS" is not the fix** — that option already exists (`CD Boot Mode = Real BIOS`) and is exactly what was tested.
- **Every Jaguar CD track is `TRACK AUDIO / FLAGS DCP`, including data tracks.** Game discs and music CDs are indistinguishable by track type; the BIOS separates them by the `ATARI APPROVED DATA HEADER` magic.
- **`disk_control = "false"` is correct as written.** The CD BIOS jump table (18 entries, `jagcd_hle.c:60-77`) has no disc-status call and the reverse-engineered DSA set has no lid/status opcode — no game can be told a disc changed. Enabling disk control would let a frontend swap the image under a running game, which is a corruption path rather than a feature. It only becomes meaningful after the VLM chain lands.
- **Dependabot #278 deserves a look before merging.** It is a major bump (`ad-m/github-push-action` 0.8.0 → 1.3.0) of the action that pushes regenerated translations in the Crowdin sync workflow — a pipeline that has never had a green live run, so a post-merge failure would be ambiguous between "the bump broke it" and "it was never set up".

## Two pieces of infrastructure worth building first

Both unblock a currently-stuck visual bug and stay useful afterwards:

- **A scripted-input fixture that reaches the AvP shotgun** (#267). That symptom has never been reproduced headlessly because nothing navigates to the weapon state; until it exists, no other step in that ticket can run.
- **An overscan column-band digest** (#266). The artefact sits at `x ≥ 320`, outside the 320-column active area — a region invisible to every existing check.

## Judgement calls stated explicitly

- Do not close #266 or #267 on headless evidence alone — both live in a path where the harness is known not to see what RetroArch composites.
- #268 is not a bug (savestate version gating, `STATE_VERSION 7` / `STATE_MIN_VERSION 2`); it needs a deliberate maintainer decision rather than code, plus a cheap header-inspector tool for future triage.
- #269 is root-caused and needs a product decision — warn-and-refuse (recommended) vs tolerating a 22-of-32-byte magic match, which carries real false-positive risk.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)