### PR TITLE
fix(ci): refresh nightly published_at so Releases page stays current

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -535,7 +535,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
       TAG: nightly
-      ISSUE_TITLE: 'Nightly builds — download, install, and what they are'
+      # Must match issue #236's title exactly (including the emoji / [Release]
+      # prefix added by hand). Label lookup is preferred; this is the
+      # fallback if the nightly-tracker label is ever removed.
+      ISSUE_TITLE: '🐈‍⬛  [Release] Nightly builds — download, install, and what they are'
     steps:
       - uses: actions/checkout@v7
         with:
@@ -663,8 +666,19 @@ jobs:
             gh release edit "${TAG}" --repo "${REPO}" \
               --title "${TITLE}" \
               --notes-file "${{ steps.prep_body.outputs.body_file }}" \
+              --target "${GITHUB_SHA}" \
               --prerelease --draft=false
             gh release upload "${TAG}" --repo "${REPO}" release/* --clobber
+            # `gh release edit` leaves published_at at the original create
+            # date, so the Releases list kept showing "Published Aug 1" while
+            # assets/body moved every develop push — looking abandoned under
+            # newer stable tags. Draft→publish is the only API that rewrites
+            # that timestamp; assets stay attached and the id is unchanged.
+            # Window is one round-trip.
+            REL_ID=$(gh api "repos/${REPO}/releases/tags/${TAG}" --jq .id)
+            gh api -X PATCH "repos/${REPO}/releases/${REL_ID}" -F draft=true >/dev/null
+            gh api -X PATCH "repos/${REPO}/releases/${REL_ID}" \
+              -F draft=false -F prerelease=true >/dev/null
           else
             gh release create "${TAG}" --repo "${REPO}" \
               --title "${TITLE}" \

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -81,6 +81,9 @@ publishing step is the `nightly` job instead of `release`:
 2. Updates the single rolling `nightly` prerelease **in place**
    (`gh release edit` + `gh release upload --clobber`, not delete-and-recreate,
    so `/releases/tag/nightly` never 404s mid-run and the release keeps its id).
+   After the upload it briefly toggles draft→published so GitHub rewrites
+   `published_at` — plain `edit` leaves that stamp on the original create
+   date and the Releases page looks abandoned under newer stable tags.
 3. Rewrites `display_version` in the bundled `.info` to
    `v<X.Y.Z>-nightly-<sha>`, so a nightly `.info` can never be mistaken for the
    file that gets PR'd to libretro-super.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The rolling [`nightly`](https://github.com/libretro/virtualjaguar-libretro/releases/tag/nightly) prerelease **was** rebuilding on every `develop` push (assets, notes, tag, and tracking issue #236 all moved), but `gh release edit` never rewrites GitHub's `published_at`. That stamp stayed at the original create date (`2026-08-01`), so the Releases list showed the nightly as days old under newer stable tags — looking like the auto-updater in #236 had stalled.

After `gh release upload --clobber`, briefly toggle the release draft→published via the Releases API so `published_at` refreshes. Assets stay attached; release id unchanged. Also pass `--target ${GITHUB_SHA}` on edit and align the tracking-issue title fallback with the renamed #236 title.

## Test plan

- [x] Confirmed develop pushes were already succeeding the nightly job (tip was `f1e84d8`)
- [x] Confirmed draft→publish refreshes `published_at` without dropping assets (34/34 kept; stamp moved `2026-08-01` → `2026-08-03`)
- [ ] After merge, next develop push (or `workflow_dispatch` on `develop`) should show a fresh Published date matching the build time in the body/issue
- [x] `make` / `make test` / c89-lint — N/A (CI workflow + docs only)

## Branch base

- [x] **Base is `develop`** (the integration branch)
- [ ] OR base is `master` *and* this is a `hotfix/*` or `release/*` branch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da12e0dd-540f-4fbe-9eb5-e1d4f937ddf2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da12e0dd-540f-4fbe-9eb5-e1d4f937ddf2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

