### PR TITLE
chore: bump development version to v3.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ TARGET_NAME := virtualjaguar
 # Single source-of-truth for the human-readable version string.
 # Bumped by .github/workflows/version-bump.yml (greps this line).
 # Composed into CORE_VERSION in src/core/version.h, generated below.
-CORE_BASE_VERSION := v3.0.0
+CORE_BASE_VERSION := v3.1.0
 
 ifeq ($(DEBUG),1)
    CFLAGS += -DBUILD_TIMESTAMP="\"debug $(shell date -u +%Y-%m-%dT%H:%M:%SZ)\""

--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -5,7 +5,7 @@ supported_extensions = "j64|jag|rom|abs|cof|bin|prg|cue|cdi"
 corename = "Virtual Jaguar"
 license = "GPLv3"
 permissions = ""
-display_version = "v3.0.0"
+display_version = "v3.1.0"
 categories = "Emulator"
 
 # Hardware Information


### PR DESCRIPTION
Nightlies were reporting **v3.0.0**, indistinguishable from the tagged release in bug reports — #268's triage was exactly this confusion class. develop has gained features since the tag (audio-CD/VLM #300, CD BIOS validation #299, savestate compat #301, DCOMPEN #292, redundant-seek #307), so the next release is 3.1.0 by semver and nightlies now self-identify as such. The embedded git rev keeps distinguishing individual builds (`v3.1.0 <rev>`).

Both version sites bumped together (Makefile `CORE_BASE_VERSION` + `dist/info` `display_version`); `src/core/version.h` regenerates. Verified: build clean, binary embeds `v3.1.0 <rev>`.

Process note: `docs/release-process.md` puts the bump at release-cut time — step 2 of the next cut becomes *verify* instead of *bump*. The release trigger is the `v*` tag, which this does not create; the `nightly` tag sits outside the `v*` filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)