### PR TITLE
docs: correct stale CHD claim; document JagGD / VLM / clock-scale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,8 @@ Frame loop is event-driven (not cycle-accurate): `JaguarExecuteNew()` in `src/co
 - `src/core/` — orchestration, memory map, events, settings, files, cheats
 - `src/tom/` — video, GPU, OP, blitter (+ SIMD)
 - `src/jerry/` — audio, DSP, DAC, EEPROM, input, wavetable, UART/netlink (`uart.c` + `jlink.c`, see `docs/netlink-design.md`)
-- `src/cd/` — Jaguar CD: BUTCH/FIFO/DSA in `cdrom.c`, image loading (CUE/BIN, CHD, CDI) in `cdintf.c`; BIOS auth bypass + boot stub in `src/core/jaguar.c`
+- `src/cd/` — Jaguar CD: BUTCH/FIFO/DSA/Q-subcode in `cdrom.c`, image loading (CUE/BIN, CDI — **no CHD**, removed during the CD overhaul; see issue #322) in `cdintf.c`; BIOS auth bypass + boot stub in `src/core/jaguar.c`
+- `src/core/jaggd.c` — Jaguar GameDrive: SPI mailbox at `$F16000`, embedded GDBIOS blob, 6×1MB page → 16-bank switching for images up to 16 MB (spec: `docs/jgd-interface-notes.md`)
 - `src/bios/` — embedded BIOS / boot stubs
 - `src/m68000/` — UAE 68K (machine-generated; treat as opaque)
 - `libretro-common/` — shared utility lib

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is the actively maintained **Atari Jaguar and Jaguar CD emulator** for [lib
 - Supported ROM formats: `.j64`, `.jag`, `.rom`, `.abs`, `.cof`, `.bin`, `.prg` (including inside ZIP archives), plus `.cue` and `.cdi` for Jaguar CD images, and conservative headerless raw homebrew loading
 - Network link play (JagLink / CatBox emulation): Doom deathmatch, AirCars, BattleSphere Gold — via RetroArch netplay, or a direct TCP link between frontends on socket-capable platforms ([setup guide](docs/netlink-user-guide.md))
 - Jaguar GameDrive (JagGD) cartridges: bank switching for images up to 16 MB, so GD-locked homebrew boots
-- Audio CDs play through the Jaguar CD player and its Virtual Light Machine visualiser
+- Audio CDs play through the Jaguar CD player and its Virtual Light Machine visualizer (set **CD Boot Mode** to `Auto` or `Real BIOS` — audio-only discs have no session-2 boot stub for the HLE path)
 - Optional M68K / RISC clock-scale (overclock) core options for framerate-limited titles
 
 ## Recent improvements (libretro fork)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This is the actively maintained **Atari Jaguar and Jaguar CD emulator** for [lib
 - Save state, run-ahead (deterministic serialization), SRAM/EEPROM via the libretro SRAM interface, cheat codes, and a memory map for RetroAchievements
 - Supported ROM formats: `.j64`, `.jag`, `.rom`, `.abs`, `.cof`, `.bin`, `.prg` (including inside ZIP archives), plus `.cue` and `.cdi` for Jaguar CD images, and conservative headerless raw homebrew loading
 - Network link play (JagLink / CatBox emulation): Doom deathmatch, AirCars, BattleSphere Gold — via RetroArch netplay, or a direct TCP link between frontends on socket-capable platforms ([setup guide](docs/netlink-user-guide.md))
+- Jaguar GameDrive (JagGD) cartridges: bank switching for images up to 16 MB, so GD-locked homebrew boots
+- Audio CDs play through the Jaguar CD player and its Virtual Light Machine visualiser
+- Optional M68K / RISC clock-scale (overclock) core options for framerate-limited titles
 
 ## Recent improvements (libretro fork)
 


### PR DESCRIPTION
Pre-release docs audit.

**Stale and wrong:** `CLAUDE.md` listed CHD among `cdintf.c`'s supported image formats. CHD was removed during the CD overhaul — there is no libchdr in-tree — and #322 now records why plus what MAME-side work would be needed first. Corrected, with the layout entry for `src/core/jaggd.c` and a mention of Q-subcode in `cdrom.c`.

**Missing:** the README feature list predated v3.1.0's user-visible additions — GameDrive cartridges, audio-CD/VLM playback, and the clock-scale options.

Verified accurate as-is (no change needed): `docs/savestate-compat.md` already records v8 + `STATE_VERSION_JAGGD`; `docs/cd-known-issues.md` §1 and §2 are struck through as RESOLVED with the #297 measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)