### PR TITLE
fix(state): load every savestate a released core ever wrote (#268 + silent v2/v3 corruption)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -923,8 +923,9 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	else \
 		echo "  SKIP: yarc.j64 ROM not available (framebuffer integrity)"; \
 	fi
-	@# Save-state version gate: a v2-layout state must still load, v1 and
-	@# future versions must be refused.  Deliberately NOT wrapped in an
+	@# Save-state version gate: every layout a released core wrote (v1, v2,
+	@# v3, v7) must still load with its chunks correctly aligned; version 0
+	@# and future versions must be refused.  Deliberately NOT wrapped in an
 	@# `if [ -f ... ]` guard like the framebuffer test above: yarc.j64 is
 	@# committed in-tree, so a missing ROM is a broken checkout and the
 	@# test's exit 77 should stop the suite rather than read as a pass.

--- a/docs/open-issue-handoff.md
+++ b/docs/open-issue-handoff.md
@@ -160,37 +160,44 @@ divergent blits corpus-wide.
 
 ## 3. #268 — AvP savestates rejected (below STATE_MIN_VERSION)
 
-**Status: not a bug. Needs a maintainer decision, plus one cheap tool.**
+**Status: fixed. This section is kept for the history; the earlier "not a
+bug, needs a decision" reading was wrong.** See `docs/savestate-compat.md`.
 
-### What is established
+### What the investigation actually found
 
-- `src/core/state.h`: `STATE_VERSION = 7` (what this build writes),
-  `STATE_MIN_VERSION = 2` (oldest it will load). `retro_unserialize()` refuses
-  anything outside that window and returns false silently.
-- A Battle Sphere Gold state loaded on the same build — so this is version
-  gating, not a general savestate bug and not AvP-specific.
-- **Unconfirmed:** the actual header version in the reporter's two files was
-  never measured; the files were not available. Do not assert they are "v1".
+Two defects, and the second is the bigger one:
 
-### Decision required (this is the ticket)
+- `STATE_MIN_VERSION` was `2`, so v1 states (release v2.2.0) were refused.
+  That is the reported symptom.
+- **v1, v2 and v3 states all mis-parsed from the CDROM chunk onward.** v2
+  (v2.3.0/v2.3.1) and v3 (v2.3.2) were *inside* the accepted window:
+  `retro_unserialize()` returned true, the core kept running, and every chunk
+  after the CD block was read at the wrong offset. The CD-support work
+  restructured the CDROM chunk (−2627 bytes) with only its trailing 28 bytes
+  version-gated. Nothing user-visible flagged it.
 
-- **Recommended:** leave as-is, document that states from sufficiently old
-  Virtual Jaguar versions do not carry forward, close as expected behaviour.
-- Alternative: add a best-effort legacy loader below `STATE_MIN_VERSION`. Only
-  worth it if there is real appetite — the format gap is old and the v3.0.0
-  freeze at v7 means the window is now stable rather than drifting.
+So the release-notes claim that states "from the v2.x line load normally" was
+false as shipped in v3.0.0.
 
-### Automation worth building (small, high leverage)
+### What was done
 
-A savestate header inspector: read the first 8 bytes, print magic (`"VJSS"`) and
-the version field. Turns "what version is this file" from an unanswerable
-support question into a one-line answer, for this and every future report. Ask
-the reporter for those 8 bytes either way.
+`STATE_MIN_VERSION` is `1`, `DACStateLoad` gates the I2S resampler fields, and
+`CDROMStateLoad` forks on `STATE_VERSION_CDROM_RESTRUCTURE` to consume the
+legacy 8004-byte block. Both fixes are exact, not best-effort — the defaulted
+fields are all re-derived before use (DAC) or belong to a CD path those cores
+never had (CDROM). This deliberately reverses the "not adding a legacy loader
+in this pass" call recorded on the issue, on the grounds that the loader turned
+out to be exact.
 
-### Acceptance criteria
+Verified with genuine states written by v2.2.0, v2.3.0 and v2.3.2 cores built
+from their own tags against the real AvP ROM; `test/test_state_compat` guards
+all four released layouts in CI.
 
-A documented, deliberate call recorded on the issue — not an implicit one — plus
-the inspector merged if the team wants triage support.
+### Still open on the ticket
+
+The reporter's two files were never available, so *their* header versions
+remain inferred rather than measured. `test/tools/vjss_info` answers it in one
+line if they turn up.
 
 ---
 

--- a/docs/savestate-compat.md
+++ b/docs/savestate-compat.md
@@ -13,7 +13,9 @@ Defined in `src/core/state.h`:
 | `STATE_MIN_VERSION` | `1` | Oldest version this build will **load** |
 
 `retro_unserialize()` refuses anything outside `STATE_MIN_VERSION … STATE_VERSION`
-and returns false (no partial load).
+outright, returning false without touching emulator state. Inside the window it
+always loads in full; chunks whose fields an older layout did not carry are
+reconstructed rather than read (see below).
 
 Header fields are stored with host-endian `memcpy` (`STATE_SAVE_VAR`). On a
 little-endian host the on-disk magic bytes are `53 53 4A 56`, not the ASCII

--- a/docs/savestate-compat.md
+++ b/docs/savestate-compat.md
@@ -1,6 +1,6 @@
 # Savestate compatibility
 
-Status as of 2026-08-03. Tracker: issue [#268](https://github.com/libretro/virtualjaguar-libretro/issues/268).
+Status as of 2026-08-04. Tracker: issue [#268](https://github.com/libretro/virtualjaguar-libretro/issues/268).
 
 ## Version window
 
@@ -10,7 +10,7 @@ Defined in `src/core/state.h`:
 |---|---|---|
 | `STATE_MAGIC` | `0x564A5353` (`"VJSS"`) | Header magic |
 | `STATE_VERSION` | `7` | Version this build **writes** |
-| `STATE_MIN_VERSION` | `2` | Oldest version this build will **load** |
+| `STATE_MIN_VERSION` | `1` | Oldest version this build will **load** |
 
 `retro_unserialize()` refuses anything outside `STATE_MIN_VERSION … STATE_VERSION`
 and returns false (no partial load).
@@ -19,16 +19,82 @@ Header fields are stored with host-endian `memcpy` (`STATE_SAVE_VAR`). On a
 little-endian host the on-disk magic bytes are `53 53 4A 56`, not the ASCII
 string `"VJSS"`.
 
-## Decision (deliberate)
+## What released cores wrote
 
-Rejecting states below `STATE_MIN_VERSION` (2) is **expected behaviour**, not
-an AvP-specific loader bug. A Battle Sphere Gold state from a current build
-loads successfully on the same build — the loader works; old Virtual Jaguar
-states simply sit outside the supported window.
+Only four format versions have ever left a release tag:
 
-A best-effort legacy loader for pre-`STATE_MIN_VERSION` files is **out of
-scope**. The format gap is old, and the v3.0.0 freeze at version 7 means the
-window is stable rather than drifting.
+| Version | Written by |
+|---|---|
+| 1 | v2.2.0 (savestate support first shipped here) |
+| 2 | v2.3.0, v2.3.1 |
+| 3 | v2.3.2 |
+| 7 | v3.0.0 |
+
+Versions 4, 5 and 6 existed only on `develop` / nightlies. All four released
+layouts load on the current core.
+
+## Two bugs, both fixed (issue #268)
+
+### 1. v1 was gated out
+
+`STATE_MIN_VERSION` was `2`, so v2.2.0's states were refused outright. The
+complete layout difference between v1 and v2 is 24 bytes — the four DAC I2S
+resampler fields (`i2sWritePos`, `i2sWriteCount`, `i2sPhase`, `i2sRateRatio`)
+— verified by extracting and diffing every `*StateSave` / `*StateLoad` body
+between the `v2.2.0` and `v2.3.0` tags.
+
+`DACStateLoad` now skips those four fields for a v1 header and leaves them at
+their `DACInit()` defaults. That is exact, not best-effort: `DACPrepareFrame`
+(libretro.c, top of `retro_run`, before `JaguarExecuteNew`) re-seeds
+writePos/writeCount, truncates the phase and re-derives the rate ratio from
+the restored SMODE/SCLK registers, so the defaults never reach the audio
+output.
+
+### 2. v1, v2 AND v3 mis-parsed from the CDROM chunk onward
+
+This one was live on `develop` for v2 and v3 — versions already inside the
+accepted window. `retro_unserialize()` returned `true` and the game kept
+running, so nothing looked wrong, but every chunk from the CD block onward was
+read at the wrong offset.
+
+The CD-support work restructured `CDROMStateSave`/`Load`: it dropped the two
+`cdBuf2` / `cdBuf3` staging buffers (`uint8_t [2532 + 96]` each, 5256 bytes
+together) and put the BUTCH/FIFO/DSA/SSI working set there instead. Only the
+last 28 bytes of that change were version-gated
+(`STATE_VERSION_CDROM_DSA_QUEUE`, `..._DRIVE_SPEED`). Net effect on an old
+blob: the loader read 5256 bytes of stale sector data as flags and finished
+2627 bytes short, desyncing the Joystick, Memory Track and DAC chunks behind
+it.
+
+`CDROMStateLoad` now forks on `STATE_VERSION_CDROM_RESTRUCTURE` (4). Below it
+the loader consumes the legacy 8004-byte block — 2748 bytes of prefix
+(`cdRam` … `firstTime`, byte-identical in every version) plus the 5256 dead
+staging bytes — and starts the drive from the idle state `CDROMReset()`
+establishes. `cdrom_eeprom_ram` is deliberately left alone: it is
+file-backed NVM, and an old blob has nothing to say about it.
+
+Zero-defaulting the CD fields is exact for these states in practice — no core
+that wrote v1/v2/v3 had a working CD path (`cdBuf2`/`cdBuf3` belonged to the
+unfinished BUTCH stub), so there is no CD session to lose.
+
+### Verification
+
+A genuine state was written by each released core built from its own tag
+(v2.2.0, v2.3.0, v2.3.2) against the real Alien vs Predator ROM, then loaded
+in the current core. In all four cases (plus a current-version control) the
+DAC chunk — the last module, so the accumulated victim of any upstream
+mis-size — lands at its correct offset with a unique match, and main RAM, TOM
+and JERRY register space come back byte-identical.
+
+`test/test_state_compat` builds v1/v2/v3 fixtures at runtime (see
+`synth_legacy_state`) and asserts the same thing in CI. Disabling the legacy
+CDROM branch turns three of its assertions red.
+
+### Still refused
+
+Anything below `STATE_MIN_VERSION` (now only the never-released version 0) and
+anything above `STATE_VERSION`. Nightly-only versions 4-6 load, but were never
+covered by the release-compat policy.
 
 ## Inspecting a file
 

--- a/src/cd/cdrom.c
+++ b/src/cd/cdrom.c
@@ -2555,6 +2555,13 @@ storew	TEMP,(r24)
 
 #include "state.h"
 
+/* Size of the two staging buffers (`static uint8_t cdBuf2[2532 + 96],
+ * cdBuf3[2532 + 96];`) that the pre-STATE_VERSION_CDROM_RESTRUCTURE CDROM
+ * chunk carried after `firstTime`.  The arrays were deleted with the
+ * unfinished BUTCH stub, so the legacy loader has to skip them by an
+ * explicit byte count rather than a sizeof. */
+#define CDROM_LEGACY_STAGING_BYTES ((size_t)((2532 + 96) * 2))
+
 size_t CDROMStateSave(uint8_t *buf)
 {
 	uint8_t *start = buf;
@@ -2627,18 +2634,54 @@ size_t CDROMStateLoad(const uint8_t *buf, uint32_t stateVersion)
 	STATE_LOAD_VAR(buf, txData);
 	STATE_LOAD_VAR(buf, rxDataBit);
 	STATE_LOAD_VAR(buf, firstTime);
-	STATE_LOAD_BUF(buf, cdrom_eeprom_ram, sizeof(cdrom_eeprom_ram));
-	STATE_LOAD_VAR(buf, dsaResponseReady);
-	STATE_LOAD_VAR(buf, isMultiWordResponse);
-	STATE_LOAD_VAR(buf, txBufferEmpty);
-	STATE_LOAD_VAR(buf, cdPlaying);
-	STATE_LOAD_VAR(buf, seekDelay);
-	STATE_LOAD_VAR(buf, fifoDataReady);
-	STATE_LOAD_VAR(buf, fifoReadCount);
-	STATE_LOAD_VAR(buf, fifoFillDelay);
-	STATE_LOAD_BUF(buf, ssiBuf, sizeof(ssiBuf));
-	STATE_LOAD_VAR(buf, ssiBufPtr);
-	STATE_LOAD_VAR(buf, ssiBlock);
+	/* Layout fork.  Everything above is common to every format version;
+	 * from here the pre-CD-support layout (STATE_VERSION_CDROM_RESTRUCTURE)
+	 * diverges completely.  Releases v2.2.0 (v1), v2.3.0/v2.3.1 (v2) and
+	 * v2.3.2 (v3) wrote two staging buffers here — cdBuf2 and cdBuf3, both
+	 * `uint8_t [2532 + 96]` — which the CD-support work removed and
+	 * replaced with the BUTCH/FIFO/DSA/SSI working set below.  Consuming
+	 * the new field list from an old blob would read 5256 bytes of stale
+	 * sector data as flags and then leave the cursor 2627 bytes short,
+	 * desyncing the Joystick, Memory Track and DAC chunks that follow.
+	 * Skip the dead buffers by their byte count (the arrays no longer
+	 * exist, so the size has to be spelled out) and start the drive from
+	 * the same idle state CDROMReset() establishes.  Those cores had no
+	 * working CD path — cdBuf2/cdBuf3 were only ever written by the
+	 * unfinished BUTCH stub — so nothing emulated is lost. */
+	if (stateVersion < STATE_VERSION_CDROM_RESTRUCTURE)
+	{
+		buf += CDROM_LEGACY_STAGING_BYTES;
+		/* cdrom_eeprom_ram is persistent NVM backed by a file on disk,
+		 * not transient drive state: an old blob simply has nothing to
+		 * say about it, so leave whatever the session loaded in place
+		 * rather than zeroing the user's CD memory. */
+		dsaResponseReady    = false;
+		isMultiWordResponse = false;
+		txBufferEmpty       = true;
+		cdPlaying           = false;
+		seekDelay           = 0;
+		fifoDataReady       = false;
+		fifoReadCount       = 0;
+		fifoFillDelay       = 0;
+		memset(ssiBuf, 0x00, sizeof(ssiBuf));
+		ssiBufPtr           = 2352;
+		ssiBlock            = 0;
+	}
+	else
+	{
+		STATE_LOAD_BUF(buf, cdrom_eeprom_ram, sizeof(cdrom_eeprom_ram));
+		STATE_LOAD_VAR(buf, dsaResponseReady);
+		STATE_LOAD_VAR(buf, isMultiWordResponse);
+		STATE_LOAD_VAR(buf, txBufferEmpty);
+		STATE_LOAD_VAR(buf, cdPlaying);
+		STATE_LOAD_VAR(buf, seekDelay);
+		STATE_LOAD_VAR(buf, fifoDataReady);
+		STATE_LOAD_VAR(buf, fifoReadCount);
+		STATE_LOAD_VAR(buf, fifoFillDelay);
+		STATE_LOAD_BUF(buf, ssiBuf, sizeof(ssiBuf));
+		STATE_LOAD_VAR(buf, ssiBufPtr);
+		STATE_LOAD_VAR(buf, ssiBlock);
+	}
 	/* v3 and older states predate the DSA response queue (see
 	 * STATE_VERSION_CDROM_DSA_QUEUE): leave those fields at a safe empty
 	 * state instead of consuming bytes the layout never carried. */

--- a/src/cd/cdrom.c
+++ b/src/cd/cdrom.c
@@ -2651,10 +2651,16 @@ size_t CDROMStateLoad(const uint8_t *buf, uint32_t stateVersion)
 	if (stateVersion < STATE_VERSION_CDROM_RESTRUCTURE)
 	{
 		buf += CDROM_LEGACY_STAGING_BYTES;
-		/* cdrom_eeprom_ram is persistent NVM backed by a file on disk,
-		 * not transient drive state: an old blob simply has nothing to
-		 * say about it, so leave whatever the session loaded in place
-		 * rather than zeroing the user's CD memory. */
+		/* Start the drive from the same clean idle state CDROMReset()
+		 * establishes.  The fields loaded above from the blob (cdRam,
+		 * cdBufPtr, etc.) come from cores that had no working CD path,
+		 * so any BIOS_OVRD or data-ready flag they carry is stale noise.
+		 * Overwrite all drive-state fields unconditionally; the one
+		 * exception is cdrom_eeprom_ram — persistent NVM backed by a
+		 * file on disk that an old blob has nothing to say about, so
+		 * leave whatever the session already loaded in place. */
+		memset(cdRam, 0x00, 0x100);
+		cdBufPtr            = 2352;
 		dsaResponseReady    = false;
 		isMultiWordResponse = false;
 		txBufferEmpty       = true;
@@ -2663,9 +2669,12 @@ size_t CDROMStateLoad(const uint8_t *buf, uint32_t stateVersion)
 		fifoDataReady       = false;
 		fifoReadCount       = 0;
 		fifoFillDelay       = 0;
+		fifoRefillAccum     = 0;
+		cdPrevShouldIRQ     = false;
 		memset(ssiBuf, 0x00, sizeof(ssiBuf));
 		ssiBufPtr           = 2352;
 		ssiBlock            = 0;
+		cdTraceLastI2SEnable = -1;
 	}
 	else
 	{

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -18,7 +18,15 @@ extern "C" {
 #endif
 
 /* Save state format identifier and version.
- * v4: CDROM chunk gained the DSA response queue + serial-delay counter.
+ * v1: original layout, written only by release v2.2.0 (savestate support
+ *     first shipped there; the bump to v2 shipped in v2.3.0).
+ * v2: DAC chunk gained the I2S resampler fields (i2sWritePos,
+ *     i2sWriteCount, i2sPhase, i2sRateRatio).
+ * v3: DAC chunk gained i2sNonZeroCount.
+ * v4: CDROM chunk restructured — the two 2628-byte staging buffers
+ *     (cdBuf2/cdBuf3) the pre-CD-support layout carried were dropped and
+ *     replaced by the BUTCH/FIFO/DSA/SSI working set, and the chunk gained
+ *     the DSA response queue + serial-delay counter.
  * v5: CDROM chunk gained the latched drive speed (DSA Set Mode $15nn).
  * v6: new UART chunk (JERRY async serial + jlink RX ring).
  * v7: Memory Track chunk gained the latched $80AAA8 override flag and
@@ -28,16 +36,29 @@ extern "C" {
 #define STATE_MAGIC     0x564A5353  /* "VJSS" */
 #define STATE_VERSION   7
 /* Oldest layout retro_unserialize still accepts.  States between
- * STATE_MIN_VERSION and STATE_VERSION load by skipping the fields added
- * after them (see DACStateLoad, CDROMStateLoad); STATE_VERSION is always
- * what we write. */
-#define STATE_MIN_VERSION 2
+ * STATE_MIN_VERSION and STATE_VERSION load by reading each chunk in the
+ * layout the header version names (see DACStateLoad, CDROMStateLoad);
+ * STATE_VERSION is always what we write.
+ *
+ * Released cores wrote exactly four versions: 1 (v2.2.0), 2 (v2.3.0 and
+ * v2.3.1), 3 (v2.3.2) and 7 (v3.0.0).  Versions 4-6 existed only on
+ * develop/nightlies.  All four released layouts load (issue #268). */
+#define STATE_MIN_VERSION 1
 
 /* Per-field version gates.  A module loader that has to skip a field an
  * older layout did not carry compares the header version against the
  * constant naming that field, never a bare literal. */
+/* First version whose DAC block carries the I2S resampler fields
+ * (i2sWritePos, i2sWriteCount, i2sPhase, i2sRateRatio). */
+#define STATE_VERSION_DAC_I2S_RESAMPLER 2
 /* First version whose DAC block carries i2sNonZeroCount. */
 #define STATE_VERSION_DAC_I2S_NONZEROCOUNT 3
+/* First version whose CDROM block carries the post-CD-support working set
+ * (cdrom_eeprom_ram, the BUTCH/FIFO/DSA flags and the SSI head) in place
+ * of the two cdBuf2/cdBuf3 staging buffers the original layout carried.
+ * Every released core below this wrote the old shape; see
+ * CDROMStateLoad. */
+#define STATE_VERSION_CDROM_RESTRUCTURE 4
 /* First version whose CDROM block carries the DSA response queue and
  * serial-delay counter. */
 #define STATE_VERSION_CDROM_DSA_QUEUE 4

--- a/src/jerry/dac.c
+++ b/src/jerry/dac.c
@@ -368,8 +368,25 @@ size_t DACStateLoad(const uint8_t *buf, uint32_t stateVersion)
 	STATE_LOAD_VAR(buf, bufferIndex);
 	STATE_LOAD_VAR(buf, numberOfSamples);
 	STATE_LOAD_VAR(buf, bufferDone);
-	STATE_LOAD_VAR(buf, i2sWritePos);
-	STATE_LOAD_VAR(buf, i2sWriteCount);
+	/* The I2S resampler fields were added in
+	 * STATE_VERSION_DAC_I2S_RESAMPLER; a v1 state (written only by
+	 * release v2.2.0) carries none of them.  Consume nothing and fall
+	 * back to the DACInit() defaults — DACPrepareFrame re-seeds
+	 * writePos/writeCount, truncates the phase, and re-derives the rate
+	 * ratio from the restored SMODE/SCLK registers at the top of the
+	 * next retro_run, before any sample is resampled, so the defaults
+	 * never reach the audio output.  Reading fields the layout does not
+	 * carry would desync every module that follows. */
+	if (stateVersion >= STATE_VERSION_DAC_I2S_RESAMPLER)
+	{
+		STATE_LOAD_VAR(buf, i2sWritePos);
+		STATE_LOAD_VAR(buf, i2sWriteCount);
+	}
+	else
+	{
+		i2sWritePos = 0;
+		i2sWriteCount = 0;
+	}
 	/* i2sNonZeroCount was added in STATE_VERSION_DAC_I2S_NONZEROCOUNT.
 	 * Older states do not carry it, so consume nothing and start from the
 	 * value DACPrepareFrame would establish; reading it would desync every
@@ -378,8 +395,16 @@ size_t DACStateLoad(const uint8_t *buf, uint32_t stateVersion)
 		STATE_LOAD_VAR(buf, i2sNonZeroCount);
 	else
 		i2sNonZeroCount = 0;
-	STATE_LOAD_VAR(buf, i2sPhase);
-	STATE_LOAD_VAR(buf, i2sRateRatio);
+	if (stateVersion >= STATE_VERSION_DAC_I2S_RESAMPLER)
+	{
+		STATE_LOAD_VAR(buf, i2sPhase);
+		STATE_LOAD_VAR(buf, i2sRateRatio);
+	}
+	else
+	{
+		i2sPhase = 0.0;
+		i2sRateRatio = 1.0;
+	}
 
 	return (size_t)(buf - start);
 }

--- a/test/test_state_compat.c
+++ b/test/test_state_compat.c
@@ -8,7 +8,10 @@
  *      DAC i2sNonZeroCount and bumped STATE_VERSION 2 -> 3 while
  *      retro_unserialize still demanded an exact version match, which
  *      silently invalidated every state written by v2.3.0 / v2.3.1.
- *   2. A state OLDER than STATE_MIN_VERSION (v1) must be refused.
+ *      Every version a RELEASED core ever wrote is covered: 1 (v2.2.0),
+ *      2 (v2.3.0 / v2.3.1), 3 (v2.3.2) and the current 7 (v3.0.0).
+ *      Issue #268.
+ *   2. A state OLDER than STATE_MIN_VERSION (v0) must be refused.
  *   3. A state NEWER than STATE_VERSION must be refused — we cannot know
  *      what fields it carries.
  *   4. A bad magic must be refused.
@@ -34,7 +37,16 @@
  * the match trustworthy: the pattern must occur exactly once, and — since
  * DAC is serialized last and retro_serialize zero-fills the tail —
  * everything after the block must be zero.  No 2.4 MB binary fixture is
- * committed; the v2 state is synthesized at runtime from a v3 one.
+ * committed; the v1/v2/v3 states are synthesized at runtime from a current
+ * one by synth_legacy_state().
+ *
+ * That synthesis has to rebuild the CDROM chunk, not just trim fields off
+ * the end of the state.  The CD-support work replaced the old block's two
+ * cdBuf2/cdBuf3 staging buffers with the BUTCH/FIFO/DSA/SSI working set,
+ * shrinking the chunk by 2627 bytes, and only the last 28 of those bytes
+ * were version-gated.  A fixture built by trimming alone is not a v1/v2/v3
+ * state, and a test built on one reports PASS while every released state
+ * silently mis-parses from the CDROM chunk onward.
  *
  * Exit codes: 0 = pass, 1 = fail, 2 = harness error, 77 = skip (ROM absent)
  *
@@ -69,7 +81,7 @@ const char *__lsan_default_suppressions(void) {
 }
 #endif
 
-#define MAX_RESULTS 16
+#define MAX_RESULTS 24
 #define DEFAULT_ROM "test/roms/yarc.j64"
 #define DEFAULT_FRAMES 120
 /* Frames run between capturing the v3 state and loading the v2 fixture,
@@ -97,6 +109,17 @@ const char *__lsan_default_suppressions(void) {
 #define DAC_I2S_NONZEROCOUNT_OFFSET   17
 #define DAC_I2S_NONZEROCOUNT_SIZE     4
 
+/* The v1 DAC block (release v2.2.0) is just bufferIndex + numberOfSamples
+ * + bufferDone = 9 bytes.  In the v2 layout the four resampler fields
+ * (i2sWritePos 4, i2sWriteCount 4, i2sPhase 8, i2sRateRatio 8 = 24 bytes)
+ * sit contiguously right after that prefix (i2sNonZeroCount is v3+). */
+#define DAC_V1_PREFIX_SIZE            9
+#define DAC_I2S_RESAMPLER_SIZE        24
+/* Offsets of the resampler fields inside the CURRENT (v3+) 37-byte block,
+ * used to build the expected post-v1-load block. */
+#define DAC_I2S_WRITEPOS_OFFSET       9    /* writePos+writeCount, 8 bytes */
+#define DAC_I2S_PHASE_OFFSET          21   /* phase+ratio, 16 bytes */
+
 /* Trailing CDROM-block fields a v2/v3 state does not carry, verified
  * against the end of CDROMStateSave() in src/cd/cdrom.c:
  *   - STATE_VERSION_CDROM_DSA_QUEUE (v4): dsaQueue (DSA_QUEUE_SIZE=4 x
@@ -111,6 +134,26 @@ const char *__lsan_default_suppressions(void) {
  * cartridge ROM the CDROM block is zero-heavy and a byte-pattern search
  * would not be unique. */
 #define CDROM_DSA_TAIL_SIZE           28
+
+/* The pre-CD-support CDROM block (STATE_VERSION_CDROM_RESTRUCTURE), i.e.
+ * what releases v2.2.0 / v2.3.0 / v2.3.1 / v2.3.2 wrote:
+ *
+ *   cdRam 256 + cdCmd/cdPtr 4 + haveCDGoodness 1 + min/sec/frm/block 16
+ *   + cdBuf 2448 + cdBufPtr 4 + trackNum/minTrack/maxTrack 3
+ *   + currentState 4 + counter 2 + cmdTx 1 + busCmd 2 + rxData/txData 4
+ *   + rxDataBit 2 + firstTime 1                                  = 2748
+ *   + cdBuf2 (2532+96) + cdBuf3 (2532+96)                        = 5256
+ *                                                          total = 8004
+ *
+ * The prefix is byte-identical in every version; everything after it was
+ * replaced wholesale by the BUTCH/FIFO/DSA/SSI working set.  A fixture that
+ * keeps the CURRENT tail is not a v1/v2/v3 state at all — it is 2627 bytes
+ * short — so synthesizing one means swapping the tail, not just trimming
+ * the version-gated fields off the end. */
+#define CDROM_LEGACY_PREFIX_SIZE      2748
+#define CDROM_LEGACY_STAGING_SIZE     5256
+#define CDROM_LEGACY_BLOCK_SIZE       (CDROM_LEGACY_PREFIX_SIZE \
+                                       + CDROM_LEGACY_STAGING_SIZE)
 
 /* Trailing v7 additions a v2..v6 state does not carry: the MT block's
  * latched $80AAA8 override flag (1 byte) plus the entire NVM BIOS block
@@ -192,6 +235,73 @@ static unsigned find_pattern(const uint8_t *hay, size_t hay_len,
     return count;
 }
 
+/* Compose a genuine pre-CD-support fixture (version 1, 2 or 3) from the
+ * current-version state in `src`.
+ *
+ * Rebuilt piecewise rather than spliced in place because the old layout is
+ * both shorter (no MT override flag, no NVM block, no DSA tail, a smaller
+ * DAC block) and LONGER (5256 bytes of cdBuf2/cdBuf3 where the current
+ * block carries 2601 bytes of BUTCH/FIFO/DSA/SSI state) than the current
+ * one.  A run of trim-only memmoves cannot express that.
+ *
+ * Writes the header version, returns the payload length, and reports where
+ * the DAC block landed via *dac_off_out. */
+static size_t synth_legacy_state(uint8_t *dst, const uint8_t *src,
+                                 size_t state_size, size_t cdrom_start,
+                                 size_t cdrom_end, size_t v7_tail,
+                                 size_t dac_off, unsigned version,
+                                 size_t *dac_off_out)
+{
+    size_t pos = 0;
+    size_t n;
+
+    /* Header through the CDROM block's version-invariant prefix. */
+    n = cdrom_start + CDROM_LEGACY_PREFIX_SIZE;
+    memcpy(dst, src, n);
+    pos = n;
+
+    /* cdBuf2 + cdBuf3.  Their contents are irrelevant to the loader (it
+     * skips them by byte count); zeros are what a cartridge title's stub
+     * BUTCH would have held anyway. */
+    memset(dst + pos, 0, CDROM_LEGACY_STAGING_SIZE);
+    pos += CDROM_LEGACY_STAGING_SIZE;
+
+    /* Joystick + Memory Track, minus the v7 MT override flag and the whole
+     * NVM BIOS block that follows it. */
+    n = (dac_off - v7_tail) - cdrom_end;
+    memcpy(dst + pos, src + cdrom_end, n);
+    pos += n;
+
+    if (dac_off_out)
+        *dac_off_out = pos;
+
+    /* DAC, in the layout that version carried. */
+    if (version >= 3) {
+        memcpy(dst + pos, src + dac_off, EXPECTED_DAC_BLOCK_SIZE);
+        pos += EXPECTED_DAC_BLOCK_SIZE;
+    } else if (version == 2) {
+        /* Everything up to i2sNonZeroCount, then phase + rateRatio. */
+        memcpy(dst + pos, src + dac_off, DAC_I2S_NONZEROCOUNT_OFFSET);
+        pos += DAC_I2S_NONZEROCOUNT_OFFSET;
+        memcpy(dst + pos,
+               src + dac_off + DAC_I2S_NONZEROCOUNT_OFFSET
+                   + DAC_I2S_NONZEROCOUNT_SIZE,
+               EXPECTED_DAC_BLOCK_SIZE - DAC_I2S_NONZEROCOUNT_OFFSET
+                   - DAC_I2S_NONZEROCOUNT_SIZE);
+        pos += EXPECTED_DAC_BLOCK_SIZE - DAC_I2S_NONZEROCOUNT_OFFSET
+               - DAC_I2S_NONZEROCOUNT_SIZE;
+    } else {
+        memcpy(dst + pos, src + dac_off, DAC_V1_PREFIX_SIZE);
+        pos += DAC_V1_PREFIX_SIZE;
+    }
+
+    /* retro_unserialize checks size >= STATE_SIZE, so the fixture keeps the
+     * full allocation with a zero tail, exactly like a real one. */
+    memset(dst + pos, 0, state_size - pos);
+    put_u32(dst, STATE_OFF_VERSION, (uint32_t)version);
+    return pos;
+}
+
 /* Patch the header of a copy of `src` and try to load it. */
 static bool try_load_patched(unserialize_fn unser, const uint8_t *src,
                              size_t len, size_t off, uint32_t value,
@@ -212,9 +322,12 @@ int main(int argc, char **argv)
     unserialize_fn unser;
     uint32_t **fb_ptr;
     int *width_ptr, *height_ptr;
-    uint8_t *state_v3 = NULL, *state_v2 = NULL, *scratch = NULL;
+    uint8_t *state_v3 = NULL, *state_v2 = NULL, *state_v1 = NULL,
+            *state_v3l = NULL, *scratch = NULL;
     uint8_t dac_v3[256], dac_now[256], dac_expect[256], dac_post[256];
+    uint8_t dac_expect_v1[256];
     size_t state_size, dac_size, dac_size_now, dac_off = 0;
+    size_t dac_off_v2 = 0;
     size_t cdrom_size, joy_size, mt_size, nvm_size, cdrom_end = 0;
     size_t tail_nonzero = 0, i;
     unsigned matches;
@@ -292,8 +405,10 @@ int main(int argc, char **argv)
 
     state_v3 = (uint8_t *)malloc(state_size);
     state_v2 = (uint8_t *)malloc(state_size);
+    state_v1 = (uint8_t *)malloc(state_size);
+    state_v3l = (uint8_t *)malloc(state_size);
     scratch  = (uint8_t *)malloc(state_size);
-    if (!state_v3 || !state_v2 || !scratch) {
+    if (!state_v3 || !state_v2 || !state_v1 || !state_v3l || !scratch) {
         fprintf(stderr, "Out of memory\n");
         goto done;
     }
@@ -386,37 +501,21 @@ int main(int argc, char **argv)
           "DAC block after same-version load is byte-identical to the saved one");
 
     /* ---- 5. Synthesize a genuine v2-layout state -------------------- */
-    /* Splice out i2sNonZeroCount and shift the rest of the DAC block left,
-     * which is exactly what a v2.3.1 build wrote, then relabel the header.
-     * The buffer stays STATE_SIZE bytes (only zero padding follows the DAC
-     * block) so it still satisfies retro_unserialize's size check. */
-    memcpy(state_v2, state_v3, state_size);
-    {
-        /* Higher-offset cuts first so the later offsets stay valid. */
-        size_t v7_tail = MEMTRACK_OVERRIDE_SIZE + nvm_size;
-        size_t cut = dac_off + DAC_I2S_NONZEROCOUNT_OFFSET;
-        size_t cut3 = dac_off - v7_tail;
-        size_t cut2 = cdrom_end - CDROM_DSA_TAIL_SIZE;
-        memmove(state_v2 + cut,
-                state_v2 + cut + DAC_I2S_NONZEROCOUNT_SIZE,
-                state_size - cut - DAC_I2S_NONZEROCOUNT_SIZE);
-        memset(state_v2 + state_size - DAC_I2S_NONZEROCOUNT_SIZE, 0,
-               DAC_I2S_NONZEROCOUNT_SIZE);
-        /* A v2..v6 state predates the MT override flag and the NVM BIOS
-         * block (see STATE_VERSION_MEMTRACK_OVERRIDE): splice both out. */
-        memmove(state_v2 + cut3,
-                state_v2 + cut3 + v7_tail,
-                state_size - cut3 - v7_tail);
-        memset(state_v2 + state_size - v7_tail, 0, v7_tail);
-        /* A v2/v3 CDROM block also predates the DSA queue tail (see
-         * STATE_VERSION_CDROM_DSA_QUEUE): splice those bytes out too. */
-        memmove(state_v2 + cut2,
-                state_v2 + cut2 + CDROM_DSA_TAIL_SIZE,
-                state_size - cut2 - CDROM_DSA_TAIL_SIZE);
-        memset(state_v2 + state_size - CDROM_DSA_TAIL_SIZE, 0,
-               CDROM_DSA_TAIL_SIZE);
-    }
-    put_u32(state_v2, STATE_OFF_VERSION, (uint32_t)STATE_MIN_VERSION);
+    /* The CDROM prefix constant has to agree with the block the current
+     * core writes, or every fixture below is nonsense.  Assert it rather
+     * than trusting the arithmetic in the comment. */
+    check(cdrom_size > CDROM_LEGACY_PREFIX_SIZE + CDROM_DSA_TAIL_SIZE
+          && CDROM_LEGACY_BLOCK_SIZE > cdrom_size,
+          "cdrom_legacy_constants_sane",
+          "current CDROM block %lu bytes, legacy %d (prefix %d + staging %d)",
+          (unsigned long)cdrom_size, CDROM_LEGACY_BLOCK_SIZE,
+          CDROM_LEGACY_PREFIX_SIZE, CDROM_LEGACY_STAGING_SIZE);
+
+    synth_legacy_state(state_v2, state_v3, state_size,
+                       cdrom_end - cdrom_size, cdrom_end,
+                       MEMTRACK_OVERRIDE_SIZE + nvm_size, dac_off, 2u,
+                       &dac_off_v2);
+    (void)dac_off_v2;
 
     /* What the DAC block must look like after loading that fixture: every
      * field as saved, except i2sNonZeroCount which a v2 state cannot carry
@@ -438,9 +537,9 @@ int main(int argc, char **argv)
 
     /* ---- 6. The v2 state must load (libretro.c half of the fix) ----- */
     check(unser(state_v2, state_size), "v2_state_loads",
-          "retro_unserialize() of a v%d-layout state (pre-fix: refused "
+          "retro_unserialize() of a v2-layout state (pre-fix: refused "
           "because the gate demanded version == %d)",
-          STATE_MIN_VERSION, STATE_VERSION);
+          STATE_VERSION);
 
     /* ---- 7. ...with the DAC block still aligned (dac.c half) -------- */
     /* This is the only assertion that catches an unconditional consume of
@@ -491,12 +590,75 @@ int main(int argc, char **argv)
               MIN_NONBLACK_FRACTION * 100.0);
     }
 
+    /* ---- 8b. Synthesize and load a genuine v1-layout state ---------- */
+    /* v1 is what release v2.2.0 wrote (the only released core that ever
+     * wrote version 1): the v2 layout minus the four DAC resampler fields,
+     * which sit contiguously after the 9-byte DAC prefix (issue #268). */
+    synth_legacy_state(state_v1, state_v3, state_size,
+                       cdrom_end - cdrom_size, cdrom_end,
+                       MEMTRACK_OVERRIDE_SIZE + nvm_size, dac_off, 1u, NULL);
+
+    /* Expected DAC block after the v1 load: the saved prefix, every
+     * resampler field at its DACInit() default (writePos/writeCount/
+     * nonZeroCount 0, phase 0.0, rateRatio 1.0 — DACPrepareFrame
+     * re-derives all of them at the next frame boundary). */
+    memcpy(dac_expect_v1, dac_v3, dac_size);
+    memset(dac_expect_v1 + DAC_I2S_WRITEPOS_OFFSET, 0,
+           DAC_I2S_PHASE_OFFSET + 8 - DAC_I2S_WRITEPOS_OFFSET);
+    {
+        double one = 1.0;
+        memcpy(dac_expect_v1 + DAC_I2S_PHASE_OFFSET + 8, &one, sizeof(one));
+    }
+
+    check(unser(state_v1, state_size), "v1_state_loads",
+          "retro_unserialize() of a v1-layout state (release v2.2.0's "
+          "format; pre-#268 fix: refused because STATE_MIN_VERSION was 2)");
+
+    check((dac_size_now = dac_save(dac_now)) == dac_size
+          && memcmp(dac_now, dac_expect_v1, dac_size) == 0,
+          "v1_dac_block_defaulted",
+          "post-load DAC block matches the saved prefix with the resampler "
+          "fields at their init defaults (fields must not shift)");
+
+    memcpy(dac_post, dac_now, dac_size);
+    for (frame = 0; frame < (unsigned)DRIFT_FRAMES; frame++)
+        harness_step(&cfg);
+    dac_size_now = dac_save(dac_now);
+    check(dac_size_now == dac_size
+          && memcmp(dac_now, dac_post, dac_size) != 0,
+          "core_advances_after_v1_load",
+          "DAC state advanced over %d frames following the v1 load",
+          DRIFT_FRAMES);
+
+    /* ---- 8c. v3 layout (release v2.3.2) ---------------------------- */
+    /* The strictest alignment assertion in the file: a v3 state carries the
+     * DAC block in full, so after the load every one of its 37 bytes must
+     * come back byte-identical.  Any mis-sized chunk anywhere upstream —
+     * the CDROM restructure was exactly that — shifts the DAC read and this
+     * fails, while retro_unserialize still returns true. */
+    synth_legacy_state(state_v3l, state_v3, state_size,
+                       cdrom_end - cdrom_size, cdrom_end,
+                       MEMTRACK_OVERRIDE_SIZE + nvm_size, dac_off, 3u, NULL);
+
+    for (frame = 0; frame < (unsigned)DRIFT_FRAMES; frame++)
+        harness_step(&cfg);
+
+    check(unser(state_v3l, state_size), "v3_state_loads",
+          "retro_unserialize() of a v3-layout state (release v2.3.2's "
+          "format)");
+
+    check((dac_size_now = dac_save(dac_now)) == dac_size
+          && memcmp(dac_now, dac_v3, dac_size) == 0,
+          "v3_dac_block_realigned",
+          "post-load DAC block is byte-identical to the saved one -- proves "
+          "every chunk before it was read in the v3 layout, not the v7 one");
+
     /* ---- 9. Rejections -------------------------------------------- */
     check(try_load_patched(unser, state_v3, state_size, STATE_OFF_VERSION,
-                           1u, scratch) == false,
-          "v1_state_rejected",
-          "version 1 is below STATE_MIN_VERSION (%d) -- the v1->v2 layout "
-          "change shipped in v2.3.0", STATE_MIN_VERSION);
+                           0u, scratch) == false,
+          "v0_state_rejected",
+          "version 0 is below STATE_MIN_VERSION (%d) -- no released core "
+          "ever wrote it", STATE_MIN_VERSION);
 
     check(try_load_patched(unser, state_v3, state_size, STATE_OFF_VERSION,
                            (uint32_t)STATE_VERSION + 1u, scratch) == false,
@@ -521,6 +683,8 @@ report:
 done:
     free(state_v3);
     free(state_v2);
+    free(state_v1);
+    free(state_v3l);
     free(scratch);
     harness_shutdown(&cfg);
     return rc;

--- a/test/tools/vjss_info.c
+++ b/test/tools/vjss_info.c
@@ -21,7 +21,7 @@
 /* Numeric copies of src/core/state.h — keep the tool standalone. */
 #define VJSS_MAGIC       0x564A5353u  /* "VJSS" */
 #define VJSS_VERSION     7u
-#define VJSS_MIN_VERSION 2u
+#define VJSS_MIN_VERSION 1u
 
 static uint32_t rd_le(const uint8_t *p)
 {

--- a/test/tools/vjss_info.c
+++ b/test/tools/vjss_info.c
@@ -13,6 +13,12 @@
  *   vjss_info <statefile>
  *
  * Exit: 0 = magic matched (any verdict), 1 = I/O or bad_magic, 2 = usage.
+ *
+ * Note on `loadable` for versions 1-3: those are the layouts releases
+ * v2.2.0 / v2.3.0 / v2.3.1 / v2.3.2 wrote.  They used to report `too_old`
+ * (or load but silently mis-parse); issue #268 lowered VJSS_MIN_VERSION to
+ * 1 and taught the CDROM and DAC loaders to read the old chunk shapes, so
+ * `loadable` now means what it says.  See docs/savestate-compat.md.
  */
 
 #include <stdio.h>


### PR DESCRIPTION
## The bug is bigger than #268

While fixing the reported v1 rejection, this turned up a **silent corruption** affecting states from **v2.3.0 / v2.3.1 / v2.3.2** — versions 2 and 3, both *inside* the documented compatibility window:

`retro_unserialize()` returned `true`, no error surfaced, the game kept running — and every chunk from the CD block onward (CDROM, Joystick, Memory Track, DAC) was read at the **wrong offset**. The claim in `docs/WHATSNEW` / `RELEASE_NOTES_v3.0.0.md` that v2.x states "load normally" was false as shipped. #268's v1 gate is the smaller half.

## Root causes

1. **v1 rejected outright** — `STATE_MIN_VERSION` was `2`; release v2.2.0 wrote version 1.
2. **CDROM chunk restructured without a version gate** — the CD-support work dropped `cdBuf2`/`cdBuf3` (`uint8_t[2532+96]` each, 5256 bytes total) and put the BUTCH/FIFO/DSA/SSI working set in their place. Only the trailing 28 bytes were gated. An old blob therefore had 5256 bytes of stale sector data read as flags, leaving the cursor **2627 bytes short**.

## Fix

- `src/core/state.h` — `STATE_MIN_VERSION` 2→1; new `STATE_VERSION_CDROM_RESTRUCTURE 4`; version-history comment corrected (it described v4 only as "gained the DSA queue", omitting the restructure).
- `src/cd/cdrom.c` — `CDROM_LEGACY_STAGING_BYTES` + a layout fork in `CDROMStateLoad`: pre-v4 blobs skip the dead staging buffers by byte count and start the drive from the same idle state `CDROMReset()` establishes. Those cores had no working CD path (`cdBuf2`/`cdBuf3` were only ever written by the unfinished BUTCH stub), so nothing emulated is lost. `cdrom_eeprom_ram` is deliberately left untouched — it's file-backed NVM, not transient drive state, so an old blob has nothing to say about it and zeroing it would wipe the user's CD memory.
- `src/jerry/dac.c` — resampler-field gate for v1. Defaulting is exact, not best-effort: `DACPrepareFrame` (libretro.c:1879, before `JaguarExecuteNew`) re-seeds writePos/writeCount, truncates phase, and re-derives the rate ratio from the restored SMODE/SCLK registers before any sample is resampled.

That CDROM is the **sole** ungated offender was established arithmetically, not by guessing: v1 module bytes before DAC = 154006, v7 = 151413; subtracting all measured chunk sizes leaves **1665 bytes for M68K+Blitter+Event+Eeprom on both sides**, and `2748 (prefix) + 5256 (staging) = 8004` matches the v2.2.0 core's measured `CDROMStateSave` size exactly.

## Evidence

End-to-end with **real cores built from their own tags** and the real AvP ROM:

```
SAVED avp_v1.state  version=1  (v2.2.0 core)  DACBLOCK size=9 offset=2333095 matches=1

BEFORE  v1 DACALIGN found_at=-1  matches=0     v3 DACALIGN found_at=-1  matches=0
AFTER   v1 found_at=2333095 m=1   v2 found_at=2333095 m=1
        v3 found_at=2333095 m=1   v7 found_at=2330502 m=1
        REGION mainRAM/tomRam8/jerry_ram_8/lowerField  IDENTICAL
```

In-repo suite: **21 passed, 0 failed** — `v1_state_loads`, `v2_dac_block_realigned`, `v3_dac_block_realigned`, plus `v0_state_rejected` / `future_state_rejected` / `bad_magic_rejected` guards. **Negative control:** stubbing the gate (`if (0 && stateVersion < …)`) reproduces `18 passed, 3 failed`, so the tests genuinely bind.

Gates (re-run by me after rebasing onto current develop, build id `88374a9` confirmed matching so nothing stale was tested): `make -j` exit 0 zero warnings; `make TEST_EXPORTS=1 test` **exit 0**; audio pair confirmed by name, not just exit code — `Clipping check: Iron Soldier 2 → PASS`, `audio is present and within expected envelope → PASS`. `scripts/c89-lint.sh` passes; `state.h` verified via a wrapper TU since the script skips headers.

## Maintainer decisions needed

- **This reverses a posted decision.** The #268 thread says "We are **not** adding a best-effort legacy loader in this pass." The loader turned out to be *exact* rather than best-effort, which changes that premise — the issue needs a comment.
- **`vjss_info` verdict inverts for v1–v3**: `too_old` → `loadable`. The thread told the reporter `too_old` meant working-as-designed. A header note explains it; the issue should say so too.
- **`docs/WHATSNEW` and `RELEASE_NOTES_v3.0.0.md` still carry the false claim** — left as shipped release history rather than rewritten. Your call.

## Honest limits

- **Versions 4–6 untested** — nightly-only, no released core wrote them. The gate value 4 is behaviorally identical for released states for any choice in [4..7], so this is unverifiable-by-construction rather than skipped.
- **The reporter's two AvP files were never available**, so *their* header versions remain inferred. The mechanism is proven with genuine states from real cores; the specific diagnosis of their files is not.
- **No RetroArch verification** — all headless. The audio path is untouched for in-window loads (the `dac.c` change only runs for `version < 2`), so risk is low, but per repo policy that's a real gap.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)
