### PR TITLE
feat(cart): Jaguar GameDrive (JGD) detection + 16 MB bank switching (#312)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -755,7 +755,7 @@ clean:
 		test/test_cart_format \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda \
 		test/test_audio_dac test/test_blitter \
-		test/test_state_compat test/test_frontend_pacing \
+		test/test_state_compat test/test_frontend_pacing test/test_jgd \
 		test/dump_pc test/heap_search \
 		test/tools/test_memory_map test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/tools/test_dsp_audio_diag \
 		test/tools/test_frame_timing test/.skipped-checks
@@ -802,7 +802,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_audio_pipeline test/test_audio_clipping test/test_audio_presence test/test_pit_clock_rate \
 		test/test_blitter_mmio test/test_blitter_cmd test/test_eeprom_lifecycle test/test_tom_visible_window \
 		test/test_framebuffer_integrity test/test_state_compat \
-		test/test_frontend_pacing \
+		test/test_frontend_pacing test/test_jgd \
 		test/test_butch_cd test/test_bios_config test/test_boot_config \
 		test/test_cart_format \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda \
@@ -993,6 +993,10 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# committed in-tree, so a missing ROM is a broken checkout and the
 	@# test's exit 77 should stop the suite rather than read as a pass.
 	./test/test_state_compat ./$(TARGET) test/roms/yarc.j64
+	@# Jaguar GameDrive detection + banking + savestate v8 gate.  Fully
+	@# synthetic (builds its own probe images), so it runs everywhere,
+	@# including checkouts without the private ROM tree.
+	./test/test_jgd ./$(TARGET)
 	@# Frontend pacing / fast-forward contract: the core must not throttle
 	@# itself, and samples-per-frame must match the advertised fps and
 	@# sample_rate, otherwise the frontend's audio driver becomes the pacing
@@ -1226,6 +1230,17 @@ test/test_state_compat: test/test_state_compat.c \
 		test/harness/harness.c test/harness/harness.h src/core/state.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_state_compat.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
+
+# Jaguar GameDrive (JagGD) detection + banking.  Synthetic-only: builds
+# its own probe cartridge images at runtime, no private ROMs needed.
+# Needs jgd*/JGD* from the wide test symbol set.
+test/test_jgd: test/test_jgd.c \
+		test/harness/harness.c test/harness/harness.h \
+		src/core/state.h src/core/jaggd.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_jgd.c \
 		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -58,6 +58,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/jerry/joystick.c \
 	$(CORE_DIR)/src/core/settings.c \
 	$(CORE_DIR)/src/core/memtrack.c \
+	$(CORE_DIR)/src/core/jaggd.c \
 	$(CORE_DIR)/src/core/nvmbios.c \
 	$(CORE_DIR)/src/core/vjag_memory.c \
 	$(CORE_DIR)/src/core/universalhdr.c \

--- a/docs/jgd-interface-notes.md
+++ b/docs/jgd-interface-notes.md
@@ -1,0 +1,415 @@
+# Jaguar GameDrive (JagGD) interface notes — research for #312
+
+Status: phases 1+2 of §9 are implemented (`src/core/jaggd.c`, core option
+`virtualjaguar_jgd`, savestate v8, `test/test_jgd.c`); the GD menu, SD/FAT
+filesystem, GPU async reads, encrypted `.jgd` and `.MRQ` remain out of scope.
+This document is the hardware/protocol spec of record for that
+implementation, at the quality bar of `docs/memory-track.md`.
+
+**Primary ground truth: RetroHQ's own published homebrew API**
+(<https://github.com/RetroHQ/JagGD>, by SainT, the JagGD author). Unlike the
+Memory Track, we did NOT have to reconstruct this interface from third-party
+behavior — the cart-side 68K source (`gdbios_bindings.s`) is public and contains
+the SPI register addresses, bit definitions, the full handshake protocol, and
+the bank-switching semantics in SainT's own comments. Local copies of
+everything cited live in the research scratchpad
+(`.../scratchpad/jaggd-api/`, `.../scratchpad/jagstudio/`,
+`.../scratchpad/bigpemu_disasm.txt`).
+
+Confidence labels used throughout:
+- **established** — stated in RetroHQ source (`gdbios_bindings.s` /
+  `gdbios.h` / `README.md`) or directly observable in shipped JagStudio code
+  (`RAPTORGD.O`, disassembled and verified identical to the bindings).
+- **established-behavioral** — read out of the BigPEmu 1.2x arm64 binary
+  (`/Applications/BigPEmu.app/Wrapper/BigPEmu.app/BigPEmu`, disassembled) or
+  its changelog. Tells us what the ecosystem's reference emulator does, not
+  necessarily what silicon does.
+- **inferred** — follows from the above but not directly stated.
+- **guessed** — plausible, must be verified before relying on it.
+
+---
+
+## 1. Hardware model
+
+The JagGD is a flash cart with (established, from the API source + product
+materials):
+
+- **16 MB of onboard SDRAM** presented to the Jaguar as cartridge ROM.
+- An **ASIC/FPGA** that decodes the cart bus, maps SDRAM into the 6 MB cart
+  window, and exposes a small SPI-style mailbox register set.
+- A **microcontroller** ("the GD", "the micro" in SainT's comments) behind
+  that SPI link. It owns the SD card, the FAT filesystem, serial numbers, the
+  menu, firmware, and it *serves the GDBIOS blob on request*.
+
+Communication model: the 68K talks to the micro through three registers in
+JERRY's **GPIO2** decode range. Cart EEPROM already works exactly this way
+through GPIO0/GPIO1 ($F14800/$F15000, see `src/jerry/eeprom.c`), so the GPIO
+chip selects demonstrably route to the cartridge connector; GPIO2 is the next
+one up and is marked "reserved" in our own jerry.c address map (established by
+analogy + the fact that the GD API uses these addresses from cart code).
+
+## 2. Register map
+
+All from `gdbios_bindings.s` (established) unless noted.
+
+| Address | Name (RetroHQ) | Access | Meaning |
+|---|---|---|---|
+| `$F16002` | `ASIC_SPI_STATUS` | R/W 16-bit | Status + control, bits below |
+| `$F16004` | `ASIC_SPI_DATA` | R/W 16-bit | Write = trigger one SPI byte exchange; word read = drain rx latch |
+| `$F16005` | `ASIC_SPI_DATA_BYTE` | R 8-bit | Received byte (low byte of `$F16004`) |
+
+`ASIC_SPI_STATUS` bits (established):
+
+| Bit | Mask | Name | Direction | Meaning |
+|---|---|---|---|---|
+| 0 | `$0001` | `SLAVE_SELECT` | W | Assert slave select (ack packet start) |
+| 3 | `$0008` | `HAVE_DATA` | R | Handshake bit; see GDWaitData below. Idle/ready state is **clear**; the slave raises it to ack/announce data |
+| 4 | `$0010` | `PACKET_START` | W | Request packet start / block boundary ("process it, GD!") |
+| 5 | `$0020` | `LATCH_FULL` | R | A received byte is sitting in the rx latch (must be drained before starting a transaction) |
+| 15 | `$8000` | (busy) | R | Exchange in progress. All waits are `tst.w $F16002` / `bmi` loops, i.e. spin while bit 15 set |
+
+Write of `$0000` to `$F16002` = end of packet / deselect (established — every
+transaction ends with `clr.w ASIC_SPI_STATUS`).
+
+**Data register semantics** (established from code shape; exact tx byte order
+inferred): writing **any word** to `$F16004` clocks **one byte exchange**. The
+transmitted byte is the **low byte of the written word** (inferred — see
+`GDExchangeWord` trace below; the bulk-read loop writes its loop counter as a
+don't-care dummy, so the written value is irrelevant when only receiving).
+After bit 15 clears, the received byte is read at `$F16005`.
+
+`GDExchangeWord` (send a 16-bit word, receive a 16-bit word — established):
+
+```
+move.w  d0,$F16004        ; exchange byte #1
+(wait not busy)
+move.b  $F16005,d0        ; rx1 -> low byte
+ror.w   #8,d0             ; rx1 -> high byte, old high byte -> low
+move.w  d0,$F16004        ; exchange byte #2 (tx = old high byte)
+(wait not busy)
+move.b  $F16005,d0        ; result = rx1<<8 | rx2
+```
+
+`GDWaitData` (the packet handshake — established):
+
+```
+1. spin until HAVE_DATA (bit 3) == 0
+2. write PACKET_START|SLAVE_SELECT ($0011) to $F16002
+3. spin until HAVE_DATA == 1        ; slave ack
+```
+
+**Consequence for a machine with no GD attached:** step 3 never completes.
+There is no timeout anywhere in the RetroHQ or JagStudio code. See §6.
+
+## 3. Micro packet protocol
+
+Transaction shape (established, from `_GD_HWVersion` and `_GD_Install`):
+
+```
+write $0010 to STATUS            ; request packet start
+GDWaitData                       ; handshake
+GDExchangeWord(command)          ; 16-bit command word
+GDExchangeWord(param_size)       ; 16-bit param byte count (0 if none)
+[param bytes...]
+write $0010 to STATUS            ; "we're done, process it GD!"
+--- response ---
+GDWaitData
+GDExchangeWord / byte loop       ; response payload, format per command
+write $0010 to STATUS            ; after each ≤512-byte block
+...
+write $0000 to STATUS            ; end of packet
+```
+
+Known command words (established):
+
+| Cmd | Function | Response |
+|---|---|---|
+| `12` (`$0C`) | HW version | u32: high word = **firmware version, BCD** (e.g. `$0111` = v1.11), low word = ASIC version, BCD. Read as two `GDExchangeWord`s, high word first. After reading, the caller busy-waits ~500 dbra iterations "to let the micro finish up" |
+| `$80` | Fetch GDBIOS | u16 blob size, then the blob streamed in ≤512-byte chunks, one `PACKET_START` write between chunks; each byte clocked out by a dummy word write to `$F16004` |
+
+Before `$80`, the installer drains the rx latch: while `LATCH_FULL` set, read
+`$F16004` (word) and re-check ("in case of FIFO DMA termination",
+established).
+
+All other micro commands (file I/O, serials, LED, reset, page set, …) are
+issued **by the GDBIOS blob**, not by game code, and their SPI encodings are
+**unknown** — and irrelevant for us, because the blob itself comes from the
+emulated micro, i.e. *we get to supply our own blob* (see §7). BigPEmu
+necessarily does the same thing (it cannot ship RetroHQ's copyrighted blob).
+
+## 4. GDBIOS blob ABI (what games actually link against)
+
+Games do not poke registers for anything except the two commands above. They
+call `GD_Install(buffer)` (a 4 KB, long-aligned RAM buffer), which:
+
+1. Calls HW version (cmd 12); **fails if firmware < `$111` (v1.11)** —
+   established, both in RetroHQ bindings (`MINVERSION`... actually the FW
+   gate) and JagStudio's `RAPTOR_GD_Init` (identical code, verified by
+   disassembling `RAPTORGD.O`).
+2. Streams the blob (cmd `$80`) into the buffer, stores the pointer
+   (`GDB_Base`).
+3. Checks blob version word ≥ `$100`, then calls blob function 1 (`GD_Init`).
+
+Blob memory layout (established):
+
+| Offset | Size | Meaning |
+|---|---|---|
+| `+0` | u16 | GDBIOS version, BCD, min `$100` |
+| `+2` | u16 | Highest function number implemented |
+| `+N*4` | 4 bytes | Entry point of function N (a 4-byte slot — enough for one `bra.w`/`jmp` stub) |
+
+Call convention (established): `a6` = blob base; caller does
+`cmp.w #N,2(a6)` / `blt fail` then `jsr N*4(a6)`. `d0-d1/a0-a1` scratch,
+everything else callee-saved. Function numbers and register ABI:
+
+| N | Name | Args in | Returns (d0) |
+|---|---|---|---|
+| 1 | `GD_Init` | — | — |
+| 2 | `GD_InitGPURead` | a0=GPU RAM buffer (224 bytes), d0=flags (0 preserve / 1 fast) | — |
+| 3 | `GD_BIOSVersion` | — | u16 BCD |
+| 4 | `GD_ROMWriteEnable` | d0=1 enable / 0 disable | — |
+| 5 | `GD_ROMSetPage` | d0 = page<<16 \| bank | — |
+| 6 | `GD_ROMSetPages` | d0 = u32, one bank nibble per page, LSN = page 0 | — |
+| 7 | `GD_GetCartSerial` | a0=16-byte buffer | 0 ok / !0 fail |
+| 8 | `GD_GetCardSerial` | a0=16-byte buffer | 0 ok / !0 fail |
+| 9 | `GD_CardIn` | — | 0 no / 1 yes |
+| 10 | `GD_FileOpen` | a0=path, d0=mode | handle ≥0 / <0 fail |
+| 11 | `GD_FileClose` | d0=handle | 0 / <0 |
+| 12 | `GD_FileSeek` | d0 = flags<<16 \| handle, d1=offset | 0 / <0 |
+| 13 | `GD_FileRead` | d0 = flags<<16 \| handle, a0=buffer, d1=size | 0 / <0 |
+| 14 | `GD_FileWrite` | d0=handle, a0=buffer, d1=size | 0 / <0 |
+| 15 | `GD_FileTell` | d0=handle | offset / $FFFFFFFF |
+| 16 | `GD_FileSize` | d0=handle | size / $FFFFFFFF |
+| 17 | `GD_FileAsyncPos` | — | pos |
+| 18 | `GD_FileAsyncWait` | — | — |
+| 19 | `GD_FileAsyncActive` | — | 0/1 |
+| 20 | `GD_FileInfo` | a0=path, a1=buffer, d0=flags (bit0 = long name) | ≥0 / <0 |
+| 21 | `GD_DirOpen` | a0=path | handle / <0 |
+| 22 | `GD_DirRead` | d0 = flags<<16 \| handle, a0=buffer | ≥0 / <0 |
+| 23 | `GD_DirClose` | d0=handle | 0 / <0 |
+| 24 | `GD_Reset` | d0 = 0 normal / 1 to GD menu / 2 debug | — |
+| 25 | `GD_SetLED` | d0=flags | — |
+| 26 | `GD_DebugString` | a0=C string (→ virtual USB COM port) | — |
+
+`GD_HWVersion` is **not** a blob function — it is raw SPI in the binding and
+works pre-install.
+
+## 5. Bank switching semantics
+
+Verbatim from SainT's comments in `gdbios_bindings.s` (established):
+
+```
+ROMSetPage(u16 page, u16 bank)
+  Page 0 : $8xxxxx      1 : $9xxxxx      2 : $axxxxx
+       3 : $bxxxxx      4 : $cxxxxx      5 : $dxxxxx
+  Bank 0-15 is 1MB pages of the onboard 16MB SDRAM
+
+ROMSetPages(u32 banks)
+  Set all SDRAM banks at once, one per nibble.
+  Lowest significant nibble is page 0, upto nibble 5. Data above is ignored.
+```
+
+So:
+
+- **Granularity:** 1 MB. The 6 MB cart window ($800000–$DFFFFF) is six
+  independent 1 MB pages, each mappable to any of sixteen 1 MB banks of the
+  16 MB SDRAM. (established)
+- **Window:** whole cart space. Note page 5 covers $Dxxxxx including the
+  $DFFF00 BUTCH-overlay tail — for emulation, keep our existing
+  $DFFF00–$DFFFFF handling above the banked read, exactly as today's dispatch
+  already orders it. (inferred, trivially safe)
+- **Latch behavior:** immediate on the next bus access; a page register is
+  plain combinational address-translation state in the ASIC. No evidence of
+  any delay or double-buffering. (inferred)
+- **Initial mapping:** identity (page N → bank N) so that a flat ≤6 MB image
+  looks like a normal cart, and a >6 MB image exposes its first 6 MB.
+  (inferred — required for anything to boot at all; BigPEmu boots >6 MB
+  images this way per its changelog)
+- **Writes:** `GD_ROMWriteEnable(1)` makes the SDRAM-backed "ROM" writable
+  (the GD menu uses this to load; homebrew can use cart space as extra RAM).
+  Granularity global vs per-page unknown; assume global. (established that it
+  exists; granularity guessed)
+- **How the real blob performs the switch is unknown** (SPI command to the
+  micro vs. a direct ASIC register). Deliberately irrelevant to us: games can
+  only reach banking through the blob ABI, and the emulator supplies the
+  blob. (established consequence)
+
+## 6. GD detection — what a GD-locked title actually does
+
+From JagStudio v1.11 (`RAPTORGD.O` disassembled; `buildfiles/template/rapapp.s`;
+`projects/basic/jaguargd/`) — JagStudio is what real GD homebrew (e.g. SKYLAR)
+is built with (established):
+
+1. Projects opt in with `useGD=1`; startup then calls `RAPTOR_GD_Init`
+   **unconditionally, before DSP setup** ("MUST be before DSP setup").
+2. `RAPTOR_GD_Init` = RetroHQ's `GD_Install` with a detect flag:
+   `raptor_GD_detect = 1`, run HW-version (cmd 12); if FW < `$111` →
+   `GDB_Base = 0`, `detect = -1`, return. Otherwise install blob + `GD_Init`.
+3. Game code branches on `raptor_GD_detect == 1` ("GD Cart Detected") — and
+   every wrapped call re-checks `GDB_Base != 0` and the function-count word,
+   returning -1 gracefully when absent.
+
+**The failure mode without a GD is a hang, not a refusal**: `GDWaitData`
+step 3 spins forever waiting for `HAVE_DATA` to go high. On our core today,
+`$F16002` reads fall into the `F14000–F1A0FF` catch-all in
+`src/jerry/jerry.c` → `EepromReadWord` → returns `$0000` for non-EEPROM
+offsets — bit 3 never rises, the 68K wedges in `.waitAck`, and `crash_detect`
+will report `video_stall`. BigPEmu with JGD off behaves the same way (its GD
+register special-case is gated on a JGD-enabled flag bit; disabled, the read
+falls through to a flat memory array) — which is exactly why Batocera tells
+users GD-locked games "won't boot" until they turn on Force JGD.
+
+So the **detection contract we must implement** is precisely:
+status handshake (bit 3 sequencing + bit 15 busy + bit 5 drain), command 12
+returning FW ≥ `$111` (recommend `$0300`/`$0102`-style current-ish BCD values;
+anything ≥ `$0111` works), and command `$80` serving a valid blob.
+
+What we do *not* have to implement for detection: serial numbers can return
+zeros-with-success (titles hard-locked to one physical cart serial are
+distributed as encrypted `.jgd` files we can't load anyway — out of scope,
+same as BigPEmu).
+
+## 7. What BigPEmu does (established-behavioral)
+
+From its changelog (mirrored at emunations.com) and the arm64 binary:
+
+- v1.01 "Added JaguarGD bank switching support." v1.02 "Added an option to
+  force Jaguar GD emulation, which enables bank switching even in ROM images
+  smaller than 6MB" (config key `ForceJGD`; sits alongside `AttachButch`,
+  `AttachMT`, `ShareMT`, `CDSeekSpeed` in `BigPEmuConfig.System`). v1.19
+  "Added more Jaguar GD functionality. Filesystem functions are stubbed out…"
+- Its JERRY byte/word read+write handlers special-case addresses ≥ `$F16002`
+  behind a JGD-enable flag. The status read is synthesized: `LATCH_FULL` is
+  set from a response-FIFO head≠tail comparison, and the read has
+  side effects on the stored status bits (read-sensitive handshake
+  emulation). `PACKET_START` writes raise a "process packet" flag consumed by
+  a command engine that fills the response FIFO. I.e. **BigPEmu emulates the
+  GD at the SPI-register level for detection/install**, matching §2–§3.
+- GD *function* services are HLE'd host-side: its file-open paths read the
+  filename out of emulated RAM and call host filesystem/`wcslen` code — i.e.
+  the blob it serves is a thin trampoline into native handlers. (This is the
+  v1.19 "filesystem stubs" layer.)
+- Auto-enable: banking turns on automatically for images ≥ 6 MB; `ForceJGD`
+  covers smaller GD-locked images. Our proposed core option
+  `virtualjaguar_jgd = disabled|auto|enabled` maps 1:1.
+- `.MRQ` (GD box-art/metadata sidecar) support is pure UI, ignore.
+
+## 8. Remaining unknowns, and the cheapest experiment for each
+
+| Unknown | Impact | Cheapest resolution |
+|---|---|---|
+| Exact tx byte order of `$F16004` word writes (low-byte-out inferred) | None if we implement to satisfy the binding code shape (we are the only slave); matters only for exotic homebrew doing raw SPI | Write a 20-line probe ROM from the bindings, run under BigPEmu with its scripting/debugger tracing `$F16004`; or ask SainT on AtariAge |
+| Full micro SPI command set beyond 12/`$80` | None for scope of #312 (blob is ours) | Dump the real blob: run `GD_Install` on real hardware and save the 4 KB buffer to SD with `GD_FileWrite` — a ~30-line JagStudio program; also answers the next row |
+| What the real GDBIOS `ROMSetPage` pokes | None (same reason); would be nice for a hardware-faithful mode | Same blob dump, disassemble |
+| Initial page map on boot (identity assumed) | Boot of >6 MB images | Run SKYLAR 1.0 in BigPEmu, break before first `ROMSetPage`, checksum the six pages against file offsets |
+| `ROMWriteEnable` granularity (global assumed) | Writable-cart feature only | Blob dump / SainT |
+| Stock-console (no GD) read value at `$F16002` | Only affects how faithfully "GD absent" hangs; our current `$0000` reproduces the observed hang class | Real-hardware probe; not needed for #312 |
+| Whether any homebrew calls raw SPI beyond `GD_HWVersion` | Compatibility ceiling | Corpus scan for `$F160` word constants in ROM images once we have GD titles locally |
+
+None of these block implementation.
+
+## 9. Implementation sketch (mapped onto our code)
+
+New `src/core/jaggd.c` + `jaggd.h` (mirror `memtrack.c` structure):
+
+- **State:** `jgdEnabled` (from core option `virtualjaguar_jgd =
+  disabled|auto|enabled`; `auto` = on when image > `0x5FFF00` bytes),
+  `uint8_t jgdPage[6]` (init 0..5), full-image buffer `jgdROM` (≤16 MB;
+  `jaguarMainROM`/`jagMemSpace` cart region stays as-is for the non-GD path),
+  SPI engine: `status`, small state machine (IDLE → HANDSHAKE → CMD → LEN →
+  PARAMS → RESPONSE), response byte-FIFO, `rxLatch`.
+- **Register hook:** in `src/jerry/jerry.c`, intercept `$F16000–$F16007`
+  in `JERRYReadByte/Word` and `JERRYWriteByte/Word` **before** the
+  `F14000–F1A0FF` EEPROM catch-all (which currently swallows these
+  addresses), delegating to `JGDControlRead/Write` when `jgdEnabled`.
+  Behavior per §2–§3: implement exactly the sequence the bindings perform;
+  respond to cmd 12 with FW `$0300` / ASIC `$0102` (any BCD ≥ `$0111` FW),
+  cmd `$80` with our blob; unknown commands → zero-filled responses.
+- **The served blob:** ~200 bytes of hand-written 68K, embedded via bin2c
+  like `src/bios/*` (source checked in under `src/bios/` with its build
+  script, same pattern as the CD boot stub). Header `$0100`, func count 26.
+  Implemented: 1 (rts), 3 (version), 4 (write enable), 5/6 (page set),
+  7/8 (zero serial, return 0), 9 (return 0), 24 (write to reset backdoor —
+  or just rts initially), 25/26 (rts); file/dir/async functions return -1
+  (`moveq #-1,d0; rts` — BigPEmu also only "stubs" these; genuinely
+  implementing them against a host directory is possible later via the same
+  backdoor). Banking mechanism for the blob: functions 5/6 write the packed
+  bank value to a **backdoor register we define at `$F16006`** (word write,
+  inside the GPIO2 range we already own; nothing else decodes it). This
+  keeps the blob 68K-only and trivially small, and keeps all interpretation
+  in `jaggd.c`. `retro_deinit` must reset all of this (iOS static-state
+  rule).
+- **Cart read path:** in `src/core/jaguar.c` `JaguarReadByte/Word/Long`
+  cart branches (and the DMA/`JaguarRead*`-alike helpers at lines ~659-690),
+  when `jgdBankingActive`:
+  `off = address - 0x800000; return jgdROM[((uint32_t)jgdPage[off >> 20] << 20) | (off & 0xFFFFF)]`
+  — one table lookup + shift, same cost class as the existing MEMTRACK
+  gate. Word/long reads that could straddle a 1 MB boundary: only possible
+  for the odd-address/boundary cases; handle by composing bytes (straddling
+  reads are already rare/degenerate on real carts). `GD_ROMWriteEnable`
+  makes the same translation apply in `JaguarWriteByte/Word` cart branches
+  (write into `jgdROM`).
+- **Loader:** `src/core/file.c` `JaguarLoadROM`/callers currently cap at
+  the cart window; accept up to `0x1000000` (16 MB), copy first 6 MB into
+  `jaguarMainROM` for the flat path, keep full image in `jgdROM`, set
+  auto-enable. (Alignment/padding to 1 MB multiple.)
+- **Savestate:** serialize `jgdEnabled(active)`, `jgdPage[6]`, SPI engine
+  state + FIFO; single version bump per release policy
+  (`docs/savestate-compat.md`). The 16 MB image itself is NOT serialized
+  (same as cart ROM today) — but pages written via `ROMWriteEnable` are
+  dirty state; simplest correct v1: serialize a dirty flag and, if any
+  write occurred, the full written-page set. (Defer: most titles won't
+  write.)
+- **Memory map / RA:** `test/tools/test_memory_map.c` expects the current
+  descriptor layout; cart descriptor stays the 6 MB window (it describes the
+  68K address space, which is unchanged).
+- **Out of scope** (match BigPEmu): GD menu, SD/FAT filesystem semantics,
+  `GD_InitGPURead` GPU async reads (function 2 = rts; `GD_FREAD_GPU` modes
+  are documented to not function without it, so returning -1 from FileRead
+  keeps the contract honest), `.jgd` encrypted images, `.MRQ` sidecars.
+
+Suggested implementation order: (1) register hook + detection handshake +
+blob install — gets "GD Cart Detected" on the JagStudio example; (2) banking
++ >6 MB loader — gets SKYLAR; (3) savestate + core option plumbing + tests.
+
+## 10. Test cases
+
+| Title | What it exercises | Local availability |
+|---|---|---|
+| JagStudio `jaguargd` example | `GD_Install`, detect flag, serials, LED, file I/O — prints "GD Cart Detected"/"NOT Detected" on screen | **Yes** — prebuilt `build/jaguargd.bin` (BJL/RAM-load format) in the scratchpad JagStudio tree; rebuild to `.rom` with JagStudio (Windows/Wine or the shipped `jaggd-x64` tooling) for a cart image |
+| SKYLAR 1.0 preview (JagFest 2024) | The real thing: 16 MB image, live `ROMSetPage` banking + GD file access | No — download from the AtariAge thread ("SKYLAR 1.0 - 16MB BankSwitching GameDrive ROM", topic 371072; needs the SKYLAR directory on "SD card" — file calls will return -1 under our stub, so expect partial function: boot+banking yes, streamed assets no |
+| Own probe ROM (recommended) | Deterministic harness ROM built with rmac + the RetroHQ bindings: install, `ROMSetPages`, checksum each page window, report via screen color / RAM flag readable by `harness_dlsym` | Build ourselves — best regression asset, no distribution problem, drop into `test/roms/` |
+| GD-locked commercial homebrew | The ForceJGD path for <6 MB images | None in the local corpus (scanned `test/roms/private` — no GD titles, nothing >4 MB unpacked). Names of specific GD-locked retail homebrew were not pinned down by public sources during this research; Batocera/BigPEmu docs confirm the class exists without naming titles. Acquire via AtariAge when needed; the probe ROM covers the mechanism in the meantime |
+
+The local corpus check: `test/roms/private/ROMS` is a classic-era set (139
+retail entries + PD folder); no GD-aware or >6 MB images. The two >4 MB files
+are 7z archives (Ultra Vortek, PD collection).
+
+## 11. Source index (provenance)
+
+- `github.com/RetroHQ/JagGD` — `gdbios.h`, `gdbios_bindings.s`, `README.md`
+  (SainT/RetroHQ, official). Registers, bits, protocol, blob ABI, page/bank
+  semantics, GPU-read notes. Cloned to scratchpad `jaggd-api/`.
+- JagStudio v1.11 (`reboot-games.com/jagstudio/releases/jagstudio-v1.11.zip`)
+  — `buildfiles/raptor/RAPTORGD.O` (disassembled with capstone; byte-for-byte
+  the same logic as the bindings + `raptor_GD_detect`), `RAPTORGD.INC`,
+  `template/rapapp.s` (`useGD=1` init ordering), `projects/basic/jaguargd/`
+  example. Scratchpad `jagstudio/`.
+- BigPEmu macOS arm64 binary — JERRY handler special-cases at
+  `0x1001d0a0c`/`0x1001d1f88`/`0x1001d22f8` (GD SPI status/data emulation,
+  gated on a mode flag), GD filesystem HLE cluster near `0x10014b150`
+  (host-side file ops on emulated-RAM filenames), config key block
+  (`ForceJGD` next to `AttachButch`/`AttachMT`). Disasm at scratchpad
+  `bigpemu_disasm.txt` (2M lines).
+- BigPEmu changelog v1.01/v1.02/v1.19 via emunations.com mirror; BigPEmu user
+  manual (richwhitehouse.com) for MRQ note.
+- AtariAge topic 371072 (SKYLAR 1.0) — existence/shape of a real 16 MB
+  banking title; JagStudio credit "Rik, CJ and SainT for implementing …
+  Bankswitching / GameDrive files … in JagStudio".
+- Batocera wiki `systems:jaguar` — user-facing confirmation that GD-locked
+  games need Force JGD Emulation.
+- This repo: `src/jerry/jerry.c` GPIO map comment (F16000-F16FFF = GPIO2
+  reserved; F14000-F1A0FF catch-all currently swallowing GD addresses via
+  `EepromReadByte` → `$0000`), `src/core/jaguar.c` cart dispatch + MEMTRACK
+  overlay pattern, `src/jerry/eeprom.c` GPIO0/1 precedent that GPIO decodes
+  reach the cart connector.

--- a/docs/savestate-compat.md
+++ b/docs/savestate-compat.md
@@ -9,7 +9,7 @@ Defined in `src/core/state.h`:
 | Constant | Value | Meaning |
 |---|---|---|
 | `STATE_MAGIC` | `0x564A5353` (`"VJSS"`) | Header magic |
-| `STATE_VERSION` | `7` | Version this build **writes** |
+| `STATE_VERSION` | `8` | Version this build **writes** |
 | `STATE_MIN_VERSION` | `1` | Oldest version this build will **load** |
 
 `retro_unserialize()` refuses anything outside `STATE_MIN_VERSION … STATE_VERSION`
@@ -30,10 +30,27 @@ Only four format versions have ever left a release tag:
 | 1 | v2.2.0 (savestate support first shipped here) |
 | 2 | v2.3.0, v2.3.1 |
 | 3 | v2.3.2 |
-| 7 | v3.0.0 |
+| 7 | v3.0.0, v3.1.0 |
+| 8 | develop (unreleased): trailing Jaguar GameDrive chunk, `STATE_VERSION_JAGGD` |
 
 Versions 4, 5 and 6 existed only on `develop` / nightlies. All four released
 layouts load on the current core.
+
+## v8: Jaguar GameDrive chunk
+
+v8 (one shared bump per release policy — all in-flight changes since v3.1.0
+use it) appends a fixed-size 540-byte GameDrive chunk (`JGDStateSave` in
+`src/core/jaggd.c`) after the bus-arbiter accumulators: active/write-enable
+flags, the six 1 MB bank page registers, and the SPI mailbox engine
+(state machine + response FIFO). The chunk is written all-zero for non-GD
+content, which keeps the zero-tail property `test_state_compat`'s
+`dac_block_is_last` structural check relies on. Loading a pre-v8 state
+resets the GameDrive to its power-on mapping (identity pages, write
+protect, idle SPI) — the game re-runs `GD_Install` after a console reset
+anyway, so nothing is lost. The 16 MB SDRAM image itself is NOT serialized
+(same policy as cart ROM); pages modified via `GD_ROMWriteEnable` do not
+survive a load — a deliberate v1 simplification, called out in
+`docs/jgd-interface-notes.md` §9.
 
 ## Two bugs, both fixed (issue #268)
 

--- a/exports-test.list
+++ b/exports-test.list
@@ -62,3 +62,5 @@ _JoystickState*
 _MTState*
 _NVMBios*
 _NVM_*
+_JGD*
+_jgd*

--- a/libretro.c
+++ b/libretro.c
@@ -39,6 +39,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "tom.h"
 #include "eeprom.h"
 #include "memtrack.h"
+#include "jaggd.h"
 #include "nvmbios.h"
 #include "vjag_memory.h"
 #include "state.h"
@@ -643,6 +644,23 @@ static void check_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       opt_memory_track = (strcmp(var.value, "disabled") != 0);
 
+   /* Jaguar GameDrive: mode is latched here; activation happens at
+    * content load (JGDLoadROM), so mid-game toggles apply on restart. */
+   var.key = "virtualjaguar_jgd";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "enabled") == 0)
+         JGDSetMode(JGD_MODE_ENABLED);
+      else if (strcmp(var.value, "disabled") == 0)
+         JGDSetMode(JGD_MODE_DISABLED);
+      else
+         JGDSetMode(JGD_MODE_AUTO);
+   }
+   else
+      JGDSetMode(JGD_MODE_AUTO);
+
    var.key = "virtualjaguar_cd_bios_type";
    var.value = NULL;
 
@@ -1031,6 +1049,10 @@ bool retro_serialize(void *data, size_t size)
    STATE_SAVE_VAR(buf, busArbiter.op_clk_accum);
    STATE_SAVE_VAR(buf, busArbiter.m68k_pending_stall);
 
+   /* v8: Jaguar GameDrive chunk (bank pages + SPI engine; all-zero for
+    * non-GD content). */
+   buf += JGDStateSave(buf);
+
    written = (size_t)(buf - start);
    if (written > STATE_SIZE)
       return false;
@@ -1111,6 +1133,13 @@ bool retro_unserialize(const void *data, size_t size)
       busArbiter.op_clk_accum = 0;
       busArbiter.m68k_pending_stall = 0;
    }
+
+   if (version >= STATE_VERSION_JAGGD)
+      buf += JGDStateLoad(buf);
+   else
+      /* Pre-v8 states carry no GameDrive chunk: reset mapping (identity
+       * pages, write protect, idle SPI) — the game re-installs. */
+      JGDReset();
    /* tomRam8 was restored raw above; recompute the DRAM/refresh timing
     * that bus_arbiter derives from MEMCON1/MEMCON2 so it matches the
     * loaded state (dram_row_miss/rom_clocks/dram_refresh_clks from

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -292,6 +292,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "virtualjaguar_jgd",
+      "Jaguar GameDrive (Restart)",
+      NULL,
+      "Emulate the Jaguar GameDrive (JagGD) flash cartridge: its detection/install interface and 1 MB bank switching of up to 16 MB of cart SDRAM. 'Auto' turns it on only for ROM images larger than the 6 MB cartridge window. 'Enabled' forces it on for smaller images too, for GD-locked homebrew that refuses to boot without the cart (equivalent to BigPEmu's Force JGD). Without it, GD-locked titles hang at boot exactly as on a stock console.",
+      NULL,
+      "bios_boot",
+      {
+         { "auto",     "Auto (images over 6 MB)" },
+         { "disabled", NULL },
+         { "enabled",  "Enabled (force, for GD-locked images)" },
+         { NULL, NULL },
+      },
+      "auto"
+   },
+   {
       "virtualjaguar_pal",
       "PAL (Restart)",
       NULL,

--- a/link-test.T
+++ b/link-test.T
@@ -65,5 +65,7 @@
       MTState*;
       NVMBios*;
       NVM_*;
+      JGD*;
+      jgd*;
    local: *;
 };

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -21,6 +21,7 @@
 #include "crc32.h"
 #include "filedb.h"
 #include "eeprom.h"
+#include "jaggd.h"
 #include "jaguar.h"
 #include "log.h"
 #include "vjag_memory.h"
@@ -245,8 +246,24 @@ static bool JaguarLoadFileInternal(uint8_t *buffer, size_t bufsize)
 
    if (fileType == JST_ROM)
    {
+      /* The flat cart window holds 6 MB ($800000-$DFFFFF).  Larger
+       * images are Jaguar GameDrive content: the first 6 MB fill the
+       * flat window as the GD's identity page mapping would, and the
+       * full image (up to 16 MB) goes to the banked path. */
+      uint32_t flatSize = jaguarROMSize;
+
+      if (jaguarROMSize > JGD_ROM_SIZE)
+      {
+         LOG_ERR("[CART] image is %u bytes; the largest supported cartridge is the 16 MB Jaguar GameDrive\n",
+               (unsigned)jaguarROMSize);
+         return false;
+      }
+      if (flatSize > 0x600000)
+         flatSize = 0x600000;
+
       jaguarCartInserted = true;
-      memcpy(jagMemSpace + 0x800000, buffer, jaguarROMSize);
+      memcpy(jagMemSpace + 0x800000, buffer, flatSize);
+      JGDLoadROM(buffer, jaguarROMSize);
       // Checking something...
       jaguarRunAddress = GET32(jagMemSpace, 0x800404);
       return true;

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -258,8 +258,13 @@ static bool JaguarLoadFileInternal(uint8_t *buffer, size_t bufsize)
                (unsigned)jaguarROMSize);
          return false;
       }
-      if (flatSize > 0x600000)
-         flatSize = 0x600000;
+      /* Cap the flat copy at the dispatchable cart window ($800000-
+       * $DFFEFF): the final $100 bytes ($DFFF00-$DFFFFF) are the CDROM
+       * overlay and must not receive ROM bytes.  Same constant the
+       * auto-enable threshold uses, so loader and banking agree on
+       * where the flat window ends. */
+      if (flatSize > JGD_AUTO_THRESHOLD)
+         flatSize = JGD_AUTO_THRESHOLD;
 
       jaguarCartInserted = true;
       memcpy(jagMemSpace + 0x800000, buffer, flatSize);

--- a/src/core/jaggd.c
+++ b/src/core/jaggd.c
@@ -1,0 +1,629 @@
+/*
+ * jaggd.c -- Jaguar GameDrive (JagGD) flash cartridge emulation
+ *
+ * Implements the two things game code actually touches on a GameDrive
+ * (issue #312, spec: docs/jgd-interface-notes.md):
+ *
+ *   1. The ASIC SPI mailbox at $F16002/$F16004/$F16005 (JERRY GPIO2),
+ *      exactly as driven by RetroHQ's published gdbios_bindings.s:
+ *      the GDWaitData handshake (HAVE_DATA bit 3 sequencing), the
+ *      byte-exchange data register (bit 15 busy, bit 5 rx latch), and
+ *      the two micro commands games issue raw: 12 (HW version) and
+ *      $80 (fetch the GDBIOS blob).
+ *
+ *   2. 1 MB-granular bank switching of a 16 MB SDRAM image into the
+ *      six cart-window pages ($8xxxxx..$Dxxxxx), reached exclusively
+ *      through the GDBIOS blob ABI (functions 5/6) -- and since the
+ *      emulated micro serves the blob, we serve our own ~200-byte 68K
+ *      blob whose banking functions poke an emulator-defined backdoor
+ *      register at $F16006.  BigPEmu does the same thing structurally
+ *      (it cannot ship RetroHQ's copyrighted blob either).
+ *
+ * Out of scope (matches BigPEmu): GD menu, SD/FAT filesystem, GPU
+ * async reads, encrypted .jgd images, .MRQ sidecars.  File/dir/async
+ * blob functions return -1; serial numbers return zeros-with-success.
+ */
+
+#include "jaggd.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "log.h"
+
+/* ------------------------------------------------------------------ */
+/* State                                                              */
+/* ------------------------------------------------------------------ */
+
+uint8_t  jgdActive = 0;
+uint8_t  jgdWriteEnabled = 0;
+uint8_t  jgdPage[6] = { 0, 1, 2, 3, 4, 5 };
+uint8_t *jgdROM = NULL;
+
+static int jgdMode = JGD_MODE_AUTO;
+
+/* SPI engine.  Transactions complete instantly, so the busy bit (15)
+ * always reads clear; HAVE_DATA (bit 3) and LATCH_FULL (bit 5) are the
+ * only synthesized status bits.  State machine mirrors the exact code
+ * shape of gdbios_bindings.s (see JGDStatusWrite below). */
+enum
+{
+   JGD_SPI_IDLE = 0,   /* nothing in flight */
+   JGD_SPI_START,      /* $0010 seen, awaiting the $0011 handshake ack */
+   JGD_SPI_CMD,        /* collecting cmd lo/hi + param-size lo/hi */
+   JGD_SPI_PARAMS,     /* collecting declared parameter bytes */
+   JGD_SPI_PROC,       /* header+params complete, awaiting "process it" */
+   JGD_SPI_RESP        /* serving the response FIFO */
+};
+
+#define JGD_ST_SLAVE_SELECT 0x0001
+#define JGD_ST_HAVE_DATA    0x0008
+#define JGD_ST_PACKET_START 0x0010
+#define JGD_ST_LATCH_FULL   0x0020
+
+#define JGD_PARAM_MAX 64
+
+static uint8_t  spiState = JGD_SPI_IDLE;
+static uint8_t  spiHaveData = 0;
+static uint8_t  spiLatchFull = 0;
+static uint8_t  spiRxLatch = 0;
+static uint8_t  spiHdrCount = 0;
+static uint16_t spiCmd = 0;
+static uint16_t spiParamLen = 0;
+static uint16_t spiParamCount = 0;
+static uint8_t  spiParams[JGD_PARAM_MAX];
+static uint16_t spiFifoLen = 0;
+static uint16_t spiFifoPos = 0;
+static uint8_t  spiFifo[JGD_FIFO_SIZE];
+
+/* Backdoor pages latch: op $9xxx stages pages 0-2, op $Axxx applies
+ * pages 3-5 together with the staged half. */
+static uint16_t pagesLatch = 0;
+
+/* ------------------------------------------------------------------ */
+/* The served GDBIOS blob                                             */
+/* ------------------------------------------------------------------ */
+/*
+ * Hand-assembled 68000, position independent (bra.w only), poking the
+ * $F16006 backdoor for banking / write enable.  Layout per the blob
+ * ABI in docs/jgd-interface-notes.md section 4:
+ *   +0  u16 version ($0100), +2 u16 highest function (26),
+ *   +N*4 four-byte entry slot for function N (jsr N*4(a6)).
+ *
+ * Backdoor word encoding (JGDControlWriteWord):
+ *   $8000 | page<<4 | bank   set one page          (GD_ROMSetPage)
+ *   $9000 | nibbles 0-2      stage pages 0-2       (GD_ROMSetPages)
+ *   $A000 | nibbles 3-5      apply pages 3-5 + staged half
+ *   $B000 | enable bit 0     ROM write enable      (GD_ROMWriteEnable)
+ */
+static const uint8_t jgdBlob[] =
+{
+   /* 000 */ 0x01, 0x00,                     /* dc.w $0100  version        */
+   /* 002 */ 0x00, 0x1A,                     /* dc.w 26     function count */
+   /* 004 */ 0x4E, 0x75, 0x4E, 0x71,         /* f1  GD_Init:        rts    */
+   /* 008 */ 0x4E, 0x75, 0x4E, 0x71,         /* f2  GD_InitGPURead: rts    */
+   /* 00C */ 0x60, 0x00, 0x00, 0x5E,         /* f3  bra.w biosver (06C)    */
+   /* 010 */ 0x60, 0x00, 0x00, 0x60,         /* f4  bra.w wren    (072)    */
+   /* 014 */ 0x60, 0x00, 0x00, 0x6C,         /* f5  bra.w setpage (082)    */
+   /* 018 */ 0x60, 0x00, 0x00, 0x84,         /* f6  bra.w setpages(09E)    */
+   /* 01C */ 0x60, 0x00, 0x00, 0xA6,         /* f7  bra.w serial  (0C4)    */
+   /* 020 */ 0x60, 0x00, 0x00, 0xA2,         /* f8  bra.w serial  (0C4)    */
+   /* 024 */ 0x70, 0x00, 0x4E, 0x75,         /* f9  GD_CardIn: moveq #0,d0; rts */
+   /* 028 */ 0x70, 0xFF, 0x4E, 0x75,         /* f10 GD_FileOpen:  moveq #-1,d0; rts */
+   /* 02C */ 0x70, 0xFF, 0x4E, 0x75,         /* f11 GD_FileClose */
+   /* 030 */ 0x70, 0xFF, 0x4E, 0x75,         /* f12 GD_FileSeek  */
+   /* 034 */ 0x70, 0xFF, 0x4E, 0x75,         /* f13 GD_FileRead  */
+   /* 038 */ 0x70, 0xFF, 0x4E, 0x75,         /* f14 GD_FileWrite */
+   /* 03C */ 0x70, 0xFF, 0x4E, 0x75,         /* f15 GD_FileTell  */
+   /* 040 */ 0x70, 0xFF, 0x4E, 0x75,         /* f16 GD_FileSize  */
+   /* 044 */ 0x70, 0xFF, 0x4E, 0x75,         /* f17 GD_FileAsyncPos    */
+   /* 048 */ 0x70, 0xFF, 0x4E, 0x75,         /* f18 GD_FileAsyncWait   */
+   /* 04C */ 0x70, 0xFF, 0x4E, 0x75,         /* f19 GD_FileAsyncActive */
+   /* 050 */ 0x70, 0xFF, 0x4E, 0x75,         /* f20 GD_FileInfo  */
+   /* 054 */ 0x70, 0xFF, 0x4E, 0x75,         /* f21 GD_DirOpen   */
+   /* 058 */ 0x70, 0xFF, 0x4E, 0x75,         /* f22 GD_DirRead   */
+   /* 05C */ 0x70, 0xFF, 0x4E, 0x75,         /* f23 GD_DirClose  */
+   /* 060 */ 0x4E, 0x75, 0x4E, 0x71,         /* f24 GD_Reset:       rts */
+   /* 064 */ 0x4E, 0x75, 0x4E, 0x71,         /* f25 GD_SetLED:      rts */
+   /* 068 */ 0x4E, 0x75, 0x4E, 0x71,         /* f26 GD_DebugString: rts */
+   /* biosver: */
+   /* 06C */ 0x30, 0x3C, 0x01, 0x00,         /* move.w #$0100,d0 */
+   /* 070 */ 0x4E, 0x75,                     /* rts */
+   /* wren: (d0 = 1 enable / 0 disable) */
+   /* 072 */ 0x02, 0x40, 0x00, 0x01,         /* andi.w #1,d0     */
+   /* 076 */ 0x00, 0x40, 0xB0, 0x00,         /* ori.w #$B000,d0  */
+   /* 07A */ 0x33, 0xC0, 0x00, 0xF1, 0x60, 0x06, /* move.w d0,$F16006 */
+   /* 080 */ 0x4E, 0x75,                     /* rts */
+   /* setpage: (d0 = page<<16 | bank) */
+   /* 082 */ 0x32, 0x00,                     /* move.w d0,d1     */
+   /* 084 */ 0x02, 0x41, 0x00, 0x0F,         /* andi.w #$F,d1    */
+   /* 088 */ 0x48, 0x40,                     /* swap d0          */
+   /* 08A */ 0xE9, 0x48,                     /* lsl.w #4,d0      */
+   /* 08C */ 0x02, 0x40, 0x00, 0x70,         /* andi.w #$70,d0   */
+   /* 090 */ 0x82, 0x40,                     /* or.w d0,d1       */
+   /* 092 */ 0x00, 0x41, 0x80, 0x00,         /* ori.w #$8000,d1  */
+   /* 096 */ 0x33, 0xC1, 0x00, 0xF1, 0x60, 0x06, /* move.w d1,$F16006 */
+   /* 09C */ 0x4E, 0x75,                     /* rts */
+   /* setpages: (d0 = u32, one bank nibble per page, LSN = page 0) */
+   /* 09E */ 0x22, 0x00,                     /* move.l d0,d1     */
+   /* 0A0 */ 0x02, 0x41, 0x0F, 0xFF,         /* andi.w #$FFF,d1  */
+   /* 0A4 */ 0x00, 0x41, 0x90, 0x00,         /* ori.w #$9000,d1  */
+   /* 0A8 */ 0x33, 0xC1, 0x00, 0xF1, 0x60, 0x06, /* move.w d1,$F16006 */
+   /* 0AE */ 0x22, 0x00,                     /* move.l d0,d1     */
+   /* 0B0 */ 0xE0, 0x89,                     /* lsr.l #8,d1      */
+   /* 0B2 */ 0xE8, 0x89,                     /* lsr.l #4,d1      */
+   /* 0B4 */ 0x02, 0x41, 0x0F, 0xFF,         /* andi.w #$FFF,d1  */
+   /* 0B8 */ 0x00, 0x41, 0xA0, 0x00,         /* ori.w #$A000,d1  */
+   /* 0BC */ 0x33, 0xC1, 0x00, 0xF1, 0x60, 0x06, /* move.w d1,$F16006 */
+   /* 0C2 */ 0x4E, 0x75,                     /* rts */
+   /* serial: (a0 = 16-byte buffer; zeros-with-success) */
+   /* 0C4 */ 0x72, 0x03,                     /* moveq #3,d1      */
+   /* 0C6 */ 0x42, 0x98,                     /* .l: clr.l (a0)+  */
+   /* 0C8 */ 0x51, 0xC9, 0xFF, 0xFC,         /* dbra d1,.l       */
+   /* 0CC */ 0x70, 0x00,                     /* moveq #0,d0      */
+   /* 0CE */ 0x4E, 0x75                      /* rts */
+};
+
+#define JGD_BLOB_SIZE ((uint16_t)sizeof(jgdBlob))
+
+/* HW version response (cmd 12): high word firmware, low word ASIC,
+ * BCD.  Any firmware >= $0111 satisfies the GD_Install gate. */
+#define JGD_FW_VERSION   0x0300
+#define JGD_ASIC_VERSION 0x0102
+
+/* ------------------------------------------------------------------ */
+/* Lifecycle                                                          */
+/* ------------------------------------------------------------------ */
+
+void JGDSetMode(int mode)
+{
+   jgdMode = mode;
+}
+
+
+int JGDGetMode(void)
+{
+   return jgdMode;
+}
+
+
+static void JGDSpiReset(void)
+{
+   spiState = JGD_SPI_IDLE;
+   spiHaveData = 0;
+   spiLatchFull = 0;
+   spiRxLatch = 0;
+   spiHdrCount = 0;
+   spiCmd = 0;
+   spiParamLen = 0;
+   spiParamCount = 0;
+   spiFifoLen = 0;
+   spiFifoPos = 0;
+   memset(spiParams, 0, sizeof(spiParams));
+   memset(spiFifo, 0, sizeof(spiFifo));
+   pagesLatch = 0;
+}
+
+
+void JGDReset(void)
+{
+   unsigned i;
+
+   for (i = 0; i < 6; i++)
+      jgdPage[i] = (uint8_t)i;
+   jgdWriteEnabled = 0;
+   JGDSpiReset();
+}
+
+
+void JGDUnload(void)
+{
+   JGDReset();
+   jgdActive = 0;
+   if (jgdROM)
+   {
+      free(jgdROM);
+      jgdROM = NULL;
+   }
+}
+
+
+void JGDDone(void)
+{
+   /* iOS cannot dlclose cores: every static must return to its
+    * power-on value here (see CLAUDE.md / feedback_ios_static_state). */
+   JGDUnload();
+   jgdMode = JGD_MODE_AUTO;
+}
+
+
+void JGDLoadROM(const uint8_t *buffer, uint32_t size)
+{
+   int wantActive;
+
+   JGDUnload();
+
+   if (!buffer || size == 0 || size > JGD_ROM_SIZE)
+      return;
+
+   wantActive = (jgdMode == JGD_MODE_ENABLED)
+      || (jgdMode == JGD_MODE_AUTO && size > JGD_AUTO_THRESHOLD);
+
+   if (!wantActive)
+      return;
+
+   jgdROM = (uint8_t *)malloc(JGD_ROM_SIZE);
+   if (!jgdROM)
+   {
+      LOG_ERR("[JGD] failed to allocate 16 MB SDRAM image; GameDrive disabled\n");
+      return;
+   }
+
+   memcpy(jgdROM, buffer, size);
+   if (size < JGD_ROM_SIZE)
+      memset(jgdROM + size, 0, JGD_ROM_SIZE - size);
+
+   jgdActive = 1;
+   LOG_INF("[JGD] GameDrive emulation active (%s, image %u bytes)\n",
+           jgdMode == JGD_MODE_ENABLED ? "forced" : "auto", (unsigned)size);
+}
+
+
+void JGDWriteROM8(uint32_t off, uint8_t v)
+{
+   jgdROM[((uint32_t)jgdPage[off >> 20] << 20) | (off & 0xFFFFF)] = v;
+}
+
+/* ------------------------------------------------------------------ */
+/* SPI engine                                                         */
+/* ------------------------------------------------------------------ */
+
+static void JGDFifoPush(uint8_t b)
+{
+   if (spiFifoLen < JGD_FIFO_SIZE)
+      spiFifo[spiFifoLen++] = b;
+}
+
+
+static uint8_t JGDFifoPop(void)
+{
+   if (spiFifoPos < spiFifoLen)
+      return spiFifo[spiFifoPos++];
+   return 0;
+}
+
+
+/* Fill the response FIFO for the completed command.  Responses stream
+ * high byte first (GDExchangeWord reassembles rx1<<8 | rx2). */
+static void JGDProcessCommand(void)
+{
+   uint16_t i;
+
+   spiFifoLen = 0;
+   spiFifoPos = 0;
+
+   switch (spiCmd)
+   {
+      case 12:  /* HW version: u32, firmware word then ASIC word */
+         JGDFifoPush((uint8_t)(JGD_FW_VERSION >> 8));
+         JGDFifoPush((uint8_t)(JGD_FW_VERSION & 0xFF));
+         JGDFifoPush((uint8_t)(JGD_ASIC_VERSION >> 8));
+         JGDFifoPush((uint8_t)(JGD_ASIC_VERSION & 0xFF));
+         break;
+
+      case 0x80: /* Fetch GDBIOS: u16 size, then the blob */
+         JGDFifoPush((uint8_t)(JGD_BLOB_SIZE >> 8));
+         JGDFifoPush((uint8_t)(JGD_BLOB_SIZE & 0xFF));
+         for (i = 0; i < JGD_BLOB_SIZE; i++)
+            JGDFifoPush(jgdBlob[i]);
+         break;
+
+      default:  /* unknown command: zero-filled response */
+         break;
+   }
+}
+
+
+/* ASIC_SPI_STATUS write.  Decoded per the gdbios_bindings.s sequences:
+ *
+ *   $0000            end of packet / deselect     -> engine idle
+ *   $0010 (START)    "attention": begin a packet, or "process it GD!"
+ *                    after the header/params, or a block boundary in
+ *                    the response -> HAVE_DATA drops
+ *   $0011 (START|SS) GDWaitData handshake ack -> HAVE_DATA rises
+ */
+static void JGDStatusWrite(uint16_t v)
+{
+   if (v == 0)
+   {
+      /* clr.w ASIC_SPI_STATUS: end of packet. */
+      spiState = JGD_SPI_IDLE;
+      spiHaveData = 0;
+      spiFifoLen = 0;
+      spiFifoPos = 0;
+      spiHdrCount = 0;
+      return;
+   }
+
+   if (!(v & JGD_ST_PACKET_START))
+      return;
+
+   if (v & JGD_ST_SLAVE_SELECT)
+   {
+      /* Handshake ack: slave raises HAVE_DATA. */
+      spiHaveData = 1;
+      if (spiState == JGD_SPI_START || spiState == JGD_SPI_IDLE)
+      {
+         spiState = JGD_SPI_CMD;
+         spiHdrCount = 0;
+      }
+      /* JGD_SPI_RESP: stay -- next block ready. */
+      return;
+   }
+
+   /* Plain PACKET_START. */
+   spiHaveData = 0;
+   if (spiState == JGD_SPI_IDLE)
+   {
+      spiState = JGD_SPI_START;
+      spiFifoLen = 0;
+      spiFifoPos = 0;
+      spiHdrCount = 0;
+   }
+   else if (spiState == JGD_SPI_PROC)
+   {
+      JGDProcessCommand();
+      spiState = JGD_SPI_RESP;
+   }
+   /* JGD_SPI_RESP / others: block boundary, nothing to do. */
+}
+
+
+/* ASIC_SPI_DATA write: clock one byte exchange (tx = low byte). */
+static void JGDDataWrite(uint16_t v)
+{
+   uint8_t tx = (uint8_t)(v & 0xFF);
+   uint8_t rx = 0;
+
+   switch (spiState)
+   {
+      case JGD_SPI_CMD:
+         switch (spiHdrCount)
+         {
+            case 0: spiCmd = tx;                            break;
+            case 1: spiCmd |= (uint16_t)tx << 8;            break;
+            case 2: spiParamLen = tx;                       break;
+            default:
+               spiParamLen |= (uint16_t)tx << 8;
+               spiParamCount = 0;
+               spiState = spiParamLen ? JGD_SPI_PARAMS : JGD_SPI_PROC;
+               break;
+         }
+         if (spiHdrCount < 3)
+            spiHdrCount++;
+         break;
+
+      case JGD_SPI_PARAMS:
+         if (spiParamCount < JGD_PARAM_MAX)
+            spiParams[spiParamCount] = tx;
+         spiParamCount++;
+         if (spiParamCount >= spiParamLen)
+            spiState = JGD_SPI_PROC;
+         break;
+
+      case JGD_SPI_RESP:
+         rx = JGDFifoPop();
+         break;
+
+      default:
+         break;
+   }
+
+   spiRxLatch = rx;
+   spiLatchFull = 1;
+}
+
+
+/* Backdoor register (see the blob's op encoding above). */
+static void JGDBackdoorWrite(uint16_t v)
+{
+   unsigned page;
+
+   switch (v & 0xF000)
+   {
+      case 0x8000:
+         page = (v >> 4) & 0x7;
+         if (page < 6)
+            jgdPage[page] = (uint8_t)(v & 0xF);
+         break;
+      case 0x9000:
+         pagesLatch = v & 0x0FFF;
+         break;
+      case 0xA000:
+         jgdPage[0] = (uint8_t)(pagesLatch & 0xF);
+         jgdPage[1] = (uint8_t)((pagesLatch >> 4) & 0xF);
+         jgdPage[2] = (uint8_t)((pagesLatch >> 8) & 0xF);
+         jgdPage[3] = (uint8_t)(v & 0xF);
+         jgdPage[4] = (uint8_t)((v >> 4) & 0xF);
+         jgdPage[5] = (uint8_t)((v >> 8) & 0xF);
+         break;
+      case 0xB000:
+         jgdWriteEnabled = (uint8_t)(v & 1);
+         break;
+      default:
+         break;
+   }
+}
+
+/* ------------------------------------------------------------------ */
+/* JERRY register window                                              */
+/* ------------------------------------------------------------------ */
+
+uint16_t JGDControlReadWord(uint32_t offset)
+{
+   switch (offset & 0xFFFFFFFE)
+   {
+      case JGD_ASIC_SPI_STATUS:
+         /* Busy (bit 15) never set: exchanges complete instantly. */
+         return (uint16_t)((spiHaveData ? JGD_ST_HAVE_DATA : 0)
+                           | (spiLatchFull ? JGD_ST_LATCH_FULL : 0));
+      case JGD_ASIC_SPI_DATA:
+         /* Word read drains the rx latch (the pre-install "in case of
+          * FIFO DMA termination" drain loop in GD_Install). */
+         spiLatchFull = 0;
+         return spiRxLatch;
+      default:
+         return 0;
+   }
+}
+
+
+uint8_t JGDControlReadByte(uint32_t offset)
+{
+   uint16_t w;
+
+   if (offset == JGD_ASIC_SPI_DATA + 1)
+   {
+      /* ASIC_SPI_DATA_BYTE: the received byte. */
+      spiLatchFull = 0;
+      return spiRxLatch;
+   }
+
+   w = JGDControlReadWord(offset & 0xFFFFFFFE);
+   return (offset & 1) ? (uint8_t)(w & 0xFF) : (uint8_t)(w >> 8);
+}
+
+
+void JGDControlWriteWord(uint32_t offset, uint16_t data)
+{
+   switch (offset & 0xFFFFFFFE)
+   {
+      case JGD_ASIC_SPI_STATUS:
+         JGDStatusWrite(data);
+         break;
+      case JGD_ASIC_SPI_DATA:
+         JGDDataWrite(data);
+         break;
+      case JGD_BACKDOOR:
+         JGDBackdoorWrite(data);
+         break;
+      default:
+         break;
+   }
+}
+
+
+void JGDControlWriteByte(uint32_t offset, uint8_t data)
+{
+   /* Byte writes are not used by the published bindings; approximate
+    * them as a word write carrying the byte in the low lane. */
+   JGDControlWriteWord(offset & 0xFFFFFFFE, data);
+}
+
+/* ------------------------------------------------------------------ */
+/* Savestate                                                          */
+/* ------------------------------------------------------------------ */
+
+#include "state.h"
+
+/* Fixed-size chunk.  Deliberately all-zero while inactive so states of
+ * non-GD content keep a zero tail (test_state_compat's dac_block_is_last
+ * structural check relies on trailing chunks being zero there). */
+
+size_t JGDStateSave(uint8_t *buf)
+{
+   uint8_t *start = buf;
+   uint8_t zero8 = 0;
+   uint16_t zero16 = 0;
+   unsigned i;
+
+   if (!jgdActive)
+   {
+      static const uint8_t zeros[16] = { 0 };
+      STATE_SAVE_BUF(buf, zeros, 16);            /* flags/pages/spi bytes */
+      for (i = 0; i < 5; i++)
+         STATE_SAVE_VAR(buf, zero16);            /* latch/cmd/len/count/fifoLen */
+      STATE_SAVE_VAR(buf, zero16);               /* fifoPos */
+      {
+         uint8_t zfifo[JGD_FIFO_SIZE];
+         memset(zfifo, 0, sizeof(zfifo));
+         STATE_SAVE_BUF(buf, zfifo, JGD_FIFO_SIZE);
+      }
+      return (size_t)(buf - start);
+   }
+
+   STATE_SAVE_VAR(buf, jgdActive);
+   STATE_SAVE_VAR(buf, jgdWriteEnabled);
+   STATE_SAVE_BUF(buf, jgdPage, 6);
+   STATE_SAVE_VAR(buf, spiState);
+   STATE_SAVE_VAR(buf, spiHaveData);
+   STATE_SAVE_VAR(buf, spiLatchFull);
+   STATE_SAVE_VAR(buf, spiRxLatch);
+   STATE_SAVE_VAR(buf, spiHdrCount);
+   STATE_SAVE_VAR(buf, zero8);                   /* pad */
+   STATE_SAVE_VAR(buf, zero8);                   /* pad */
+   STATE_SAVE_VAR(buf, zero8);                   /* pad */
+   STATE_SAVE_VAR(buf, pagesLatch);
+   STATE_SAVE_VAR(buf, spiCmd);
+   STATE_SAVE_VAR(buf, spiParamLen);
+   STATE_SAVE_VAR(buf, spiParamCount);
+   STATE_SAVE_VAR(buf, spiFifoLen);
+   STATE_SAVE_VAR(buf, spiFifoPos);
+   STATE_SAVE_BUF(buf, spiFifo, JGD_FIFO_SIZE);
+
+   return (size_t)(buf - start);
+}
+
+
+size_t JGDStateLoad(const uint8_t *buf)
+{
+   const uint8_t *start = buf;
+   uint8_t active, pad;
+   unsigned i;
+
+   STATE_LOAD_VAR(buf, active);
+   STATE_LOAD_VAR(buf, jgdWriteEnabled);
+   STATE_LOAD_BUF(buf, jgdPage, 6);
+   STATE_LOAD_VAR(buf, spiState);
+   STATE_LOAD_VAR(buf, spiHaveData);
+   STATE_LOAD_VAR(buf, spiLatchFull);
+   STATE_LOAD_VAR(buf, spiRxLatch);
+   STATE_LOAD_VAR(buf, spiHdrCount);
+   STATE_LOAD_VAR(buf, pad);
+   STATE_LOAD_VAR(buf, pad);
+   STATE_LOAD_VAR(buf, pad);
+   STATE_LOAD_VAR(buf, pagesLatch);
+   STATE_LOAD_VAR(buf, spiCmd);
+   STATE_LOAD_VAR(buf, spiParamLen);
+   STATE_LOAD_VAR(buf, spiParamCount);
+   STATE_LOAD_VAR(buf, spiFifoLen);
+   STATE_LOAD_VAR(buf, spiFifoPos);
+   STATE_LOAD_BUF(buf, spiFifo, JGD_FIFO_SIZE);
+
+   if (!active || !jgdROM)
+   {
+      /* State written without GD banking (or the current session has
+       * no 16 MB image to bank): back to the reset mapping. */
+      JGDReset();
+   }
+   else
+   {
+      /* Sanitize untrusted fields so a corrupt state cannot index out
+       * of range. */
+      for (i = 0; i < 6; i++)
+         jgdPage[i] &= 0xF;
+      jgdWriteEnabled &= 1;
+      if (spiState > JGD_SPI_RESP)
+         spiState = JGD_SPI_IDLE;
+      if (spiFifoLen > JGD_FIFO_SIZE)
+         spiFifoLen = JGD_FIFO_SIZE;
+      if (spiFifoPos > spiFifoLen)
+         spiFifoPos = spiFifoLen;
+      if (spiParamCount > JGD_PARAM_MAX)
+         spiParamCount = JGD_PARAM_MAX;
+      if (spiHdrCount > 3)
+         spiHdrCount = 3;
+   }
+
+   return (size_t)(buf - start);
+}

--- a/src/core/jaggd.h
+++ b/src/core/jaggd.h
@@ -1,0 +1,82 @@
+#ifndef _VIRTUALJAGUAR_JAGGD_H
+#define _VIRTUALJAGUAR_JAGGD_H
+
+/*
+ * jaggd.h: Jaguar GameDrive (JagGD) flash cartridge emulation
+ *
+ * Register/protocol/ABI ground truth: docs/jgd-interface-notes.md
+ * (synthesized from RetroHQ's published gdbios_bindings.s, JagStudio
+ * v1.11 and BigPEmu behavior).  Issue #312.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Core option modes (virtualjaguar_jgd) */
+#define JGD_MODE_DISABLED 0
+#define JGD_MODE_AUTO     1   /* enable when the image exceeds the 6 MB cart window */
+#define JGD_MODE_ENABLED  2
+
+/* 16 MB of onboard SDRAM presented as cartridge ROM. */
+#define JGD_ROM_SIZE      0x1000000
+/* Auto mode threshold: the usable flat cart window ($800000-$DFFEFF). */
+#define JGD_AUTO_THRESHOLD 0x5FFF00
+
+/* SPI response FIFO: sized for the largest response we serve (the
+ * GDBIOS blob plus its u16 size prefix). */
+#define JGD_FIFO_SIZE     512
+
+/* GD registers in JERRY's GPIO2 decode range (gdbios_bindings.s). */
+#define JGD_REG_FIRST     0xF16000
+#define JGD_REG_LAST      0xF16007
+#define JGD_ASIC_SPI_STATUS 0xF16002
+#define JGD_ASIC_SPI_DATA   0xF16004
+/* Emulator-defined backdoor the served GDBIOS blob pokes for banking /
+ * write enable.  Inside the GPIO2 range we already own; nothing else
+ * decodes it.  See JGDControlWriteWord for the op encoding. */
+#define JGD_BACKDOOR        0xF16006
+
+/* Banking state.  jgdActive gates every hook; when it is 0 the cart
+ * read path and the JERRY register windows behave exactly as before
+ * (reads of $F16002 fall into the EEPROM catch-all and return 0, which
+ * reproduces the stock-console "GD absent" hang in GD-locked titles). */
+extern uint8_t  jgdActive;
+extern uint8_t  jgdWriteEnabled;
+extern uint8_t  jgdPage[6];
+extern uint8_t *jgdROM;          /* 16 MB when active, NULL otherwise */
+
+/* Hot-path helpers for the cart read dispatch in jaguar.c: one table
+ * lookup + shift, same cost class as the MEMTRACK_PRESENT() gate. */
+#define JGD_BANKING() (jgdActive)
+#define JGDReadROM8(off) \
+   (jgdROM[((uint32_t)jgdPage[(uint32_t)(off) >> 20] << 20) \
+           | ((uint32_t)(off) & 0xFFFFF)])
+
+void JGDSetMode(int mode);
+int  JGDGetMode(void);
+
+/* Called for every JST_ROM cartridge load; decides activation from the
+ * mode + image size and keeps the full (up to 16 MB) image. */
+void JGDLoadROM(const uint8_t *buffer, uint32_t size);
+/* Drop the image + deactivate (fresh content load boundary). */
+void JGDUnload(void);
+/* Console reset: identity pages, write-protect, idle SPI engine.
+ * Keeps the loaded image and the active flag. */
+void JGDReset(void);
+/* Full teardown incl. statics (iOS cannot dlclose; retro_deinit path). */
+void JGDDone(void);
+
+/* GD write path for ROMWriteEnable'd cart space (offset = addr - $800000). */
+void JGDWriteROM8(uint32_t off, uint8_t v);
+
+/* JERRY register window ($F16000-$F16007), called only when jgdActive. */
+uint16_t JGDControlReadWord(uint32_t offset);
+uint8_t  JGDControlReadByte(uint32_t offset);
+void     JGDControlWriteWord(uint32_t offset, uint16_t data);
+void     JGDControlWriteByte(uint32_t offset, uint8_t data);
+
+/* Savestate (fixed-size chunk; all-zero when inactive). */
+size_t JGDStateSave(uint8_t *buf);
+size_t JGDStateLoad(const uint8_t *buf);
+
+#endif

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -35,6 +35,7 @@
 #include "m68000/cpudefs.h"   /* regs.remainingCycles — 68K DRAM self-cost */
 #include "bus_arbiter.h"
 #include "memtrack.h"
+#include "jaggd.h"
 #include "nvmbios.h"
 #include "settings.h"
 #include "tom.h"
@@ -425,6 +426,8 @@ unsigned int m68k_read_memory_8(unsigned int address)
    {
       if (MEMTRACK_PRESENT() && MTClaimsRead(address))
          return MTReadByte(address);
+      if (JGD_BANKING())
+         return JGDReadROM8(address - 0x800000);
       return jaguarMainROM[address - 0x800000];
    }
    else if ((address >= 0xE00000) && (address <= 0xE3FFFF))
@@ -465,9 +468,15 @@ unsigned int m68k_read_memory_16(unsigned int address)
       /* Memory Track reading... */
       if (MEMTRACK_PRESENT() && MTClaimsRead(address))
          return MTReadWord(address);
-      else
-         return (jaguarMainROM[address - 0x800000] << 8)
-            | jaguarMainROM[address - 0x800000 + 1];
+      if (JGD_BANKING())
+      {
+         /* Byte-composed so a read straddling a 1 MB page boundary
+          * pulls each half from its own bank. */
+         uint32_t off = address - 0x800000;
+         return (JGDReadROM8(off) << 8) | JGDReadROM8(off + 1);
+      }
+      return (jaguarMainROM[address - 0x800000] << 8)
+         | jaguarMainROM[address - 0x800000 + 1];
    }
    else if ((address >= 0xE00000) && (address <= 0xE3FFFE))
       return (jagMemSpace[address] << 8) | jagMemSpace[address + 1];
@@ -504,6 +513,16 @@ unsigned int m68k_read_memory_32(unsigned int address)
       M68K_BUS_CHARGE(address, 2);
       if (MEMTRACK_PRESENT() && MTClaimsRead(address))
          return MTReadLong(address);
+
+      if (JGD_BANKING())
+      {
+         /* Byte-composed: a long can straddle a 1 MB page boundary. */
+         uint32_t off = address - 0x800000;
+         return ((uint32_t)JGDReadROM8(off) << 24)
+            | ((uint32_t)JGDReadROM8(off + 1) << 16)
+            | ((uint32_t)JGDReadROM8(off + 2) << 8)
+            | JGDReadROM8(off + 3);
+      }
 
       return GET32(jaguarMainROM, address - 0x800000);
    }
@@ -553,6 +572,11 @@ void m68k_write_memory_8(unsigned int address, unsigned int value)
    // Note that the Jaguar only has 2M of RAM, not 4!
    if ((address >= 0x000000) && (address <= 0x1FFFFF))
       jaguarMainRAM[address] = value;
+   /* GameDrive: GD_ROMWriteEnable makes the SDRAM-backed "ROM" writable
+    * (the GD menu loads through this; homebrew uses cart space as RAM). */
+   else if (jgdActive && jgdWriteEnabled
+            && (address >= 0x800000) && (address <= 0xDFFEFF))
+      JGDWriteROM8(address - 0x800000, (uint8_t)value);
    /* Memory Track byte writes: cart space is otherwise read-only, so this
     * branch exists purely for the device (command window + NVRAM). */
    else if (((address >= 0x800000) && (address <= 0x87FFFF))
@@ -590,6 +614,13 @@ void m68k_write_memory_16(unsigned int address, unsigned int value)
    if ((address >= 0x000000) && (address <= 0x1FFFFE))
    {
       SET16(jaguarMainRAM, address, value);
+   }
+   /* GameDrive write-enabled cart space (see the byte handler). */
+   else if (jgdActive && jgdWriteEnabled
+            && (address >= 0x800000) && (address <= 0xDFFEFE))
+   {
+      JGDWriteROM8(address - 0x800000, (uint8_t)(value >> 8));
+      JGDWriteROM8(address - 0x800000 + 1, (uint8_t)(value & 0xFF));
    }
    /* Memory Track device writes: the flash command addresses live inside the
     * $8xxxxx ROM window, but the NVRAM itself is a separate window at
@@ -679,7 +710,11 @@ uint8_t JaguarReadByte(uint32_t offset, uint32_t who)
    if (offset < 0x800000)
       return jaguarMainRAM[offset & 0x1FFFFF];
    else if ((offset >= 0x800000) && (offset < 0xDFFF00))
+   {
+      if (JGD_BANKING())
+         return JGDReadROM8(offset - 0x800000);
       return jaguarMainROM[offset - 0x800000];
+   }
    else if ((offset >= 0xDFFF00) && (offset <= 0xDFFFFF))
       return CDROMReadByte(offset, who);
    else if ((offset >= 0xE00000) && (offset < 0xE40000))
@@ -704,6 +739,8 @@ uint16_t JaguarReadWord(uint32_t offset, uint32_t who)
    else if ((offset >= 0x800000) && (offset < 0xDFFF00))
    {
       offset -= 0x800000;
+      if (JGD_BANKING())
+         return (JGDReadROM8(offset) << 8) | JGDReadROM8(offset + 1);
       return (jaguarMainROM[offset+0] << 8) | jaguarMainROM[offset+1];
    }
    //	else if ((offset >= 0xDFFF00) && (offset < 0xDFFF00))
@@ -743,6 +780,13 @@ void JaguarWriteByte(uint32_t offset, uint8_t data, uint32_t who)
    }
    else if (offset < 0x800000)
       return;
+   /* GameDrive write-enabled cart space (GPU/DSP/blitter writers). */
+   else if (jgdActive && jgdWriteEnabled
+            && (offset >= 0x800000) && (offset < 0xDFFF00))
+   {
+      JGDWriteROM8(offset - 0x800000, data);
+      return;
+   }
    else if ((offset >= 0xDFFF00) && (offset <= 0xDFFFFF))
    {
       CDROMWriteByte(offset, data, who);
@@ -776,6 +820,14 @@ void JaguarWriteWord(uint32_t offset, uint16_t data, uint32_t who)
    }
    else if (offset <= 0x7FFFFE)
       return;
+   /* GameDrive write-enabled cart space (GPU/DSP/blitter writers). */
+   else if (jgdActive && jgdWriteEnabled
+            && offset >= 0x800000 && offset < 0xDFFF00)
+   {
+      JGDWriteROM8(offset - 0x800000, (uint8_t)(data >> 8));
+      JGDWriteROM8(offset - 0x800000 + 1, (uint8_t)(data & 0xFF));
+      return;
+   }
    else if (offset >= 0xDFFF00 && offset <= 0xDFFFFE)
    {
       CDROMWriteWord(offset, data, who);
@@ -879,6 +931,10 @@ void JaguarInit(void)
    JERRYInit();
    CDROMInit();
 
+   /* Fresh content boundary: drop any GameDrive image/state a previous
+    * load in this process left behind (JGDLoadROM re-arms it for JST_ROM
+    * content when the option + image size call for it). */
+   JGDUnload();
 }
 
 /* New timer based code stuffola... */
@@ -995,6 +1051,10 @@ void JaguarReset(void)
     * that must be cleared on every reset.  Cart strategy reset is a no-op. */
    if (bootConfig.strategy && bootConfig.strategy->reset)
       bootConfig.strategy->reset();
+
+   /* GameDrive: console reset returns the ASIC to identity pages,
+    * write-protected, SPI idle; the game re-runs GD_Install itself. */
+   JGDReset();
 
    // Contents of local RAM are quasi-stable; we simulate this by randomizing RAM contents.
    // Skip over any region where a RAM-loaded executable resides so we don't wipe it out.
@@ -1180,6 +1240,7 @@ void JaguarDone(void)
    DSPDone();
    TOMDone();
    JERRYDone();
+   JGDDone();
    m68k_done();
 }
 

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -32,17 +32,20 @@ extern "C" {
  * v7: Memory Track chunk gained the latched $80AAA8 override flag and
  *     the NVM BIOS dispatcher state (nvmbios.c); trailing bus-arbiter
  *     68K self-cost carry (symmetric DRAM timing).  One shared bump —
- *     all in-flight changes since the last release use v7. */
+ *     all in-flight changes since the last release use v7.
+ * v8: trailing Jaguar GameDrive chunk (bank pages + SPI mailbox engine,
+ *     jaggd.c).  One shared bump — all in-flight changes since the
+ *     v3.1.0 release use v8. */
 #define STATE_MAGIC     0x564A5353  /* "VJSS" */
-#define STATE_VERSION   7
+#define STATE_VERSION   8
 /* Oldest layout retro_unserialize still accepts.  States between
  * STATE_MIN_VERSION and STATE_VERSION load by reading each chunk in the
  * layout the header version names (see DACStateLoad, CDROMStateLoad);
  * STATE_VERSION is always what we write.
  *
  * Released cores wrote exactly four versions: 1 (v2.2.0), 2 (v2.3.0 and
- * v2.3.1), 3 (v2.3.2) and 7 (v3.0.0).  Versions 4-6 existed only on
- * develop/nightlies.  All four released layouts load (issue #268). */
+ * v2.3.1), 3 (v2.3.2) and 7 (v3.0.0, v3.1.0).  Versions 4-6 existed only
+ * on develop/nightlies.  All four released layouts load (issue #268). */
 #define STATE_MIN_VERSION 1
 
 /* Per-field version gates.  A module loader that has to skip a field an
@@ -71,6 +74,10 @@ extern "C" {
 /* First version carrying the trailing bus-arbiter 68K carry (symmetric
  * DRAM self-cost). */
 #define STATE_VERSION_BUS_ARBITER 7
+/* First version carrying the trailing Jaguar GameDrive chunk.  Older
+ * states load with the GD at its reset state (identity pages, write
+ * protect, idle SPI) — see JGDStateLoad / the caller's else branch. */
+#define STATE_VERSION_JAGGD 8
 
 /* Header flags */
 #define STATE_FLAG_MEMTRACK  0x01

--- a/src/jerry/jerry.c
+++ b/src/jerry/jerry.c
@@ -161,6 +161,7 @@
 #include "dsp.h"
 #include "eeprom.h"
 #include "event.h"
+#include "jaggd.h"
 #include "jaguar.h"
 #include "perf_counters.h"
 
@@ -495,6 +496,12 @@ uint8_t JERRYReadByte(uint32_t offset, uint32_t who/*=UNKNOWN*/)
       // This is wrong, should only have the lowest bit from $F14001
       return value | EepromReadByte(offset);
    }
+   /* JagGD SPI mailbox (GPIO2).  Must sit above the EEPROM catch-all,
+    * which otherwise swallows these addresses and returns $0000.  When
+    * the GameDrive is not active we deliberately fall through: a $0000
+    * status read reproduces the stock-console "GD absent" hang. */
+   else if (jgdActive && offset >= JGD_REG_FIRST && offset <= JGD_REG_LAST)
+      return JGDControlReadByte(offset);
    else if (offset >= 0xF14000 && offset <= 0xF1A0FF)
       return EepromReadByte(offset);
 
@@ -550,6 +557,9 @@ uint16_t JERRYReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
       return (JoystickReadWord(offset) & 0xFFFE) | EepromReadWord(offset);
    else if ((offset >= 0xF14002) && (offset < 0xF14003))
       return JoystickReadWord(offset);
+   /* JagGD SPI mailbox (GPIO2) -- see JERRYReadByte. */
+   else if (jgdActive && offset >= JGD_REG_FIRST && offset <= JGD_REG_LAST)
+      return JGDControlReadWord(offset);
    else if ((offset >= 0xF14000) && (offset <= 0xF1A0FF))
       return EepromReadWord(offset);
 
@@ -628,6 +638,12 @@ void JERRYWriteByte(uint32_t offset, uint8_t data, uint32_t who/*=UNKNOWN*/)
    {
       JoystickWriteWord(offset & 0xFE, (uint16_t)data);
       EepromWriteByte(offset, data);
+      return;
+   }
+   /* JagGD SPI mailbox (GPIO2) -- see JERRYReadByte. */
+   else if (jgdActive && offset >= JGD_REG_FIRST && offset <= JGD_REG_LAST)
+   {
+      JGDControlWriteByte(offset, data);
       return;
    }
    else if ((offset >= 0xF14000) && (offset <= 0xF1A0FF))
@@ -723,6 +739,12 @@ void JERRYWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
    {
       JoystickWriteWord(offset, data);
       EepromWriteWord(offset, data);
+      return;
+   }
+   /* JagGD SPI mailbox (GPIO2) -- see JERRYReadByte. */
+   else if (jgdActive && offset >= JGD_REG_FIRST && offset <= JGD_REG_LAST)
+   {
+      JGDControlWriteWord(offset, data);
       return;
    }
    else if (offset >= 0xF14000 && offset <= 0xF1A0FF)

--- a/test/test_jgd.c
+++ b/test/test_jgd.c
@@ -1,0 +1,802 @@
+/*
+ * test/test_jgd.c — Jaguar GameDrive (JagGD) detection + banking test.
+ *
+ * Synthetic-only (no private ROMs needed, like test_cd_synth_*): builds a
+ * probe cartridge image at runtime whose 68K program replays the exact
+ * logic of RetroHQ's published gdbios_bindings.s — the GDWaitData
+ * handshake, the HW-version command (12), the GDBIOS install command
+ * ($80), then blob calls (GD_BIOSVersion / GD_ROMSetPages / GD_ROMSetPage
+ * / GD_ROMWriteEnable) — and stores every intermediate result at fixed
+ * main-RAM addresses this harness reads back via dlsym'd core internals.
+ *
+ * Unlike the real bindings, the probe's handshake spin loops carry a
+ * bail-out counter: on a machine with no GD the real code spins forever
+ * (GDWaitData .waitAck), so the "option disabled" phase asserts the
+ * timeout marker — proof the wedge would have happened — instead of
+ * hanging the suite.
+ *
+ * Phases (separate core lifecycles in one process, which also exercises
+ * the iOS static-state reset contract):
+ *   A) virtualjaguar_jgd=disabled + 16 MB image: detect must FAIL cleanly
+ *   B) virtualjaguar_jgd=auto + 16 MB image: install + banking + straddle
+ *      + write-enable, then savestate round-trip (v8) and the pre-v8
+ *      degradation contract (v7-headered state loads, GD resets)
+ *   C) virtualjaguar_jgd=enabled + 2 MB image: the ForceJGD path for
+ *      GD-locked images smaller than the cart window
+ *
+ * Exit codes: 0 = pass, 1 = fail, 2 = harness error.
+ *
+ * Build:  cc -O2 -Wall -std=c99 $(INCFLAGS) -o test/test_jgd \
+ *           test/test_jgd.c test/harness/harness.c -ldl -lm
+ */
+
+#include "harness/harness.h"
+#include "state.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#define MAX_RESULTS 64
+
+/* Probe result mailbox in Jaguar main RAM. */
+#define R_FLAG      0x10000   /* progress / final magic */
+#define R_ERR       0x10004   /* failure marker */
+#define R_HWVER     0x10010   /* u32 from command 12 */
+#define R_BLOBSIZE  0x10014   /* u16 size prefix from command $80 */
+#define R_BLOBHDR   0x10018   /* blob version<<16 | function count */
+#define R_BIOSVER   0x1001C   /* GD_BIOSVersion() */
+#define R_MARKERS   0x10020   /* six u32 window markers after ROMSetPages */
+#define R_STRADDLE  0x10040   /* u32 read straddling the page 0/1 boundary */
+#define R_SETPAGE   0x10044   /* marker after ROMSetPage(2,3) */
+#define R_WREN      0x10048   /* read-back of write-enabled cart write */
+#define R_WRDIS     0x1004C   /* read-back after write disable (must miss) */
+
+#define MAGIC_DONE     0xC0DE600Du
+#define MAGIC_FAILED   0xDEADDEADu
+#define ERR_TIMEOUT    0xDEAD0001u
+#define ERR_VERSION    0xDEAD0002u
+
+/* Blob served by jaggd.c (kept in sync with src/core/jaggd.c). */
+#define EXPECT_BLOB_SIZE   208
+#define EXPECT_BLOB_HDR    0x0100001Au  /* version $0100, 26 functions */
+#define EXPECT_HWVER       0x03000102u  /* FW $03.00 (>= $01.11), ASIC $01.02 */
+#define EXPECT_BIOSVER     0x00000100u
+/* JGD chunk byte count (see JGDStateSave): 16 + 6*2 + 512. */
+#define EXPECT_JGD_CHUNK   540
+
+#define STATE_OFF_VERSION  4
+
+typedef size_t (*jgd_state_save_fn)(uint8_t *buf);
+typedef size_t (*serialize_size_fn)(void);
+typedef int    (*serialize_fn)(void *data, size_t size);
+typedef int    (*unserialize_fn)(const void *data, size_t size);
+typedef void   (*reset_fn)(void);
+typedef uint32_t (*read_long_fn)(uint32_t offset, uint32_t who);
+
+static int pass_count = 0;
+static int fail_count = 0;
+static harness_result results[MAX_RESULTS];
+static unsigned num_results = 0;
+static char detail_store[MAX_RESULTS][192];
+
+static void check(int cond, const char *name, const char *fmt, ...)
+{
+    va_list ap;
+
+    if (num_results >= MAX_RESULTS)
+        return;
+
+    va_start(ap, fmt);
+    vsnprintf(detail_store[num_results], sizeof(detail_store[0]), fmt, ap);
+    va_end(ap);
+
+    results[num_results].status = cond ? "PASS" : "FAIL";
+    results[num_results].name   = name;
+    results[num_results].detail = detail_store[num_results];
+    num_results++;
+
+    if (cond)
+        pass_count++;
+    else
+        fail_count++;
+}
+
+/* ================================================================
+ * Probe ROM builder — 68K hand-assembly (big-endian), same approach
+ * as test_boot_patterns.c's ROM builder.
+ * ================================================================ */
+
+#define CODE_ADDR   0x00802000u
+#define BLOB_BUF    0x00004000u   /* long-aligned RAM buffer for the blob */
+
+#define GD_STATUS   0x00F16002u
+#define GD_DATA     0x00F16004u
+#define GD_DATAB    0x00F16005u
+
+/* Bounded-spin iteration count for the disabled phase (the real
+ * bindings spin forever; ~50k iterations is a dozen frames). */
+#define SPIN_LIMIT  50000
+
+static uint8_t *g_rom;
+static uint32_t g_pos;         /* current emit offset within the image */
+
+static void e16(uint16_t v)
+{
+    g_rom[g_pos++] = (uint8_t)(v >> 8);
+    g_rom[g_pos++] = (uint8_t)(v & 0xFF);
+}
+
+static void e32(uint32_t v)
+{
+    e16((uint16_t)(v >> 16));
+    e16((uint16_t)(v & 0xFFFF));
+}
+
+/* move.l #imm,abs.l */
+static void e_movel_imm_abs(uint32_t imm, uint32_t addr)
+{ e16(0x23FC); e32(imm); e32(addr); }
+/* move.w #imm,abs.l */
+static void e_movew_imm_abs(uint16_t imm, uint32_t addr)
+{ e16(0x33FC); e16(imm); e32(addr); }
+/* move.w abs.l,dn */
+static void e_movew_abs_dn(uint32_t addr, int dn)
+{ e16((uint16_t)(0x3039 | (dn << 9))); e32(addr); }
+/* move.l abs.l,dn */
+static void e_movel_abs_dn(uint32_t addr, int dn)
+{ e16((uint16_t)(0x2039 | (dn << 9))); e32(addr); }
+/* move.l dn,abs.l */
+static void e_movel_dn_abs(int dn, uint32_t addr)
+{ e16((uint16_t)(0x23C0 | dn)); e32(addr); }
+/* move.w dn,abs.l */
+static void e_movew_dn_abs(int dn, uint32_t addr)
+{ e16((uint16_t)(0x33C0 | dn)); e32(addr); }
+/* move.b abs.l,dn */
+static void e_moveb_abs_dn(uint32_t addr, int dn)
+{ e16((uint16_t)(0x1039 | (dn << 9))); e32(addr); }
+/* move.b abs.l,(a0)+ */
+static void e_moveb_abs_a0inc(uint32_t addr)
+{ e16(0x10F9); e32(addr); }
+/* move.l #imm,dn */
+static void e_movel_imm_dn(int dn, uint32_t imm)
+{ e16((uint16_t)(0x203C | (dn << 9))); e32(imm); }
+/* move.w #imm,dn */
+static void e_movew_imm_dn(int dn, uint16_t imm)
+{ e16((uint16_t)(0x303C | (dn << 9))); e16(imm); }
+/* movea.l #imm,an */
+static void e_movea_imm(int an, uint32_t imm)
+{ e16((uint16_t)(0x207C | (an << 9))); e32(imm); }
+/* moveq #v,dn */
+static void e_moveq(int dn, int v)
+{ e16((uint16_t)(0x7000 | (dn << 9) | (v & 0xFF))); }
+/* btst #bit,d0 */
+static void e_btst_d0(int bit)
+{ e16(0x0800); e16((uint16_t)bit); }
+/* subq.l #1,dn */
+static void e_subql_1(int dn)
+{ e16((uint16_t)(0x5380 | dn)); }
+/* subq.w #1,dn */
+static void e_subqw_1(int dn)
+{ e16((uint16_t)(0x5340 | dn)); }
+/* andi.l #imm,d0 */
+static void e_andil_d0(uint32_t imm)
+{ e16(0x0280); e32(imm); }
+/* cmpi.w #imm,d0 */
+static void e_cmpiw_d0(uint16_t imm)
+{ e16(0x0C40); e16(imm); }
+/* clr.w abs.l */
+static void e_clrw_abs(uint32_t addr)
+{ e16(0x4279); e32(addr); }
+/* swap d0 */
+static void e_swap_d0(void)
+{ e16(0x4840); }
+/* move.w d0,d1 */
+static void e_movew_d0_d1(void)
+{ e16(0x3200); }
+/* ror.w #8,d0 */
+static void e_rorw8_d0(void)
+{ e16(0xE058); }
+/* jsr d16(a6) */
+static void e_jsr_a6(int disp)
+{ e16(0x4EAE); e16((uint16_t)disp); }
+/* rts */
+static void e_rts(void)
+{ e16(0x4E75); }
+/* bra.s self */
+static void e_bra_self(void)
+{ e16(0x60FE); }
+
+/* Short conditional/unconditional branches to a KNOWN (backward) target,
+ * and a forward-patch variant. */
+static void e_bcc_s_to(uint16_t opcode, uint32_t target)
+{
+    int disp = (int)target - (int)(g_pos + 2);
+    e16((uint16_t)(opcode | (disp & 0xFF)));
+}
+
+static uint32_t e_bcc_s_fwd(uint16_t opcode)   /* returns patch position */
+{
+    uint32_t at = g_pos;
+    e16(opcode);   /* displacement patched later */
+    return at;
+}
+
+static void patch_bcc_s(uint32_t at, uint32_t target)
+{
+    int disp = (int)target - (int)(at + 2);
+    g_rom[at + 1] = (uint8_t)(disp & 0xFF);
+}
+
+/* bra.w / bsr.w to a known target */
+static void e_braw_to(uint32_t target)
+{
+    e16(0x6000);
+    e16((uint16_t)((int)target - (int)g_pos));
+}
+
+static void e_bsrw_to(uint32_t target)
+{
+    e16(0x6100);
+    e16((uint16_t)((int)target - (int)g_pos));
+}
+
+/* dbra dn,<target> */
+static void e_dbra_to(int dn, uint32_t target)
+{
+    e16((uint16_t)(0x51C8 | dn));
+    e16((uint16_t)((int)target - (int)g_pos));
+}
+
+/*
+ * Build the probe image.  size must be a multiple of 1 MB.  Every 1 MB
+ * bank that exists in the image gets:
+ *   +$00  u16 pattern (0x50+bank)<<8 | (0xA0+bank)   [straddle low half]
+ *   +$10  u32 0xC0DE0000 | bank                      [window marker]
+ * and bank 0 additionally carries the cart header, the code, and
+ *   +$FFFFC u32 0xAA55A0A0                           [straddle high half]
+ */
+static void build_probe_rom(uint8_t *rom, uint32_t size)
+{
+    uint32_t banks = size >> 20;
+    uint32_t b;
+    uint32_t l_waitdata, l_xword, l_timeout, l_verfail, l_main;
+    uint32_t l_wd1, l_wd2, l_drain, l_copy;
+    uint32_t p_sel, p_ok, p_fwok, p_nodrain;
+
+    memset(rom, 0, size);
+    g_rom = rom;
+
+    for (b = 0; b < banks; b++)
+    {
+        uint32_t base = b << 20;
+        rom[base + 0] = (uint8_t)(0x50 + b);
+        rom[base + 1] = (uint8_t)(0xA0 + b);
+        rom[base + 0x10] = 0xC0;
+        rom[base + 0x11] = 0xDE;
+        rom[base + 0x12] = 0x00;
+        rom[base + 0x13] = (uint8_t)b;
+    }
+    /* bank 0, last long before the page 0/1 boundary */
+    rom[0xFFFFC] = 0xAA; rom[0xFFFFD] = 0x55;
+    rom[0xFFFFE] = 0xA0; rom[0xFFFFF] = 0xA0;
+
+    /* Cart header: universal marker + run address (patched to main below) */
+    rom[0x400] = 0x04; rom[0x401] = 0x04; rom[0x402] = 0x04; rom[0x403] = 0x04;
+
+    g_pos = 0x2000;
+
+    /* ---- timeout_fail ---- */
+    l_timeout = g_pos;
+    e_movel_imm_abs(ERR_TIMEOUT, R_ERR);
+    e_movel_imm_abs(MAGIC_FAILED, R_FLAG);
+    e_bra_self();
+
+    /* ---- version_fail ---- */
+    l_verfail = g_pos;
+    e_movel_imm_abs(ERR_VERSION, R_ERR);
+    e_movel_imm_abs(MAGIC_FAILED, R_FLAG);
+    e_bra_self();
+
+    /* ---- gd_waitdata (bounded) ----
+     * spin HAVE_DATA==0; write $0011; spin HAVE_DATA==1.  Real bindings
+     * spin forever; the bail-out proves the no-GD wedge without hanging. */
+    l_waitdata = g_pos;
+    e_movel_imm_dn(7, SPIN_LIMIT);
+    l_wd1 = g_pos;
+    e_movew_abs_dn(GD_STATUS, 0);
+    e_btst_d0(3);
+    p_sel = e_bcc_s_fwd(0x6700);          /* beq.s .sel */
+    e_subql_1(7);
+    e_bcc_s_to(0x6600, l_wd1);            /* bne.s .wd1 */
+    e_braw_to(l_timeout);
+    patch_bcc_s(p_sel, g_pos);            /* .sel: */
+    e_movew_imm_abs(0x0011, GD_STATUS);
+    e_movel_imm_dn(7, SPIN_LIMIT);
+    l_wd2 = g_pos;
+    e_movew_abs_dn(GD_STATUS, 0);
+    e_btst_d0(3);
+    p_ok = e_bcc_s_fwd(0x6600);           /* bne.s .ok */
+    e_subql_1(7);
+    e_bcc_s_to(0x6600, l_wd2);            /* bne.s .wd2 */
+    e_braw_to(l_timeout);
+    patch_bcc_s(p_ok, g_pos);             /* .ok: */
+    e_rts();
+
+    /* ---- gd_xword: word exchange, tx low byte first, rx high first ---- */
+    l_xword = g_pos;
+    e_movew_dn_abs(0, GD_DATA);
+    e_moveb_abs_dn(GD_DATAB, 0);
+    e_rorw8_d0();
+    e_movew_dn_abs(0, GD_DATA);
+    e_moveb_abs_dn(GD_DATAB, 0);
+    e_rts();
+
+    /* ---- main ---- */
+    l_main = g_pos;
+    e_movel_imm_abs(1, R_FLAG);
+
+    /* HW version (command 12) */
+    e_movew_imm_abs(0x0010, GD_STATUS);
+    e_bsrw_to(l_waitdata);
+    e_movel_imm_abs(2, R_FLAG);
+    e_movew_imm_dn(0, 12);
+    e_bsrw_to(l_xword);
+    e_moveq(0, 0);
+    e_bsrw_to(l_xword);
+    e_movew_imm_abs(0x0010, GD_STATUS);
+    e_bsrw_to(l_waitdata);
+    e_bsrw_to(l_xword);                   /* firmware word */
+    e_swap_d0();
+    e_bsrw_to(l_xword);                   /* ASIC word */
+    e_movel_dn_abs(0, R_HWVER);
+    /* GD_Install's firmware gate: FW must be >= $0111 */
+    e_swap_d0();
+    e_cmpiw_d0(0x0111);
+    p_fwok = e_bcc_s_fwd(0x6C00);         /* bge.s .fwok */
+    e_braw_to(l_verfail);
+    patch_bcc_s(p_fwok, g_pos);           /* .fwok: */
+    e_clrw_abs(GD_STATUS);
+
+    /* Drain the rx latch ("in case of FIFO DMA termination") */
+    l_drain = g_pos;
+    e_movew_abs_dn(GD_STATUS, 0);
+    e_btst_d0(5);
+    p_nodrain = e_bcc_s_fwd(0x6700);      /* beq.s .nodrain */
+    e_movew_abs_dn(GD_DATA, 1);           /* word read drains the latch */
+    e_bcc_s_to(0x6000, l_drain);          /* bra.s .drain */
+    patch_bcc_s(p_nodrain, g_pos);        /* .nodrain: */
+
+    /* Install the GDBIOS blob (command $80) */
+    e_movew_imm_abs(0x0010, GD_STATUS);
+    e_bsrw_to(l_waitdata);
+    e_movew_imm_dn(0, 0x80);
+    e_bsrw_to(l_xword);
+    e_moveq(0, 0);
+    e_bsrw_to(l_xword);
+    e_movew_imm_abs(0x0010, GD_STATUS);
+    e_bsrw_to(l_waitdata);
+    e_bsrw_to(l_xword);                   /* u16 blob size */
+    e_movew_imm_abs(0x0010, GD_STATUS);   /* done with this block */
+    e_andil_d0(0xFFFF);
+    e_movel_dn_abs(0, R_BLOBSIZE);
+    /* copy loop (our blob is 208 bytes: a single <=512 block) */
+    e_movea_imm(0, BLOB_BUF);
+    e_movew_d0_d1();
+    e_bsrw_to(l_waitdata);
+    e_subqw_1(1);
+    l_copy = g_pos;
+    e_movew_dn_abs(1, GD_DATA);           /* dummy tx clocks a byte out */
+    e_moveb_abs_a0inc(GD_DATAB);
+    e_dbra_to(1, l_copy);
+    e_movew_imm_abs(0x0010, GD_STATUS);
+    e_clrw_abs(GD_STATUS);
+    e_movel_imm_abs(3, R_FLAG);
+
+    /* Blob header: version + function count */
+    e_movel_abs_dn(BLOB_BUF, 0);
+    e_movel_dn_abs(0, R_BLOBHDR);
+
+    /* a6 = blob base (GDFunc convention), call GD_BIOSVersion (3) */
+    e_movea_imm(6, BLOB_BUF);
+    e_jsr_a6(3 * 4);
+    e_andil_d0(0xFFFF);
+    e_movel_dn_abs(0, R_BIOSVER);
+
+    /* GD_ROMSetPages($BCDEF0): page0=0, pages 1..5 = banks 15,14,13,12,11 */
+    e_movel_imm_dn(0, 0x00BCDEF0);
+    e_jsr_a6(6 * 4);
+
+    /* Window markers */
+    e_movel_abs_dn(0x800010, 0); e_movel_dn_abs(0, R_MARKERS + 0);
+    e_movel_abs_dn(0x900010, 0); e_movel_dn_abs(0, R_MARKERS + 4);
+    e_movel_abs_dn(0xA00010, 0); e_movel_dn_abs(0, R_MARKERS + 8);
+    e_movel_abs_dn(0xB00010, 0); e_movel_dn_abs(0, R_MARKERS + 12);
+    e_movel_abs_dn(0xC00010, 0); e_movel_dn_abs(0, R_MARKERS + 16);
+    e_movel_abs_dn(0xD00010, 0); e_movel_dn_abs(0, R_MARKERS + 20);
+
+    /* Long read straddling the page 0 / page 1 bank boundary */
+    e_movel_abs_dn(0x8FFFFE, 0);
+    e_movel_dn_abs(0, R_STRADDLE);
+
+    /* GD_ROMSetPage(2, 3): d0 = page<<16 | bank */
+    e_movel_imm_dn(0, 0x00020003);
+    e_jsr_a6(5 * 4);
+    e_movel_abs_dn(0xA00010, 0);
+    e_movel_dn_abs(0, R_SETPAGE);
+
+    /* GD_ROMWriteEnable(1): write through page 1 (bank 15), read back */
+    e_moveq(0, 1);
+    e_jsr_a6(4 * 4);
+    e_movew_imm_abs(0x1234, 0x900100);
+    e_movew_abs_dn(0x900100, 0);
+    e_andil_d0(0xFFFF);
+    e_movel_dn_abs(0, R_WREN);
+    /* GD_ROMWriteEnable(0): the same write must now miss */
+    e_moveq(0, 0);
+    e_jsr_a6(4 * 4);
+    e_movew_imm_abs(0x4321, 0x900104);
+    e_movew_abs_dn(0x900104, 0);
+    e_andil_d0(0xFFFF);
+    e_movel_dn_abs(0, R_WRDIS);
+
+    e_movel_imm_abs(MAGIC_DONE, R_FLAG);
+    e_bra_self();
+
+    /* Run address -> main */
+    rom[0x404] = (uint8_t)((CODE_ADDR + (l_main - 0x2000)) >> 24);
+    rom[0x405] = (uint8_t)((CODE_ADDR + (l_main - 0x2000)) >> 16);
+    rom[0x406] = (uint8_t)((CODE_ADDR + (l_main - 0x2000)) >> 8);
+    rom[0x407] = (uint8_t)((CODE_ADDR + (l_main - 0x2000)) & 0xFF);
+}
+
+/* ================================================================
+ * Host-side helpers
+ * ================================================================ */
+
+static uint32_t ram32(uint8_t *ram, uint32_t addr)
+{
+    return ((uint32_t)ram[addr] << 24) | ((uint32_t)ram[addr + 1] << 16)
+         | ((uint32_t)ram[addr + 2] << 8) | ram[addr + 3];
+}
+
+static int write_rom_file(const char *path, const uint8_t *data, uint32_t size)
+{
+    FILE *f = fopen(path, "wb");
+    if (!f)
+        return 0;
+    if (fwrite(data, 1, size, f) != size)
+    {
+        fclose(f);
+        return 0;
+    }
+    fclose(f);
+    return 1;
+}
+
+/* One core lifecycle: load the image with the given option value and run.
+ * Returns the harness config through *cfg (caller shuts it down). */
+static int run_phase(harness_config *cfg, int argc, char **argv,
+                     const char *rom_path, const char *jgd_value,
+                     unsigned frames)
+{
+    harness_config fresh = HARNESS_CONFIG_DEFAULT;
+    *cfg = fresh;
+    cfg->frames = frames;
+    cfg->quiet = 1;
+
+    if (!harness_init_from_args(cfg, argc, argv))
+        return 0;
+    cfg->rom_path = rom_path;
+    harness_set_option(cfg, "virtualjaguar_jgd", jgd_value);
+    if (!harness_load_rom(cfg))
+        return 0;
+    harness_run(cfg);
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    char rom16_path[512], rom2_path[512];
+    const char *tmpdir;
+    uint8_t *rom16, *rom2;
+    harness_config cfg;
+    uint8_t *ram;
+    uint8_t **ram_ptr;
+    uint8_t *active_ptr, *wren_ptr, *page_ptr;
+    int rc;
+
+    tmpdir = getenv("TMPDIR");
+    if (!tmpdir || !tmpdir[0])
+        tmpdir = "/tmp";
+    snprintf(rom16_path, sizeof(rom16_path), "%s/vj_jgd_probe16_%ld.j64",
+             tmpdir, (long)getpid());
+    snprintf(rom2_path, sizeof(rom2_path), "%s/vj_jgd_probe2_%ld.j64",
+             tmpdir, (long)getpid());
+
+    rom16 = (uint8_t *)malloc(16u << 20);
+    rom2  = (uint8_t *)malloc(2u << 20);
+    if (!rom16 || !rom2)
+    {
+        fprintf(stderr, "Out of memory building probe images\n");
+        return 2;
+    }
+    build_probe_rom(rom16, 16u << 20);
+    build_probe_rom(rom2, 2u << 20);
+    if (!write_rom_file(rom16_path, rom16, 16u << 20)
+        || !write_rom_file(rom2_path, rom2, 2u << 20))
+    {
+        fprintf(stderr, "Cannot write probe images under %s\n", tmpdir);
+        free(rom16); free(rom2);
+        return 2;
+    }
+
+    /* ============================================================
+     * Phase A: option disabled -> GD detect must FAIL cleanly.
+     * The probe's bounded GDWaitData must hit its bail-out (the real
+     * bindings would spin in .waitAck forever = the stock-console
+     * hang), and the core must still be running frames.
+     * ============================================================ */
+    if (!run_phase(&cfg, argc, argv, rom16_path, "disabled", 90))
+    {
+        fprintf(stderr, "Phase A: harness init/load failed\n");
+        rc = 2;
+        goto cleanup_files;
+    }
+
+    ram_ptr    = (uint8_t **)harness_dlsym(&cfg, "jaguarMainRAM");
+    active_ptr = (uint8_t *)harness_dlsym(&cfg, "jgdActive");
+    if (!ram_ptr || !active_ptr)
+    {
+        fprintf(stderr, "Cannot resolve jaguarMainRAM/jgdActive "
+                        "(needs a TEST_EXPORTS=1 build)\n");
+        harness_shutdown(&cfg);
+        rc = 2;
+        goto cleanup_files;
+    }
+    ram = *ram_ptr;
+
+    check(*active_ptr == 0, "disabled_not_active",
+          "jgdActive=%u with option disabled", *active_ptr);
+    check(ram32(ram, R_FLAG) == MAGIC_FAILED
+          && ram32(ram, R_ERR) == ERR_TIMEOUT,
+          "disabled_detect_times_out",
+          "flag=$%08X err=$%08X (expect $%08X/$%08X: the handshake never "
+          "acked, so unbounded GD code would have wedged)",
+          ram32(ram, R_FLAG), ram32(ram, R_ERR), MAGIC_FAILED, ERR_TIMEOUT);
+    check(ram32(ram, R_HWVER) == 0, "disabled_no_hwversion",
+          "R_HWVER=$%08X (expect 0: transaction never reached command 12)",
+          ram32(ram, R_HWVER));
+    check(cfg.video.total_frames_rendered >= 90, "disabled_core_not_hung",
+          "%u frames rendered (bail-out kept the suite alive)",
+          cfg.video.total_frames_rendered);
+    harness_shutdown(&cfg);
+
+    /* ============================================================
+     * Phase B: auto + 16 MB image -> full install + banking.
+     * ============================================================ */
+    if (!run_phase(&cfg, argc, argv, rom16_path, "auto", 30))
+    {
+        fprintf(stderr, "Phase B: harness init/load failed\n");
+        rc = 2;
+        goto cleanup_files;
+    }
+
+    ram_ptr    = (uint8_t **)harness_dlsym(&cfg, "jaguarMainRAM");
+    active_ptr = (uint8_t *)harness_dlsym(&cfg, "jgdActive");
+    wren_ptr   = (uint8_t *)harness_dlsym(&cfg, "jgdWriteEnabled");
+    page_ptr   = (uint8_t *)harness_dlsym(&cfg, "jgdPage");
+    if (!ram_ptr || !active_ptr || !wren_ptr || !page_ptr)
+    {
+        fprintf(stderr, "Cannot resolve JGD internals\n");
+        harness_shutdown(&cfg);
+        rc = 2;
+        goto cleanup_files;
+    }
+    ram = *ram_ptr;
+
+    check(*active_ptr == 1, "auto_active_over_6mb",
+          "jgdActive=%u for a 16 MB image in auto mode", *active_ptr);
+    check(ram32(ram, R_FLAG) == MAGIC_DONE, "probe_completed",
+          "flag=$%08X err=$%08X (expect $%08X)",
+          ram32(ram, R_FLAG), ram32(ram, R_ERR), MAGIC_DONE);
+    check(ram32(ram, R_HWVER) == EXPECT_HWVER, "hw_version",
+          "cmd 12 -> $%08X (expect $%08X; FW word must be >= $0111)",
+          ram32(ram, R_HWVER), EXPECT_HWVER);
+    check(ram32(ram, R_BLOBSIZE) == EXPECT_BLOB_SIZE, "blob_size",
+          "cmd $80 size prefix = %u (expect %u)",
+          ram32(ram, R_BLOBSIZE), EXPECT_BLOB_SIZE);
+    check(ram32(ram, R_BLOBHDR) == EXPECT_BLOB_HDR, "blob_header",
+          "blob version/funccount = $%08X (expect $%08X)",
+          ram32(ram, R_BLOBHDR), EXPECT_BLOB_HDR);
+    check(ram32(ram, R_BIOSVER) == EXPECT_BIOSVER, "blob_biosversion",
+          "GD_BIOSVersion() = $%08X (expect $%08X)",
+          ram32(ram, R_BIOSVER), EXPECT_BIOSVER);
+
+    check(ram32(ram, R_MARKERS + 0)  == 0xC0DE0000u
+          && ram32(ram, R_MARKERS + 4)  == 0xC0DE000Fu
+          && ram32(ram, R_MARKERS + 8)  == 0xC0DE000Eu
+          && ram32(ram, R_MARKERS + 12) == 0xC0DE000Du
+          && ram32(ram, R_MARKERS + 16) == 0xC0DE000Cu
+          && ram32(ram, R_MARKERS + 20) == 0xC0DE000Bu,
+          "banking_markers",
+          "windows after ROMSetPages($BCDEF0): %08X %08X %08X %08X %08X %08X",
+          ram32(ram, R_MARKERS + 0), ram32(ram, R_MARKERS + 4),
+          ram32(ram, R_MARKERS + 8), ram32(ram, R_MARKERS + 12),
+          ram32(ram, R_MARKERS + 16), ram32(ram, R_MARKERS + 20));
+    check(ram32(ram, R_STRADDLE) == 0xA0A05FAFu, "boundary_straddle",
+          "long at $8FFFFE = $%08X (expect $A0A05FAF: bank 0 tail + "
+          "bank 15 head)", ram32(ram, R_STRADDLE));
+    check(ram32(ram, R_SETPAGE) == 0xC0DE0003u, "single_page_remap",
+          "window 2 after ROMSetPage(2,3) = $%08X (expect $C0DE0003)",
+          ram32(ram, R_SETPAGE));
+    check(ram32(ram, R_WREN) == 0x1234u, "rom_write_enable",
+          "write-enabled cart write reads back $%04X (expect $1234)",
+          ram32(ram, R_WREN));
+    check(ram32(ram, R_WRDIS) == 0u, "rom_write_disable",
+          "write-protected cart write reads back $%04X (expect $0000)",
+          ram32(ram, R_WRDIS));
+    check(page_ptr[0] == 0 && page_ptr[1] == 15 && page_ptr[2] == 3
+          && page_ptr[3] == 13 && page_ptr[4] == 12 && page_ptr[5] == 11,
+          "page_table_state",
+          "jgdPage = {%u,%u,%u,%u,%u,%u} (expect {0,15,3,13,12,11})",
+          page_ptr[0], page_ptr[1], page_ptr[2],
+          page_ptr[3], page_ptr[4], page_ptr[5]);
+    check(*wren_ptr == 0, "write_enable_left_clear",
+          "jgdWriteEnabled=%u after the probe disabled it", *wren_ptr);
+
+    /* ---- Savestate round-trip (still phase B's session) ---- */
+    {
+        jgd_state_save_fn jgd_save =
+            (jgd_state_save_fn)harness_dlsym(&cfg, "JGDStateSave");
+        serialize_size_fn ser_size =
+            (serialize_size_fn)harness_dlsym(&cfg, "retro_serialize_size");
+        serialize_fn ser = (serialize_fn)harness_dlsym(&cfg, "retro_serialize");
+        unserialize_fn unser =
+            (unserialize_fn)harness_dlsym(&cfg, "retro_unserialize");
+        reset_fn do_reset = (reset_fn)harness_dlsym(&cfg, "retro_reset");
+        read_long_fn jag_read_long =
+            (read_long_fn)harness_dlsym(&cfg, "JaguarReadLong");
+        uint8_t *state = NULL, *state7 = NULL;
+        uint8_t chunk[1024];
+        size_t ssize;
+
+        if (!jgd_save || !ser_size || !ser || !unser || !do_reset
+            || !jag_read_long)
+        {
+            fprintf(stderr, "Cannot resolve savestate symbols\n");
+            harness_shutdown(&cfg);
+            rc = 2;
+            goto cleanup_files;
+        }
+
+        check(jgd_save(chunk) == EXPECT_JGD_CHUNK, "jgd_chunk_size",
+              "JGDStateSave wrote %lu bytes (expect %d; active and "
+              "inactive layouts must match)",
+              (unsigned long)jgd_save(chunk), EXPECT_JGD_CHUNK);
+
+        ssize = ser_size();
+        state  = (uint8_t *)malloc(ssize);
+        state7 = (uint8_t *)malloc(ssize);
+        if (!state || !state7)
+        {
+            fprintf(stderr, "Out of memory for states\n");
+            free(state); free(state7);
+            harness_shutdown(&cfg);
+            rc = 2;
+            goto cleanup_files;
+        }
+
+        check(ser(state, ssize) != 0, "v8_serialize",
+              "retro_serialize of a banked GameDrive session");
+        {
+            uint32_t hdr_ver;
+            memcpy(&hdr_ver, state + STATE_OFF_VERSION, 4);
+            check(hdr_ver == (uint32_t)STATE_VERSION
+                  && STATE_VERSION == 8,
+                  "v8_header", "state header version=%u (expect 8)", hdr_ver);
+        }
+
+        /* Console reset returns the mapping to identity... */
+        do_reset();
+        check(page_ptr[0] == 0 && page_ptr[1] == 1 && page_ptr[2] == 2
+              && page_ptr[3] == 3 && page_ptr[4] == 4 && page_ptr[5] == 5,
+              "reset_returns_identity",
+              "jgdPage after retro_reset = {%u,%u,%u,%u,%u,%u}",
+              page_ptr[0], page_ptr[1], page_ptr[2],
+              page_ptr[3], page_ptr[4], page_ptr[5]);
+
+        /* ...and the state load restores the remap. */
+        check(unser(state, ssize) != 0, "v8_unserialize", "state loads back");
+        check(page_ptr[0] == 0 && page_ptr[1] == 15 && page_ptr[2] == 3
+              && page_ptr[3] == 13 && page_ptr[4] == 12 && page_ptr[5] == 11,
+              "v8_pages_restored",
+              "jgdPage after load = {%u,%u,%u,%u,%u,%u} (expect {0,15,3,13,12,11})",
+              page_ptr[0], page_ptr[1], page_ptr[2],
+              page_ptr[3], page_ptr[4], page_ptr[5]);
+        check(jag_read_long(0xA00010, 0) == 0xC0DE0003u,
+              "v8_banked_read_after_load",
+              "JaguarReadLong($A00010) = $%08X (expect $C0DE0003)",
+              jag_read_long(0xA00010, 0));
+
+        /* Pre-v8 contract: a v7-headered state (no JGD chunk) must load,
+         * with the GD falling back to its reset mapping. */
+        memcpy(state7, state, ssize);
+        {
+            uint32_t v7 = 7;
+            memcpy(state7 + STATE_OFF_VERSION, &v7, 4);
+        }
+        check(unser(state7, ssize) != 0, "v7_state_loads",
+              "v7-headered state accepted");
+        check(page_ptr[0] == 0 && page_ptr[1] == 1 && page_ptr[2] == 2
+              && page_ptr[3] == 3 && page_ptr[4] == 4 && page_ptr[5] == 5,
+              "v7_jgd_defaults_to_reset",
+              "jgdPage after v7 load = {%u,%u,%u,%u,%u,%u} (expect identity)",
+              page_ptr[0], page_ptr[1], page_ptr[2],
+              page_ptr[3], page_ptr[4], page_ptr[5]);
+
+        free(state);
+        free(state7);
+    }
+    harness_shutdown(&cfg);
+
+    /* ============================================================
+     * Phase C: forced enable + 2 MB image (the "GD-locked homebrew
+     * smaller than the cart window" / ForceJGD path).
+     * ============================================================ */
+    if (!run_phase(&cfg, argc, argv, rom2_path, "enabled", 30))
+    {
+        fprintf(stderr, "Phase C: harness init/load failed\n");
+        rc = 2;
+        goto cleanup_files;
+    }
+
+    ram_ptr    = (uint8_t **)harness_dlsym(&cfg, "jaguarMainRAM");
+    active_ptr = (uint8_t *)harness_dlsym(&cfg, "jgdActive");
+    if (!ram_ptr || !active_ptr)
+    {
+        fprintf(stderr, "Cannot resolve internals (phase C)\n");
+        harness_shutdown(&cfg);
+        rc = 2;
+        goto cleanup_files;
+    }
+    ram = *ram_ptr;
+
+    check(*active_ptr == 1, "forced_active_small_image",
+          "jgdActive=%u for a 2 MB image with option enabled", *active_ptr);
+    check(ram32(ram, R_FLAG) == MAGIC_DONE, "forced_probe_completed",
+          "flag=$%08X err=$%08X (expect $%08X)",
+          ram32(ram, R_FLAG), ram32(ram, R_ERR), MAGIC_DONE);
+    check(ram32(ram, R_HWVER) == EXPECT_HWVER, "forced_hw_version",
+          "cmd 12 -> $%08X (expect $%08X)", ram32(ram, R_HWVER), EXPECT_HWVER);
+    /* Banks 2-15 don't exist in a 2 MB image: their SDRAM reads zeros. */
+    check(ram32(ram, R_MARKERS + 0) == 0xC0DE0000u
+          && ram32(ram, R_MARKERS + 4) == 0
+          && ram32(ram, R_MARKERS + 20) == 0,
+          "forced_missing_banks_zero",
+          "window 0 = $%08X, windows 1/5 = $%08X/$%08X (missing banks read 0)",
+          ram32(ram, R_MARKERS + 0), ram32(ram, R_MARKERS + 4),
+          ram32(ram, R_MARKERS + 20));
+    check(ram32(ram, R_STRADDLE) == 0xA0A00000u, "forced_straddle",
+          "long at $8FFFFE = $%08X (expect $A0A00000)",
+          ram32(ram, R_STRADDLE));
+    check(ram32(ram, R_WREN) == 0x1234u, "forced_write_enable",
+          "write-enabled write into a missing bank reads back $%04X",
+          ram32(ram, R_WREN));
+
+    harness_report(&cfg, results, num_results);
+    if (!cfg.json_output)
+        printf("  %d passed, %d failed\n", pass_count, fail_count);
+    harness_shutdown(&cfg);
+
+    rc = fail_count > 0 ? 1 : 0;
+
+cleanup_files:
+    remove(rom16_path);
+    remove(rom2_path);
+    free(rom16);
+    free(rom2);
+    return rc;
+}

--- a/test/test_jgd.c
+++ b/test/test_jgd.c
@@ -72,8 +72,12 @@
 
 typedef size_t (*jgd_state_save_fn)(uint8_t *buf);
 typedef size_t (*serialize_size_fn)(void);
-typedef int    (*serialize_fn)(void *data, size_t size);
-typedef int    (*unserialize_fn)(const void *data, size_t size);
+/* bool, not int: retro_serialize/unserialize return bool, and UBSan's
+ * function-type-mismatch check (Linux CI) rejects calls through a
+ * mistyped pointer even when the ABI happens to coincide.  Matches
+ * test_state_compat.c. */
+typedef bool   (*serialize_fn)(void *data, size_t size);
+typedef bool   (*unserialize_fn)(const void *data, size_t size);
 typedef void   (*reset_fn)(void);
 typedef uint32_t (*read_long_fn)(uint32_t offset, uint32_t who);
 


### PR DESCRIPTION
## Summary

Implements #312 phases 1+2 from the committed spec (`docs/jgd-interface-notes.md`, included in this PR): **Jaguar GameDrive detection + 16 MB bank switching**. GD-locked homebrew currently hangs forever on our core (the GD handshake spins on a bit that never rises); with this, `virtualjaguar_jgd = auto` (default) enables GD emulation for >6 MB images, `enabled` forces it for GD-locked <6 MB images (BigPEmu's `ForceJGD` equivalent), `disabled` reproduces stock-console behaviour.

Ground truth is RetroHQ's own published sources — SainT's `gdbios_bindings.s` documents the SPI registers, protocol, and 6×1MB-page/16-bank semantics in his own comments. **The spec worked on first contact: zero discrepancies found during implementation.**

## What ships

- `src/core/jaggd.c/.h` (mirrors `memtrack.c` structure): SPI engine at `$F16000–$F16007` (intercepted in `jerry.c` before the EEPROM catch-all), command 12 → FW `$0300`/ASIC `$0102`, command `$80` serves our own **208-byte hand-assembled GDBIOS blob** (games only ever reach banking through the blob ABI, and the cart serves the blob — so we supply ours, exactly as BigPEmu must)
- Banking: `jgdPage[6]`, translation in every cart read path (68K 8/16/32 + GPU/DSP/OP/blitter readers), byte-composed reads across 1 MB page boundaries, `GD_ROMWriteEnable` support
- Loader accepts up to 16 MB — which also closes a **pre-existing buffer overflow** for >6 MB images into `jagMemSpace`
- Savestate **v8** (`STATE_VERSION_JAGGD`, the shared bump since v3.1.0 per policy): 540-byte chunk, all-zero when inactive, pre-v8 states load with JGD at reset
- Out of scope per spec §9: GD menu, SD/FAT (file/dir functions return −1, matching BigPEmu's stubs), GPU async reads, encrypted `.jgd`, `.MRQ`

## Evidence

`test/test_jgd.c` — **32/32**, synthetic-only (runs in CI, no ROMs): probe cartridges whose 68K program replays the RetroHQ bindings byte-for-byte. Detection contract (FW ≥ `$0111`), blob install + version, `ROMSetPages($BCDEF0)` → all six windows read the right bank markers, boundary-straddling long composes two banks, write-enable round-trip, forced-enable on a 2 MB image, disabled-mode hang reproduced via bounded spin, v8 savestate round-trip across `retro_reset`.

**Negative controls red on both translation paths**: the agent's control pinned the read-path translation (banking markers all `C0DE0000`, exit 1); my independent pre-merge sabotage hit the write-path site (`write reads back $0000`, exit 1). JERRY-hook-disabled and v8-gate-skipped controls also verified red.

## Perf + compat at defaults

- 10 interleaved benchmark pairs: delta is noise (gate is one predictable-false branch per cart access)
- Boot smoke A/B vs develop on yarc, Iron Soldier, AvP, Doom at defaults: **bit-identical** frames/geometry/audio-sample counts
- Full suite exit 0 post-rebase, audio pair by name, "Skipped checks: none", `test_state_compat` passes **unmodified** (the v8 chunk is all-zero when inactive, which its zero-tail check requires)

## Honest limits

- No GD-locked retail homebrew in the local corpus — the mechanism is proven by the probe ROM; a SKYLAR 1.0 spot-check in RetroArch is recommended when a copy is available
- Write-enabled page contents don't survive savestate load (documented v1 simplification)

Closes #312 (manual close needed — develop merges don't auto-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
