### PR TITLE
test(tools): add VJFBDIG3 overscan column-band digest (#266)

### DIFF
--- a/test/tools/fb_row_diff.py
+++ b/test/tools/fb_row_diff.py
@@ -141,7 +141,9 @@ def main():
             any_band_nonblack = True
 
         if (wa, ha) != (wb, hb):
-            unexpected.append((n, -1, f"geometry {wa}x{ha} -> {wb}x{hb}"))
+            # "rows" is the stored row count (clamped), not presented height.
+            unexpected.append((n, -1, f"geometry w={wa} rows={ha} -> "
+                                      f"w={wb} rows={hb}"))
             continue
 
         if banda[2] != bandb[2]:

--- a/test/tools/fb_row_diff.py
+++ b/test/tools/fb_row_diff.py
@@ -6,6 +6,9 @@ ever change rows the core previously left unwritten, and must only ever
 change them to opaque black.  This checks that mechanically so a 46-title
 sweep does not depend on reading 46 screenshots.
 
+VJFBDIG3 adds a per-frame overscan column-band digest (columns x >= 320).
+Both inputs must be VJFBDIG3; VJFBDIG2 dumps exit 2 with a clear error.
+
 Checks, in order of severity:
   1. Geometry must match frame for frame.  Any difference is a hard failure.
   2. Per-frame audio digests must match.  A video-window change cannot alter
@@ -13,8 +16,9 @@ Checks, in order of severity:
   3. Every row whose hash differs must be >= the patched build's written-row
      extent for that frame, and its patched hash must equal the all-opaque-
      black hash for that width.  Anything else is a hard failure.
+  4. Overscan band_hash must match frame for frame (unless --ignore-band).
 
-Usage:  fb_row_diff.py <stock.bin> <patched.bin> [--label NAME] [--quiet]
+Usage:  fb_row_diff.py <stock.bin> <patched.bin> [--label NAME] [--ignore-band]
 Exit:   0 = identical or only expected differences, 1 = unexpected difference,
         2 = usage/format error.
 """
@@ -22,8 +26,9 @@ Exit:   0 = identical or only expected differences, 1 = unexpected difference,
 import struct
 import sys
 
-MAGIC = b"VJFBDIG2"
+MAGIC = b"VJFBDIG3"
 HDR = struct.Struct("<4I")          # width, height, frame_hash, written_extent
+BAND = struct.Struct("<6I")         # x0, width, hash, nonblack, first_x, first_y
 NO_EXTENT = 0xFFFFFFFF
 
 
@@ -49,7 +54,7 @@ def load(path):
     with open(path, "rb") as f:
         blob = f.read()
     if blob[:8] != MAGIC:
-        raise ValueError(f"{path}: bad magic {blob[:8]!r}")
+        raise ValueError(f"{path}: bad magic {blob[:8]!r} (need VJFBDIG3)")
     nvideo, naudio = struct.unpack_from("<2I", blob, 8)
     frames = []
     off = 16
@@ -58,7 +63,9 @@ def load(path):
         off += HDR.size
         rows = struct.unpack_from(f"<{h}I", blob, off)
         off += 4 * h
-        frames.append((w, h, fh, extent, rows))
+        band = BAND.unpack_from(blob, off)
+        off += BAND.size
+        frames.append((w, h, fh, extent, rows, band))
     audio = struct.unpack_from(f"<{naudio}I", blob, off) if naudio else ()
     return frames, list(audio)
 
@@ -66,12 +73,16 @@ def load(path):
 def main():
     argv = sys.argv[1:]
     label = "run"
+    ignore_band = False
     args = []
     i = 0
     while i < len(argv):
         if argv[i] == "--label" and i + 1 < len(argv):
             label = argv[i + 1]
             i += 2
+        elif argv[i] == "--ignore-band":
+            ignore_band = True
+            i += 1
         elif argv[i].startswith("--"):
             i += 1
         else:
@@ -81,28 +92,24 @@ def main():
         print(__doc__)
         return 2
 
-    frames_a, audio_a = load(args[0])
-    frames_b, audio_b = load(args[1])
+    try:
+        frames_a, audio_a = load(args[0])
+        frames_b, audio_b = load(args[1])
+    except ValueError as e:
+        print(f"FAIL {label}: {e}", file=sys.stderr)
+        return 2
 
     unexpected = []
     changed_frames = 0
     changed_rows = set()
     first_changed_frame = None
+    band_changed_frames = 0
+    max_band_nonblack = 0
+    any_band_nonblack = False
 
-    # How many frames actually had a tail gap for the fix to act on, and how
-    # often the written-row extent moved.  Without these, "changed_frames=0"
-    # is ambiguous: it cannot distinguish "this title is unaffected" from
-    # "this run never reached an affected state", so a wall of OKs would
-    # imply coverage the sweep does not have.
-    #
-    # extent_changes also bounds a class the row check cannot see: the extent
-    # is read at end of frame, but rows are written across the frame, so a
-    # title that moves VDB mid-frame could have a legitimately-written row
-    # blanked using the new extent.  A title whose extent barely moves cannot
-    # be hitting that; one that churns every frame deserves a look.
-    gap_frames = sum(1 for (_w, h, _fh, ext, _r) in frames_b
+    gap_frames = sum(1 for (_w, h, _fh, ext, _r, _b) in frames_b
                      if ext != NO_EXTENT and ext < h)
-    extents = [ext for (_w, _h, _fh, ext, _r) in frames_b if ext != NO_EXTENT]
+    extents = [ext for (_w, _h, _fh, ext, _r, _b) in frames_b if ext != NO_EXTENT]
     extent_changes = sum(1 for a_, b_ in zip(extents, extents[1:]) if a_ != b_)
 
     if len(frames_a) != len(frames_b):
@@ -116,12 +123,24 @@ def main():
                                    f"first at audio frame {first}"))
 
     for n, (fa, fb_) in enumerate(zip(frames_a, frames_b)):
-        wa, ha, fha, _exta, rowsa = fa
-        wb, hb, fhb, extb, rowsb = fb_
+        wa, ha, fha, _exta, rowsa, banda = fa
+        wb, hb, fhb, extb, rowsb, bandb = fb_
+
+        if bandb[3] > max_band_nonblack:
+            max_band_nonblack = bandb[3]
+        if bandb[3] > 0:
+            any_band_nonblack = True
 
         if (wa, ha) != (wb, hb):
             unexpected.append((n, -1, f"geometry {wa}x{ha} -> {wb}x{hb}"))
             continue
+
+        if banda[2] != bandb[2]:
+            band_changed_frames += 1
+            if not ignore_band:
+                unexpected.append((n, -1, f"overscan band_hash differs "
+                                          f"({banda[2]:08X} -> {bandb[2]:08X})"))
+
         if fha == fhb:
             continue
 
@@ -146,6 +165,9 @@ def main():
           f"gap_frames={gap_frames} extent_changes={extent_changes} "
           f"changed_frames={changed_frames} changed_rows={rows_desc} "
           f"first_changed_frame={first_changed_frame} "
+          f"band_changed_frames={band_changed_frames} "
+          f"max_band_nonblack={max_band_nonblack} "
+          f"band_nonblack_any={int(any_band_nonblack)} "
           f"unexpected={len(unexpected)}")
     for frame, row, why in unexpected[:10]:
         print(f"       frame {frame} row {row}: {why}")

--- a/test/tools/fb_row_diff.py
+++ b/test/tools/fb_row_diff.py
@@ -20,14 +20,15 @@ Checks, in order of severity:
 
 Usage:  fb_row_diff.py <stock.bin> <patched.bin> [--label NAME] [--ignore-band]
 Exit:   0 = identical or only expected differences, 1 = unexpected difference,
-        2 = usage/format error.
+        2 = usage/format error (missing, unreadable, truncated or wrong-magic
+        input included).
 """
 
 import struct
 import sys
 
 MAGIC = b"VJFBDIG3"
-HDR = struct.Struct("<4I")          # width, height, frame_hash, written_extent
+HDR = struct.Struct("<4I")          # width, rows, frame_hash, written_extent
 BAND = struct.Struct("<6I")         # x0, width, hash, nonblack, first_x, first_y
 NO_EXTENT = 0xFFFFFFFF
 
@@ -95,6 +96,14 @@ def main():
     try:
         frames_a, audio_a = load(args[0])
         frames_b, audio_b = load(args[1])
+    except OSError as e:
+        print(f"FAIL {label}: cannot read {e.filename or '?'}: "
+              f"{e.strerror or e}", file=sys.stderr)
+        return 2
+    except struct.error as e:
+        print(f"FAIL {label}: truncated or malformed digest: {e}",
+              file=sys.stderr)
+        return 2
     except ValueError as e:
         print(f"FAIL {label}: {e}", file=sys.stderr)
         return 2

--- a/test/tools/fb_row_digest.c
+++ b/test/tools/fb_row_digest.c
@@ -28,7 +28,7 @@
  * host -- which is the intended use, two builds on one machine.  The reader's
  * all-black row constant likewise assumes little-endian XRGB8888 in memory.)
  *
- *   magic  "VJFBDIG2"                        8 bytes
+ *   magic  "VJFBDIG3"                        8 bytes
  *   uint32 video_frame_count
  *   uint32 audio_frame_count
  *   video_frame_count records of:
@@ -36,6 +36,10 @@
  *       (written_extent is 0xFFFFFFFF when the core does not export
  *        TOMGetWrittenRowExtent, i.e. for a pre-fix reference build)
  *     uint32 row_hash[height]
+ *     uint32 band_x0, band_width, band_hash, band_nonblack,
+ *            band_first_x, band_first_y
+ *       (overscan strip: columns x >= 320. band_width=0 when width<=320;
+ *        band_first_* = 0xFFFFFFFF when the band has no non-black pixels)
  *   audio_frame_count records of:
  *     uint32 audio_hash   (samples, peaks, non-silent count, RMS L/R)
  */
@@ -90,6 +94,13 @@ static void on_video(void *userdata, const void *data,
     uint32_t frame_hash = FNV_SEED;
     unsigned row;
     unsigned rows = height;
+    uint32_t band_x0 = 0;
+    uint32_t band_width = 0;
+    uint32_t band_hash = 0;
+    uint32_t band_nonblack = 0;
+    uint32_t band_first_x = 0xFFFFFFFFu;
+    uint32_t band_first_y = 0xFFFFFFFFu;
+    unsigned col;
 
     if (!data || !st->out)
         return;
@@ -103,12 +114,46 @@ static void on_video(void *userdata, const void *data,
         frame_hash = fnv1a(&row_hash[row], sizeof(uint32_t), frame_hash);
     }
 
+    /* Overscan / border strip: columns at and past the 320-wide active area.
+     * AvP presents ~326 wide; every prior check folded these into row hashes. */
+    if (width > 320)
+    {
+        band_x0 = 320;
+        band_width = width - 320;
+        band_hash = FNV_SEED;
+        for (row = 0; row < rows; row++)
+        {
+            const uint8_t *line = (const uint8_t *)data + (size_t)row * pitch;
+            const uint32_t *px = (const uint32_t *)line;
+            band_hash = fnv1a(line + (size_t)band_x0 * 4,
+                              (size_t)band_width * 4, band_hash);
+            for (col = band_x0; col < width; col++)
+            {
+                if ((px[col] & 0x00FFFFFFu) != 0)
+                {
+                    band_nonblack++;
+                    if (band_first_x == 0xFFFFFFFFu)
+                    {
+                        band_first_x = col;
+                        band_first_y = row;
+                    }
+                }
+            }
+        }
+    }
+
     put_u32(st->out, width);
     put_u32(st->out, rows);
     put_u32(st->out, frame_hash);
     put_u32(st->out, st->get_extent ? st->get_extent() : 0xFFFFFFFFu);
     for (row = 0; row < rows; row++)
         put_u32(st->out, row_hash[row]);
+    put_u32(st->out, band_x0);
+    put_u32(st->out, band_width);
+    put_u32(st->out, band_hash);
+    put_u32(st->out, band_nonblack);
+    put_u32(st->out, band_first_x);
+    put_u32(st->out, band_first_y);
 
     st->frames_written++;
 }
@@ -158,7 +203,7 @@ int main(int argc, char **argv)
     cfg.video_callback      = on_video;
     cfg.video_callback_data = &st;
 
-    fwrite("VJFBDIG2", 1, 8, st.out);
+    fwrite("VJFBDIG3", 1, 8, st.out);
     put_u32(st.out, 0);   /* video frame count, patched below */
     put_u32(st.out, 0);   /* audio frame count, patched below */
 

--- a/test/tools/fb_row_digest.c
+++ b/test/tools/fb_row_digest.c
@@ -132,12 +132,19 @@ static void on_video(void *userdata, const void *data,
         for (row = 0; row < rows; row++)
         {
             const uint8_t *line = (const uint8_t *)data + (size_t)row * pitch;
-            const uint32_t *px = (const uint32_t *)line;
+            uint32_t pix;
             band_hash = fnv1a(line + (size_t)band_x0 * 4,
                               (size_t)band_width * 4, band_hash);
             for (col = band_x0; col < width; col++)
             {
-                if ((px[col] & 0x00FFFFFFu) != 0)
+                /* memcpy, not a byte-wise OR: pitch is a byte stride with no
+                 * 4-byte-multiple guarantee, so casting line to uint32_t* and
+                 * indexing it is UB on strict-alignment hosts.  Reassembling
+                 * the pixel by hand would instead pick the wrong three bytes
+                 * on a big-endian host, where XRGB8888-as-uint32 puts RGB at
+                 * bytes 1..3 rather than 0..2. */
+                memcpy(&pix, line + (size_t)col * 4, sizeof(pix));
+                if ((pix & 0x00FFFFFFu) != 0)
                 {
                     band_nonblack++;
                     if (band_first_x == 0xFFFFFFFFu)

--- a/test/tools/fb_row_digest.c
+++ b/test/tools/fb_row_digest.c
@@ -32,14 +32,22 @@
  *   uint32 video_frame_count
  *   uint32 audio_frame_count
  *   video_frame_count records of:
- *     uint32 width, height, frame_hash, written_extent
+ *     uint32 width, rows, frame_hash, written_extent
+ *       (rows is the stored row count, min(presented height, MAX_ROWS=512),
+ *        not the presented height; readers must size row_hash[] by it)
  *       (written_extent is 0xFFFFFFFF when the core does not export
  *        TOMGetWrittenRowExtent, i.e. for a pre-fix reference build)
- *     uint32 row_hash[height]
+ *     uint32 row_hash[rows]
  *     uint32 band_x0, band_width, band_hash, band_nonblack,
  *            band_first_x, band_first_y
- *       (overscan strip: columns x >= 320. band_width=0 when width<=320;
- *        band_first_* = 0xFFFFFFFF when the band has no non-black pixels)
+ *       (overscan strip: columns x >= 320, hashed over the same stored rows.
+ *        When width > 320: band_x0=320, band_width=width-320, band_hash is
+ *        FNV-1a over the strip, band_nonblack counts pixels whose RGB is not
+ *        zero, and band_first_x/band_first_y are the first such pixel in
+ *        row-major order, or 0xFFFFFFFF each when the band is all black.
+ *        When width <= 320 the band block is skipped and the fields are
+ *        written as band_x0=0, band_width=0, band_hash=0, band_nonblack=0,
+ *        band_first_x=0xFFFFFFFF, band_first_y=0xFFFFFFFF.)
  *   audio_frame_count records of:
  *     uint32 audio_hash   (samples, peaks, non-silent count, RMS L/R)
  */


### PR DESCRIPTION
## Summary
- `fb_row_digest` emits a per-frame digest for the overscan strip, columns x≥320 (`VJFBDIG3`).
- `fb_row_diff.py` reads the new record and reports `band_changed_frames` / `max_band_nonblack`; requires matching `VJFBDIG3` inputs and returns exit 2 on missing, truncated, or wrong-magic files.
- Tooling only — does not claim #266 fixed. Do not close #266.

## Band record

Six LE uint32 appended per frame: `band_x0, band_width, band_hash, band_nonblack, band_first_x, band_first_y`.
When `width <= 320` the writer emits `band_x0=band_width=band_hash=band_nonblack=0` and `band_first_x=band_first_y=0xFFFFFFFF`.

## Measured (400-frame AvP, 120-frame yarc)

| ROM | Width distribution | First wide frame | Band on wide frames |
|---|---|---|---|
| Alien vs Predator (1994) | 320×31, 326×369 | 31 | `band_x0=320`, `band_width=6` |
| yarc.j64 | 320×1, 326×119 | 1 | `band_x0=320`, `band_width=6` |

**Correction to an earlier revision of this description:** yarc is *not* a
320-wide-only title. Only frame 0 is 320 wide; from frame 1 on it also presents
326. The original claim came from a check that inspected frame 0 only. The
`width <= 320` zero/sentinel path is still verified — on AvP's 31 narrow frames
and yarc's frame 0, every band field carries exactly the documented values.

AvP's first 326-wide frame is index 31, so **use ≥400 frames** for any AvP band
assertion; a short run sees only the 320-wide title screen.

## Acceptance gate transcript
```
$ python3 test/tools/fb_row_diff.py /tmp/yarc_dig3.bin /tmp/yarc_dig3.bin --label yarc
OK   yarc: frames=120 … unexpected=0   (exit 0)

$ python3 test/tools/fb_row_diff.py /tmp/does_not_exist.bin /tmp/yarc_dig3.bin --label missing
FAIL missing: cannot read /tmp/does_not_exist.bin: No such file or directory   (exit 2)

$ python3 test/tools/fb_row_diff.py /tmp/trunc_dig3.bin /tmp/yarc_dig3.bin --label trunc
FAIL trunc: truncated or malformed digest: unpack_from requires a buffer of at least 992 bytes …   (exit 2)

$ python3 test/tools/fb_row_diff.py /tmp/oldmagic.bin /tmp/yarc_dig3.bin --label oldmagic
FAIL oldmagic: /tmp/oldmagic.bin: bad magic b'VJFBDIG2' (need VJFBDIG3)   (exit 2)
```