### PR TITLE
test(fixtures): AvP scripted input to sustained gameplay (#267 unlock)

### DIFF
--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -1,0 +1,16 @@
+# Scripted-input fixtures
+
+Plain-text `--press` scripts for the shared harness (`test/harness/`).
+
+## `avp_reach_gameplay.press`
+
+Drives **Alien vs Predator (1994)** from boot into sustained Alien
+first-person gameplay. Unlocks #266 / #267 follow-on work; does **not**
+reach weapon-select / shotgun.
+
+```bash
+bash test/tools/run_avp_fixture.sh ./virtualjaguar_libretro.dylib
+```
+
+Requires `test/roms/private` → private ROM tree and a `TEST_EXPORTS=1` core
+build. Gate is mechanical (late-window motion + non-black), not visual.

--- a/test/fixtures/avp_reach_gameplay.press
+++ b/test/fixtures/avp_reach_gameplay.press
@@ -1,0 +1,29 @@
+# Alien vs Predator (1994).jag — reach sustained Alien first-person gameplay.
+# BIOS off (core default). Frames are absolute from boot.
+#
+# Timeline (measured on develop @ 4eab779):
+#   ~240-480  title art animates
+#   ~720      main menu (SELECT CHARACTER)
+#   ~900-1100 character select / confirm
+#   ~1140-1500 briefing ("LOADING SIMULATION... PRESS FIRE")
+#   ~1500+    in-game; hold d-pad for sustained motion
+
+780:b:10
+900:b:10
+1020:b:10
+1140:b:10
+1260:b:15
+1380:b:15
+1500:b:15
+1620:b:15
+1740:b:10
+1860:up:120
+1980:right:120
+2100:down:120
+2220:left:120
+2340:up:120
+2460:right:120
+2580:up:120
+2700:left:120
+2820:right:120
+2940:up:60

--- a/test/tools/run_avp_fixture.sh
+++ b/test/tools/run_avp_fixture.sh
@@ -29,6 +29,12 @@ if [ ! -x "$VERIFY" ]; then
   exit 1
 fi
 
+if [ ! -r "$PRESS_FILE" ]; then
+  echo "run_avp_fixture: press fixture not readable: $PRESS_FILE" >&2
+  echo "run_avp_fixture: set PRESS_FILE=<path> to override the default" >&2
+  exit 1
+fi
+
 press_args=()
 while IFS= read -r line || [ -n "$line" ]; do
   case "$line" in
@@ -36,6 +42,11 @@ while IFS= read -r line || [ -n "$line" ]; do
   esac
   press_args+=(--press "$line")
 done < "$PRESS_FILE"
+
+if [ ${#press_args[@]} -eq 0 ]; then
+  echo "run_avp_fixture: press fixture has no input lines: $PRESS_FILE" >&2
+  exit 1
+fi
 
 mkdir -p "$OUTDIR"
 log="$OUTDIR/timeline.log"
@@ -49,8 +60,16 @@ set +e
   --system-dir "$SYSTEM_DIR" \
   --quiet \
   "$@" 2>&1 | tee "$log"
-rc=${PIPESTATUS[0]}
+# PIPESTATUS is clobbered by the next command, so copy the whole array at once.
+status=("${PIPESTATUS[@]}")
 set -e
+rc=${status[0]}
+tee_rc=${status[1]}
+
+if [ "$tee_rc" -ne 0 ]; then
+  echo "run_avp_fixture: failed to write log $log (tee exited $tee_rc)" >&2
+  exit 1
+fi
 
 # Gate: in windows covering the last 300 frames, require
 #   sum(moving_frames) >= 40  (AvP first-person tops out ~12/60 per window)

--- a/test/tools/run_avp_fixture.sh
+++ b/test/tools/run_avp_fixture.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Expand test/fixtures/avp_reach_gameplay.press into cd_visual_verify --press
+# args and enforce a mechanical gameplay gate.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+PRESS_FILE=${PRESS_FILE:-"$ROOT/test/fixtures/avp_reach_gameplay.press"}
+VERIFY=${VERIFY:-"$ROOT/test/tools/cd_visual_verify"}
+AVP=${AVP:-"$ROOT/test/roms/private/ROMS/Alien vs Predator (1994).jag"}
+FRAMES=${FRAMES:-3000}
+OUTDIR=${OUTDIR:-/tmp/avp_fixture_$$}
+CORE=${1:?usage: run_avp_fixture.sh <core> [extra args...]}
+shift || true
+
+if [ ! -f "$AVP" ]; then
+  AVP=$(find -L "$ROOT/test/roms/private" -iname 'Alien vs Predator (1994).jag' | head -1 || true)
+fi
+if [ ! -f "$AVP" ]; then
+  echo "run_avp_fixture: AvP ROM missing" >&2
+  exit 1
+fi
+if [ ! -x "$VERIFY" ]; then
+  echo "run_avp_fixture: build cd_visual_verify first" >&2
+  exit 1
+fi
+
+press_args=()
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    ''|\#*) continue ;;
+  esac
+  press_args+=(--press "$line")
+done < "$PRESS_FILE"
+
+mkdir -p "$OUTDIR"
+log="$OUTDIR/timeline.log"
+
+set +e
+"$VERIFY" "$CORE" "$AVP" \
+  --frames "$FRAMES" \
+  "${press_args[@]}" \
+  --outdir "$OUTDIR" \
+  --shot-every "${SHOT_EVERY:-0}" \
+  --quiet \
+  "$@" 2>&1 | tee "$log"
+rc=${PIPESTATUS[0]}
+set -e
+
+# Gate: in windows covering the last 300 frames, require
+#   sum(moving_frames) >= 40  (AvP first-person tops out ~12/60 per window)
+#   max nonblack >= 5000
+python3 - "$log" "$FRAMES" <<'PY'
+import re, sys
+log, frames = sys.argv[1], int(sys.argv[2])
+start = frames - 300
+wins = []
+for line in open(log, encoding='utf-8', errors='replace'):
+    m = re.search(
+        r'\[win\s+(\d+)\] frames\s+(\d+)-\s*(\d+): motion\s+(\d+)/(\d+)'
+        r'.*max nonblack\s+(\d+)/',
+        line,
+    )
+    if m:
+        wins.append(tuple(map(int, m.groups())))
+if not wins:
+    print('GATE FAIL: no timeline windows parsed', file=sys.stderr)
+    sys.exit(1)
+mov_sum = 0
+max_nb = 0
+for wid, a, b, mov, tot, nb in wins:
+    if b < start:
+        continue
+    mov_sum += mov
+    if nb > max_nb:
+        max_nb = nb
+    print(f'late win {wid} {a}-{b} motion={mov}/{tot} nonblack={nb}')
+print(f'late_moving_sum={mov_sum} max_nonblack={max_nb}')
+if mov_sum >= 40 and max_nb >= 5000:
+    print('GATE PASS')
+    sys.exit(0)
+print('GATE FAIL', file=sys.stderr)
+sys.exit(1)
+PY
+gate=$?
+exit $(( rc != 0 ? rc : gate ))

--- a/test/tools/run_avp_fixture.sh
+++ b/test/tools/run_avp_fixture.sh
@@ -7,6 +7,11 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 PRESS_FILE=${PRESS_FILE:-"$ROOT/test/fixtures/avp_reach_gameplay.press"}
 VERIFY=${VERIFY:-"$ROOT/test/tools/cd_visual_verify"}
 AVP=${AVP:-"$ROOT/test/roms/private/ROMS/Alien vs Predator (1994).jag"}
+# cd_visual_verify defaults system_dir to the CWD-relative "test/roms/private",
+# so pass an absolute one to keep this script runnable from anywhere.  It is
+# placed before "$@" and the harness takes the last --system-dir it sees, so a
+# caller-supplied --system-dir still wins.
+SYSTEM_DIR=${SYSTEM_DIR:-"$ROOT/test/roms/private"}
 FRAMES=${FRAMES:-3000}
 OUTDIR=${OUTDIR:-/tmp/avp_fixture_$$}
 CORE=${1:?usage: run_avp_fixture.sh <core> [extra args...]}
@@ -41,6 +46,7 @@ set +e
   "${press_args[@]}" \
   --outdir "$OUTDIR" \
   --shot-every "${SHOT_EVERY:-0}" \
+  --system-dir "$SYSTEM_DIR" \
   --quiet \
   "$@" 2>&1 | tee "$log"
 rc=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- Adds `test/fixtures/avp_reach_gameplay.press` + `test/tools/run_avp_fixture.sh`.
- Reaches Alien first-person gameplay (not shotgun / weapon-select).
- Mechanical gate: last-300-frame moving-frame sum ≥ 40 and max nonblack ≥ 5000 (AvP first-person tops out ~12/60 per 60-frame window under `cd_visual_verify`'s 0.5% motion detector).
- Two consecutive runs pass. Does **not** close #267.

## Acceptance gate transcript
```
$ VJ_EXPECT_BUILD=$(./scripts/build-id.sh) bash test/tools/run_avp_fixture.sh ./virtualjaguar_libretro.dylib --outdir /tmp/avp_fix1
… late_moving_sum=50 max_nonblack=73143
GATE PASS
$ … --outdir /tmp/avp_fix2
… late_moving_sum=50 max_nonblack=73143
GATE PASS
```

Made with [Cursor](https://cursor.com)