### PR TITLE
fix(cd): validate external CD BIOS content, accept developer BIOS dumps

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -18,6 +18,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 
 #include "cheat.h"
 #include "crash_detect.h"
+#include "crc32.h"
 #include "bus_arbiter.h"
 #include "file.h"
 #include "jagbios.h"
@@ -1134,13 +1135,22 @@ static bool has_extension(const char *path, const char *ext)
    return strcasecmp(dot + 1, ext) == 0;
 }
 
+/* CRC32s of known-good 256 KB CD BIOS dumps.  The developer BIOS has
+ * $FFFFFFFF at the $404 run-address slot, so it can only be recognized
+ * by checksum -- a header check alone always rejects it. */
+#define CD_BIOS_CRC_RETAIL 0x687068D5u
+#define CD_BIOS_CRC_DEV    0x55A0669Cu
+
 /* Try to load a 256 KB CD BIOS image from the given path.
- * Returns true on success and sets cd_bios_loaded_externally. */
-static bool try_load_cd_bios_file(const char *path)
+ * Returns true on success and sets cd_bios_loaded_externally.
+ * A file that exists but fails validation bumps *rejected so the
+ * caller's final warning can distinguish "no file" from "bad file". */
+static bool try_load_cd_bios_file(const char *path, int *rejected)
 {
    RFILE   *f;
    int64_t  size;
    uint32_t run_addr;
+   uint32_t crc;
 
    f = rfopen(path, "rb");
    if (!f)
@@ -1155,16 +1165,38 @@ static bool try_load_cd_bios_file(const char *path)
       LOG_DBG("[CD-BIOS]   wrong size (%lld, need 262144): %s\n",
               (long long)size, path);
       rfclose(f);
+      (*rejected)++;
       return false;
    }
 
    if (rfread(external_cd_bios, 1, 0x40000, f) != 0x40000)
    {
+      LOG_DBG("[CD-BIOS]   short read (need 262144): %s\n", path);
       rfclose(f);
+      (*rejected)++;
       return false;
    }
    rfclose(f);
 
+   /* Known dumps are accepted by checksum, no header check needed. */
+   crc = (uint32_t)crc32_calcCheckSum(external_cd_bios, 0x40000);
+   if (crc == CD_BIOS_CRC_RETAIL)
+   {
+      LOG_INF("[CD-BIOS] using external %s (recognized retail CD BIOS, crc32=%08X)\n",
+              path, (unsigned)crc);
+      cd_bios_loaded_externally = true;
+      return true;
+   }
+   if (crc == CD_BIOS_CRC_DEV)
+   {
+      LOG_INF("[CD-BIOS] using external %s (recognized developer CD BIOS, crc32=%08X)\n",
+              path, (unsigned)crc);
+      cd_bios_loaded_externally = true;
+      return true;
+   }
+
+   /* Unknown checksum: fall back to the header sanity check so genuine
+    * revisions/regions we don't have CRCs for still load. */
    run_addr = ((uint32_t)external_cd_bios[0x404] << 24)
             | ((uint32_t)external_cd_bios[0x405] << 16)
             | ((uint32_t)external_cd_bios[0x406] <<  8)
@@ -1172,11 +1204,17 @@ static bool try_load_cd_bios_file(const char *path)
 
    if (run_addr < 0x800000 || run_addr > 0x840000)
    {
-      LOG_DBG("[CD-BIOS]   bad run addr $%08X: %s\n",
-              (unsigned)run_addr, path);
+      LOG_DBG("[CD-BIOS]   bad run addr $%08X (crc32=%08X): %s\n",
+              (unsigned)run_addr, (unsigned)crc, path);
+      (*rejected)++;
       return false;
    }
 
+   LOG_WRN("[CD-BIOS] %s is an unrecognized CD BIOS revision "
+           "(crc32=%08X, plausible run=$%06X) -- accepting it, but if boot "
+           "black-screens right after this line, this file is the prime "
+           "suspect: verify it is a genuine Jaguar CD BIOS dump\n",
+           path, (unsigned)crc, (unsigned)run_addr);
    LOG_INF("[CD-BIOS] using external %s (run=$%06X)\n",
            path, (unsigned)run_addr);
    cd_bios_loaded_externally = true;
@@ -1188,9 +1226,11 @@ static bool try_load_cd_bios_file(const char *path)
 static bool load_external_cd_bios(void)
 {
    /* Filenames conventionally used for each 'CD BIOS Type', plus generic
-    * names that could hold either image.  Selection is by NAME only — the
-    * loader does not inspect the image to confirm which BIOS it actually
-    * is, so a mislabelled file is taken at its filename's word.
+    * names that could hold either image.  The name drives the SEARCH ORDER
+    * only; the contents are validated by try_load_cd_bios_file(), which
+    * checksums the image and logs which revision it actually is.  So a
+    * mislabelled file is still loaded (its name only decided when it was
+    * tried), but the log names the real revision rather than the label.
     *
     * The selected type's names are searched FIRST.  The previous code used
     * one flat list with the retail names ahead of the developer ones, so a
@@ -1228,6 +1268,7 @@ static bool load_external_cd_bios(void)
    };
    const char *system_dir = NULL;
    int s, i, g;
+   int rejected = 0;
 
    if (!environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir)
        || !system_dir)
@@ -1268,13 +1309,18 @@ static bool load_external_cd_bios(void)
                snprintf(path, sizeof(path), "%s/%s",
                         system_dir, name_groups[g][i]);
 
-            if (try_load_cd_bios_file(path))
+            if (try_load_cd_bios_file(path, &rejected))
                return true;
          }
       }
    }
 
-   LOG_WRN("[CD-BIOS] CD BIOS not found in %s\n", system_dir);
+   if (rejected > 0)
+      LOG_WRN("[CD-BIOS] no usable CD BIOS in %s: %d candidate file(s) "
+              "rejected (size or header); using embedded BIOS\n",
+              system_dir, rejected);
+   else
+      LOG_WRN("[CD-BIOS] CD BIOS not found in %s\n", system_dir);
    return false;
 }
 


### PR DESCRIPTION
## Summary

Fixes both external CD BIOS loader defects confirmed empirically in #296.

The loader validated a candidate file on one signal: the 32-bit run address at offset `$404` had to land in `[$800000,$840000]`. That has two failure modes:

1. **Genuine developer CD BIOS dumps were always rejected.** The developer BIOS (crc32 `55A0669C`) carries `$FFFFFFFF` at `$404`, so the run-addr test can never pass for it. A user dropping a real dev BIOS in `system/` got the misleading `CD BIOS not found` warning and a silent fall back to the embedded image — their file could never be used.
2. **A 256 KiB file of arbitrary content with a plausible long at `$404` was accepted** and staged as the CD BIOS, producing the user-reported cube-animation-then-permanent-black-screen (watchdog logs `dsp_pc_escape` / `gpu_pc_escape` at `$8xxxxxxx`).

Validation is now content-based, in order:

- **(a)** crc32 matches a known dump (`687068D5` retail, `55A0669C` developer) → accept, logging which revision was recognized.
- **(b)** unknown crc32 but plausible run address → accept as an unrecognized revision, behind a loud warning naming the file as prime suspect if boot black-screens immediately after. Genuine revisions/regions we don't have CRCs for still load.
- **(c)** neither → reject, keep searching, fall back to embedded.

The final "no BIOS" warning now distinguishes *nothing was there* from *N candidate file(s) rejected*, so a bad file no longer looks like a missing one.

Reuses `crc32_calcCheckSum()` from `src/core/crc32.c` — no new checksum code. Filenames still drive search order only; the log now reports the revision a file actually contains rather than what its name claims.

## Testing

`bash scripts/c89-lint.sh libretro.c` → passed. Clean build. `make TEST_EXPORTS=1 test` → **exit 0**, 19 result blocks, 0 failed.

Headless matrix (Hover Strike: Unconquered Lands, `virtualjaguar_cd_boot_mode=bios`, 1200 frames, scratch system dirs):

| System-dir contents | Result |
|---|---|
| **developer BIOS file** | **now accepted** — `using external ... (recognized developer CD BIOS, crc32=55A0669C)`; identical per-window timeline and audio RMS to the embedded dev image (control run) |
| retail BIOS file | still accepted — `(recognized retail CD BIOS, crc32=687068D5)`, boots to game code (71.8% non-black, RMS 1544) |
| 256 KiB junk w/ plausible `$404` | accepted only behind the new `unrecognized CD BIOS revision (crc32=8CE070BE ...)` warning; the expected `dsp_pc_escape`/`video_stall` cascade follows, now traceable to the named file |
| 2 bad files (bad `$404` + truncated) | `no usable CD BIOS in ...: 2 candidate file(s) rejected (size or header); using embedded BIOS` → embedded fallback boots |
| empty | unchanged — `CD BIOS not found` → embedded retail → boots |

Note on the dev-BIOS case: both the external file and the embedded dev image render through frame ~479 then blank on this title. That blackout is **pre-existing dev-BIOS behavior, identical on both paths** and outside this fix's scope — the point proven here is that the external file is now loaded at all.

## Notes / follow-ups

- Tier (b) still *accepts* junk by design, so #296's black screen becomes **diagnosable, not prevented**. Hard-rejecting unknown CRCs would break genuine alternate dumps.
- `bios_boot()` sets `jaguarRunAddress = GET32(jagMemSpace, 0x800404)`, which is `$FFFFFFFF` for the developer BIOS. It appears inert on this path (boot ROM is forced on) and behaves identically for the embedded dev image, so it predates this change — worth a separate look if dev-BIOS titles are pursued.

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)
