### PR TITLE
docs: document embedded BIOS handling and optional CD BIOS override

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ works out of the box:
   boot animation) and the real boot ROM. The console boot ROM is always the
   embedded copy; it is never loaded from disk.
 - **CD discs** — the `CD Boot Mode` core option chooses between the HLE CD
-  BIOS (default, recommended) and a real CD BIOS. In real-BIOS mode the
+  BIOS (default, recommended) and a real CD BIOS (`Real BIOS`, or `Auto`,
+  which currently also boots the real BIOS). In the real-BIOS modes the
   `CD BIOS Type` option selects the retail or developer image.
 
 ### Optional external CD BIOS override
 
-In real-BIOS CD mode only, a CD BIOS ROM file in the RetroArch `system`
+In the real-BIOS CD modes only (`CD Boot Mode` set to `Real BIOS` or
+`Auto`), a CD BIOS ROM file in the RetroArch `system`
 directory takes precedence over the embedded images — useful if you want to
 run a specific BIOS revision. The file must be exactly 256 KiB and can live
 directly in `system/` or in an `Atari - Jaguar/`, `Atari - Jaguar CD/`,

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Port of the [Virtual Jaguar](http://shamusworld.gotdns.org/git/virtualjaguar) At
 - Supports NTSC and PAL video modes
 - 2-player input with configurable numpad mapping
 - Fast and legacy blitter modes (the legacy/accurate path is SIMD-accelerated on SSE2 and NEON)
-- Optional BIOS boot sequence, plus an HLE BIOS so games can boot without a BIOS image
+- No BIOS files required: the Jaguar boot ROM and both Jaguar CD BIOSes are built into the core, with an HLE BIOS as the default boot path (see [BIOS](#bios))
 - Save state, run-ahead (deterministic serialization), SRAM/EEPROM via the libretro SRAM interface, cheat codes, and a memory map for RetroAchievements
 - Supported ROM formats: `.j64`, `.jag`, `.rom`, `.abs`, `.cof`, `.bin`, `.prg` (including inside ZIP archives), plus `.cue` and `.cdi` for Jaguar CD images, and conservative headerless raw homebrew loading
 - Network link play (JagLink / CatBox emulation): Doom deathmatch, AirCars, BattleSphere Gold — via RetroArch netplay, or a direct TCP link between frontends on socket-capable platforms ([setup guide](docs/netlink-user-guide.md))
@@ -37,6 +37,39 @@ make platform=ios-arm64                         # Cross-compile (ios-arm64, osx,
 ```
 
 Output varies by platform: `.so` (Linux), `.dylib` (macOS), `.dll` (Windows).
+
+## BIOS
+
+**No BIOS files are required.** The Jaguar console boot ROM and both Jaguar CD
+BIOSes (retail and developer) are embedded in the core, so every boot mode
+works out of the box:
+
+- **Cartridges** — the `BIOS (Cartridges)` core option chooses between the
+  HLE BIOS (default: the core performs the boot setup itself, skipping the
+  boot animation) and the real boot ROM. The console boot ROM is always the
+  embedded copy; it is never loaded from disk.
+- **CD discs** — the `CD Boot Mode` core option chooses between the HLE CD
+  BIOS (default, recommended) and a real CD BIOS. In real-BIOS mode the
+  `CD BIOS Type` option selects the retail or developer image.
+
+### Optional external CD BIOS override
+
+In real-BIOS CD mode only, a CD BIOS ROM file in the RetroArch `system`
+directory takes precedence over the embedded images — useful if you want to
+run a specific BIOS revision. The file must be exactly 256 KiB and can live
+directly in `system/` or in an `Atari - Jaguar/`, `Atari - Jaguar CD/`,
+`jaguar/`, or `jaguarcd/` sub-folder, under one of these names:
+
+| Type | Accepted filenames |
+| --- | --- |
+| Retail | `[BIOS] Atari Jaguar CD (World).j64` / `.rom` / `.bin` |
+| Developer | `[BIOS] Atari Jaguar Developer CD (World).j64` / `.rom` / `.bin` |
+| Generic | `jaguarcd_bios.bin`, `jagcd_bios.bin`, `jaguarcd.bin`, `jagcd.bin`, `Jaguar CD BIOS.rom`, `Jaguar CD BIOS.bin` |
+
+Selection is by filename only — the core does not verify which BIOS a file
+actually contains, so a mislabelled or corrupt file will boot to a black
+screen. If real-BIOS CD boots misbehave, remove or rename any CD BIOS files
+in `system/` to fall back to the known-good embedded images.
 
 ## Documentation
 

--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -29,4 +29,14 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 
-description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. Supports Jaguar CD (CUE/BIN, CDI) with Memory Track saves, JagLink/CatBox network play over TCP or RetroArch netplay, a high-level BIOS that lets most commercial titles boot without a real BIOS image, save states, SRAM, cheat codes, and RetroAchievements. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM); the Blitter core option can be set to 'Fast' to trade some accuracy for additional speed on lower-end hardware."
+# BIOS / Firmware (all optional -- embedded copies are used when absent)
+notes = "(!) No BIOS files are required: the Jaguar boot ROM and CD BIOS images are embedded in the core.|(!) An optional CD BIOS file in the system directory overrides the embedded copy in real-BIOS CD boot mode."
+firmware_count = 2
+firmware0_desc = "[BIOS] Atari Jaguar CD (World).j64 (Jaguar CD BIOS, retail - optional override)"
+firmware0_path = "[BIOS] Atari Jaguar CD (World).j64"
+firmware0_opt = "true"
+firmware1_desc = "[BIOS] Atari Jaguar Developer CD (World).j64 (Jaguar CD BIOS, developer - optional override)"
+firmware1_path = "[BIOS] Atari Jaguar Developer CD (World).j64"
+firmware1_opt = "true"
+
+description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. No BIOS files are required: the Jaguar boot ROM and CD BIOS images are embedded in the core. Supports Jaguar CD (CUE/BIN, CDI) with Memory Track saves, JagLink/CatBox network play over TCP or RetroArch netplay, a high-level BIOS that lets most commercial titles boot without a real BIOS image, save states, SRAM, cheat codes, and RetroAchievements. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM); the Blitter core option can be set to 'Fast' to trade some accuracy for additional speed on lower-end hardware."


### PR DESCRIPTION
## Summary

Closes #295 (split out of #294, where a user assumed a BIOS file was required and couldn't find the expected filename documented anywhere).

- **README**: new `BIOS` section — states that **no BIOS files are required** (boot ROM + retail/developer CD BIOSes are embedded), explains the `BIOS (Cartridges)` / `CD Boot Mode` / `CD BIOS Type` core options, and documents the optional external CD BIOS override: accepted filenames, searched sub-folders, the 256 KiB size check, and the filename-only-selection caveat (a mislabelled file boots to a black screen — relevant to #296).
- **`.info`**: adds optional `firmware0/1` entries for the two canonical CD BIOS filenames so RetroArch's Core Information screen lists them, plus `notes` lines and a description one-liner saying no BIOS files are required.

All content verified against `stage_cd_bios()` / `load_external_cd_bios()` in `libretro.c` and the core-option sublabels in `libretro_core_options.h`.

## Testing

Docs-only change — no code paths touched. README markdown table render checked; `.info` remains valid key/value format (firmware entries follow the standard libretro info-file schema, both marked `opt = "true"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)