### PR TITLE
fix(blitter): key DCOMPEN transparency on unshaded source data (#267)

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -1376,7 +1376,7 @@ static BLITTER_ALWAYS_INLINE
 void DATA(uint64_t *wdata, uint8_t *dcomp, uint8_t *zcomp, bool *nowrite,
 	bool big_pix, bool cmpdst, uint8_t daddasel, uint8_t daddbsel, uint8_t daddmode, bool daddq_sel, uint8_t data_sel,
 	uint8_t dbinh, uint8_t dend, uint8_t dstart, uint64_t dstd, uint32_t iinc, uint8_t lfu_func, uint64_t *patd, bool patdadd,
-	bool phrase_mode, uint64_t srcd, bool srcdread, bool srczread, bool srcz2add, uint8_t zmode,
+	bool phrase_mode, uint64_t srcd, uint64_t srcd_cmp, bool srcdread, bool srczread, bool srcz2add, uint8_t zmode,
 	bool bcompen, bool bkgwren, bool dcompen, uint8_t icount, uint8_t pixsize,
 	uint64_t *srcz, uint64_t dstz, uint32_t zinc)
 {
@@ -1457,7 +1457,10 @@ Zstep		:= JOIN (zstep, zstep[0..31]);*/
 
 /*Datacomp	:= DATACOMP (dcomp[0..7], cmpdst, dstdlo, dstdhi, patdlo, patdhi, srcdlo, srcdhi);*/
 ////////////////////////////////////// C++ CODE //////////////////////////////////////
-	*dcomp = blitter_simd_ops.dcomp(*patd, srcd, dstd, cmpdst);
+	/* srcd_cmp is the source data as read from memory; srcd may carry the
+	 * SRCSHADE intensity offset.  The transparency comparison keys on the
+	 * unshaded pixel -- see the SRCSHADE block in BlitterMidsummer2. */
+	*dcomp = blitter_simd_ops.dcomp(*patd, srcd_cmp, dstd, cmpdst);
 
 	/* Source-pixel transparency for DCOMPEN+!CMPDST.
 	 *
@@ -1500,7 +1503,7 @@ Zstep		:= JOIN (zstep, zstep[0..31]);*/
 		 * borrow -- e.g. s=0x0001_0000 spuriously flags byte 2 as zero
 		 * because the borrow chain propagates the wrong way.  The loop
 		 * is honest and compiles to predictable code on every target.) */
-		uint64_t s = srcd;
+		uint64_t s = srcd_cmp;
 		uint8_t zero_mask = 0;
 		unsigned i;
 		for (i = 0; i < 8; i++)
@@ -2266,7 +2269,7 @@ void BlitterMidsummer2(void)
                      false/*daddq_sel*/,
                      0/*data_sel*/, 0/*dbinh*/, pf_dend, pf_dstart, pf_dstd_local,
                      iinc, lfufunc, &patd, false/*patdadd*/,
-                     phrase_mode, 0/*srcd*/, false/*srcdread*/, false/*srczread*/,
+                     phrase_mode, 0/*srcd*/, 0/*srcd_cmp*/, false/*srcdread*/, false/*srczread*/,
                      false/*srcz2add*/, zmode,
                      bcompen, bkgwren, dcompen, icount & 0x07, pixsize,
                      &srcz, dstz, zinc);
@@ -2585,7 +2588,7 @@ void BlitterMidsummer2(void)
                         false/*daddq_sel*/, 1/*data_sel=LFU*/, 0/*dbinh*/,
                         fc_dend, fc_dstart, dstd, iinc, lfufunc, &patd,
                         false/*patdadd*/,
-                        phrase_mode, fc_srcd, false/*srcdread*/, false/*srczread*/,
+                        phrase_mode, fc_srcd, fc_srcd/*srcd_cmp*/, false/*srcdread*/, false/*srczread*/,
                         false/*srcz2add*/, zmode,
                         false/*bcompen*/, bkgwren, false/*dcompen*/,
                         icount & 0x07, pixsize,
@@ -3034,6 +3037,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
                uint16_t oldicount;
                uint8_t dstart = 0;
                uint8_t ppp;
+               uint64_t srcd_cmp;
 #ifdef BENCH_PROFILE
                blitter_did_io = 1;
 #endif
@@ -3176,6 +3180,11 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
                //after the add?
                //Dest write address/pix address: 0014E83E/0 [dstart=0 dend=10 pwidth=8 srcshift=0][daas=4 dabs=5 dam=7 ds=1 daq=F] [0000000000006505] (icount=003F, inc=1)
                //Let's try this:
+               /* The intensity offset belongs to the write data only.  DCOMPEN
+                * transparency keys on the source pixel as read from memory, so
+                * keep an unshaded copy for the comparator: shading a
+                * transparent (PATD-matching) pixel must not make it opaque. */
+               srcd_cmp = srcd;
                if (srcshade)
                {
                   uint16_t addq[4];
@@ -3223,7 +3232,7 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
                DATA(&wdata, &dcomp, &zcomp, &winhibit,
                      true, cmpdst, daddasel, daddbsel, daddmode, daddq_sel, data_sel, 0/*dbinh*/,
                      dend, dstart, dstd, iinc, lfufunc, &patd, patdadd,
-                     phrase_mode, srcd, false/*srcdread*/, false/*srczread*/, srcz2add, zmode,
+                     phrase_mode, srcd, srcd_cmp, false/*srcdread*/, false/*srczread*/, srcz2add, zmode,
                      bcompen, bkgwren, dcompen, icount & 0x07, pixsize,
                      &srcz, dstz, zinc);
 


### PR DESCRIPTION
## Problem

**#267 — AvP: red backdrop behind the shotgun HUD icon (accurate blitter).**

With Fast Blitter OFF (the core default), Alien vs Predator's shotgun HUD
slot-1 icon renders on a solid red rectangle instead of showing the game view
through it. Reproduces from frame ~10600 onward in a 50x18 box at
`x[249..298] y[62..79]`.

The offending blit:

```
cmd=$49800601  = SRCEN | UPDA1 | UPDA2 | LFU_AN | LFU_A | DCOMPEN | SRCSHADE
8bpp, pixel mode, PATD = 0, SRCD = 0 (fully transparent source),
IINC ramps $00000000 -> $00010001 -> $00020000 ... as the icon fades in
```

`BKGWREN` and `DSTEN` are both clear, which is why the earlier #166 fix (which
gates a phrase-mode `dstd` read on `!bkgwren`) never applied here.

## Root cause

This is **(b): DCOMPEN failing to inhibit the write on a transparent source
pixel** — caused by operand ordering.

`BlitterMidsummer2` applied the SRCSHADE intensity offset to `srcd` *before*
calling `DATA()`:

```c
if (srcshade) { ADDARRAY(...); srcd = addq; }   /* shade */
...
DATA(..., srcd, ...);                            /* then compare */
```

`DATA()` computes the data comparator from that same `srcd`, so a transparent
source pixel (0, matching `PATD` = 0) arrived at DATACOMP already shaded to a
non-zero value, no longer matched, and the write went through. Because the
source is *entirely* zero across the icon's bounding box, every pixel in the
box got written with the shade value — CLUT index 1, dark red in AvP's HUD
palette. The game's fade-in then drags the whole box up the ramp in lockstep,
which is exactly the +1 offset the earlier investigation measured.

The fast blitter does the opposite ordering — comparator first
(`blitter.c:509-550`), then `if (!inhibit)` and SRCSHADE inside the write-data
computation (`blitter.c:617-629`).

## JTRM justification

`docs/jtrm-register-map.md`, B_CMD bit fields:

- bit 25 **CMPDST** — "Compare destination data (**else source**) with pattern data for DCOMPEN"
- bit 27 **DCOMPEN** — "Data comparator enable (transparency: inhibit write on match)"
- bit 30 **SRCSHADE** — "Source shading (use IINC to modify **intensity** of data read from source address)"

The spec defines the comparator's operand as *the source data read from the
source address* and defines SRCSHADE as an intensity modification of that data.
Nothing in the JTRM makes the post-shade value the comparator operand.
`docs/jtrm-blitter.md` describes DCOMPEN as "pixel-level transparency" and
BKGWREN (bit 28) as "Allow writes to background (**transparent**) pixels",
i.e. DCOMPEN is *the* transparency mechanism — it has to survive shading, or
SRCSHADE and DCOMPEN could never be used together.

### Uncertainty — please read

**The distilled JTRM docs do not explicitly state the ordering of the SRCSHADE
add relative to the data comparator.** I went to the Jaguar ASIC netlists
(`Torlus/JagNetlists`, the same source the `:= DATACOMP (...)` comments in
`blitter.c` are transcribed from), and the structural evidence there is
genuinely ambiguous and, read literally, arguably supports the *current*
behaviour:

- `INNER.NET`: `Srcdread := AOR1 (srcdread, srcshade, srcdreadd, srcdreadt);`
  annotated *"2/9/92 - enhancement? / Load srcdread on the next tick as well to
  modify it in srcshade"* — the shaded value is written back into the source
  data register.
- `DCONTROL.NET`: `Srcshadd := AN2 (srcshadd, srcdreadd, srcshade);` and
  `Daddq_sel := OR5 (daddq_sel, patfadd, patdadd, srcz1add, srcz2add, srcshadd);`
  — the adder output is routed onto the local data bus on that extra tick.
- `DATA.NET`: `Datacomp := DATACOMP (dcomp[0..7], cmpdst, dstd[0..1], patd[0..1], srcdlo, srcdhi);`
  — the comparator reads the same `srcdlo/srcdhi` the LFU reads, and that comes
  from `SRCSHIFT(srcd1, srcd2)` where `srcd1` is the register receiving the
  shaded write-back.

Read purely structurally that chain suggests DATACOMP could see the shaded
value. I did not take that reading, for three reasons:

1. It makes SRCSHADE and DCOMPEN mutually exclusive — the instant the intensity
   offset is non-zero, every transparent pixel of a shaded sprite becomes
   opaque. That is precisely the artefact.
2. AvP is a shipped 1994 title that uses exactly this combination for its HUD
   weapon icons and drives IINC up from zero; under the literal reading the
   backdrop would appear on real hardware as soon as the fade started.
3. `DCONTROL.NET` gates the adder operand selection on `shadeadd = dwrite . srcshade`
   while the write-back strobe is `srcdreadd . srcshade` — two different
   timings that only coincide if the source read-ack lands inside `dwrite`.
   `blitter.c:3029` already records the related silicon caveat: *"SRCSHADE
   requires GOURZ to be set to work properly--another Jaguar I bug"*. The
   SRCSHADE datapath is a late addition (dated 2/9/92 and annotated with a
   question mark) with known Jaguar I errata, so the netlist is not a reliable
   oracle for its exact pipeline ordering.

If someone can test this blit on real hardware, that would settle it
definitively. Flagging so the ambiguity is on the record rather than buried.

## The change

Keep an unshaded copy of the source for the comparator; the LFU / write path
still sees the shaded value, so the icon's fade-in is unchanged.

`srcd_cmp` differs from `srcd` **only** when SRCSHADE is set, so every
non-SRCSHADE blit in the core is bit-identical. 15 insertions, 6 deletions in
`src/tom/blitter.c`.

## Verification

Red pixels in the artefact box `x[249..298] y[62..79]` (900 px total), accurate
blitter, driven from boot via `test/fixtures/avp_reach_marine_shotgun.press`
(12000 frames):

| frames 10600-12000 | before | after |
|---|---|---|
| reddish pixels in box | **448** | **0** |

Confirmed visually on the converted PNGs, not just by pixel count — the icon
still fades in identically, only the backdrop became transparent. The fast
blitter's rendering of the same frames is unchanged and now matches.

Note for reproducers: the shared harness defaults `virtualjaguar_usefastblitter`
to `enabled`, the opposite of the core default, so the artefact only appears
with an explicit `--option virtualjaguar_usefastblitter=disabled`.

| gate | result |
|---|---|
| `bash scripts/c89-lint.sh src/tom/blitter.c` | `C89 lint passed` |
| `make -j TEST_EXPORTS=1` | clean, no warnings |
| `make TEST_EXPORTS=1 test` | **exit 0** — 529 assertions, 0 failed |
| `bash test/regression_test.sh` | **10 passed, 0 failed, 0 new** |
| `make -C test/acid check-baseline` | `Total in run: 143 / Known FAILs (OK): 3 / Improvements: 0 / **Regressions: 0** / OK: no regressions.` |

Fast-vs-accurate A/B with `test/tools/test_blitter_compare` (600 frames), before
and after the change:

| title | blits | diffs before | diffs after |
|---|---|---|---|
| Atari Karts (1995) | 132378 | 0 (IDENTICAL) | 0 (IDENTICAL) |
| Attack of the Mutant Penguins (1996) | 132429 | 0 (IDENTICAL) | 0 (IDENTICAL) |

## Does not close #267

Headless tests cannot confirm what the RetroArch compositor actually shows —
`test/regression_test.sh`'s own known headless read-path caveat applies. This
should stay open until someone verifies the shotgun HUD icon in RetroArch on a
real run with Fast Blitter off.

Made with [Cursor](https://cursor.com)