### PR TITLE
fix(cd): distance-dependent seek model calibrated to the BigPEmu reference (#297)

### DIFF
--- a/docs/cd-known-issues.md
+++ b/docs/cd-known-issues.md
@@ -59,34 +59,43 @@ code (1 = single, 2 = double), then `bset #3,d2` for data mode, then
 expected reply is `$1700 | payload` (`bset #9`), which
 `src/cd/cdrom.c:1641` already synthesizes correctly.
 
-### 2. FMV scene-jump schedule drift (Dragon's Lair / Space Ace / BD13)
+### 2. ~~FMV scene-jump schedule drift (Dragon's Lair / Space Ace / BD13)~~ -- RESOLVED (#297: every lead run to ground; seek model calibrated to reference)
 
-FMV titles occasionally jump scenes early/late. **The original root-cause
-note here was wrong on both counts** -- see
-[`fmv-drift-notes.md`](fmv-drift-notes.md) for the measurements:
+**Closed 2026-08-05.** The investigation is in
+[`fmv-drift-notes.md`](fmv-drift-notes.md) (§2–§11); the summary of where
+each hypothesis ended:
 
-- `$129AD6/$129ADE` is not a clock. Dragon's Lair's presentation counter
-  lives at `$562E/$5630` (the address its poll loop at `$004C0A` actually
-  reads), with a second accumulator at `$5688/$568A`.
-- That counter is **video-field-locked, not CD-derived**: it advances
-  exactly 32760 per field with zero jitter, and its per-field histogram is
-  identical at 1x/2x/4x read speed. Clock-vs-data drift through that
-  mechanism is structurally impossible.
+- **"Schedule drift" is structurally impossible.** Dragon's Lair's
+  presentation counter is at `$562E/$5630` (not the `$129AD6/$129ADE`
+  this note originally cited) and it is **video-field-locked**: +32760
+  per field, zero jitter, identical histogram at 1x/2x/4x read speed
+  (§2).
+- **Transfer rate is exonerated.** Both paths deliver within +0.15% of
+  the 352,800 B/s hardware 2x rate; the earlier "-1.11% slow /
+  `fifoFillDelay` re-arm" claim was refuted by direct measurement — the
+  fill→drain latency it blamed is zero for 99.997% of drains (§9, #305).
+- **A real stream-corruption bug was found and fixed on this path**: a
+  redundant `$12xx` seek re-framed the in-flight FIFO/SSI stream,
+  replaying up to ~13 ms of CD-DA (#306, fixed #307). It may well have
+  been the visible "glitchy transition" in the original report.
+- **Seek latency — the last open lead — is now modeled and calibrated.**
+  A BigPEmu reference capture of Dragon's Lair's death branch (558 ms ≈
+  33.4 fields of black vs our 29–30) showed the missing term is ~60 ms
+  on a near-full-stroke seek — tens of ms, **not** the unsourced
+  "30–315 ms multi-tier" range this file used to cite (its ~300 ms top
+  end would have shown as ~+18 fields; the capture shows +4).
+  `CDROMSeekDistanceTicks()` (src/cd/cdrom.c) now charges 1 halfline
+  tick per 72 sectors of head travel in **both** boot modes; the
+  measured branch gap lands at 33 fields in both, matching the
+  reference within a field (§11).
 
-Measured transfer rates against the 352,800 B/s hardware 2x figure: the
-HLE path is effectively exact (-0.000025%), the real-BIOS FIFO path runs -1.11% slow
-(`fifoFillDelay` is re-armed only after a drain completes, so GPU-ISR
-latency adds to the refill period instead of overlapping it). No
-accumulating jitter in either mode -- repeat attract loops are
-byte-identical.
-
-The symptom itself has **never been reproduced headlessly**. The leading
-un-measured suspect is seek/branch latency: `SEEK_DELAY_TICKS 100`
-(~3.2 ms) is 10-100x shorter than the 30-315 ms its own comment cites, and
-the HLE `CD_read` path has no seek model at all -- the one mechanism whose
-signature matches "jumps scenes *early*". The attract loop never branches,
-so it never seeks, which is why the measurement above cannot see it.
-Subcode registers remain exonerated.
+The reproducible branch fixture (`test/tools/run_dl_branch_fixture.sh`,
+#311) plus long-run cycle checks pin the behaviour: the die/retry loop
+repeats with a constant period and identical LBA sequence over 6+
+consecutive cycles in each mode. Standing caveat: the seek constant is
+**reference parity with BigPEmu, not silicon ground truth** — if a
+hardware capture ever materializes, recalibrate `SEEK_SECTORS_PER_TICK`
+against it (one number, linear model, no tiers).
 
 ### 3. Myst BIOS-mode audio parity listen
 

--- a/docs/fmv-drift-notes.md
+++ b/docs/fmv-drift-notes.md
@@ -988,3 +988,153 @@ so capture both if possible.
   The **first incoming content frame is unambiguous and identical in both modes**
   — prefer it as the comparison anchor against BigPEmu.
 * Measurement only. No emulation behaviour was changed in this pass.
+
+## 11. Seek model shipped (2026-08-05) — calibrated to the BigPEmu reference capture
+
+Status: **the fix pass for #297.** Everything above was measurement; this
+section records the one behavioural change that came out of it, its
+provenance, and the A/B evidence.
+
+### 11.1 The reference capture, and what it killed
+
+The maintainer captured Dragon's Lair's death branch in BigPEmu (macOS/iOS,
+120 Hz screen recording, measured against real PTS timestamps — details in
+the 2026-08-05 comment on #297):
+
+| | black window (last content → first incoming content) |
+|---|---|
+| BigPEmu | **558 ms ≈ 33.4 fields** |
+| ours, pre-change (§10) | 29–30 fields ≈ 500 ms |
+
+Delta ≈ +4 fields ≈ +60–75 ms on a near-full-stroke seek. That number
+settles two things:
+
+* **The "30–315 ms multi-tier" comment in `cdrom.c` is dead.** Its ~300 ms
+  top end on this full-stroke branch would have shown as ~+18 fields; the
+  reference shows +4. Whatever a real drive does, the reference charges
+  **tens of ms, not hundreds** — and no primary source for the tier table
+  was ever found (§8.4). The comment block has been rewritten.
+* **A calibrated linear term is justified.** §8.3 already proved
+  experimentally that seek latency displaces branch boundaries exactly 1:1
+  (a +300 ms probe moved the gap +18.0 fields), so a distance term of X ms
+  moves the gap X ms, no second-order effects.
+
+### 11.2 The model
+
+One constant, linear in head travel, both boot modes
+(`CDROMSeekDistanceTicks()` in `src/cd/cdrom.c`, shared via `cdrom.h`):
+
+```
+extra_ticks = |target_LBA − head_LBA| / 72        (1 tick = 31.78 µs)
+```
+
+* **Real-BIOS path** (`cdrom.c`): added on top of the base
+  `SEEK_DELAY_TICKS 100` ordering delay at `$12xx` (Goto Frame) time.
+  The redundant-seek path (#306/#307) is untouched — a no-op Goto moves
+  no sled and must not disturb the in-flight stream.
+* **HLE path** (`jagcd_hle.c`): a per-arm `startDelay` counted down in
+  `JaguarCDHLEStreamTick()` before the first byte flows; head position =
+  the in-flight stream LBA, else the parked post-read LBA, else 0 (cold
+  drive — matches the real path's reset `block = 0`). HLE gets only the
+  distance term, not the 100-tick base: its zero-latency arm already
+  landed frames on the same field as the BIOS path (§10.4), so adding the
+  same delta to both preserves that parity exactly. Zeroed when
+  `virtualjaguar_cd_read_speed` is `instant` (the user asked for instant).
+
+Calibration: the measured death branch travels 137,936 sectors (head LBA
+16 125 → 154 061). 137 936 / 72 = 1 915 ticks = 60.9 ms = 3.65 fields —
+moving our 30-field gap to ~33.7 against the 33.4-field reference. Sizes
+of everything else this touches:
+
+| seek | distance | extra delay |
+|---|---|---|
+| DL death branch | ~130–138 k sectors | 60.9 ms (3.65 fields) |
+| DL retry branch | ~133.5 k | 58.9 ms |
+| boot seeks (DL 15 236 / SA 15 479 / BD13 22 656) | 15–23 k | 6.7–10.0 ms |
+| streaming reads | 339–428 | 0.15–0.19 ms (4–5 ticks) |
+
+No tiers: there is exactly one calibrated data point, and a line through
+the origin fits it. `FIFO_REFILL_PERIOD_X100`, the 2-tick refill floor
+(§9.5), the `$15nn` drive-speed latch and the DSA response delay are all
+untouched.
+
+Savestates: unchanged format. The BIOS side reuses the already-serialized
+`seekDelay` counter (it just holds larger values); the HLE stream state was
+never serialized, and the new `startDelay` field follows that existing
+policy.
+
+### 11.3 A/B, per-frame, both modes (method identical to §10.3)
+
+Same fixture, same build host, `libretro/develop` @ `f36ae03` vs +model.
+Note the second-cycle death branch measured here reads LBA 153 995 from
+head 23 862 (distance 130 133), not the first cycle's 138 035 — the game
+re-reads the death clip at a slightly different offset per remaining life.
+
+**Branch A — death clip → "LIVES" card:**
+
+| | BIOS before | BIOS after | HLE before | HLE after |
+|---|---|---|---|---|
+| branch seek issued (field) | 2310.5 | 2316.5 | 1871.2 | 1877.6 |
+| `SEEK_DONE` | +0.19 fields | +3.7 fields | — | — (startDelay 1811 ticks) |
+| last outgoing content | 2311 | 2317 | 1871 | 1878 |
+| fully black run | 2312–2340 (**29**) | 2318–2350 (**33**) | 1872–1901 (**30**) | 1879–1911 (**33**) |
+| first incoming content | 2341 | 2351 | 1902 | 1912 |
+| gap last-out → first-in | 30 | **34** | 31 | **34** |
+
+Black window vs the reference: **33 fields (both modes) vs BigPEmu 33.4** —
+inside the capture's own ±35 ms VFR uncertainty. (The branch fields
+themselves sit ~6 fields later than §10 because the *first* death/retry
+branch pair upstream now also pays its ~3.5-field seeks — the whole
+timeline shifts, which is exactly the 1:1 displacement §8.3 predicted.)
+
+**Branch B — "LIVES" card → retry scene** (distance ~133.5 k → +3.54
+fields): black run 105 → **107** (BIOS) / 105 → **108** (HLE); first-in
+2557 (BIOS) vs 2558 (HLE-aligned +439). The 1-field mode skew is the same
+±1 boundary-rounding ambiguity §10.6 documents for branch A's *outgoing*
+edge; branch A's incoming edge stays field-identical in both modes.
+
+### 11.4 Long-run stability (the ticket's own success criterion)
+
+8 600 fields, fixture presses only (nothing after field 1139), both modes,
+with the model:
+
+```
+bios  deaths at 1139.0  2316.5  3494.1  4671.6  5849.2  | 7314.6 (game over)
+      periods:   1177.5  1177.6  1177.5  1177.6  1465.4
+hle   deaths at  700.1  1877.6  3055.1  4232.7  5410.3  | 6875.7 (game over)
+      periods:   1177.5  1177.5  1177.6  1177.6  1465.4
+```
+
+Six branch cycles per mode: five die/retry loops with the period constant
+to **0.1 field** and the LBA sequence stepping deterministically
+(154 061, 153 995, 153 929, 153 863, 153 797 — −66 sectors per remaining
+life), then the sixth transitions to the game-over scene (24 351 →
+154 127) and back to the attract loop (→ 15 236) — the game ran out of
+lives after five retries.
+
+**Control:** the identical 8 600-field run on the same rev *without* the
+model produces the same 12-branch structure with the byte-identical LBA
+sequence, deaths at period 1 171.5–1 171.6, game over on cycle six. So the
+sixth-cycle scene change is DL game logic, not drift, and the model's only
+effect on the long run is the period: 1 171.5 → 1 177.5, **+6.0 fields per
+cycle, identical for every cycle and in both modes** (each cycle contains
+a death seek + a retry seek plus the game's partial re-sync at the
+playback threshold). Mode alignment holds at +438.9–439.0 fields through
+every die/retry cycle. No early transitions, no late transitions, no
+cross-cycle drift. One residual: the final game-over → attract handoff
+lands 1.6 fields further apart between modes than the control (441.0 vs
+439.4) — a threshold-rounding tail on a transition whose two sides both
+reach attract normally.
+
+### 11.5 Caveats
+
+* **This is reference parity, not silicon ground truth.** BigPEmu is
+  another emulator. No hardware capture of Jaguar CD seek time exists in
+  this project (the JTRM CD-ROM manual specifies landing *tolerance*, not
+  access time). One data point calibrates one constant; if a hardware
+  capture ever materializes, recalibrate `SEEK_SECTORS_PER_TICK` — do not
+  add tiers to a model with a single-point calibration.
+* The boot seek now costs ~7–10 ms (real drives pay it too). Verified
+  benign across the full `cd_boot_matrix.sh` battery in both modes.
+* The capture's two edges carry ±35 ms of VFR frame-spacing uncertainty;
+  matching to ±1 field is the honest resolution limit of the comparison.

--- a/src/cd/cdrom.c
+++ b/src/cd/cdrom.c
@@ -39,13 +39,16 @@
 #endif
 
 // Timing constants for seek and FIFO simulation (in half-line ticks, ~31.8μs each)
-// Per MiSTer FPGA: seek has a multi-tier delay (30-315ms), FIFO fills at I2S rate.
-// These values are shortened for software emulation but preserve the required ordering:
+// SEEK_DELAY_TICKS is a fixed ORDERING delay only; the actual seek-time
+// magnitude is the distance-dependent term below (CDROMSeekDistanceTicks,
+// calibrated to a reference capture -- see that block).  FIFO fills at I2S
+// rate.  The ordering this fixed delay preserves:
 // seek response MUST arrive via interrupt AFTER DSA_tx returns, and FIFO MUST NOT
 // be ready during the DSARX phase (or the 68K handler sends STOP).
 // The BIOS polls BUTCH+2 once after $12xx (no response expected yet), then sends
 // STOP. On real hardware the seek continues internally despite STOP — the drive
-// completes the seek and queues the $0100 response 30-300ms later. The BIOS's
+// completes the seek and queues the $0100 response once the sled arrives
+// (distance-dependent; see CDROMSeekDistanceTicks below). The BIOS's
 // main loop (or DSP) detects the seek completion and initiates data transfer.
 // STOP must NOT cancel the seek delay. Value chosen to be short enough to complete
 // within a few frames but long enough to occur AFTER the BIOS's single poll.

--- a/src/cd/cdrom.c
+++ b/src/cd/cdrom.c
@@ -53,6 +53,42 @@
 #define FIFO_FILL_TICKS      8    // ~254μs before FIFO half-full after play starts
 #define FIFO_DRAIN_READS     16   // 16 word-reads = 8 GPU longword loads = 32 bytes
 
+/* Distance-dependent seek term (reference parity, #297).
+ *
+ * On top of the fixed SEEK_DELAY_TICKS ordering delay above, a real seek
+ * costs time proportional to how far the sled travels.  The old "30-315ms
+ * multi-tier" comment was unsourced and its top end is REFUTED by
+ * measurement: a BigPEmu reference capture of Dragon's Lair's death branch
+ * (2026-08-05, issue #297) shows 558 ms ~= 33.4 fields of black for a
+ * near-full-stroke seek where we showed ~30 fields — i.e. the reference
+ * charges roughly +60 ms on ~138k sectors, tens of ms, not hundreds.
+ *
+ * Model: linear in sector distance, one extra halfline tick (31.78 us)
+ * per SEEK_SECTORS_PER_TICK sectors.  Calibration: the measured branch
+ * seek travels 137,936 sectors (head LBA 16125 -> 154061); 137,936 / 72
+ * = 1,915 ticks = 60.9 ms = 3.65 fields, moving our 30-field gap to
+ * ~33.7 — matching the 33.4-field reference within a field.  Short
+ * streaming seeks (339-428 sectors) add 4-5 ticks (~0.15 ms): nothing.
+ * Boot seeks (15k-23k sectors from the parked head at LBA 0) add 7-10 ms,
+ * which real drives also pay.  No tiers — there is no data for tiers.
+ *
+ * This is REFERENCE PARITY against another emulator, not silicon ground
+ * truth: no hardware capture of Jaguar CD seek time exists yet (the JTRM
+ * CD-ROM manual gives landing tolerance, not access time).  See
+ * docs/fmv-drift-notes.md §11.
+ *
+ * Deliberately NOT applied to the redundant-seek path ($12xx to the block
+ * already playing): that path must not disturb the in-flight stream
+ * (#306/#307), and a no-op Goto moves no sled. */
+#define SEEK_SECTORS_PER_TICK 72
+
+uint32_t CDROMSeekDistanceTicks(uint32_t fromLBA, uint32_t toLBA)
+{
+   uint32_t dist = (toLBA >= fromLBA) ? (toLBA - fromLBA)
+                                      : (fromLBA - toLBA);
+   return dist / SEEK_SECTORS_PER_TICK;
+}
+
 /* Refill pacing: the real drive streams data at double-speed CD-DA rate,
  * 150 sectors/s x 2352 bytes = 352,800 B/s (= the 2x I2S rate).  One
  * half-full batch (8 x 32-bit FIFO entries = 32 bytes) therefore arrives
@@ -1692,7 +1728,14 @@ void CDROMWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
             CDTracePush(CD_TRACE_SEEK_START, data, newBlock);
             dsaResponseReady = false;
             isMultiWordResponse = false;
-            seekDelay = SEEK_DELAY_TICKS;
+            /* Base ordering delay + distance term (see SEEK_SECTORS_PER_TICK
+             * above).  `block` still holds the current head position here —
+             * the position block below updates it.  (An out-of-range seek
+             * gets redirected there; the distance term then overestimates
+             * by the redirect delta, which only affects a pathological
+             * seek that was already being rewritten.) */
+            seekDelay = SEEK_DELAY_TICKS
+                      + (int32_t)CDROMSeekDistanceTicks(block, newBlock);
          }
       }
       else if ((data & 0xFF00) == 0x1000 || (data & 0xFF00) == 0x1100)
@@ -1869,7 +1912,7 @@ void CDROMWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
             if (diag_firstSeekBlock == 0xFFFFFFFFu)
                diag_firstSeekBlock = block;
             CD_LOG("Seek started: block=%u (MSF %02u:%02u:%02u), delay=%d ticks\n",
-                   block, min, sec, frm, SEEK_DELAY_TICKS);
+                   block, min, sec, frm, seekDelay);
          }
       }
       else if ((data & 0xFF00) == 0x1500)			// Set Mode

--- a/src/cd/cdrom.h
+++ b/src/cd/cdrom.h
@@ -18,6 +18,15 @@ void CDROMReset(void);
 void CDROMSetHeadPosition(uint32_t lba);
 void CDROMDone(void);
 
+/* Distance-dependent seek cost in halfline ticks (31.78 us each): one tick
+ * per 72 sectors of head travel, calibrated against a BigPEmu reference
+ * capture of Dragon's Lair's death branch (#297) — ~138k sectors ~= 60.9 ms.
+ * Pure function, shared by the real-BIOS seek state machine (cdrom.c, on
+ * top of its fixed base delay) and the HLE CD_read stream arm
+ * (jagcd_hle.c, which otherwise has no seek at all) so both boot modes
+ * land the same branch gap. */
+uint32_t CDROMSeekDistanceTicks(uint32_t fromLBA, uint32_t toLBA);
+
 void BUTCHExec(uint32_t cycles);
 
 uint8_t CDROMReadByte(uint32_t offset, uint32_t who);

--- a/src/cd/jagcd_hle.c
+++ b/src/cd/jagcd_hle.c
@@ -184,6 +184,15 @@ static struct
                          * rationale as statusBase: flipping the core option
                          * while a transfer is in flight must not change the
                          * rate the game is already pacing itself against. */
+   uint32_t startDelay; /* halfline ticks the stream sits idle before its
+                         * first byte: the distance-dependent seek term
+                         * (CDROMSeekDistanceTicks, #297).  HLE intercepts
+                         * CD_read above BUTCH, so it never runs cdrom.c's
+                         * seek state machine — without this the head
+                         * teleports and HLE branch gaps run ~60 ms shorter
+                         * than the real-BIOS path on full-stroke seeks.
+                         * Zero when the latched speed is CDSPEED_INSTANT
+                         * (the user asked for instant transfers). */
    uint8_t  buf[2352];
 } hleStream;
 
@@ -527,6 +536,7 @@ static void HLEHandleCDRead(void)
    uint32_t startLBA;
    bool wasRedirected = false;
    uint32_t phase;
+   uint32_t seekFromLBA = 0;
 
    lba = ((uint32_t)min * 60 + sec) * 75 + frm;
    if (lba >= 150)
@@ -973,6 +983,19 @@ hle_cd_read_post_scan:
               hleStream.written, hleStream.total, hleStream.reqTotal,
               hleStream.dest);
 
+   /* Head position BEFORE this read repositions it, for the seek-distance
+    * term latched below (must be sampled before the hleStream fields are
+    * overwritten): a still-streaming read leaves the head at its current
+    * streaming LBA; otherwise the drive parked one sector past the last
+    * read (hle_post_read_lba).  A cold drive (no read yet) sits at the
+    * disc start, matching the real path's reset state (block = 0). */
+   if (hleStream.active && hleStream.written < hleStream.total)
+      seekFromLBA = hleStream.lba;
+   else if (hle_post_read_lba != 0xFFFFFFFFu)
+      seekFromLBA = hle_post_read_lba;
+   else
+      seekFromLBA = 0;
+
    hleStream.active   = true;
    hleStream.lba      = scanLBA;
    hleStream.bufOff   = scanOff;
@@ -1001,6 +1024,16 @@ hle_cd_read_post_scan:
    hleStream.sigA0    = a0;
    hleStream.sigA1    = a1;
    hleStream.speedMult = vjs.cdReadSpeed;  /* latch for this transfer */
+   /* Distance-dependent seek term (#297, reference parity — see
+    * CDROMSeekDistanceTicks in cdrom.c for the model + calibration).
+    * Only the distance term, NOT cdrom.c's fixed SEEK_DELAY_TICKS base:
+    * HLE's zero-latency arm already lands branch frames on the same
+    * field as the real path (fmv-drift-notes.md §10.4 — 100 ticks =
+    * 0.19 fields is sub-resolution), so adding the distance term to
+    * both paths preserves that parity exactly. */
+   hleStream.startDelay = (hleStream.speedMult == CDSPEED_INSTANT)
+      ? 0
+      : CDROMSeekDistanceTicks(seekFromLBA, scanLBA);
    hle_stream_arm_count++;
 
    hle_read_dest     = destAddr;
@@ -1230,6 +1263,16 @@ void JaguarCDHLEStreamTick(void)
 
    if (!hleStream.active)
       return;
+
+   /* Seek in flight: the sled is still traveling (distance term latched
+    * at arm time, zero for CDSPEED_INSTANT).  No bytes flow and no byte
+    * budget accrues until it lands — mirrors cdrom.c, where the FIFO
+    * fill starts only after SEEK_DONE. */
+   if (hleStream.startDelay > 0)
+   {
+      hleStream.startDelay--;
+      return;
+   }
 
    if (hleStream.speedMult == CDSPEED_INSTANT)
    {


### PR DESCRIPTION
## Summary

Finishes #297 with the last missing mechanism: a **distance-dependent seek model, calibrated to the BigPEmu reference capture**, applied in both boot modes. One constant, linear in head travel — `SEEK_SECTORS_PER_TICK 72` (1 halfline tick per 72 sectors) via the shared pure function `CDROMSeekDistanceTicks()`.

Calibration math: BigPEmu's death-branch black window (558 ms ≈ 33.4 fields) minus ours (29–30) ≈ 60 ms over the measured head travel of 137,936 sectors → 137,936 / 72 = 1,915 ticks = 60.9 ms. Full-stroke branch ≈ 61 ms; streaming reads (339–428 sectors) ≈ 0.15 ms; boot seeks ≈ 7–10 ms (and BIOS-mode boot seeks are nearly free — the boot-stub shortcut already parks the head at the exe end, so the "boot seek trap" turned out to be an HLE/cold-drive concern only).

- **BIOS path**: `seekDelay = SEEK_DELAY_TICKS + CDROMSeekDistanceTicks(block, newBlock)` in the `$12xx` handler. The unsourced "30–315 ms multi-tier" comment is finally replaced by a calibrated, provenance-carrying model.
- **HLE path**: new `hleStream.startDelay` counted down before any byte flows. HLE gets only the distance term (no 100-tick base) because its zero-latency arm already landed frames on the same field as BIOS — adding the same delta to both preserves mode parity exactly. Zeroed for `CDSPEED_INSTANT`.
- **Untouched by design**: redundant seeks (#306/#307), `FIFO_REFILL_PERIOD_X100`, the 2-tick refill floor, `$15nn` speed latch, DSA delay. **No savestate change** — the BIOS side reuses the already-serialized `seekDelay`; STATE_VERSION stays untouched by this PR.

## Result

| | BIOS before | BIOS after | HLE before | HLE after | BigPEmu ref |
|---|---|---|---|---|---|
| black window (fields) | 29 | **33** | 30 | **33** | **33.4** |

Both modes within ±1 field of the reference (inside the capture's own ±35 ms VFR uncertainty).

**The ticket's own success criterion holds**: 8,600-field runs, six death/retry cycles per mode, period constant to **0.1 field**, LBA sequence byte-identical to a no-model control (154061 → −66/life; the 6th-cycle change is Dirk running out of lives, confirmed in the control). No drift, no early/late transitions. Interesting find: the cycle period grew only +6.0 fields against +7.2 of added seek — the game partially re-syncs at its playback threshold, so the 1:1 rule applies to the immediate boundary only.

## Gates

- **CD boot matrix: all 22 rows GAME_CODE, both modes**, fresh run (an earlier run was invalidated when a baseline rebuild swapped the dylib mid-run at the same `-dirty` build-id — a known guard blind spot — and was redone clean)
- `make TEST_EXPORTS=1 test` exit 0 twice (pre- and post-rebase, build-id verified); every seek-related synth test green unmodified, audio pair by name
- Space Ace + BrainDead 13 boot-to-attract verified both modes; drain counts identical to baseline (104,311 @ f3500); watchdog lines match the committed benign-idle signatures
- Independently re-verified before this PR: rebuild + `test_cd_synth_butch` 8/8, `test_cd_synth_cdda` 5/5, DL branch fixture PASS
- c89-lint clean; docs updated (`fmv-drift-notes.md` §11, `cd-known-issues.md` §2 → RESOLVED)

## Standing caveat

This is **reference parity with another emulator, not silicon ground truth** — one data point calibrates one constant. If a hardware capture materializes, recalibrate `SEEK_SECTORS_PER_TICK`; don't add tiers.

Closes #297 (manual close — develop merges don't auto-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
