### PR TITLE
test(netlink): replace the load-sensitive ratio with frame-ceiling assertions (#310)

### DIFF
--- a/test/tools/netlink_latency.c
+++ b/test/tools/netlink_latency.c
@@ -238,6 +238,7 @@ int main(int argc, char **argv)
     {
         long long t0, t1;
         uint32_t rx0, rx1;
+        long frames = 0;
         double rate, elapsed;
 
         jerry_ww(0xF10030, 0x0040, 0);   /* first byte starts the chain */
@@ -255,7 +256,10 @@ int main(int argc, char **argv)
         rx0 = rx_total();
         t0 = now_usec();
         while (now_usec() - t0 < (long long)measure_sec * 1000000LL)
+        {
             paced_frame(run_frame);
+            frames++;
+        }
         t1 = now_usec();
         rx1 = rx_total();
 
@@ -263,6 +267,15 @@ int main(int argc, char **argv)
         rate = (double)(rx1 - rx0) / elapsed;
         printf("[probe] %.1f exchanges/sec (%u exchanges in %.2f s, "
                "wait=%s)\n", rate, rx1 - rx0, elapsed, wait_opt);
+        /* Pacing telemetry: how close the 60 fps frame slots came to
+           wall clock during the window.  ~60 = the runner kept pace
+           (an under-ceiling exchange rate is then the core's doing);
+           well under 60 = frames overran, the runner itself was the
+           bottleneck.  netlink_latency_test.sh uses this to decide
+           FAIL vs SKIP when the enabled rate lands under the frame
+           ceiling. */
+        printf("[probe] %.1f frames/sec paced (%ld frames)\n",
+               (double)frames / elapsed, frames);
 
         harness_shutdown(&cfg);
         if (min_rate >= 0.0 && rate < min_rate)

--- a/test/tools/netlink_latency_test.sh
+++ b/test/tools/netlink_latency_test.sh
@@ -8,10 +8,15 @@
 #   enabled (default): the adaptive wait rides out the RTT inside the
 #             frame and sustains a multiple of the quantized rate.
 #
-# CI runners vary widely in speed, so the assertion is a RATIO —
-# enabled must beat disabled by >= 1.5x (measured ~2x locally, ~2.7x on
-# GH Actions macOS) — plus an absolute ceiling on the control proving
-# the injected delay actually quantized it.
+# The assertions are ABSOLUTE, anchored to the 60 fps frame ceiling the
+# bug imposes (issue #310): the probe paces retro_run at 60 fps, so a
+# quantized control physically cannot exceed ~60 exchanges/sec, while
+# the fixed path is uncapped and beats it.  A ratio (the old >= 1.5x
+# check) compresses under machine load — both rates fall together and
+# the test flaked on loaded runners and in CI with the netlink code
+# unmodified.  When load drags even the enabled rate under the ceiling
+# the effect cannot be demonstrated either way, and the test SKIPs
+# loudly (suite skip ledger) instead of failing.
 #
 # Usage: netlink_latency_test.sh <core>
 set -u
@@ -31,11 +36,13 @@ trap cleanup EXIT
 trap 'cleanup; trap - EXIT; exit 130' INT TERM
 
 # run_case <label> <core_port> <proxy_port> <wait>
-# Prints the measured exchanges/sec on stdout; returns nonzero on error.
+# Prints "<exchanges/sec> <frames/sec>" on stdout; returns nonzero on
+# error.  frames/sec is the probe's achieved pacing rate — the load
+# witness (0.0 if the probe binary predates the telemetry line).
 run_case()
 {
     local label="$1" core_port="$2" proxy_port="$3" wait_opt="$4"
-    local probe_log rate
+    local probe_log rate fps
     probe_log="$(mktemp "${TMPDIR:-/tmp}/vj_nl_lat_XXXXXX.log")"
 
     "$TOOLS/netlink_delay_proxy" --listen "$proxy_port" \
@@ -54,41 +61,104 @@ run_case()
     kill "$PROXY_PID" 2>/dev/null
     wait "$PROXY_PID" 2>/dev/null
     PROXY_PID=""
-    grep -E "exchanges/sec|FAIL" "$probe_log" | sed "s/^/[$label] /" >&2
+    grep -E "exchanges/sec|frames/sec|FAIL" "$probe_log" | sed "s/^/[$label] /" >&2
     rate="$(sed -n 's/.*\] \([0-9.]*\) exchanges\/sec.*/\1/p' "$probe_log" | head -1)"
+    fps="$(sed -n 's/.*\] \([0-9.]*\) frames\/sec.*/\1/p' "$probe_log" | head -1)"
     rm -f "$probe_log"
     [ "$rv" -ne 0 ] && return "$rv"
     [ -z "$rate" ] && return 1
-    echo "$rate"
+    echo "$rate ${fps:-0.0}"
     return 0
 }
 
-rate_off="$(run_case "control disabled" 42751 42761 disabled)" || {
-    echo "netlink_latency_test: FAIL (control case errored)"; exit 1; }
-rate_on="$(run_case "fixed enabled" 42752 42762 enabled)" || {
-    echo "netlink_latency_test: FAIL (enabled case errored)"; exit 1; }
+# skip <reason> — loud skip: prints in-context AND records in the suite
+# skip ledger (scripts/test-skip.sh) when run from the repo, so an
+# aborted-suite run can never masquerade as "nothing skipped".
+ROOT="$(cd "$TOOLS/../.." && pwd)"
+skip()
+{
+    echo "netlink_latency_test: SKIP ($*)"
+    if [ -f "$ROOT/scripts/test-skip.sh" ]; then
+        bash "$ROOT/scripts/test-skip.sh" record \
+            "Netlink latency (frame quantization)" "$*"
+    fi
+    exit 0
+}
 
-# Frame quantization needs emulation to run much faster than real time:
-# a frame's 68K spin then burns out in ~1 ms of wall clock and the
-# delayed reply always slips to the next retro_run.  On heavily
-# instrumented builds (ASan, gcov) run_frame is SLOWER than real time,
-# the spin itself spans the network delay, and the control never
-# quantizes (seen: 110/s on the ASan runner).  The bug physically
-# cannot manifest there, so the test skips rather than asserting.
-slow=$(awk -v off="$rate_off" 'BEGIN { print (off > 65) ? "yes" : "no" }')
+out_off="$(run_case "control disabled" 42751 42761 disabled)" || {
+    echo "netlink_latency_test: FAIL (control case errored)"; exit 1; }
+out_on="$(run_case "fixed enabled" 42752 42762 enabled)" || {
+    echo "netlink_latency_test: FAIL (enabled case errored)"; exit 1; }
+read -r rate_off fps_off <<<"$out_off"
+read -r rate_on  fps_on  <<<"$out_on"
+
+# Chain sanity: something actually ping-ponged in the control case.
+ok=$(awk -v off="$rate_off" 'BEGIN { print (off >= 5) ? "yes" : "no" }')
+if [ "$ok" != "yes" ]; then
+    echo "netlink_latency_test: FAIL (control=$rate_off/s — exchange chain" \
+         "never ran; proxy/link problem, not a quantization verdict)"
+    exit 1
+fi
+
+# The verdict is anchored to the 60/s frame ceiling.  The probe paces
+# retro_run at 60 fps, and without the reply wait every delayed reply
+# slips to the next frame — so a genuinely quantized control CANNOT
+# exceed ~60 exchanges/sec no matter how fast the host is, and the
+# fixed path proves itself by beating that ceiling.  Both claims are
+# absolute: proportional machine-load slowdown moves both rates DOWN,
+# never across these thresholds in the failing direction.
+FRAME_CEILING=60
+
+# Skip 1: control never quantized.  Frame quantization needs emulation
+# to run much faster than real time: a frame's 68K spin then burns out
+# in ~1 ms of wall clock and the delayed reply always slips to the next
+# retro_run.  On heavily instrumented builds (ASan, gcov) run_frame is
+# SLOWER than real time, the spin itself spans the network delay, and
+# the control never quantizes (seen: 110/s on the ASan runner).  The
+# bug physically cannot manifest there.
+slow=$(awk -v off="$rate_off" -v c="$FRAME_CEILING" \
+    'BEGIN { print (off > c) ? "yes" : "no" }')
 if [ "$slow" = "yes" ]; then
-    echo "netlink_latency_test: SKIP (control=$rate_off/s never quantized —" \
-         "runner emulates slower than real time, cannot exhibit the bug)"
+    skip "control=$rate_off/s never quantized — runner emulates slower" \
+         "than real time, cannot exhibit the bug"
+fi
+
+# Control was quantized (off <= 60).  Fixed path must beat the ceiling.
+fast=$(awk -v on="$rate_on" -v c="$FRAME_CEILING" \
+    'BEGIN { print (on > c) ? "yes" : "no" }')
+if [ "$fast" = "yes" ]; then
+    echo "netlink_latency_test: PASS (disabled=$rate_off quantized <=" \
+         "$FRAME_CEILING/s, enabled=$rate_on beat the frame ceiling)"
     exit 0
 fi
 
-# Control sanity: the chain ran, and the injected delay quantized it
-# (paced 60 fps probe can't exceed ~60/s when every reply slips a frame).
-ok=$(awk -v off="$rate_off" -v on="$rate_on" 'BEGIN {
-    print (off >= 5 && on >= 1.5 * off) ? "yes" : "no" }')
-if [ "$ok" != "yes" ]; then
-    echo "netlink_latency_test: FAIL (disabled=$rate_off enabled=$rate_on;" \
-         "need disabled >= 5 and enabled >= 1.5x disabled)"
-    exit 1
+# Enabled landed under the ceiling too.  Two causes look alike in the
+# exchange rates alone — a broken reply wait (enabled quantizes just
+# like the control) or a runner too loaded for the uncapped path to
+# clear 60/s — and the rates cannot disambiguate them: quantized-run
+# variance (~40-57/s observed) swamps any lift threshold.  So FAIL
+# only on positive evidence of quantization in the enabled case,
+# using the probe's pacing telemetry:
+#
+#   quantized identity: a quantized run does <= 1 exchange per paced
+#   frame (the control shows this exactly: e.g. 105 exchanges in 105
+#   frames).  rate_on <= 1.05 * fps_on means the wait bought nothing.
+#
+#   pacing held: fps_on >= 45 means the probe kept a near-normal frame
+#   cadence (idle macOS paces ~52-55 due to usleep overhead), so the
+#   core HAD its frame slots and still never beat one exchange per
+#   frame — that is the bug.  A load-crushed runner (CI flake: rates
+#   21.9/29.5 imply ~30 fps) fails this and SKIPs loudly instead:
+#   it cannot demonstrate the effect in either direction.
+quant=$(awk -v on="$rate_on" -v fps="$fps_on" 'BEGIN {
+    print (fps >= 45 && on <= 1.05 * fps) ? "yes" : "no" }')
+if [ "$quant" != "yes" ]; then
+    skip "disabled=$rate_off enabled=$rate_on (paced $fps_on fps) —" \
+         "under the $FRAME_CEILING/s ceiling but not demonstrably" \
+         "quantized; runner too slow/loaded to demonstrate the effect"
 fi
-echo "netlink_latency_test: PASS (disabled=$rate_off enabled=$rate_on)"
+echo "netlink_latency_test: FAIL (enabled=$rate_on <= 1 exchange per" \
+     "paced frame at $fps_on fps, same frame quantization as the" \
+     "control ($rate_off) — reply wait is not defeating receive-side" \
+     "frame quantization)"
+exit 1


### PR DESCRIPTION
## Summary

Fixes #310: `netlink_latency_test.sh` asserted a **ratio** (`enabled >= 1.5 * disabled`), and under load both rates fall so the ratio compresses — it failed 4× in one day including once in CI on an unrelated PR, and because it runs early, a flake aborted the suite before the skip summary printed.

## New assertions — absolute and physically meaningful

- **PASS** = `off <= 60` (control genuinely frame-quantized: a quantized exchange physically cannot exceed one per paced frame) AND `on > 60` (the fixed path beat the frame ceiling). Proportional slowdown moves both rates *down*, never across a threshold in the failing direction.
- `off > 60` → loud SKIP (control never quantized; the ASan-class-runner case — replaces the old `off > 65` guard).
- Degraded regime (`on <= 60`): FAIL only on **positive evidence of quantization** — `on <= 1.05 × achieved pacing fps` while pacing held ≥ 45 fps; otherwise loud SKIP into the suite's skip ledger.

## One deviation from "script-only", disclosed

13 lines added to `test/tools/netlink_latency.c` (the probe harness, not emulation code) to report its achieved paced fps. The first, pure-shell attempt's negative control **failed to go red** — run-to-run quantized-rate variance (40.5–57.0/s spread) produced a 1.23× apparent "lift" from noise alone, so any lift threshold that catches sabotage would also re-flake on #310's real 1.26–1.35 loaded ratios. The pacing witness is the only measured quantity separating "broken wait" (pacing normal, rate capped at 1/frame) from "loaded runner" (pacing collapsed).

## Evidence

- Idle 3×: PASS (52.1/89.4, 52.2/91.2, 52.6/86.5). Parallel-build load 3×: PASS. 24-spinner saturation: SKIP, PASS, PASS — **never FAIL**.
- All four flaky data points from #310 replayed through the real verdict code: rows 1–2 → PASS, row 3 + the CI row → loud SKIP.
- **Negative control red 6/6** (idle + loaded): sabotage runs the "enabled" case with the wait actually disabled →
  `FAIL (enabled=52.3 <= 1 exchange per paced frame at 52.3 fps, same frame quantization as the control (51.9)…)`
  Also stays red for "broken fix under mild load" (off=47, on=48 @ 47.5 fps) — the red survives load, unlike a naive `on<=60 → SKIP`.
- Full suite exit 0; audio pair by name; in-suite line: `PASS (disabled=51.2 quantized <= 60/s, enabled=108.6 beat the frame ceiling)`; skip ledger "none". **Independently re-verified before opening this PR** (fresh rebuild: `PASS (disabled=44.9 …, enabled=101.2 …)`).

## Residual risk, stated

A false FAIL needs sustained load stretching RTT past the adaptive wait budget on ~every frame while probe pacing stays ≥ 45 fps — never observed across all runs; the FAIL message carries the fps evidence to diagnose it if it ever bites. The degraded regime was validated by replaying #310's measured numbers rather than live reproduction (this 12-core machine won't compress under a parallel build) — worth one eye on the first CI runs.

Closes #310 (manual close needed — merges to develop don't auto-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
