### PR TITLE
fix(cd): emit boot-stub hex dumps as one line each

### DIFF
--- a/src/cd/cdintf.c
+++ b/src/cd/cdintf.c
@@ -1483,14 +1483,27 @@ bool CDIntfExtractBootStub(uint8_t *outBuf, uint32_t outBufSize,
       swapped[i + 1] = raw[i];
    }
 
-   LOG_DBG("[CD-BOOTSTUB] Raw bytes 0x40-0x6F (pre-swap): ");
-   for (i = 0x40; i < 0x70 && i < (uint32_t)bytesRead; i++)
-      LOG_DBG("%02X ", raw[i]);
-   LOG_DBG("\n");
-   LOG_DBG("[CD-BOOTSTUB] Swapped bytes 0x40-0x6F: ");
-   for (i = 0x40; i < 0x70 && i < (uint32_t)bytesRead; i++)
-      LOG_DBG("%02X ", swapped[i]);
-   LOG_DBG("\n");
+   /* One LOG_DBG per byte produced 48 separate log lines: the frontend's
+    * log callback prefixes and newline-terminates every call, so a
+    * partial-line idiom does not concatenate. Format into a buffer and
+    * emit each dump as a single line. */
+   {
+      char hex[0x30 * 3 + 1];
+      uint32_t n;
+      uint32_t last = (0x70 < (uint32_t)bytesRead) ? 0x70 : (uint32_t)bytesRead;
+
+      n = 0;
+      for (i = 0x40; i < last; i++)
+         n += (uint32_t)sprintf(hex + n, "%02X ", raw[i]);
+      hex[n] = '\0';
+      LOG_DBG("[CD-BOOTSTUB] Raw bytes 0x40-0x6F (pre-swap): %s\n", hex);
+
+      n = 0;
+      for (i = 0x40; i < last; i++)
+         n += (uint32_t)sprintf(hex + n, "%02X ", swapped[i]);
+      hex[n] = '\0';
+      LOG_DBG("[CD-BOOTSTUB] Swapped bytes 0x40-0x6F: %s\n", hex);
+   }
    LOG_DBG("[CD-BOOTSTUB] Swapped as text: '%.32s'\n", swapped + 0x42);
 
    if (memcmp(swapped + 0x42, MAGIC, sizeof(MAGIC)) != 0)

--- a/src/cd/cdintf.c
+++ b/src/cd/cdintf.c
@@ -1485,24 +1485,33 @@ bool CDIntfExtractBootStub(uint8_t *outBuf, uint32_t outBufSize,
 
    /* One LOG_DBG per byte produced 48 separate log lines: the frontend's
     * log callback prefixes and newline-terminates every call, so a
-    * partial-line idiom does not concatenate. Format into a buffer and
-    * emit each dump as a single line. */
+    * partial-line idiom does not concatenate.  Build each dump with
+    * fixed indexing (no sprintf in a loop: the bounds are then obvious
+    * by construction and no format string is involved) and emit it as a
+    * single line. */
    {
-      char hex[0x30 * 3 + 1];
-      uint32_t n;
+      static const char hexd[] = "0123456789ABCDEF";
+      char rawhex[0x30 * 3 + 1];
+      char swphex[0x30 * 3 + 1];
       uint32_t last = (0x70 < (uint32_t)bytesRead) ? 0x70 : (uint32_t)bytesRead;
+      uint32_t n = 0;
 
-      n = 0;
-      for (i = 0x40; i < last; i++)
-         n += (uint32_t)sprintf(hex + n, "%02X ", raw[i]);
-      hex[n] = '\0';
-      LOG_DBG("[CD-BOOTSTUB] Raw bytes 0x40-0x6F (pre-swap): %s\n", hex);
+      for (i = 0x40; i < last; i++, n += 3)
+      {
+         rawhex[n]     = hexd[(raw[i] >> 4) & 0x0F];
+         rawhex[n + 1] = hexd[raw[i] & 0x0F];
+         rawhex[n + 2] = ' ';
+         swphex[n]     = hexd[(swapped[i] >> 4) & 0x0F];
+         swphex[n + 1] = hexd[swapped[i] & 0x0F];
+         swphex[n + 2] = ' ';
+      }
+      rawhex[n] = '\0';
+      swphex[n] = '\0';
 
-      n = 0;
-      for (i = 0x40; i < last; i++)
-         n += (uint32_t)sprintf(hex + n, "%02X ", swapped[i]);
-      hex[n] = '\0';
-      LOG_DBG("[CD-BOOTSTUB] Swapped bytes 0x40-0x6F: %s\n", hex);
+      LOG_DBG("[CD-BOOTSTUB] Raw bytes 0x40-0x%02X (pre-swap): %s\n",
+              (unsigned)(last ? last - 1 : 0), rawhex);
+      LOG_DBG("[CD-BOOTSTUB] Swapped bytes 0x40-0x%02X: %s\n",
+              (unsigned)(last ? last - 1 : 0), swphex);
    }
    LOG_DBG("[CD-BOOTSTUB] Swapped as text: '%.32s'\n", swapped + 0x42);
 


### PR DESCRIPTION
Reported from a real device log: the `[CD-BOOTSTUB] Raw bytes` dump printed **one byte per line** — 48 lines per boot, twice. The per-byte `LOG_DBG` partial-line idiom doesn't work because the frontend's log callback prefixes and newline-terminates every call. Formats into a buffer and emits each dump once.

DEBUG-gated either way, so no effect on normal runs; the payoff is that CD boot-stub traces are readable when someone actually needs them.

Verified: build clean, c89-lint passes, `make TEST_EXPORTS=1 test` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)