### PR TITLE
test(cd): pin CD-DA delivery on a synthetic chirp disc; root-cause the VLM blocker (#291)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -753,7 +753,7 @@ clean:
 		test/test_tom_visible_window test/test_framebuffer_integrity \
 		test/test_butch_cd test/test_bios_config test/test_boot_config \
 		test/test_cart_format \
-		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_synth_read test/test_cd_synth_butch \
+		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda \
 		test/test_audio_dac test/test_blitter \
 		test/test_state_compat test/test_frontend_pacing \
 		test/dump_pc test/heap_search \
@@ -805,7 +805,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_frontend_pacing \
 		test/test_butch_cd test/test_bios_config test/test_boot_config \
 		test/test_cart_format \
-		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_synth_read test/test_cd_synth_butch \
+		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda \
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
 		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy
@@ -920,6 +920,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	./test/test_cd_pregap
 	./test/test_cd_synth_read
 	./test/test_cd_synth_butch
+	./test/test_cd_synth_cdda
 	@# VJ_BIOS_DIR: both tests used to hardcode "test/roms/private" as the
 	@# libretro system dir, but the corpus keeps its BIOS dumps one level
 	@# down in ROMS/.  The paths never resolved, so ten real-BIOS assertions
@@ -1250,6 +1251,10 @@ test/test_cd_synth_read: test/test_cd_synth_read.c test/test_framework.h test/cd
 test/test_cd_synth_butch: test/test_cd_synth_butch.c test/test_framework.h
 	$(CC) -O2 -Wall -Wno-unused-function -Wno-unused-variable -std=c99 $(INCFLAGS) \
 		-o $@ test/test_cd_synth_butch.c -ldl
+
+test/test_cd_synth_cdda: test/test_cd_synth_cdda.c test/test_framework.h
+	$(CC) -O2 -Wall -Wno-unused-function -Wno-unused-variable -std=c99 $(INCFLAGS) \
+		-o $@ test/test_cd_synth_cdda.c -ldl
 
 test/test_cd_bios_boot: test/test_cd_bios_boot.c test/test_framework.h test/cd_assertions.h
 	$(CC) -O2 -Wall -Wno-unused-function -Wno-unused-variable -std=c99 $(INCFLAGS) \

--- a/docs/vlm-audio-cd-plan.md
+++ b/docs/vlm-audio-cd-plan.md
@@ -14,6 +14,15 @@ synthetic music CD all the way to the BIOS's **CD player front-end and into the
 VLM screen** — no loader change at all. That fix is implemented on this branch;
 what remains is CDDA audio routing.
 
+> **Update, 2026-08-04, `develop` @ `b399eb1`.** §3.2's diagnosis ("Phase 2:
+> CDDA routing on `$01nn` Play Title") is **withdrawn — it was a measurement
+> error, not a bug.** The SSI head is already streaming correct CD-DA at
+> 44.1 kHz before and after Play Title; nothing needs positioning. The real
+> blocker is one bit inside the VLM's own DSP code, and everything downstream
+> of it works: forcing that bit clear makes the Virtual Light Machine render
+> and react to the music. Full evidence, and the new committed regression
+> test, in **§8**. Read §8 before acting on §3.2 or on the Phase 2 row of §6.
+
 ---
 
 ## 1. Confirmation of the prior finding
@@ -231,6 +240,18 @@ written; audio discs simply have no boot stub, and the BIOS handles that itself.
 
 ### 3.2 Still required for a working VLM (not implemented)
 
+> **WITHDRAWN — see §8.** The paragraph below is wrong. It inferred "no CDDA"
+> from the output RMS not moving, and inferred from `cdrom.c:1852` that only a
+> `$12xx` seek can position the head. Direct instrumentation of
+> `SetSSIWordsXmittedFromButch()` shows the head *is* primed and streaming (it
+> refills from `ssiBlock` on its own when `cdPlaying` goes true) and delivers
+> the disc's samples to `lrxd`/`rrxd` at 44.1 kHz, correctly, including the
+> silence of an inter-track pregap at exactly the right offset. The RMS did not
+> move because the DSP never forwards the samples to LTXD/RTXD — for a reason
+> that has nothing to do with head position. **Do not implement this.** The
+> only surviving item from this section is the `$61nn` `LONG_TOC_CA` nit at the
+> end, which remains true and remains non-blocking.
+
 **CDDA routing on `$01nn` Play Title.** The SSI head that feeds JERRY's I2S port
 (`SetSSIWordsXmittedFromButch`, `cdrom.c:2110+`) is positioned **only by a `$12xx`
 Goto-Frame seek** (`ssiBlock = block + 1; memcpy(ssiBuf, cdBuf, ...)` at
@@ -336,7 +357,7 @@ headless framebuffer read path is not proof of what is presented.
 | Phase | Scope | Effort | Gate |
 |---|---|---|---|
 | **1. DSA session-TOC protocol fix** *(implemented on this branch)* | `src/cd/cdrom.c`: `$20..$24` response tags, `$0400` terminator, multi-word RX-full re-arm | ~0.5 day incl. validation | `make TEST_EXPORTS=1 test` green; full `cd_boot_matrix.sh` all-`GAME_CODE`; audio disc reaches the CD player UI |
-| **2. CDDA routing for `$01nn` Play Title** | Position `block`/`cdBuf`/`ssiBuf`/`ssiBlock` from the track table on Play; verify SMODE slave | 1–2 days | Audible CDDA on the synthetic disc; `test_audio_clipping` + `test_audio_presence` both pass; Primal Rage CDDA unchanged |
+| ~~**2. CDDA routing for `$01nn` Play Title**~~ **CANCELLED (§8)** | Nothing to do: the SSI head already streams correct CD-DA on Play Title, verified sample-for-sample against the disc image. Superseded by "unmute the VLM's DSP audio path" — see §8.4 | — | Now pinned by `test/test_cd_synth_cdda.c` |
 | **3. Loader/frontend acceptance for audio discs** | Let `hle` mode stop rejecting audio-only images — either force the real-BIOS path when `numSessions == 1 && no ATRI` (cheap, honest: the VLM is BIOS code and `hle` can never produce it), or fail with a clear message. Touches `libretro.c:1507-1517`, `jagcd_hle.c:1586-1591` | 0.5–1 day | Audio disc boots regardless of the `CD Boot Mode` setting |
 | **4. VLM polish + transport** | Track sequencing, Pause/Unpause/Volume, repeat modes, end-of-disc | 1–2 days | Player transport works end to end; VLM visualisation reacts to the audio |
 | **5. Follow-ons (separate tickets, do not bundle)** | `supports_no_game` (boot BIOS with no disc), libretro disk control — both correctly disabled today and blocked on a disc-status DSA opcode the jump table does not have | — | File only after Phase 4 lands |
@@ -389,3 +410,283 @@ for f in /tmp/vlm_shots/*.ppm; do sips -s format png "$f" --out "${f%.ppm}.png";
 `VJ_CD_TRACE_LIVE=1` is what makes the drive dialogue visible — the `[CDDA] DSA cmd`
 log line filters on command high byte (`cdrom.c:1608-1610`) and can never show
 `$03`, `$14`, `$10`, `$11`, `$12`, `$02` or `$18`. Do not infer absence from it.
+
+---
+
+## 8. Second pass — the VLM works; one bit in its DSP code keeps it muted
+
+Investigated on `develop` @ `b399eb1` (post #300, #305, #307), macOS/clang,
+embedded retail CD BIOS, 2026-08-04. Every number below came from the runs
+described in §8.6.
+
+### 8.1 The disc
+
+Still synthetic — no real audio CD exists in the corpus (`find -L
+test/roms/private -name '*.cue'` returns 35 CUEs, all Jaguar game discs). But a
+much more informative one than §2.1's two-tone pair, built so that **the decoded
+audio itself says what is playing and where**:
+
+- **multi-file CUE, one BIN per track**, `REM SESSION 01` — the exact shape
+  every CUE in the corpus uses, so `dataLBA != startLBA` and the loader's
+  pregap handling is exercised rather than bypassed;
+- **6 tracks**, each preceded (2..6) by a real **150-sector `INDEX 00`
+  pregap** of digital silence;
+- **track *t* is a square-wave chirp sweeping `882*t` → `882*t + 441` Hz**, so
+  a zero-crossing count identifies the track, and the instantaneous frequency
+  identifies the position within it;
+- **left ≠ right**: right is the second harmonic at a different amplitude, so a
+  channel swap — invisible on a mono disc, and this repo has SSI channel
+  history — is glaring;
+- **constant known amplitude** (±20000 L / ±12000 R), never zero, so the pregap
+  is the only silence anywhere on the disc.
+
+Generator: §8.6. The identical PCM model is generated in C by
+`test/test_cd_synth_cdda.c`, so the committed test and the manual repro agree.
+
+### 8.2 What the BIOS does with it — both modes, mode taken from the log
+
+`bios` (`[BOOT] CD game, mode=BIOS -- boot ROM forced on`): the full drive
+dialogue completes, including the six-track long TOC —
+
+```
+DSA_TX $7001  $150A  $0300  $1400  $0301  $1501  $0200  $0101
+```
+
+— and the **CD player front-end renders correctly for a 6-track disc**:
+STOP/REW/PLAY/FF/PAUSE transport, `TRK 6`, a `TIME` readout showing the disc's
+lead-out, `NORMAL` / `NO REPEAT` / `VLM`, and a track grid with cells 1–6 lit.
+(The player-UI screenshot was read on an earlier 6-track disc whose lead-out is
+`1:21`; the chirp disc's is `1:00`. Everything else about the screen is
+identical — the readout tracks the disc, which is the point.) Navigating with **B** (right) to
+PLAY and pressing **A** issues `$0101` Play Title and switches to the VLM
+screen. That screen is black apart from a `1-4` preset indicator and a
+track/time readout. RMS 980, 240573 non-silent samples — *byte-identical to a
+run where PLAY is never pressed*. No CD audio reaches the output.
+
+`hle` (`[BOOT] CD game, mode=HLE`): `retro_load_game()` fails —
+`[CD-BOOTSTUB] Early exit: loaded=1 numSessions=1` → "unsupported or invalid
+content format". This is the documented pre-existing state, Phase 3 scope, and
+is **not** a regression from anything here. The VLM is BIOS code; `hle` can
+never produce it (§5 trap). There is therefore no HLE run to compare against
+for an audio disc, and any "both modes" comparison for the VLM itself is
+meaningless by construction.
+
+### 8.3 The SSI head is fine — §3.2 refuted
+
+Instrumenting `SetSSIWordsXmittedFromButch()` (`src/cd/cdrom.c`) directly:
+
+```
+[VLMDIAG] SSI live #1      nonzero=0      lrxd=$0000 rrxd=$0000 ssiBlock=1    ptr=0
+[VLMDIAG] SSI live #44101  nonzero=44094  lrxd=$0378 rrxd=$0378 ssiBlock=76   ptr=0
+[VLMDIAG] SSI live #88201  nonzero=88188  lrxd=$B756 rrxd=$B756 ssiBlock=151  ptr=0
+...
+[VLMDIAG] SSI live #617401 nonzero=617283 ... ssiBlock=1051
+[VLMDIAG] SSI live #661501 nonzero=617283 ... ssiBlock=1126   <- nonzero frozen
+[VLMDIAG] SSI live #705601 nonzero=617283 ... ssiBlock=1201   <- inter-track pregap
+[VLMDIAG] SSI live #749701 nonzero=661376 ... ssiBlock=1276   <- audio resumes
+```
+
+44100 samples/s, `ssiBlock` advancing 75 sectors/s (the drive rate), nearly all
+samples non-zero — and the plateau in `nonzero` lands exactly on the 150-sector
+pregap the disc has between tracks. The head is streaming the right bytes from
+the right place. Positioning it on `$01nn` would fix nothing.
+
+`cdPlaying` is true, `seekDelay` is 0, `ButchIsReadyToSend()` is true (the
+`I2S_CTRL $000F` write sets the I2CNTRL bit), JERRY is in slave mode
+(`[CDDA] SMODE $0015 -> $0014 (slave: CD -> I2S)`), and the DSP takes the SSI
+interrupt 44100 times a second (`ssiAssert` and `ssiDispatch` both advance
+44060 per 60 frames). Every stage up to the DSP is working.
+
+### 8.4 The actual blocker: alt-bank R13 bit 30 in the VLM's DSP code
+
+The output is silent because **the DSP writes nothing to LTXD/RTXD**. Counting
+`DACWriteWord` calls per frame (`i2sWrites`, reset each frame in
+`DACPrepareFrame`):
+
+```
+frame 360: i2sWrites=348 dspRun=1 dspPC=$F1B11E flags=$00004461   <- BIOS boot audio
+frame 420: i2sWrites=348 dspRun=1 dspPC=$F1B120 flags=$00004461
+frame 480: i2sWrites=2   dspRun=0 dspPC=$F1B26E flags=$00000000   <- DSP reloaded: VLM
+frame 540: i2sWrites=2   dspRun=1 dspPC=$F1BA5A flags=$00000420
+...           (2 = the two seed values DACPrepareFrame writes; zero real writes)
+```
+
+Disassembling the DSP RAM at that point: the SSI vector `$F1B010` jumps to
+`$F1BC54`, and the handler opens with
+
+```
+$F1BC54  LOAD   (R26), R27
+$F1BC56  MOVEFA R13, R30
+$F1BC58  BTST   #30, R30
+$F1BC5A  JR     EQ, $00F1BC66      ; bit 30 clear -> pass-through path
+$F1BC5E  LOAD   (R28), R23        ; bit 30 set   -> read LRXD, discard
+$F1BC60  MOVEQ  #0, R30           ;                 zero the FFT input
+$F1BC64  MOVEQ  #0, R29
+$F1BC66  MOVEFA R11, R25          ; pass-through path:
+$F1BC6A  LOAD   (R28), R23        ;   R28 = $F1A148
+$F1BC6E  IMULT  R25, R23          ;   scale by volume
+$F1BC74  STORE  R23, (R28)        ;   R28 += 4 -> write RTXD
+$F1BC80  STORE  R23, (R28)        ;   R28 -= 4 -> write LTXD
+```
+
+so **bit 30 of alternate-bank R13 gates both the audio pass-through and the FFT
+input**. Measured at every ISR entry, it is `$40000000` — set — for the whole
+VLM session. It is set by the VLM's own init:
+
+```
+$F1BA1A  MOVEI  #$40000000, R00
+$F1BA20  MOVETA R00, R13
+```
+
+i.e. **the VLM starts muted by design and something must clear the bit**. The
+only other writer of alt-R13 in the whole 8 KB of DSP RAM is `MOVETA R25, R13`
+at `$F1BD92`, inside the block at `$F1BD34..$F1BE04` — and that block polls
+`$DFFF1A`:
+
+```
+$F1B9CA  MOVEI  #$00DFFF1A, R00
+$F1B9D0  MOVETA R00, R21
+...
+$F1BD44  MOVEFA R21, R30
+$F1BD4C  LOADW  (R30), R29
+$F1BD4E  BTST   #4, R29
+```
+
+`$DFFF1A` is `SUBDATA+2` — **BUTCH's CD subcode data register**, which this core
+does not implement (RAM-backed only; `src/cd/cdrom.c:1486` has had a
+`[SUBCODE] read` diagnostic on it for a while). Confirmed live:
+
+```
+[SUBCODE] write SBCNTRL+0 = $0000 who=6 68kpc=$080082
+[SUBCODE] write SBCNTRL+2 = $00F2 who=6 68kpc=$080082
+[SUBCODE] read  SUBDATA+2 -> $0000 who=2 68kpc=$193040     (who=2 = DSP)
+```
+
+The VLM's 68K side arms subcode capture via `SBCNTRL`, and its DSP side polls
+`SUBDATA` and always reads zero. The `0  0:01` readout on the VLM screen —
+**track 0** with a ticking time — is the same story from the other end.
+
+**Not yet proven:** that supplying valid subcode is what clears bit 30. The
+static read of `$F1BD92` places the writer inside the subcode block, and the
+DSP demonstrably polls the register, but the delay-slot/computed-jump structure
+of that block is not safely readable statically. A crude probe (forcing
+`SUBDATA+2` reads to return `$0010`, `$0011`, `$FFFF`) changed nothing —
+output stayed byte-identical at RMS 980 / 240573 non-silent — so a naive
+bit-4 stub is not enough, and the real Q-channel frame format Butch presents
+has no local ground truth (MiSTer's `butch.v`, our reference for the DSA
+protocol, does not implement subcode either; `test/mister_ground_truth.h`
+has the register addresses and nothing more).
+
+### 8.5 Everything downstream of that bit is correct
+
+Diagnostic hack, **not shipped**: clear bit 30 of `dsp_reg_bank_1[13]` on every
+SSI interrupt. Same disc, same input script, `bios` mode confirmed from the log:
+
+| | muted (as shipped) | bit 30 forced clear |
+|---|---|---|
+| non-silent samples / 1200000 | 240573 | **785123** |
+| average RMS | 980 | **1268** |
+| frame motion, VLM window | 0/60 | **60/60** |
+| avg frame change | 0.00 % | **9.8–14.8 %** |
+| non-black pixels | 0.3 % | **up to 16.5 %** |
+
+and on screen: a full radial spectrum analyser — concentric rings of coloured
+cells pulsing outward, a cyan waveform trace across the middle, the `1-4`
+preset indicator and the track/time readout — visibly changing between
+screenshots as the chirp climbs. **The Virtual Light Machine runs, renders, and
+reacts to the audio.** The one thing between it and working is the mute bit.
+
+That table is the oracle for the eventual fix: a correct implementation must
+reproduce those numbers with no hack in the DSP.
+
+### 8.6 Regression test, and the repro
+
+`test/test_cd_synth_cdda.c` (new, in `make test`) pins the part that works, on
+its own synthetic disc — it never touches `test/roms/private`, so unlike
+`test/test_cd_ssi_stream.c` (which SKIPs without `VJ_SSI_DISC`) it actually
+runs on a fresh clone and in CI:
+
+| assertion | negative control | result |
+|---|---|---|
+| LRXD = left, RRXD = right, sample-aligned from byte 0, across sector boundaries | swap the two reads in `SetSSIWordsXmittedFromButch` | 4 of 5 tests red |
+| measured frequency identifies the seeked track, right = 2× left | `CDIntfGetTrackInfo` uses `startLBA` instead of `dataLBA` | 5 of 5 red |
+| a redundant `$12xx` does not rewind the head; the chirp keeps climbing | restore `ssiBufPtr = 0` on the redundant-seek branch (pre-#307) | exactly that one test red |
+| the pregap is silence and the tone starts at `INDEX 01` | as row 2 | red |
+
+Each control was run at the same git rev with `src/cd/*.o` and the dylib
+deleted first (`make` skips rebuilds on second-identical mtimes, and
+`VJ_EXPECT_BUILD` cannot catch that when both builds are dirty at the same
+rev). Verified green with `test/roms/private` removed, then restored.
+
+Manual repro of §8.2 and §8.5:
+
+```bash
+DEVELOPER_DIR=/Library/Developer/CommandLineTools make TEST_EXPORTS=1 -j8
+DEVELOPER_DIR=/Library/Developer/CommandLineTools cc -O2 -Wall -std=c99 \
+  -I./libretro-common/include -I./src -o test/tools/cd_visual_verify \
+  test/tools/cd_visual_verify.c test/harness/harness.c -lm
+
+# 6-track chirp audio CD, real pregaps, L != R -- same PCM model as
+# test/test_cd_synth_cdda.c
+mkdir -p /tmp/vlmcd && python3 - /tmp/vlmcd <<'EOF'
+import os, struct, sys
+SECTOR, SAMP_SEC, BASE_INC, MASK = 2352, 588, 85899346, 0xFFFFFFFF
+outdir, ntracks, sectors, pregap = sys.argv[1], 6, 600, 150
+def gen(track, sectors):
+    n = sectors * SAMP_SEC; dinc = (BASE_INC // 2) // n
+    ph, inc, buf = 0, track * BASE_INC, bytearray()
+    for _ in range(n):
+        buf += struct.pack('<hh', -20000 if ph & 0x80000000 else 20000,
+                                  -12000 if ph & 0x40000000 else 12000)
+        ph = (ph + inc) & MASK; inc = (inc + dinc) & MASK
+    return bytes(buf)
+cue = ['REM SESSION 01']
+for t in range(1, ntracks + 1):
+    name = 'track%02d.bin' % t; pcm = gen(t, sectors)
+    cue += ['FILE "%s" BINARY' % name, '  TRACK %02d AUDIO' % t]
+    if t > 1:
+        pcm = b'\x00' * (pregap * SECTOR) + pcm
+        cue += ['    INDEX 00 00:00:00', '    INDEX 01 00:02:00']
+    else:
+        cue += ['    INDEX 01 00:00:00']
+    open(os.path.join(outdir, name), 'wb').write(pcm)
+open(os.path.join(outdir, 'musiccd.cue'), 'w').write('\n'.join(cue) + '\n')
+EOF
+
+# Boot the real CD BIOS.  B moves the transport cursor right (STOP -> REW ->
+# PLAY), A activates -- that is what issues $0101 Play Title.  Pressing A
+# from the default cursor position goes straight to the VLM WITHOUT playing.
+mkdir -p /tmp/vlmshots
+VJ_EXPECT_BUILD=$(./scripts/build-id.sh) VJ_CD_TRACE=1 VJ_CD_TRACE_LIVE=1 \
+VJ_HARNESS_LOG_INFO=1 VJ_HARNESS_LOG_DEBUG=1 \
+  ./test/tools/cd_visual_verify ./virtualjaguar_libretro.dylib \
+  /tmp/vlmcd/musiccd.cue --option virtualjaguar_cd_boot_mode=bios \
+  --frames 1500 --outdir /tmp/vlmshots --shot-every 300 \
+  --press 700:b --press 760:b --press 820:a
+for f in /tmp/vlmshots/*.ppm; do sips -s format png "$f" --out "${f%.ppm}.png"; done
+```
+
+Traps, both of which cost time here:
+
+- **`--bios` does not select the CD boot mode.** Only
+  `--option virtualjaguar_cd_boot_mode=bios` does. Confirm from the run's own
+  `[BOOT] CD game, mode=...` line, never from the flag.
+- **Pressing A immediately enters the VLM without starting playback** (`$0101`
+  never goes out), which looks exactly like the failure being investigated.
+  Drive PLAY explicitly: `--press N:b --press N+60:b --press N+120:a`.
+
+### 8.7 What is left
+
+1. **Find what clears alt-R13 bit 30** — the one open question. Runtime
+   evidence, not static disassembly: single-step or trap the
+   `$F1BD34..$F1BE04` block and watch what its inputs must be for it to reach
+   `$F1BD92` with bit 30 clear in R25.
+2. **Probably: model BUTCH's subcode Q-channel.** Data-only first — do **not**
+   newly assert `SBCNTRL` bit 2 (frame-time) or bit 3 (time-match) interrupts;
+   those are enables a title may have set speculatively, and firing IRQs that
+   never fired before is the regression path. Needs a wire-format reference we
+   do not currently have locally.
+3. **Phase 3 (loader/frontend acceptance in `hle` mode)** and **Phase 4
+   (transport: `$02` Stop, `$04`/`$05` Pause/Unpause, `$51` Volume, track
+   sequencing, repeat modes)** are unchanged from §6.
+4. **RetroArch verification is still owed.** Everything above is headless.

--- a/docs/vlm-audio-cd-plan.md
+++ b/docs/vlm-audio-cd-plan.md
@@ -429,8 +429,8 @@ audio itself says what is playing and where**:
 - **multi-file CUE, one BIN per track**, `REM SESSION 01` — the exact shape
   every CUE in the corpus uses, so `dataLBA != startLBA` and the loader's
   pregap handling is exercised rather than bypassed;
-- **6 tracks**, each preceded (2..6) by a real **150-sector `INDEX 00`
-  pregap** of digital silence;
+- **6 tracks** (manual repro), each preceded (2..6) by a real **150-sector
+  `INDEX 00` pregap** of digital silence;
 - **track *t* is a square-wave chirp sweeping `882*t` → `882*t + 441` Hz**, so
   a zero-crossing count identifies the track, and the instantaneous frequency
   identifies the position within it;
@@ -440,9 +440,9 @@ audio itself says what is playing and where**:
 - **constant known amplitude** (±20000 L / ±12000 R), never zero, so the pregap
   is the only silence anywhere on the disc.
 
-Generator: §8.6. The identical PCM model is generated in C by
-`test/test_cd_synth_cdda.c`, so the committed test and the manual repro agree.
-
+Generator: §8.6. The waveform/PCM model is shared with
+`test/test_cd_synth_cdda.c`; note that the committed CI test uses **4 tracks**
+(2 s each) to keep runtime and disc size small.
 ### 8.2 What the BIOS does with it — both modes, mode taken from the log
 
 `bios` (`[BOOT] CD game, mode=BIOS -- boot ROM forced on`): the full drive

--- a/test/test_cd_synth_cdda.c
+++ b/test/test_cd_synth_cdda.c
@@ -722,10 +722,9 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    /* Deterministic per-process scratch dir.  Everything below is
-     * synthetic -- this test never touches test/roms/private. */
-    snprintf(base, sizeof(base), "/tmp/vj_cd_cdda_%ld", (long)getpid());
-    if (mkdir(base, 0755) != 0 && errno != EEXIST)
+    /* Scratch dir for the synthetic disc (never touches test/roms/private). */
+    snprintf(base, sizeof(base), "/tmp/vj_cd_cdda_XXXXXX");
+    if (!mkdtemp(base))
     {
         fprintf(stderr, "  SKIP  cannot create scratch dir %s\n", base);
         vj_core_unload(&C);

--- a/test/test_cd_synth_cdda.c
+++ b/test/test_cd_synth_cdda.c
@@ -101,7 +101,10 @@ static uint16_t *p_rrxd;
 #define ST_RX_FULL       0x2000u
 #define I2S_DATA_ENABLE  0x0001u
 
-#define CALLER 0u                   /* `who` argument -- M68K */
+#define CALLER 0u                   /* `who` argument -- UNKNOWN; the enum in
+                                     * vjag_memory.h is { UNKNOWN, JAGUAR, DSP,
+                                     * GPU, TOM, JERRY, M68K, ... }, so 0 is
+                                     * UNKNOWN and M68K would be 6.           */
 
 /* ------------------------------------------------------------------ */
 /* Synthetic disc geometry                                              */
@@ -722,9 +725,17 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    /* Scratch dir for the synthetic disc (never touches test/roms/private). */
-    snprintf(base, sizeof(base), "/tmp/vj_cd_cdda_XXXXXX");
-    if (!mkdtemp(base))
+    /* Deterministic per-process scratch dir.  Everything below is
+     * synthetic -- this test never touches test/roms/private.
+     *
+     * Deliberately mkdir()+getpid() rather than mkdtemp(): mkdtemp is not
+     * declared under -std=c99 on glibc without a feature-test macro, and
+     * building it that way fails on Linux/Clang and the ASan job with
+     * "call to undeclared function 'mkdtemp'".  A predictable name is fine
+     * here -- this is a scratch dir for a synthetic disc, not a security
+     * boundary, and the pid already makes it per-process unique. */
+    snprintf(base, sizeof(base), "/tmp/vj_cd_cdda_%ld", (long)getpid());
+    if (mkdir(base, 0755) != 0 && errno != EEXIST)
     {
         fprintf(stderr, "  SKIP  cannot create scratch dir %s\n", base);
         vj_core_unload(&C);

--- a/test/test_cd_synth_cdda.c
+++ b/test/test_cd_synth_cdda.c
@@ -1,0 +1,771 @@
+/*
+ * test_cd_synth_cdda.c -- CD-DA (Red Book audio) delivery over the SSI,
+ * pinned against a SYNTHETIC multi-track audio disc.
+ *
+ * test/test_cd_ssi_stream.c already covers this contract, but it SKIPs
+ * unless VJ_SSI_DISC points at a commercial image under
+ * test/roms/private -- gitignored, absent in CI and on a fresh clone -- so
+ * in practice nothing guards the CD-audio path.  This test builds its own
+ * disc in a scratch dir and therefore always runs.
+ *
+ * THE DISC IS THE ORACLE
+ * ----------------------
+ * The PCM is generated from a closed-form integer phase accumulator, so
+ * the decoded AUDIO ITSELF says what is playing and where -- the audio
+ * analogue of test_cd_synth_butch.c's disc_pat() byte pattern:
+ *
+ *   - Base frequency encodes the TRACK.  Track t starts at 882*t Hz, and
+ *     a zero-crossing count over any window identifies t on its own.
+ *   - A linear chirp inside each track (+441 Hz over its 2 s) encodes the
+ *     POSITION within the track: instantaneous frequency rises
+ *     monotonically, so a rewound or re-framed head shows up as a
+ *     frequency that goes backwards -- in the audio domain, without
+ *     needing to know any LBA.
+ *   - LEFT and RIGHT differ: right is the second harmonic at a different
+ *     amplitude.  A channel swap is invisible on a mono disc and glaring
+ *     here.  (This repo has real SSI channel/alignment history.)
+ *   - Amplitude is a known constant (square wave, never zero), so
+ *     "silence where there should be tone" is unambiguous.
+ *   - The only silence on the disc is the 150-sector INDEX 00 pregap in
+ *     front of tracks 2..4.  Silence anywhere else is a failure.
+ *
+ * The disc is a MULTI-FILE CUE (one BIN per track) with real pregaps --
+ * the exact shape every CUE in the Jaguar CD corpus uses.  That makes
+ * dataLBA != startLBA, so the loader's pregap handling is under test
+ * rather than bypassed (a single-file no-pregap disc has them equal and
+ * hides that whole class).
+ *
+ * INVARIANTS PINNED (each with a documented negative control)
+ * ----------------------------------------------------------
+ *   1. Channel order and sample framing -- LRXD carries the LEFT channel
+ *      (little-endian bytes [4i+0..1]) and RRXD the RIGHT ([4i+2..3]),
+ *      sample-aligned from byte 0 of the seek target sector, crossing
+ *      sector boundaries linearly.
+ *      NEGATIVE CONTROL: swap the two reads in
+ *      SetSSIWordsXmittedFromButch() (src/cd/cdrom.c) -> test 2 fails.
+ *   2. Track identity from the audio -- a seek to track t's INDEX 01
+ *      delivers audio whose measured frequency is in track t's band and
+ *      in no other track's.
+ *      NEGATIVE CONTROL: make CDIntfGetTrackInfo() use startLBA instead
+ *      of dataLBA (src/cd/cdintf.c), i.e. drop the pregap from the TOC ->
+ *      the seek lands 150 sectors early, in silence -> test 3 fails.
+ *   3. Stream continuity across a redundant seek -- re-issuing the seek
+ *      the drive is already serving must not rewind the SSI head.  The
+ *      chirp makes this an audio-domain assertion: instantaneous
+ *      frequency never goes backwards.  (Regression guard for #306/#307,
+ *      where a redundant seek replayed up to ~13 ms of CD-DA.)
+ *      NEGATIVE CONTROL: restore `ssiBufPtr = 0;` on the redundant-seek
+ *      branch of the $12xx handler (src/cd/cdrom.c) -> test 4 fails.
+ *   4. Pregap is silence and the tone starts exactly at INDEX 01 --
+ *      seeking two sectors before track t's data start yields exactly
+ *      1176 zero samples and then phase 0 of track t.
+ *      NEGATIVE CONTROL: same dataLBA/startLBA sabotage as 2 -> test 5
+ *      fails.
+ *
+ * No timing constant is asserted; every timing claim is relational.
+ *
+ * Build: make test/test_cd_synth_cdda      (needs TEST_EXPORTS=1)
+ * Run:   DYLD_LIBRARY_PATH=. test/test_cd_synth_cdda
+ */
+
+#include "test_framework.h"
+
+#include <unistd.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+static struct vj_core C;
+
+/* ------------------------------------------------------------------ */
+/* Core internals resolved by dlsym                                     */
+/* ------------------------------------------------------------------ */
+
+static bool     (*p_open_image)(const char *);
+static void     (*p_close_image)(void);
+static uint32_t (*p_num_tracks)(void);
+static uint8_t  (*p_track_info)(uint32_t, uint32_t);
+static void     (*p_butch_exec)(uint32_t);
+static void     (*p_seek_state)(uint32_t *, uint32_t *, uint32_t *);
+static void     (*p_ssi_xmit)(void);
+static uint16_t *p_lrxd;
+static uint16_t *p_rrxd;
+
+/* ------------------------------------------------------------------ */
+/* BUTCH register offsets (CDROMReadWord/CDROMWriteWord mask to & $FF)   */
+/* ------------------------------------------------------------------ */
+
+#define R_BUTCH_LO    0x02u
+#define R_DS_DATA     0x0Au
+#define R_I2CNTRL_LO  0x12u
+
+#define ST_RX_FULL       0x2000u
+#define I2S_DATA_ENABLE  0x0001u
+
+#define CALLER 0u                   /* `who` argument -- UNKNOWN            */
+
+/* ------------------------------------------------------------------ */
+/* Synthetic disc geometry                                              */
+/* ------------------------------------------------------------------ */
+
+#define SECTOR_BYTES      2352u
+#define SAMPLES_PER_SECT  (SECTOR_BYTES / 4u)      /* 588 stereo frames    */
+#define NUM_TRACKS        4u
+#define AUDIO_SECTORS     150u                     /* 2 s per track        */
+#define PREGAP_SECTORS    150u                     /* 2 s, Red Book gap    */
+#define TRACK_SAMPLES     (AUDIO_SECTORS * SAMPLES_PER_SECT)   /* 88200    */
+
+/* Bounds: generous enough that a legitimate constant change cannot trip
+ * them, tight enough that a hang is reported instead of spinning. */
+#define MAX_SEEK_TICKS   200000u
+#define MAX_DSA_TICKS      4096u
+
+/* ------------------------------------------------------------------ */
+/* Deterministic PCM: a per-track chirp                                 */
+/* ------------------------------------------------------------------ */
+
+/* Phase increment per sample for 882.0 Hz at 44100 Hz, in 32-bit phase
+ * units: 882/44100 * 2^32 = 0.02 * 2^32.  Track t starts at 882*t Hz. */
+#define BASE_INC     85899346u
+/* Chirp rate: +441 Hz spread over one track's 88200 samples.  Track t
+ * therefore sweeps 882*t -> 882*t + 441 Hz, leaving a 441 Hz gap between
+ * adjacent tracks' bands -- wide enough that a windowed frequency
+ * measurement identifies the track with no ambiguity. */
+#define CHIRP_DINC   487u
+
+#define AMP_LEFT     20000
+#define AMP_RIGHT    12000
+
+/* Phase after `n` samples of track `track` (1-based).
+ *
+ *   phase(n) = n*inc0 + DINC * (n*(n-1)/2)      (mod 2^32)
+ *
+ * Closed form, so any sample is reproducible without generating the ones
+ * before it.  All arithmetic is uint32 and wrapping is intended. */
+static uint32_t pcm_phase(uint32_t track, uint32_t n)
+{
+    uint32_t inc0 = track * BASE_INC;
+    uint32_t tri;
+
+    /* n*(n-1)/2 without overflowing before the (intended) mod-2^32 wrap:
+     * exactly one of n, n-1 is even, so halve that one first. */
+    if (n & 1u)
+        tri = ((n - 1u) / 2u) * n;
+    else
+        tri = (n / 2u) * (n - 1u);
+
+    return n * inc0 + CHIRP_DINC * tri;
+}
+
+/* Sample `n` of track `track`.  Square waves: the amplitude is an exact
+ * known constant and the value is never zero, so a zero sample always
+ * means "no disc audio here". */
+static void pcm_sample(uint32_t track, uint32_t n, int16_t *l, int16_t *r)
+{
+    uint32_t ph = pcm_phase(track, n);
+
+    *l = (ph & 0x80000000u) ? (int16_t)(-AMP_LEFT) : (int16_t)AMP_LEFT;
+    /* Right channel is the second harmonic (phase doubled) at a different
+     * amplitude -- L and R never agree in both sign pattern and level. */
+    *r = (ph & 0x40000000u) ? (int16_t)(-AMP_RIGHT) : (int16_t)AMP_RIGHT;
+}
+
+/* ------------------------------------------------------------------ */
+/* Synthetic disc construction                                          */
+/* ------------------------------------------------------------------ */
+
+static void track_bin_name(char *out, size_t outLen, const char *dir,
+                           uint32_t track)
+{
+    snprintf(out, outLen, "%s/track%02u.bin", dir, (unsigned)track);
+}
+
+static bool write_track_bin(const char *dir, uint32_t track)
+{
+    char path[1024];
+    uint8_t *bin = NULL;
+    uint32_t pregap = (track == 1u) ? 0u : PREGAP_SECTORS;
+    size_t binLen = (size_t)(pregap + AUDIO_SECTORS) * SECTOR_BYTES;
+    size_t gapLen = (size_t)pregap * SECTOR_BYTES;
+    uint32_t n;
+    size_t written;
+    FILE *f;
+    bool ok = false;
+
+    bin = (uint8_t *)calloc(1, binLen);
+    if (!bin)
+        return false;
+
+    /* [0, gapLen) stays zero: the INDEX 00 pregap.  Audio follows. */
+    for (n = 0; n < TRACK_SAMPLES; n++)
+    {
+        size_t o = gapLen + (size_t)n * 4u;
+        int16_t l, r;
+
+        pcm_sample(track, n, &l, &r);
+        bin[o + 0] = (uint8_t)((uint16_t)l & 0xFFu);
+        bin[o + 1] = (uint8_t)(((uint16_t)l >> 8) & 0xFFu);
+        bin[o + 2] = (uint8_t)((uint16_t)r & 0xFFu);
+        bin[o + 3] = (uint8_t)(((uint16_t)r >> 8) & 0xFFu);
+    }
+
+    track_bin_name(path, sizeof(path), dir, track);
+    f = fopen(path, "wb");
+    if (!f)
+        goto done;
+    written = fwrite(bin, 1, binLen, f);
+    fclose(f);
+    ok = (written == binLen);
+
+done:
+    free(bin);
+    return ok;
+}
+
+static bool make_disc(const char *dir, char *cueOut, size_t cueOutLen)
+{
+    uint32_t t;
+    FILE *f;
+
+    for (t = 1u; t <= NUM_TRACKS; t++)
+        if (!write_track_bin(dir, t))
+            return false;
+
+    snprintf(cueOut, cueOutLen, "%s/musiccd.cue", dir);
+    f = fopen(cueOut, "wb");
+    if (!f)
+        return false;
+
+    /* Multi-file CUE, file-relative INDEX MSF -- the corpus shape.  Tracks
+     * 2..4 carry a real 150-sector (00:02:00) INDEX 00 pregap. */
+    fprintf(f, "REM SESSION 01\n");
+    for (t = 1u; t <= NUM_TRACKS; t++)
+    {
+        fprintf(f, "FILE \"track%02u.bin\" BINARY\n", (unsigned)t);
+        fprintf(f, "  TRACK %02u AUDIO\n", (unsigned)t);
+        if (t == 1u)
+            fprintf(f, "    INDEX 01 00:00:00\n");
+        else
+            fprintf(f, "    INDEX 00 00:00:00\n"
+                       "    INDEX 01 00:02:00\n");
+    }
+    fclose(f);
+    return true;
+}
+
+static void scrub_scratch(const char *base)
+{
+    char path[1024];
+    uint32_t t;
+
+    for (t = 1u; t <= NUM_TRACKS; t++)
+    {
+        track_bin_name(path, sizeof(path), base, t);
+        remove(path);
+    }
+    snprintf(path, sizeof(path), "%s/musiccd.cue", base);
+    remove(path);
+    rmdir(base);
+}
+
+/* ------------------------------------------------------------------ */
+/* BUTCH driving helpers -- these are the CD BIOS's moves                */
+/* ------------------------------------------------------------------ */
+
+static uint16_t butch_status(void)
+{
+    return C.CDROMReadWord(R_BUTCH_LO, CALLER);
+}
+
+static void dsa_send(uint16_t cmd)
+{
+    C.CDROMWriteWord(R_DS_DATA, cmd, CALLER);
+}
+
+static uint16_t dsa_recv(void)
+{
+    return C.CDROMReadWord(R_DS_DATA, CALLER);
+}
+
+static uint32_t wait_rx_full(uint32_t max)
+{
+    uint32_t n = 0;
+
+    while (n <= max)
+    {
+        if (butch_status() & ST_RX_FULL)
+            return n;
+        p_butch_exec(0);
+        n++;
+    }
+    return 0xFFFFFFFFu;
+}
+
+static void dsa_seek(uint32_t lba)
+{
+    uint32_t tf = lba + 150u;
+
+    dsa_send((uint16_t)(0x1000u | (tf / 4500u)));
+    dsa_send((uint16_t)(0x1100u | ((tf / 75u) % 60u)));
+    dsa_send((uint16_t)(0x1200u | (tf % 75u)));
+}
+
+static uint32_t seek_dones(void)
+{
+    uint32_t dones = 0;
+    p_seek_state(NULL, &dones, NULL);
+    return dones;
+}
+
+static uint32_t wait_seek_done(uint32_t before, uint32_t max)
+{
+    uint32_t n = 0;
+
+    while (n <= max)
+    {
+        if (seek_dones() != before)
+            return n;
+        p_butch_exec(0);
+        n++;
+    }
+    return 0xFFFFFFFFu;
+}
+
+/* Reset + I2S enable + seek to `lba` + consume the Found response, leaving
+ * the drive playing with the SSI head parked at byte 0 of `lba`. */
+static bool prime_stream(uint32_t lba)
+{
+    uint32_t before;
+    uint16_t r;
+
+    C.CDROMReset();
+    C.CDROMWriteWord(R_I2CNTRL_LO, I2S_DATA_ENABLE, CALLER);
+
+    before = seek_dones();
+    dsa_seek(lba);
+    if (wait_seek_done(before, MAX_SEEK_TICKS) == 0xFFFFFFFFu)
+    {
+        fprintf(stderr, "        (seek to LBA %u never completed)\n", lba);
+        return false;
+    }
+    if (wait_rx_full(MAX_DSA_TICKS) == 0xFFFFFFFFu)
+    {
+        fprintf(stderr, "        (seek response never became visible)\n");
+        return false;
+    }
+    r = dsa_recv();
+    if (r != 0x0100)
+    {
+        fprintf(stderr, "        (seek response was $%04X, expected $0100)\n", r);
+        return false;
+    }
+    return true;
+}
+
+/* One SSI sample pair, exactly as JERRY's slave-mode I2S callback takes
+ * it: SetSSIWordsXmittedFromButch() advances the head and latches
+ * LRXD/RRXD, which the DSP then reads. */
+static void ssi_next(int16_t *l, int16_t *r)
+{
+    p_ssi_xmit();
+    *l = (int16_t)*p_lrxd;
+    *r = (int16_t)*p_rrxd;
+}
+
+/* ------------------------------------------------------------------ */
+/* Frequency measurement -- the audio-domain oracle                     */
+/* ------------------------------------------------------------------ */
+
+/* Sign changes over `n` samples.  For a square wave that is exactly two
+ * per cycle, so freq_hz = crossings * 44100 / (2 * n). */
+static uint32_t count_crossings(const int16_t *buf, uint32_t n)
+{
+    uint32_t i, c = 0;
+
+    for (i = 1; i < n; i++)
+        if ((buf[i] < 0) != (buf[i - 1] < 0))
+            c++;
+    return c;
+}
+
+static uint32_t crossings_to_hz(uint32_t crossings, uint32_t n)
+{
+    if (n < 2u)
+        return 0;
+    return (crossings * 44100u) / (2u * n);
+}
+
+/* Track t occupies [882*t, 882*t + 442] Hz; the next band starts 441 Hz
+ * above the top of this one. */
+static uint32_t track_lo_hz(uint32_t t) { return 882u * t; }
+static uint32_t track_hi_hz(uint32_t t) { return 882u * t + 442u; }
+
+/* Disc LBA of track `t`'s INDEX 01, read back through the same TOC path
+ * the CD BIOS uses (absolute MSF, 150-frame lead-in included). */
+static uint32_t track_data_lba(uint32_t t)
+{
+    uint32_t m = p_track_info(t, 0);
+    uint32_t s = p_track_info(t, 1);
+    uint32_t f = p_track_info(t, 2);
+    uint32_t abs = ((m * 60u) + s) * 75u + f;
+
+    return (abs >= 150u) ? (abs - 150u) : 0u;
+}
+
+/* ------------------------------------------------------------------ */
+/* 1. Preflight: the disc loaded, and its geometry is what we wrote      */
+/* ------------------------------------------------------------------ */
+
+/* Everything below silently no-ops if haveCDGoodness is false, so a setup
+ * failure would look like a behaviour failure.  This test fails first and
+ * unambiguously instead.  It also pins the pregap arithmetic the seek
+ * targets depend on: track 1 at LBA 0, every later track 150 sectors past
+ * the end of the previous one. */
+TEST(preflight_disc_geometry_and_pregaps)
+{
+    uint32_t t;
+    uint32_t expect = 0;
+
+    if (p_num_tracks() != NUM_TRACKS)
+        FAIL("disc reports %u tracks, expected %u",
+             p_num_tracks(), NUM_TRACKS);
+
+    for (t = 1u; t <= NUM_TRACKS; t++)
+    {
+        uint32_t lba;
+
+        if (t > 1u)
+            expect += PREGAP_SECTORS;
+        lba = track_data_lba(t);
+        if (lba != expect)
+            FAIL("track %u INDEX 01 at LBA %u, expected %u",
+                 t, lba, expect);
+        expect += AUDIO_SECTORS;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* 2. Channel order and sample framing                                  */
+/* ------------------------------------------------------------------ */
+
+/* The SSI head is sample-aligned from byte 0 of the seek target sector
+ * (unlike the BUTCH FIFO data path, which starts one word in), LRXD is
+ * the LEFT channel and RRXD the RIGHT, and the stream crosses sector
+ * boundaries linearly.  Runs past 2 sectors' worth of samples so the
+ * refill path is covered, on a track whose left and right channels differ
+ * in both sign pattern and amplitude. */
+TEST(ssi_delivers_left_in_lrxd_right_in_rrxd)
+{
+    const uint32_t COUNT = SAMPLES_PER_SECT * 2u + 17u;
+    uint32_t track = 3u;
+    uint32_t n;
+
+    if (!prime_stream(track_data_lba(track)))
+        FAIL("could not prime the stream at track %u", track);
+
+    for (n = 0; n < COUNT; n++)
+    {
+        int16_t gotL, gotR, wantL, wantR;
+
+        ssi_next(&gotL, &gotR);
+        pcm_sample(track, n, &wantL, &wantR);
+
+        if (gotL != wantL || gotR != wantR)
+            FAIL("sample %u: got L=%d R=%d, expected L=%d R=%d "
+                 "(swapped channels would read L=%d R=%d)",
+                 n, gotL, gotR, wantL, wantR, wantR, wantL);
+    }
+
+    /* The disc must actually distinguish the channels, or the check above
+     * cannot fail on a swap.  The amplitudes differ by construction, so
+     * this only guards against someone equalising them later. */
+    {
+        int16_t l, r;
+
+        pcm_sample(track, 0u, &l, &r);
+        if (l == r)
+            FAIL("disc is mono at sample 0 -- channel assertions are vacuous");
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* 3. Track identity, measured from the audio alone                     */
+/* ------------------------------------------------------------------ */
+
+/* Seeking to track t's INDEX 01 delivers audio in track t's frequency
+ * band and in no other track's.  Nothing here looks at an LBA or a disc
+ * byte: the decoded audio is the whole oracle, which is what makes it
+ * able to catch a seek that lands on the wrong track or inside a pregap.
+ * The right channel is checked to be the second harmonic, so a channel
+ * swap is caught in the frequency domain too. */
+TEST(audio_frequency_identifies_the_seeked_track)
+{
+    static int16_t bufL[4096];
+    static int16_t bufR[4096];
+    uint32_t track;
+
+    for (track = 1u; track <= NUM_TRACKS; track++)
+    {
+        uint32_t n, hzL, hzR, other;
+
+        if (!prime_stream(track_data_lba(track)))
+            FAIL("could not prime the stream at track %u", track);
+
+        for (n = 0; n < 4096u; n++)
+            ssi_next(&bufL[n], &bufR[n]);
+
+        hzL = crossings_to_hz(count_crossings(bufL, 4096u), 4096u);
+        hzR = crossings_to_hz(count_crossings(bufR, 4096u), 4096u);
+
+        if (hzL < track_lo_hz(track) || hzL > track_hi_hz(track))
+            FAIL("track %u: measured %u Hz, outside its band %u..%u Hz",
+                 track, hzL, track_lo_hz(track), track_hi_hz(track));
+
+        for (other = 1u; other <= NUM_TRACKS; other++)
+            if (other != track &&
+                hzL >= track_lo_hz(other) && hzL <= track_hi_hz(other))
+                FAIL("track %u: measured %u Hz, which is also track %u's band",
+                     track, hzL, other);
+
+        /* Right channel is the second harmonic: twice the crossings.
+         * The window quantises to 44100/(2*4096) = 5.4 Hz, and that error
+         * is doubled by the comparison, so allow 16 Hz. */
+        if (hzR < 2u * hzL - 16u || hzR > 2u * hzL + 16u)
+            FAIL("track %u: right channel %u Hz, expected ~%u Hz "
+                 "(2x left) -- channels swapped or mis-framed",
+                 track, hzR, 2u * hzL);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* 4. Continuity across a redundant seek (#306 / #307)                  */
+/* ------------------------------------------------------------------ */
+
+/* Re-issuing the seek the drive is already serving must not rewind the
+ * SSI head.  Before the #307 fix a redundant $12xx reloaded the sector
+ * buffer and reset ssiBufPtr to 0, replaying up to a sector (~13 ms) of
+ * CD-DA.
+ *
+ * Two independent assertions:
+ *   (a) audio-domain -- the chirp's instantaneous frequency never goes
+ *       backwards across the seek, which is true of a continuous stream
+ *       and false of any rewind, without reference to an LBA;
+ *   (b) exact -- the samples after the seek are the samples that were
+ *       next, not ones already delivered. */
+TEST(redundant_seek_does_not_rewind_the_audio_head)
+{
+    /* 8 windows of 8192 samples = 65536 samples, 1.49 s -- inside a
+     * 2 s track.  The window is large because the frequency measurement
+     * quantises to 44100/(2*8192) = 2.7 Hz; over one window the chirp
+     * climbs 8192 * 441/88200 = 41 Hz, comfortably above it. */
+#define RW_WINDOWS  8u
+#define RW_SAMPLES  8192u
+    static int16_t win[RW_WINDOWS][RW_SAMPLES];
+    const uint32_t track = 2u;
+    uint32_t delivered = 0;
+    uint32_t w, n;
+    uint32_t target;
+    uint32_t firstHz, lastHz, rise;
+
+    target = track_data_lba(track);
+
+    if (!prime_stream(target))
+        FAIL("could not prime the stream at track %u", track);
+
+    for (w = 0; w < RW_WINDOWS; w++)
+    {
+        /* Halfway through, re-issue the identical seek while the stream
+         * is running -- the redundant-seek path. */
+        if (w == RW_WINDOWS / 2u)
+        {
+            dsa_seek(target);
+            /* The drive still answers a no-op Goto with Found; drain it so
+             * the DSA queue does not stay armed. */
+            if (wait_rx_full(MAX_DSA_TICKS) != 0xFFFFFFFFu)
+                (void)dsa_recv();
+        }
+
+        for (n = 0; n < RW_SAMPLES; n++)
+        {
+            int16_t gotL, gotR, wantL, wantR;
+
+            ssi_next(&gotL, &gotR);
+            pcm_sample(track, delivered, &wantL, &wantR);
+            /* The sharp assertion: any rewind, of any size down to a
+             * single sample, lands here immediately. */
+            if (gotL != wantL || gotR != wantR)
+                FAIL("window %u sample %u (stream position %u): got L=%d R=%d, "
+                     "expected L=%d R=%d -- the head moved",
+                     w, n, delivered, gotL, gotR, wantL, wantR);
+            win[w][n] = gotL;
+            delivered++;
+        }
+    }
+
+    /* The audio-domain assertion, independent of any LBA or disc byte:
+     * the chirp must still be climbing at its known rate after the
+     * redundant seek.  This is coarser than the sample check above -- it
+     * cannot resolve a rewind smaller than about a window -- but it holds
+     * even if the sample values themselves were to change, and it is what
+     * a listener would hear. */
+    firstHz = crossings_to_hz(count_crossings(win[0], RW_SAMPLES), RW_SAMPLES);
+    lastHz  = crossings_to_hz(count_crossings(win[RW_WINDOWS - 1u], RW_SAMPLES),
+                              RW_SAMPLES);
+    if (lastHz <= firstHz)
+        FAIL("chirp did not advance: %u Hz at the start, %u Hz after %u "
+             "samples -- the audio head stalled or rewound",
+             firstHz, lastHz, delivered);
+
+    /* Expected climb across (RW_WINDOWS-1) windows at 441 Hz per 88200
+     * samples; allow a generous band around it so a legitimate change to
+     * the chirp constants does not have to move a magic number. */
+    rise = lastHz - firstHz;
+    {
+        uint32_t want = ((RW_WINDOWS - 1u) * RW_SAMPLES * 441u) / TRACK_SAMPLES;
+
+        if (rise < want / 2u || rise > want * 2u)
+            FAIL("chirp climbed %u Hz over %u samples, expected about %u Hz "
+                 "-- the stream is not advancing at the drive rate",
+                 rise, (RW_WINDOWS - 1u) * RW_SAMPLES, want);
+    }
+#undef RW_WINDOWS
+#undef RW_SAMPLES
+}
+
+/* ------------------------------------------------------------------ */
+/* 5. The pregap is silence, and the tone starts exactly at INDEX 01     */
+/* ------------------------------------------------------------------ */
+
+/* Seeking two sectors before track t's data start must deliver exactly
+ * 2*588 zero samples -- the only silence anywhere on this disc -- and
+ * then phase 0 of track t.  A one-sector or one-sample framing error in
+ * the pregap arithmetic moves that boundary and fails here. */
+TEST(pregap_is_silent_and_tone_starts_at_index01)
+{
+    const uint32_t track = 4u;
+    const uint32_t lead = 2u;              /* sectors of pregap to read    */
+    const uint32_t silent = lead * SAMPLES_PER_SECT;
+    uint32_t n;
+
+    if (!prime_stream(track_data_lba(track) - lead))
+        FAIL("could not prime the stream in track %u's pregap", track);
+
+    for (n = 0; n < silent; n++)
+    {
+        int16_t l, r;
+
+        ssi_next(&l, &r);
+        if (l != 0 || r != 0)
+            FAIL("pregap sample %u is L=%d R=%d, expected silence "
+                 "(head landed inside the audio -- pregap arithmetic)",
+                 n, l, r);
+    }
+
+    for (n = 0; n < 512u; n++)
+    {
+        int16_t gotL, gotR, wantL, wantR;
+
+        ssi_next(&gotL, &gotR);
+        pcm_sample(track, n, &wantL, &wantR);
+        if (gotL != wantL || gotR != wantR)
+            FAIL("sample %u after the pregap: got L=%d R=%d, expected "
+                 "L=%d R=%d -- the tone did not start at INDEX 01",
+                 n, gotL, gotR, wantL, wantR);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Symbol resolution                                                    */
+/* ------------------------------------------------------------------ */
+
+static bool resolve_symbols(void)
+{
+    p_open_image  = (bool (*)(const char *))     dlsym(C.handle, "CDIntfOpenImage");
+    p_close_image = (void (*)(void))             dlsym(C.handle, "CDIntfCloseImage");
+    p_num_tracks  = (uint32_t (*)(void))         dlsym(C.handle, "CDIntfGetNumTracks");
+    p_track_info  = (uint8_t (*)(uint32_t, uint32_t))
+                                                 dlsym(C.handle, "CDIntfGetTrackInfo");
+    p_butch_exec  = (void (*)(uint32_t))         dlsym(C.handle, "BUTCHExec");
+    p_seek_state  = (void (*)(uint32_t *, uint32_t *, uint32_t *))
+                                    dlsym(C.handle, "CDROMDiagGetSeekWedgeState");
+    p_ssi_xmit    = (void (*)(void)) dlsym(C.handle, "SetSSIWordsXmittedFromButch");
+    p_lrxd        = (uint16_t *)     dlsym(C.handle, "lrxd");
+    p_rrxd        = (uint16_t *)     dlsym(C.handle, "rrxd");
+
+    return p_open_image && p_close_image && p_num_tracks && p_track_info &&
+           p_butch_exec && p_seek_state && p_ssi_xmit && p_lrxd && p_rrxd &&
+           C.CDROMInit && C.CDROMReset && C.CDROMReadWord && C.CDROMWriteWord;
+}
+
+int main(int argc, char *argv[])
+{
+    char base[512];
+    char cue[1024];
+    int rc = 1;
+    bool opened = false;
+
+    (void)argc; (void)argv;
+
+    TEST_INIT("CD-DA delivery over the SSI (synthetic multi-track disc)");
+
+    if (!vj_core_load(&C))
+    {
+        fprintf(stderr, "FATAL: failed to load core\n");
+        return 1;
+    }
+    vj_core_init(&C);
+
+    if (!resolve_symbols())
+    {
+        fprintf(stderr, "  FAIL  missing test exports "
+                        "(build with `make TEST_EXPORTS=1`)\n");
+        vj_core_unload(&C);
+        return 1;
+    }
+
+    /* Deterministic per-process scratch dir.  Everything below is
+     * synthetic -- this test never touches test/roms/private. */
+    snprintf(base, sizeof(base), "/tmp/vj_cd_cdda_%ld", (long)getpid());
+    if (mkdir(base, 0755) != 0 && errno != EEXIST)
+    {
+        fprintf(stderr, "  SKIP  cannot create scratch dir %s\n", base);
+        vj_core_unload(&C);
+        return 0;
+    }
+    if (!make_disc(base, cue, sizeof(cue)))
+    {
+        fprintf(stderr, "  SKIP  cannot write synthetic disc under %s\n", base);
+        goto out;
+    }
+
+    if (!p_open_image(cue))
+    {
+        fprintf(stderr, "  FAIL  synthetic disc did not load\n");
+        goto out;
+    }
+    opened = true;
+
+    /* CDROMInit latches haveCDGoodness from the now-open image; without it
+     * every path under test silently no-ops. */
+    C.CDROMInit();
+    C.CDROMReset();
+
+    fprintf(stderr, "synthetic audio disc: %u tracks, %u pregap + %u audio "
+                    "sectors each, track t chirps %u..%u Hz\n",
+            NUM_TRACKS, PREGAP_SECTORS, AUDIO_SECTORS,
+            track_lo_hz(1u), track_hi_hz(NUM_TRACKS));
+
+    RUN_TEST(preflight_disc_geometry_and_pregaps);
+    RUN_TEST(ssi_delivers_left_in_lrxd_right_in_rrxd);
+    RUN_TEST(audio_frequency_identifies_the_seeked_track);
+    RUN_TEST(redundant_seek_does_not_rewind_the_audio_head);
+    RUN_TEST(pregap_is_silent_and_tone_starts_at_index01);
+
+    rc = TEST_REPORT();
+
+out:
+    if (opened)
+        p_close_image();
+    vj_core_unload(&C);
+    scrub_scratch(base);
+    return rc;
+}

--- a/test/test_cd_synth_cdda.c
+++ b/test/test_cd_synth_cdda.c
@@ -101,7 +101,7 @@ static uint16_t *p_rrxd;
 #define ST_RX_FULL       0x2000u
 #define I2S_DATA_ENABLE  0x0001u
 
-#define CALLER 0u                   /* `who` argument -- UNKNOWN            */
+#define CALLER 0u                   /* `who` argument -- M68K */
 
 /* ------------------------------------------------------------------ */
 /* Synthetic disc geometry                                              */


### PR DESCRIPTION
## Headline: the VLM works. The blocker is subcode, and it is localized but unproven.

Test + docs only — **no `src/` change in this commit at all.**

Every behavioural claim in #291 previously came from a **synthetic two-tone CUE**. So "audio discs reach the VLM" was established; "the VLM works" was not. This settles that.

## The disc: the decoded audio is the oracle

No real audio CD exists in the corpus (all 35 CUEs are Jaguar game discs), so this builds a much stronger synthetic one — multi-file CUE (the corpus shape, so `dataLBA != startLBA`), 6 tracks, real 150-sector `INDEX 00` pregaps, and:

- **track *t* is a square-wave chirp sweeping `882t → 882t+441` Hz** — base frequency says *which track*, instantaneous frequency says *where in the track*
- **right channel = second harmonic at a different amplitude**, so L ≠ R everywhere
- constant known amplitude; **pregaps are the only silence**

That makes track identity, playback position, and channel identity all recoverable from the samples — the audio analogue of the `disc_pat()` byte pattern the data tests use.

## The VLM renders

**BIOS mode** (`[BOOT] CD game, mode=BIOS`): full drive dialogue `$7001 $150A $0300 $1400 $0301 $1501 $0200 $0101`. Player UI correct for 6 tracks — transport row, `TRK 6`, time readout, `NORMAL`/`NO REPEAT`/`VLM`, grid cells 1–6 lit. Entering the VLM gives black plus a `1-4` preset indicator and `0 0:01`.

With a **forced-unmute diagnostic** (reverted, not shipped): non-silent samples 240,573 → **785,123**, RMS 980 → 1268, motion 0/60 → **60/60**, non-black 0.3% → 16.5%. Screenshots read first-hand show **a full radial spectrum analyser — concentric rings of coloured cells and a cyan waveform trace — visibly changing between frames as the chirp climbs.**

## Two claims withdrawn rather than shipped

- **Plan §3.2 / Phase 2 ("CDDA routing on `$01nn`") was a measurement error, not a bug.** The SSI head already streams correct CD-DA at 44.1 kHz with `ssiBlock` advancing 75/s; the clincher is that the `nonzero` counter plateaus for exactly the length of the 150-sector inter-track pregap. Nothing needed positioning. **Not implemented**; withdrawn in three places in the doc.
- **The real blocker was not fixed, deliberately.** Bit 30 of alternate-bank R13 in the VLM's own DSP SSI ISR (`$F1BC58 BTST #30`) gates both LTXD/RTXD pass-through and FFT input; the VLM sets it at init and it stays set. Its only other writer sits in a DSP block polling `$DFFF1A` — BUTCH's **subcode data register**, which this core doesn't implement (confirmed live: `[SUBCODE] read SUBDATA+2 -> $0000`, while the VLM's 68K arms capture via `SBCNTRL`). The `0 0:01` readout (track 0) tells the same story from the other end.

  That subcode link is **a hypothesis with supporting evidence, not a conclusion**: the delay-slot/computed-jump structure of that DSP block isn't safely readable statically, a crude probe left output byte-identical, and there is no ground truth for Butch's Q-channel wire format (MiSTer's `butch.v` doesn't implement subcode either). Implementing it would have been guesswork. The doc marks it unproven.

## Tests + negative controls

`test/test_cd_synth_cdda.c` builds its own disc and never touches `test/roms/private` — so unlike `test_cd_ssi_stream.c` (which SKIPs without `VJ_SSI_DISC`) it **actually runs in CI**.

| assertion | sabotage | result |
|---|---|---|
| LRXD=left / RRXD=right, sample-aligned from byte 0, across sector boundaries | swap the two reads in `SetSSIWordsXmittedFromButch` | 4/5 red |
| frequency identifies the seeked track; right = 2× left | `CDIntfGetTrackInfo` uses `startLBA` not `dataLBA` | 5/5 red |
| **redundant `$12xx` doesn't rewind the audio head (pins #306/#307)** | restore `ssiBufPtr = 0` on that branch | exactly that one red |
| pregap is silence, tone starts at `INDEX 01` | as row 2 | red |

**I re-ran the third one independently before merging.** Reintroducing the rewind turns exactly that test red:

```
FAIL redundant_seek_does_not_rewind_the_audio_head:598:
  window 4 sample 0 (stream position 32768): got L=-20000 R=-12000,
  expected L=-20000 R=12000 -- the head moved
```

Note it catches it on the **right-channel sign** — only possible because L ≠ R by design. Restored: 5/5.

## Gates

- `make TEST_EXPORTS=1 test` → **exit 0**, zero FAIL lines; audio pair by name (`Clipping check: Iron Soldier 2`, `audio is present and within expected envelope`)
- 5/5 green with `test/roms/private` removed, then restored
- `scripts/c89-lint.sh` passes
- `cd_boot_matrix.sh` not run and **not required — there is no `src/` change**

## Unverified

RetroArch (all headless). Whether subcode is what clears bit 30 — the one open question, with a runtime-evidence plan in §8.7. HLE acceptance of audio discs (Phase 3) and transport controls (Phase 4) untouched; HLE `retro_load_game()` still fails on audio discs, which is pre-existing and documented Phase 3 scope.

One trap worth carrying forward: pressing **A** from the player's default cursor enters the VLM **without** starting playback — indistinguishable from the bug under investigation. You must drive to PLAY with **B** first.

Refs #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)
