### PR TITLE
perf(blitter): inline the SIMD ops into BlitterMidsummer2 (+16% accurate blitter on Tempest 2000)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1214,7 +1214,8 @@ test/test_tom_visible_window: test/test_tom_visible_window.c src/tom/tom.c \
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_tom_visible_window.c
 
-test/test_blitter_simd: test/test_blitter_simd.c $(BLITTER_SIMD_SRC) src/tom/blitter_simd.h
+test/test_blitter_simd: test/test_blitter_simd.c $(BLITTER_SIMD_SRC) src/tom/blitter_simd.h \
+	$(BLITTER_SIMD_SRC:.c=.h)
 	$(CC) $(CFLAGS) -o $@ test/test_blitter_simd.c $(BLITTER_SIMD_SRC)
 
 test/test_dsp_mac40: test/test_dsp_mac40.c src/jerry/dsp_acc40.h

--- a/Makefile.common
+++ b/Makefile.common
@@ -135,6 +135,18 @@ endif
 
 SOURCES_C += $(BLITTER_SIMD_SRC)
 
+# Tell blitter_simd.h which implementation header to inline into
+# blitter.c.  This must agree with the .c file selected above; if it
+# doesn't, that .c fails to compile (duplicate definitions) instead of
+# quietly running one impl while the vtable test validates another.
+ifeq ($(BLITTER_SIMD_SRC),$(CORE_DIR)/src/tom/blitter_simd_sse2.c)
+   CFLAGS += -DBLITTER_SIMD_SSE2
+else ifeq ($(BLITTER_SIMD_SRC),$(CORE_DIR)/src/tom/blitter_simd_neon.c)
+   CFLAGS += -DBLITTER_SIMD_NEON
+else
+   CFLAGS += -DBLITTER_SIMD_SCALAR
+endif
+
 # Add -msse2 flag for all GCC/Clang SSE2 builds. No-op on x86_64 (baseline),
 # required on i686 / gcc -m32. Skip for MSVC (uses /arch:SSE2, not -msse2).
 ifeq ($(BLITTER_SIMD_SRC),$(CORE_DIR)/src/tom/blitter_simd_sse2.c)

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -1259,7 +1259,7 @@ void ADDARRAY(uint16_t *addq, uint8_t daddasel, uint8_t daddbsel,
    sat = daddmode & 0x03;
    hicinh = ((daddmode & 0x03) == 0x03);
 
-   blitter_simd_ops.add16sat_x4(addq, co, adda, addb, cin, sat, eightbit, hicinh);
+   blitter_simd_add16sat_x4(addq, co, adda, addb, cin, sat, eightbit, hicinh);
 }
 
 static BLITTER_ALWAYS_INLINE
@@ -1424,7 +1424,7 @@ Patdhi		:= JOIN (patdhi, patd[32..63]);*/
 
 /*Lfu		:= LFU (lfu[0..1], srcdlo, srcdhi, dstdlo, dstdhi, lfu_func[0..3]);*/
 ////////////////////////////////////// C++ CODE //////////////////////////////////////
-	uint64_t lfu = blitter_simd_ops.lfu(srcd, dstd, lfu_func);
+	uint64_t lfu = blitter_simd_lfu(srcd, dstd, lfu_func);
    bool mir_bit, mir_byte;
    uint16_t masku;
    uint8_t e_coarse, e_fine;
@@ -1460,7 +1460,7 @@ Zstep		:= JOIN (zstep, zstep[0..31]);*/
 	/* srcd_cmp is the source data as read from memory; srcd may carry the
 	 * SRCSHADE intensity offset.  The transparency comparison keys on the
 	 * unshaded pixel -- see the SRCSHADE block in BlitterMidsummer2. */
-	*dcomp = blitter_simd_ops.dcomp(*patd, srcd_cmp, dstd, cmpdst);
+	*dcomp = blitter_simd_dcomp(*patd, srcd_cmp, dstd, cmpdst);
 
 	/* Source-pixel transparency for DCOMPEN+!CMPDST.
 	 *
@@ -1526,7 +1526,7 @@ Zstep		:= JOIN (zstep, zstep[0..31]);*/
 with srcshift bits 4 & 5 selecting the start position
 */
 //So... basically what we have here is:
-	*zcomp = blitter_simd_ops.zcomp(*srcz, dstz, zmode);
+	*zcomp = blitter_simd_zcomp(*srcz, dstz, zmode);
 
 //TEMP, TO TEST IF ZCOMP IS THE CULPRIT...
 //Nope, this is NOT the problem...
@@ -1781,8 +1781,8 @@ Dat[40-47]	:= MX4 (dat[40-47], dstdhi{8-15},  ddathi{8-15},  dstzhi{8-15},  srcz
 Dat[48-55]	:= MX4 (dat[48-55], dstdhi{16-23}, ddathi{16-23}, dstzhi{16-23}, srczhi{16-23}, mask[13],  zed_selb[1]);
 Dat[56-63]	:= MX4 (dat[56-63], dstdhi{24-31}, ddathi{24-31}, dstzhi{24-31}, srczhi{24-31}, mask[14],  zed_selb[1]);*/
 ////////////////////////////////////// C++ CODE //////////////////////////////////////
-	*wdata = blitter_simd_ops.byte_merge(ddat, dstd, mask);
-	*srcz = blitter_simd_ops.byte_merge(*srcz, dstz, mask);
+	*wdata = blitter_simd_byte_merge(ddat, dstd, mask);
+	*srcz = blitter_simd_byte_merge(*srcz, dstz, mask);
 //////////////////////////////////////////////////////////////////////////////////////
 
 /*Data_enab[0-1]	:= BUF8 (data_enab[0-1], data_ena);

--- a/src/tom/blitter_simd.h
+++ b/src/tom/blitter_simd.h
@@ -2,11 +2,24 @@
  * SIMD-accelerated blitter operations for Virtual Jaguar
  *
  * Provides architecture-specific implementations of the blitter's
- * hottest data-path operations. Only one implementation file is
- * compiled per build (selected in Makefile.common).
+ * hottest data-path operations. Only one implementation is active per
+ * build; the arch is selected in Makefile.common, which compiles the
+ * matching blitter_simd_<arch>.c *and* passes -DBLITTER_SIMD_<ARCH>.
  *
- * Each arch file defines:
- *   const blitter_simd_ops_t blitter_simd_ops = { ... };
+ * The implementations live in blitter_simd_<arch>.h as static inline
+ * functions so BlitterMidsummer2 can inline them.  That matters: these
+ * are a handful of SIMD instructions each, called up to six times per
+ * inner-loop iteration, and Tempest 2000 runs ~99k inner iterations per
+ * frame.  Reaching them through the blitter_simd_ops function-pointer
+ * table (a different translation unit, and no LTO on any desktop
+ * target) cost ~21% of accurate-blitter runtime in indirect-call and
+ * argument-marshalling overhead, and it also defeated the per-call-site
+ * specialisation that ADDARRAY's BLITTER_ALWAYS_INLINE exists to enable
+ * -- sat/eightbit/hicinh are compile-time constants at those sites.
+ *
+ * blitter_simd_ops still exists, and each arch .c file builds it out of
+ * thin wrappers around the very same inline functions, so
+ * test/test_blitter_simd.c validates exactly the code the core runs.
  */
 
 #ifndef BLITTER_SIMD_H
@@ -14,6 +27,16 @@
 
 #include <stdint.h>
 #include <boolean.h>
+
+/* Portable always-inline, spelled to include the inline keyword itself
+ * (MSVC's __forceinline IS the inline keyword for that compiler). */
+#if defined(_MSC_VER)
+#  define BLITTER_SIMD_INLINE __forceinline
+#elif defined(__GNUC__) || defined(__clang__)
+#  define BLITTER_SIMD_INLINE inline __attribute__((always_inline))
+#else
+#  define BLITTER_SIMD_INLINE inline
+#endif
 
 typedef struct
 {
@@ -58,5 +81,21 @@ typedef struct
 } blitter_simd_ops_t;
 
 extern const blitter_simd_ops_t blitter_simd_ops;
+
+/* Pull in the selected implementation as static inline functions:
+ *   blitter_simd_lfu / _dcomp / _zcomp / _byte_merge / _add16sat_x4
+ *
+ * Makefile.common defines exactly one of these to match the .c file it
+ * added to SOURCES_C.  Builds that don't go through it (ndk-build, and
+ * every MSVC target) get scalar, which is what those already selected.
+ * A mismatch between the -D and the compiled .c is a hard compile error
+ * rather than a silent slow path -- see blitter_simd_<arch>.c. */
+#if defined(BLITTER_SIMD_NEON)
+#  include "blitter_simd_neon.h"
+#elif defined(BLITTER_SIMD_SSE2)
+#  include "blitter_simd_sse2.h"
+#else
+#  include "blitter_simd_scalar.h"
+#endif
 
 #endif /* BLITTER_SIMD_H */

--- a/src/tom/blitter_simd_neon.c
+++ b/src/tom/blitter_simd_neon.c
@@ -1,298 +1,47 @@
 /*
- * Blitter SIMD ops — ARM NEON implementation
+ * Blitter SIMD ops -- out-of-line neon vtable.
  *
- * NEON is mandatory on AArch64 and available on most ARMv7-A with
- * VFPv3. The Makefile selects this file when targeting ARM64 or
- * when HAVE_NEON=1.
+ * The implementations themselves live in blitter_simd_neon.h so that
+ * blitter.c can inline them (see blitter_simd.h).  This file only
+ * provides the function-pointer table, which test/test_blitter_simd.c
+ * uses to exercise the very same code the core runs.
  */
 
 #include "blitter_simd.h"
-#include <arm_neon.h>
+#include "blitter_simd_neon.h"
 
-/* Logic Function Unit — NEON
- *
- * Same truth-table approach as scalar, but using 64-bit NEON
- * integer operations (uint64x1_t).
- */
-static uint64_t neon_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
+static uint64_t ops_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
 {
-   uint64x1_t vs  = vcreate_u64(srcd);
-   uint64x1_t vd  = vcreate_u64(dstd);
-   /* NEON vmvn only works up to 32-bit, so we use EOR with all-ones */
-   uint64x1_t ones = vcreate_u64(0xFFFFFFFFFFFFFFFFULL);
-   uint64x1_t vns = veor_u64(vs, ones);  /* ~srcd */
-   uint64x1_t vnd = veor_u64(vd, ones);  /* ~dstd */
-
-   uint64x1_t vf0 = vcreate_u64((lfu_func & 0x01) ? 0xFFFFFFFFFFFFFFFFULL : 0);
-   uint64x1_t vf1 = vcreate_u64((lfu_func & 0x02) ? 0xFFFFFFFFFFFFFFFFULL : 0);
-   uint64x1_t vf2 = vcreate_u64((lfu_func & 0x04) ? 0xFFFFFFFFFFFFFFFFULL : 0);
-   uint64x1_t vf3 = vcreate_u64((lfu_func & 0x08) ? 0xFFFFFFFFFFFFFFFFULL : 0);
-
-   /* (~s & ~d & f0) | (~s & d & f1) | (s & ~d & f2) | (s & d & f3) */
-   uint64x1_t t0 = vand_u64(vand_u64(vns, vnd), vf0);
-   uint64x1_t t1 = vand_u64(vand_u64(vns, vd),  vf1);
-   uint64x1_t t2 = vand_u64(vand_u64(vs,  vnd), vf2);
-   uint64x1_t t3 = vand_u64(vand_u64(vs,  vd),  vf3);
-
-   uint64x1_t result = vorr_u64(vorr_u64(t0, t1), vorr_u64(t2, t3));
-   return vget_lane_u64(result, 0);
+   return blitter_simd_lfu(srcd, dstd, lfu_func);
 }
 
-/* Data Comparator — NEON
- *
- * XOR + per-byte zero check. NEON vceq gives 0xFF per matching byte,
- * then we extract one bit per byte.
- */
-static uint8_t neon_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
+static uint8_t ops_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
 {
-   uint64_t other = cmpdst ? dstd : srcd;
-   uint8x8_t vp = vreinterpret_u8_u64(vcreate_u64(patd));
-   uint8x8_t vo = vreinterpret_u8_u64(vcreate_u64(other));
-
-   /* XOR then compare each byte to zero */
-   uint8x8_t vxor = veor_u8(vp, vo);
-   uint8x8_t vzero = vdup_n_u8(0);
-   uint8x8_t vcmp = vceq_u8(vxor, vzero);  /* 0xFF where equal, 0 otherwise */
-
-   /* Convert compare lanes from 0xFF/0x00 to 1/0, then pack into
-    * the result byte via lane extraction — avoids weights load
-    * and vpadd chain. */
-   uint8x8_t vbits = vshr_n_u8(vcmp, 7);
-
-   return (uint8_t)(
-      (vget_lane_u8(vbits, 0) << 0) |
-      (vget_lane_u8(vbits, 1) << 1) |
-      (vget_lane_u8(vbits, 2) << 2) |
-      (vget_lane_u8(vbits, 3) << 3) |
-      (vget_lane_u8(vbits, 4) << 4) |
-      (vget_lane_u8(vbits, 5) << 5) |
-      (vget_lane_u8(vbits, 6) << 6) |
-      (vget_lane_u8(vbits, 7) << 7));
+   return blitter_simd_dcomp(patd, srcd, dstd, cmpdst);
 }
 
-/* Z-buffer Comparator — NEON
- *
- * 4 packed unsigned 16-bit comparisons. NEON has native unsigned
- * compare instructions (vclt_u16, vceq_u16, vcgt_u16).
- */
-static uint8_t neon_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
+static uint8_t ops_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
 {
-   uint16x4_t vs = vreinterpret_u16_u64(vcreate_u64(srcz));
-   uint16x4_t vd = vreinterpret_u16_u64(vcreate_u64(dstz));
-   uint16x4_t vresult = vdup_n_u16(0);
-
-   if (zmode & 0x01)  /* LT */
-      vresult = vorr_u16(vresult, vclt_u16(vs, vd));
-   if (zmode & 0x02)  /* EQ */
-      vresult = vorr_u16(vresult, vceq_u16(vs, vd));
-   if (zmode & 0x04)  /* GT */
-      vresult = vorr_u16(vresult, vcgt_u16(vs, vd));
-
-   /* Extract one bit per 16-bit lane.
-    * vresult lanes are 0xFFFF or 0x0000. Narrow and extract. */
-   /* Shift each lane: lane0 >> 0, lane1 >> 1, lane2 >> 2, lane3 >> 3
-    * But easier: just read each lane */
-   uint8_t result = 0;
-   if (vget_lane_u16(vresult, 0)) result |= 0x01;
-   if (vget_lane_u16(vresult, 1)) result |= 0x02;
-   if (vget_lane_u16(vresult, 2)) result |= 0x04;
-   if (vget_lane_u16(vresult, 3)) result |= 0x08;
-
-   return result;
+   return blitter_simd_zcomp(srcz, dstz, zmode);
 }
 
-/* Byte Mask Merge — NEON
- *
- * Build a byte-level mask, then use vbsl (bitwise select) to blend.
- * vbsl(mask, src, dst) = (src & mask) | (dst & ~mask)
- */
-static uint64_t neon_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
+static uint64_t ops_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
 {
-   /* Build 8-byte selection mask entirely in registers.
-    * Byte 0 uses the low 8 bits directly; bytes 1-7 are all-ones or
-    * all-zero based on mask bits 8-14. */
-   uint64_t sel =
-      ((uint64_t)(mask & 0x00FF)) |
-      ((uint64_t)((mask & 0x0100) ? 0xFF : 0x00) <<  8) |
-      ((uint64_t)((mask & 0x0200) ? 0xFF : 0x00) << 16) |
-      ((uint64_t)((mask & 0x0400) ? 0xFF : 0x00) << 24) |
-      ((uint64_t)((mask & 0x0800) ? 0xFF : 0x00) << 32) |
-      ((uint64_t)((mask & 0x1000) ? 0xFF : 0x00) << 40) |
-      ((uint64_t)((mask & 0x2000) ? 0xFF : 0x00) << 48) |
-      ((uint64_t)((mask & 0x4000) ? 0xFF : 0x00) << 56);
-
-   uint8x8_t vmask = vreinterpret_u8_u64(vcreate_u64(sel));
-   uint8x8_t vsrc  = vreinterpret_u8_u64(vcreate_u64(src));
-   uint8x8_t vdst  = vreinterpret_u8_u64(vcreate_u64(dst));
-
-   /* vbsl: for each bit, selects src where mask=1, dst where mask=0 */
-   uint8x8_t result = vbsl_u8(vmask, vsrc, vdst);
-
-   return vget_lane_u64(vreinterpret_u64_u8(result), 0);
+   return blitter_simd_byte_merge(src, dst, mask);
 }
 
-/* ADD16SAT x4 — NEON
- *
- * Processes all four 16-bit lanes in parallel using NEON 16x4 vectors.
- * The Jaguar's segmented carry chain (low byte / mid nibble / high nibble)
- * is replicated across all 4 lanes simultaneously.
- *
- * Stage 1: low byte  (bits 7:0)   — add with per-lane cin
- * Stage 2: mid nibble (bits 11:8) — add with carry from stage 1 (if !eightbit)
- * Stage 3: high nibble (bits 15:12)— add with carry from stage 2 (if !hicinh)
- * Then: saturation logic based on overflow detection.
- */
-static void neon_add16sat_x4(uint16_t *addq, uint8_t *co,
-                              const uint16_t *adda, const uint16_t *addb,
-                              const uint8_t *cin,
-                              bool sat, bool eightbit, bool hicinh)
+static void ops_add16sat_x4(uint16_t *addq, uint8_t *co,
+                            const uint16_t *adda, const uint16_t *addb,
+                            const uint8_t *cin,
+                            bool sat, bool eightbit, bool hicinh)
 {
-   /* Load operands into NEON 16x4 vectors */
-   uint16x4_t va = vld1_u16(adda);
-   uint16x4_t vb = vld1_u16(addb);
-
-   /* Masks for isolating bit fields */
-   uint16x4_t mask_lo  = vdup_n_u16(0x00FF);
-   uint16x4_t mask_mid = vdup_n_u16(0x0F00);
-   uint16x4_t mask_hi  = vdup_n_u16(0xF000);
-   uint16x4_t vzero    = vdup_n_u16(0);
-   uint16x4_t vone     = vdup_n_u16(1);
-
-   /* Expand cin[0..3] from uint8_t to uint16x4_t */
-   uint16_t cin16[4];
-   uint16x4_t vcin;
-
-   /* Stage 1 results */
-   uint16x4_t va_lo, vb_lo, sum1, q_lo, carry0, carry1;
-
-   /* Stage 2 results */
-   uint16x4_t va_mid, vb_mid, carry_shifted1, sum2, q_mid, carry2, carry3;
-
-   /* Stage 3 results */
-   uint16x4_t va_hi, vb_hi, carry_shifted3, sum3, q_hi;
-
-   /* Combine result */
-   uint16x4_t q;
-
-   /* Saturation */
-   uint16x4_t btop, ctop, do_saturate;
-   uint16x4_t sat_lo_fill, sat_hi_fill;
-   uint16x4_t sat_lo_zero, sat_hi_zero;
-
-   cin16[0] = cin[0]; cin16[1] = cin[1]; cin16[2] = cin[2]; cin16[3] = cin[3];
-   vcin = vld1_u16(cin16);
-
-   /* Stage 1: low byte add */
-   va_lo = vand_u16(va, mask_lo);
-   vb_lo = vand_u16(vb, mask_lo);
-   sum1  = vadd_u16(vadd_u16(va_lo, vb_lo), vcin);
-   q_lo  = vand_u16(sum1, mask_lo);
-
-   /* carry0 = (sum1 & 0x100) ? 1 : 0 */
-   carry0 = vshr_n_u16(vand_u16(sum1, vdup_n_u16(0x0100)), 8);
-
-   /* carry1 = carry0 if !eightbit, else 0 */
-   carry1 = eightbit ? vzero : carry0;
-
-   /* Stage 2: mid nibble add */
-   va_mid = vand_u16(va, mask_mid);
-   vb_mid = vand_u16(vb, mask_mid);
-   carry_shifted1 = vshl_n_u16(carry1, 8);
-   sum2   = vadd_u16(vadd_u16(va_mid, vb_mid), carry_shifted1);
-   q_mid  = vand_u16(sum2, mask_mid);
-
-   /* carry2 = (sum2 & 0x1000) ? 1 : 0 */
-   carry2 = vshr_n_u16(vand_u16(sum2, vdup_n_u16(0x1000)), 12);
-
-   /* carry3 = carry2 if !hicinh, else 0 */
-   carry3 = hicinh ? vzero : carry2;
-
-   /* Stage 3: high nibble add */
-   va_hi = vand_u16(va, mask_hi);
-   vb_hi = vand_u16(vb, mask_hi);
-   carry_shifted3 = vshl_n_u16(carry3, 12);
-   sum3   = vadd_u16(vadd_u16(va_hi, vb_hi), carry_shifted3);
-   q_hi   = vand_u16(sum3, mask_hi);
-
-   /* co[i] = (sum3 & 0x10000) ? 1 : 0 — detect carry out of bit 15.
-    * Since our lanes are only 16-bit, the carry is lost. Widen to
-    * 32-bit for the overflow detection. */
-   {
-      /* Use 32-bit arithmetic to capture the carry */
-      uint32_t s0 = (uint32_t)(adda[0] & 0xF000) + (addb[0] & 0xF000) + ((uint32_t)vget_lane_u16(carry3, 0) << 12);
-      uint32_t s1 = (uint32_t)(adda[1] & 0xF000) + (addb[1] & 0xF000) + ((uint32_t)vget_lane_u16(carry3, 1) << 12);
-      uint32_t s2 = (uint32_t)(adda[2] & 0xF000) + (addb[2] & 0xF000) + ((uint32_t)vget_lane_u16(carry3, 2) << 12);
-      uint32_t s3 = (uint32_t)(adda[3] & 0xF000) + (addb[3] & 0xF000) + ((uint32_t)vget_lane_u16(carry3, 3) << 12);
-      co[0] = (s0 & 0x10000) ? 1 : 0;
-      co[1] = (s1 & 0x10000) ? 1 : 0;
-      co[2] = (s2 & 0x10000) ? 1 : 0;
-      co[3] = (s3 & 0x10000) ? 1 : 0;
-   }
-
-   /* Combine low + mid + high */
-   q = vorr_u16(vorr_u16(q_lo, q_mid), q_hi);
-
-   /* Saturation logic */
-   if (sat)
-   {
-      uint16_t co16[4];
-      uint16x4_t vco;
-      uint16x4_t do_hi_saturate;
-      uint16x4_t result_lo, result_hi;
-
-      co16[0] = co[0]; co16[1] = co[1]; co16[2] = co[2]; co16[3] = co[3];
-      vco = vld1_u16(co16);
-
-      if (eightbit)
-      {
-         btop = vshr_n_u16(vand_u16(vb, vdup_n_u16(0x0080)), 7);
-         ctop = carry0;
-      }
-      else
-      {
-         btop = vshr_n_u16(vb, 15);
-         ctop = vco;
-      }
-
-      /* saturate = sat && (btop ^ ctop) — sat is already true here */
-      do_saturate = veor_u16(btop, ctop); /* non-zero where we saturate */
-
-      /* do_hi_saturate = do_saturate && !eightbit */
-      do_hi_saturate = eightbit ? vzero : do_saturate;
-
-      /* When saturating:
-       *   low byte = ctop ? 0xFF : 0x00
-       *   high byte = ctop ? 0xFF00 : 0x0000 (only if !eightbit)
-       * When not saturating, keep q as-is. */
-
-      /* Expand ctop/do_saturate from {0,1} to full 16-bit masks {0x0000,0xFFFF} */
-      {
-         uint16x4_t ctop_mask     = vceq_u16(ctop, vone);          /* 0xFFFF where ctop=1 */
-         uint16x4_t sat_mask      = vceq_u16(do_saturate, vone);   /* 0xFFFF where saturating */
-         uint16x4_t hi_sat_mask   = vceq_u16(do_hi_saturate, vone);
-
-         /* Build saturated fill values: ctop_mask ? 0x00FF/0xFF00 : 0x0000 */
-         sat_lo_fill  = vand_u16(ctop_mask, vdup_n_u16(0x00FF));
-         sat_hi_fill  = vand_u16(ctop_mask, vdup_n_u16(0xFF00));
-
-         /* Build non-saturated values */
-         sat_lo_zero  = vand_u16(q, mask_lo);
-         sat_hi_zero  = vand_u16(q, vdup_n_u16(0xFF00));
-
-         result_lo = vbsl_u16(sat_mask, sat_lo_fill, sat_lo_zero);
-         result_hi = vbsl_u16(hi_sat_mask, sat_hi_fill, sat_hi_zero);
-      }
-
-      q = vorr_u16(result_lo, result_hi);
-   }
-
-   vst1_u16(addq, q);
+   blitter_simd_add16sat_x4(addq, co, adda, addb, cin, sat, eightbit, hicinh);
 }
 
 const blitter_simd_ops_t blitter_simd_ops = {
-   neon_lfu,
-   neon_dcomp,
-   neon_zcomp,
-   neon_byte_merge,
-   neon_add16sat_x4
+   ops_lfu,
+   ops_dcomp,
+   ops_zcomp,
+   ops_byte_merge,
+   ops_add16sat_x4
 };

--- a/src/tom/blitter_simd_neon.c
+++ b/src/tom/blitter_simd_neon.c
@@ -7,6 +7,16 @@
  * uses to exercise the very same code the core runs.
  */
 
+/* Select our own arch before blitter_simd.h picks one.  This file IS
+ * the neon implementation, so it must get the neon inline set even when
+ * compiled standalone without the Makefile's -DBLITTER_SIMD_NEON --
+ * as .github/workflows/c-cpp.yml does when it builds
+ * test_blitter_simd by hand.  Without this the header chain pulled in
+ * the scalar set as well and the two collided. */
+#ifndef BLITTER_SIMD_NEON
+#define BLITTER_SIMD_NEON 1
+#endif
+
 #include "blitter_simd.h"
 #include "blitter_simd_neon.h"
 

--- a/src/tom/blitter_simd_neon.h
+++ b/src/tom/blitter_simd_neon.h
@@ -1,0 +1,309 @@
+#ifndef BLITTER_SIMD_NEON_H
+#define BLITTER_SIMD_NEON_H
+
+/* Included by blitter_simd.h once the arch has been selected.
+ * Do not include directly -- BLITTER_SIMD_INLINE comes from there. */
+#ifndef BLITTER_SIMD_INLINE
+#error "include blitter_simd.h, not blitter_simd_neon.h"
+#endif
+
+#include <stdint.h>
+#include <boolean.h>
+#include <arm_neon.h>
+
+/*
+ * Blitter SIMD ops — ARM NEON implementation
+ *
+ * NEON is mandatory on AArch64 and available on most ARMv7-A with
+ * VFPv3. The Makefile selects this file when targeting ARM64 or
+ * when HAVE_NEON=1.
+ */
+
+
+
+/* Logic Function Unit — NEON
+ *
+ * Same truth-table approach as scalar, but using 64-bit NEON
+ * integer operations (uint64x1_t).
+ */
+static BLITTER_SIMD_INLINE
+uint64_t blitter_simd_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
+{
+   uint64x1_t vs  = vcreate_u64(srcd);
+   uint64x1_t vd  = vcreate_u64(dstd);
+   /* NEON vmvn only works up to 32-bit, so we use EOR with all-ones */
+   uint64x1_t ones = vcreate_u64(0xFFFFFFFFFFFFFFFFULL);
+   uint64x1_t vns = veor_u64(vs, ones);  /* ~srcd */
+   uint64x1_t vnd = veor_u64(vd, ones);  /* ~dstd */
+
+   uint64x1_t vf0 = vcreate_u64((lfu_func & 0x01) ? 0xFFFFFFFFFFFFFFFFULL : 0);
+   uint64x1_t vf1 = vcreate_u64((lfu_func & 0x02) ? 0xFFFFFFFFFFFFFFFFULL : 0);
+   uint64x1_t vf2 = vcreate_u64((lfu_func & 0x04) ? 0xFFFFFFFFFFFFFFFFULL : 0);
+   uint64x1_t vf3 = vcreate_u64((lfu_func & 0x08) ? 0xFFFFFFFFFFFFFFFFULL : 0);
+
+   /* (~s & ~d & f0) | (~s & d & f1) | (s & ~d & f2) | (s & d & f3) */
+   uint64x1_t t0 = vand_u64(vand_u64(vns, vnd), vf0);
+   uint64x1_t t1 = vand_u64(vand_u64(vns, vd),  vf1);
+   uint64x1_t t2 = vand_u64(vand_u64(vs,  vnd), vf2);
+   uint64x1_t t3 = vand_u64(vand_u64(vs,  vd),  vf3);
+
+   uint64x1_t result = vorr_u64(vorr_u64(t0, t1), vorr_u64(t2, t3));
+   return vget_lane_u64(result, 0);
+}
+
+/* Data Comparator — NEON
+ *
+ * XOR + per-byte zero check. NEON vceq gives 0xFF per matching byte,
+ * then we extract one bit per byte.
+ */
+static BLITTER_SIMD_INLINE
+uint8_t blitter_simd_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
+{
+   uint64_t other = cmpdst ? dstd : srcd;
+   uint8x8_t vp = vreinterpret_u8_u64(vcreate_u64(patd));
+   uint8x8_t vo = vreinterpret_u8_u64(vcreate_u64(other));
+
+   /* XOR then compare each byte to zero */
+   uint8x8_t vxor = veor_u8(vp, vo);
+   uint8x8_t vzero = vdup_n_u8(0);
+   uint8x8_t vcmp = vceq_u8(vxor, vzero);  /* 0xFF where equal, 0 otherwise */
+
+   /* Convert compare lanes from 0xFF/0x00 to 1/0, then pack into
+    * the result byte via lane extraction — avoids weights load
+    * and vpadd chain. */
+   uint8x8_t vbits = vshr_n_u8(vcmp, 7);
+
+   return (uint8_t)(
+      (vget_lane_u8(vbits, 0) << 0) |
+      (vget_lane_u8(vbits, 1) << 1) |
+      (vget_lane_u8(vbits, 2) << 2) |
+      (vget_lane_u8(vbits, 3) << 3) |
+      (vget_lane_u8(vbits, 4) << 4) |
+      (vget_lane_u8(vbits, 5) << 5) |
+      (vget_lane_u8(vbits, 6) << 6) |
+      (vget_lane_u8(vbits, 7) << 7));
+}
+
+/* Z-buffer Comparator — NEON
+ *
+ * 4 packed unsigned 16-bit comparisons. NEON has native unsigned
+ * compare instructions (vclt_u16, vceq_u16, vcgt_u16).
+ */
+static BLITTER_SIMD_INLINE
+uint8_t blitter_simd_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
+{
+   uint16x4_t vs = vreinterpret_u16_u64(vcreate_u64(srcz));
+   uint16x4_t vd = vreinterpret_u16_u64(vcreate_u64(dstz));
+   uint16x4_t vresult = vdup_n_u16(0);
+
+   if (zmode & 0x01)  /* LT */
+      vresult = vorr_u16(vresult, vclt_u16(vs, vd));
+   if (zmode & 0x02)  /* EQ */
+      vresult = vorr_u16(vresult, vceq_u16(vs, vd));
+   if (zmode & 0x04)  /* GT */
+      vresult = vorr_u16(vresult, vcgt_u16(vs, vd));
+
+   /* Extract one bit per 16-bit lane.
+    * vresult lanes are 0xFFFF or 0x0000. Narrow and extract. */
+   /* Shift each lane: lane0 >> 0, lane1 >> 1, lane2 >> 2, lane3 >> 3
+    * But easier: just read each lane */
+   uint8_t result = 0;
+   if (vget_lane_u16(vresult, 0)) result |= 0x01;
+   if (vget_lane_u16(vresult, 1)) result |= 0x02;
+   if (vget_lane_u16(vresult, 2)) result |= 0x04;
+   if (vget_lane_u16(vresult, 3)) result |= 0x08;
+
+   return result;
+}
+
+/* Byte Mask Merge — NEON
+ *
+ * Build a byte-level mask, then use vbsl (bitwise select) to blend.
+ * vbsl(mask, src, dst) = (src & mask) | (dst & ~mask)
+ */
+static BLITTER_SIMD_INLINE
+uint64_t blitter_simd_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
+{
+   /* Build 8-byte selection mask entirely in registers.
+    * Byte 0 uses the low 8 bits directly; bytes 1-7 are all-ones or
+    * all-zero based on mask bits 8-14. */
+   uint64_t sel =
+      ((uint64_t)(mask & 0x00FF)) |
+      ((uint64_t)((mask & 0x0100) ? 0xFF : 0x00) <<  8) |
+      ((uint64_t)((mask & 0x0200) ? 0xFF : 0x00) << 16) |
+      ((uint64_t)((mask & 0x0400) ? 0xFF : 0x00) << 24) |
+      ((uint64_t)((mask & 0x0800) ? 0xFF : 0x00) << 32) |
+      ((uint64_t)((mask & 0x1000) ? 0xFF : 0x00) << 40) |
+      ((uint64_t)((mask & 0x2000) ? 0xFF : 0x00) << 48) |
+      ((uint64_t)((mask & 0x4000) ? 0xFF : 0x00) << 56);
+
+   uint8x8_t vmask = vreinterpret_u8_u64(vcreate_u64(sel));
+   uint8x8_t vsrc  = vreinterpret_u8_u64(vcreate_u64(src));
+   uint8x8_t vdst  = vreinterpret_u8_u64(vcreate_u64(dst));
+
+   /* vbsl: for each bit, selects src where mask=1, dst where mask=0 */
+   uint8x8_t result = vbsl_u8(vmask, vsrc, vdst);
+
+   return vget_lane_u64(vreinterpret_u64_u8(result), 0);
+}
+
+/* ADD16SAT x4 — NEON
+ *
+ * Processes all four 16-bit lanes in parallel using NEON 16x4 vectors.
+ * The Jaguar's segmented carry chain (low byte / mid nibble / high nibble)
+ * is replicated across all 4 lanes simultaneously.
+ *
+ * Stage 1: low byte  (bits 7:0)   — add with per-lane cin
+ * Stage 2: mid nibble (bits 11:8) — add with carry from stage 1 (if !eightbit)
+ * Stage 3: high nibble (bits 15:12)— add with carry from stage 2 (if !hicinh)
+ * Then: saturation logic based on overflow detection.
+ */
+static BLITTER_SIMD_INLINE
+void blitter_simd_add16sat_x4(uint16_t *addq, uint8_t *co,
+                              const uint16_t *adda, const uint16_t *addb,
+                              const uint8_t *cin,
+                              bool sat, bool eightbit, bool hicinh)
+{
+   /* Load operands into NEON 16x4 vectors */
+   uint16x4_t va = vld1_u16(adda);
+   uint16x4_t vb = vld1_u16(addb);
+
+   /* Masks for isolating bit fields */
+   uint16x4_t mask_lo  = vdup_n_u16(0x00FF);
+   uint16x4_t mask_mid = vdup_n_u16(0x0F00);
+   uint16x4_t mask_hi  = vdup_n_u16(0xF000);
+   uint16x4_t vzero    = vdup_n_u16(0);
+   uint16x4_t vone     = vdup_n_u16(1);
+
+   /* Expand cin[0..3] from uint8_t to uint16x4_t */
+   uint16_t cin16[4];
+   uint16x4_t vcin;
+
+   /* Stage 1 results */
+   uint16x4_t va_lo, vb_lo, sum1, q_lo, carry0, carry1;
+
+   /* Stage 2 results */
+   uint16x4_t va_mid, vb_mid, carry_shifted1, sum2, q_mid, carry2, carry3;
+
+   /* Stage 3 results */
+   uint16x4_t va_hi, vb_hi, carry_shifted3, sum3, q_hi;
+
+   /* Combine result */
+   uint16x4_t q;
+
+   /* Saturation */
+   uint16x4_t btop, ctop, do_saturate;
+   uint16x4_t sat_lo_fill, sat_hi_fill;
+   uint16x4_t sat_lo_zero, sat_hi_zero;
+
+   cin16[0] = cin[0]; cin16[1] = cin[1]; cin16[2] = cin[2]; cin16[3] = cin[3];
+   vcin = vld1_u16(cin16);
+
+   /* Stage 1: low byte add */
+   va_lo = vand_u16(va, mask_lo);
+   vb_lo = vand_u16(vb, mask_lo);
+   sum1  = vadd_u16(vadd_u16(va_lo, vb_lo), vcin);
+   q_lo  = vand_u16(sum1, mask_lo);
+
+   /* carry0 = (sum1 & 0x100) ? 1 : 0 */
+   carry0 = vshr_n_u16(vand_u16(sum1, vdup_n_u16(0x0100)), 8);
+
+   /* carry1 = carry0 if !eightbit, else 0 */
+   carry1 = eightbit ? vzero : carry0;
+
+   /* Stage 2: mid nibble add */
+   va_mid = vand_u16(va, mask_mid);
+   vb_mid = vand_u16(vb, mask_mid);
+   carry_shifted1 = vshl_n_u16(carry1, 8);
+   sum2   = vadd_u16(vadd_u16(va_mid, vb_mid), carry_shifted1);
+   q_mid  = vand_u16(sum2, mask_mid);
+
+   /* carry2 = (sum2 & 0x1000) ? 1 : 0 */
+   carry2 = vshr_n_u16(vand_u16(sum2, vdup_n_u16(0x1000)), 12);
+
+   /* carry3 = carry2 if !hicinh, else 0 */
+   carry3 = hicinh ? vzero : carry2;
+
+   /* Stage 3: high nibble add */
+   va_hi = vand_u16(va, mask_hi);
+   vb_hi = vand_u16(vb, mask_hi);
+   carry_shifted3 = vshl_n_u16(carry3, 12);
+   sum3   = vadd_u16(vadd_u16(va_hi, vb_hi), carry_shifted3);
+   q_hi   = vand_u16(sum3, mask_hi);
+
+   /* co[i] = (sum3 & 0x10000) ? 1 : 0 — detect carry out of bit 15.
+    * Since our lanes are only 16-bit, the carry is lost. Widen to
+    * 32-bit for the overflow detection. */
+   {
+      /* Use 32-bit arithmetic to capture the carry */
+      uint32_t s0 = (uint32_t)(adda[0] & 0xF000) + (addb[0] & 0xF000) + ((uint32_t)vget_lane_u16(carry3, 0) << 12);
+      uint32_t s1 = (uint32_t)(adda[1] & 0xF000) + (addb[1] & 0xF000) + ((uint32_t)vget_lane_u16(carry3, 1) << 12);
+      uint32_t s2 = (uint32_t)(adda[2] & 0xF000) + (addb[2] & 0xF000) + ((uint32_t)vget_lane_u16(carry3, 2) << 12);
+      uint32_t s3 = (uint32_t)(adda[3] & 0xF000) + (addb[3] & 0xF000) + ((uint32_t)vget_lane_u16(carry3, 3) << 12);
+      co[0] = (s0 & 0x10000) ? 1 : 0;
+      co[1] = (s1 & 0x10000) ? 1 : 0;
+      co[2] = (s2 & 0x10000) ? 1 : 0;
+      co[3] = (s3 & 0x10000) ? 1 : 0;
+   }
+
+   /* Combine low + mid + high */
+   q = vorr_u16(vorr_u16(q_lo, q_mid), q_hi);
+
+   /* Saturation logic */
+   if (sat)
+   {
+      uint16_t co16[4];
+      uint16x4_t vco;
+      uint16x4_t do_hi_saturate;
+      uint16x4_t result_lo, result_hi;
+
+      co16[0] = co[0]; co16[1] = co[1]; co16[2] = co[2]; co16[3] = co[3];
+      vco = vld1_u16(co16);
+
+      if (eightbit)
+      {
+         btop = vshr_n_u16(vand_u16(vb, vdup_n_u16(0x0080)), 7);
+         ctop = carry0;
+      }
+      else
+      {
+         btop = vshr_n_u16(vb, 15);
+         ctop = vco;
+      }
+
+      /* saturate = sat && (btop ^ ctop) — sat is already true here */
+      do_saturate = veor_u16(btop, ctop); /* non-zero where we saturate */
+
+      /* do_hi_saturate = do_saturate && !eightbit */
+      do_hi_saturate = eightbit ? vzero : do_saturate;
+
+      /* When saturating:
+       *   low byte = ctop ? 0xFF : 0x00
+       *   high byte = ctop ? 0xFF00 : 0x0000 (only if !eightbit)
+       * When not saturating, keep q as-is. */
+
+      /* Expand ctop/do_saturate from {0,1} to full 16-bit masks {0x0000,0xFFFF} */
+      {
+         uint16x4_t ctop_mask     = vceq_u16(ctop, vone);          /* 0xFFFF where ctop=1 */
+         uint16x4_t sat_mask      = vceq_u16(do_saturate, vone);   /* 0xFFFF where saturating */
+         uint16x4_t hi_sat_mask   = vceq_u16(do_hi_saturate, vone);
+
+         /* Build saturated fill values: ctop_mask ? 0x00FF/0xFF00 : 0x0000 */
+         sat_lo_fill  = vand_u16(ctop_mask, vdup_n_u16(0x00FF));
+         sat_hi_fill  = vand_u16(ctop_mask, vdup_n_u16(0xFF00));
+
+         /* Build non-saturated values */
+         sat_lo_zero  = vand_u16(q, mask_lo);
+         sat_hi_zero  = vand_u16(q, vdup_n_u16(0xFF00));
+
+         result_lo = vbsl_u16(sat_mask, sat_lo_fill, sat_lo_zero);
+         result_hi = vbsl_u16(hi_sat_mask, sat_hi_fill, sat_hi_zero);
+      }
+
+      q = vorr_u16(result_lo, result_hi);
+   }
+
+   vst1_u16(addq, q);
+}
+
+#endif /* BLITTER_SIMD_NEON_H */

--- a/src/tom/blitter_simd_scalar.c
+++ b/src/tom/blitter_simd_scalar.c
@@ -1,168 +1,47 @@
 /*
- * Blitter SIMD ops — portable scalar reference implementation
+ * Blitter SIMD ops -- out-of-line scalar vtable.
  *
- * These are extracted verbatim from blitter.c DATA() and serve as:
- *   1. The fallback for platforms without SIMD
- *   2. The reference for bit-exactness testing of SIMD variants
+ * The implementations themselves live in blitter_simd_scalar.h so that
+ * blitter.c can inline them (see blitter_simd.h).  This file only
+ * provides the function-pointer table, which test/test_blitter_simd.c
+ * uses to exercise the very same code the core runs.
  */
 
 #include "blitter_simd.h"
+#include "blitter_simd_scalar.h"
 
-/* Logic Function Unit
- *
- * Implements a 4-input truth table over each bit position of two
- * 64-bit words (srcd, dstd). lfu_func selects one of 16 boolean
- * functions (AND, OR, XOR, etc.).
- */
-static uint64_t scalar_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
+static uint64_t ops_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
 {
-   uint64_t funcmask[2] = { 0, 0xFFFFFFFFFFFFFFFFULL };
-   uint64_t func0 = funcmask[lfu_func & 0x01];
-   uint64_t func1 = funcmask[(lfu_func >> 1) & 0x01];
-   uint64_t func2 = funcmask[(lfu_func >> 2) & 0x01];
-   uint64_t func3 = funcmask[(lfu_func >> 3) & 0x01];
-
-   return (~srcd & ~dstd & func0)
-        | (~srcd &  dstd & func1)
-        | ( srcd & ~dstd & func2)
-        | ( srcd &  dstd & func3);
+   return blitter_simd_lfu(srcd, dstd, lfu_func);
 }
 
-/* Data Comparator
- *
- * XORs patd with either dstd or srcd (selected by cmpdst), then
- * checks each of the 8 bytes for equality (zero). Returns an 8-bit
- * mask with bit N set when byte N matches.
- */
-static uint8_t scalar_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
+static uint8_t ops_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
 {
-   uint8_t result = 0;
-   uint64_t cmpd = patd ^ (cmpdst ? dstd : srcd);
-
-   if ((cmpd & 0x00000000000000FFULL) == 0) result |= 0x01;
-   if ((cmpd & 0x000000000000FF00ULL) == 0) result |= 0x02;
-   if ((cmpd & 0x0000000000FF0000ULL) == 0) result |= 0x04;
-   if ((cmpd & 0x00000000FF000000ULL) == 0) result |= 0x08;
-   if ((cmpd & 0x000000FF00000000ULL) == 0) result |= 0x10;
-   if ((cmpd & 0x0000FF0000000000ULL) == 0) result |= 0x20;
-   if ((cmpd & 0x00FF000000000000ULL) == 0) result |= 0x40;
-   if ((cmpd & 0xFF00000000000000ULL) == 0) result |= 0x80;
-
-   return result;
+   return blitter_simd_dcomp(patd, srcd, dstd, cmpdst);
 }
 
-/* Z-buffer Comparator
- *
- * Compares 4 packed 16-bit Z values. For each of the 4 lanes,
- * sets the output bit if the comparison selected by zmode is true:
- *   bit 0 (0x01): less-than
- *   bit 1 (0x02): equal
- *   bit 2 (0x04): greater-than
- */
-static uint8_t scalar_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
+static uint8_t ops_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
 {
-   uint8_t result = 0;
-   int i;
-
-   for (i = 0; i < 4; i++)
-   {
-      uint16_t s = (uint16_t)(srcz >> (i * 16));
-      uint16_t d = (uint16_t)(dstz >> (i * 16));
-
-      if (((s < d) && (zmode & 0x01))
-       || ((s == d) && (zmode & 0x02))
-       || ((s > d) && (zmode & 0x04)))
-         result |= (1u << i);
-   }
-
-   return result;
+   return blitter_simd_zcomp(srcz, dstz, zmode);
 }
 
-/* Byte Mask Merge
- *
- * Selects bytes from src or dst based on a 16-bit mask:
- *   - Byte 0: per-bit blend (src where mask bit is 1, dst where 0)
- *   - Bytes 1-7: whole-byte select via mask bits 8-14
- *
- * Used for both pixel data (ddat/dstd -> wdata) and Z-buffer data
- * (srcz/dstz -> zwdata).
- */
-static uint64_t scalar_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
+static uint64_t ops_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
 {
-   uint64_t result;
-
-   /* Byte 0: per-bit mask (low 8 bits of mask) */
-   result = ((src & mask) | (dst & ~(uint64_t)mask)) & 0x00000000000000FFULL;
-
-   /* Bytes 1-7: whole-byte select via mask bits 8-14 */
-   result |= ((mask & 0x0100) ? src : dst) & 0x000000000000FF00ULL;
-   result |= ((mask & 0x0200) ? src : dst) & 0x0000000000FF0000ULL;
-   result |= ((mask & 0x0400) ? src : dst) & 0x00000000FF000000ULL;
-   result |= ((mask & 0x0800) ? src : dst) & 0x000000FF00000000ULL;
-   result |= ((mask & 0x1000) ? src : dst) & 0x0000FF0000000000ULL;
-   result |= ((mask & 0x2000) ? src : dst) & 0x00FF000000000000ULL;
-   result |= ((mask & 0x4000) ? src : dst) & 0xFF00000000000000ULL;
-
-   return result;
+   return blitter_simd_byte_merge(src, dst, mask);
 }
 
-/* ADD16SAT x4 — scalar reference
- *
- * Implements 4 parallel 16-bit saturating adds using the Jaguar's
- * segmented carry chain: low byte, mid nibble (bits 11:8), high
- * nibble (bits 15:12), with conditional carry propagation.
- */
-static void scalar_add16sat_x4(uint16_t *addq, uint8_t *co,
-                                const uint16_t *adda, const uint16_t *addb,
-                                const uint8_t *cin,
-                                bool sat, bool eightbit, bool hicinh)
+static void ops_add16sat_x4(uint16_t *addq, uint8_t *co,
+                            const uint16_t *adda, const uint16_t *addb,
+                            const uint8_t *cin,
+                            bool sat, bool eightbit, bool hicinh)
 {
-   int i;
-   for (i = 0; i < 4; i++)
-   {
-      uint16_t a = adda[i];
-      uint16_t b = addb[i];
-      uint8_t carry0, carry1, carry2, carry3;
-      uint8_t btop, ctop;
-      bool saturate, hisaturate;
-      uint32_t qt;
-      uint16_t q;
-
-      qt      = (a & 0xFF) + (b & 0xFF) + cin[i];
-      q       = qt & 0x00FF;
-      carry0  = ((qt & 0x0100) ? 1 : 0);
-      carry1  = (carry0 && !eightbit ? carry0 : 0);
-      qt      = (a & 0x0F00) + (b & 0x0F00) + (carry1 << 8);
-      carry2  = ((qt & 0x1000) ? 1 : 0);
-      q      |= qt & 0x0F00;
-      carry3  = (carry2 && !hicinh ? carry2 : 0);
-      qt      = (a & 0xF000) + (b & 0xF000) + (carry3 << 12);
-      co[i]   = ((qt & 0x10000) ? 1 : 0);
-      q      |= qt & 0xF000;
-
-      if (eightbit)
-      {
-         btop = (b & 0x0080) >> 7;
-         ctop = carry0;
-      }
-      else
-      {
-         btop = (b & 0x8000) >> 15;
-         ctop = co[i];
-      }
-
-      saturate   = sat && (btop ^ ctop);
-      hisaturate = saturate && !eightbit;
-
-      addq[i]  = (saturate ? (ctop ? 0x00FF : 0x0000) : q & 0x00FF);
-      addq[i] |= (hisaturate ? (ctop ? 0xFF00 : 0x0000) : q & 0xFF00);
-   }
+   blitter_simd_add16sat_x4(addq, co, adda, addb, cin, sat, eightbit, hicinh);
 }
 
 const blitter_simd_ops_t blitter_simd_ops = {
-   scalar_lfu,
-   scalar_dcomp,
-   scalar_zcomp,
-   scalar_byte_merge,
-   scalar_add16sat_x4
+   ops_lfu,
+   ops_dcomp,
+   ops_zcomp,
+   ops_byte_merge,
+   ops_add16sat_x4
 };

--- a/src/tom/blitter_simd_scalar.c
+++ b/src/tom/blitter_simd_scalar.c
@@ -7,6 +7,16 @@
  * uses to exercise the very same code the core runs.
  */
 
+/* Select our own arch before blitter_simd.h picks one.  This file IS
+ * the scalar implementation, so it must get the scalar inline set even when
+ * compiled standalone without the Makefile's -DBLITTER_SIMD_SCALAR --
+ * as .github/workflows/c-cpp.yml does when it builds
+ * test_blitter_simd by hand.  Without this the header chain pulled in
+ * the scalar set as well and the two collided. */
+#ifndef BLITTER_SIMD_SCALAR
+#define BLITTER_SIMD_SCALAR 1
+#endif
+
 #include "blitter_simd.h"
 #include "blitter_simd_scalar.h"
 

--- a/src/tom/blitter_simd_scalar.h
+++ b/src/tom/blitter_simd_scalar.h
@@ -1,0 +1,178 @@
+#ifndef BLITTER_SIMD_SCALAR_H
+#define BLITTER_SIMD_SCALAR_H
+
+/* Included by blitter_simd.h once the arch has been selected.
+ * Do not include directly -- BLITTER_SIMD_INLINE comes from there. */
+#ifndef BLITTER_SIMD_INLINE
+#error "include blitter_simd.h, not blitter_simd_scalar.h"
+#endif
+
+#include <stdint.h>
+#include <boolean.h>
+
+/*
+ * Blitter SIMD ops — portable scalar reference implementation
+ *
+ * These are extracted verbatim from blitter.c DATA() and serve as:
+ *   1. The fallback for platforms without SIMD
+ *   2. The reference for bit-exactness testing of SIMD variants
+ */
+
+
+/* Logic Function Unit
+ *
+ * Implements a 4-input truth table over each bit position of two
+ * 64-bit words (srcd, dstd). lfu_func selects one of 16 boolean
+ * functions (AND, OR, XOR, etc.).
+ */
+static BLITTER_SIMD_INLINE
+uint64_t blitter_simd_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
+{
+   uint64_t funcmask[2] = { 0, 0xFFFFFFFFFFFFFFFFULL };
+   uint64_t func0 = funcmask[lfu_func & 0x01];
+   uint64_t func1 = funcmask[(lfu_func >> 1) & 0x01];
+   uint64_t func2 = funcmask[(lfu_func >> 2) & 0x01];
+   uint64_t func3 = funcmask[(lfu_func >> 3) & 0x01];
+
+   return (~srcd & ~dstd & func0)
+        | (~srcd &  dstd & func1)
+        | ( srcd & ~dstd & func2)
+        | ( srcd &  dstd & func3);
+}
+
+/* Data Comparator
+ *
+ * XORs patd with either dstd or srcd (selected by cmpdst), then
+ * checks each of the 8 bytes for equality (zero). Returns an 8-bit
+ * mask with bit N set when byte N matches.
+ */
+static BLITTER_SIMD_INLINE
+uint8_t blitter_simd_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
+{
+   uint8_t result = 0;
+   uint64_t cmpd = patd ^ (cmpdst ? dstd : srcd);
+
+   if ((cmpd & 0x00000000000000FFULL) == 0) result |= 0x01;
+   if ((cmpd & 0x000000000000FF00ULL) == 0) result |= 0x02;
+   if ((cmpd & 0x0000000000FF0000ULL) == 0) result |= 0x04;
+   if ((cmpd & 0x00000000FF000000ULL) == 0) result |= 0x08;
+   if ((cmpd & 0x000000FF00000000ULL) == 0) result |= 0x10;
+   if ((cmpd & 0x0000FF0000000000ULL) == 0) result |= 0x20;
+   if ((cmpd & 0x00FF000000000000ULL) == 0) result |= 0x40;
+   if ((cmpd & 0xFF00000000000000ULL) == 0) result |= 0x80;
+
+   return result;
+}
+
+/* Z-buffer Comparator
+ *
+ * Compares 4 packed 16-bit Z values. For each of the 4 lanes,
+ * sets the output bit if the comparison selected by zmode is true:
+ *   bit 0 (0x01): less-than
+ *   bit 1 (0x02): equal
+ *   bit 2 (0x04): greater-than
+ */
+static BLITTER_SIMD_INLINE
+uint8_t blitter_simd_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
+{
+   uint8_t result = 0;
+   int i;
+
+   for (i = 0; i < 4; i++)
+   {
+      uint16_t s = (uint16_t)(srcz >> (i * 16));
+      uint16_t d = (uint16_t)(dstz >> (i * 16));
+
+      if (((s < d) && (zmode & 0x01))
+       || ((s == d) && (zmode & 0x02))
+       || ((s > d) && (zmode & 0x04)))
+         result |= (1u << i);
+   }
+
+   return result;
+}
+
+/* Byte Mask Merge
+ *
+ * Selects bytes from src or dst based on a 16-bit mask:
+ *   - Byte 0: per-bit blend (src where mask bit is 1, dst where 0)
+ *   - Bytes 1-7: whole-byte select via mask bits 8-14
+ *
+ * Used for both pixel data (ddat/dstd -> wdata) and Z-buffer data
+ * (srcz/dstz -> zwdata).
+ */
+static BLITTER_SIMD_INLINE
+uint64_t blitter_simd_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
+{
+   uint64_t result;
+
+   /* Byte 0: per-bit mask (low 8 bits of mask) */
+   result = ((src & mask) | (dst & ~(uint64_t)mask)) & 0x00000000000000FFULL;
+
+   /* Bytes 1-7: whole-byte select via mask bits 8-14 */
+   result |= ((mask & 0x0100) ? src : dst) & 0x000000000000FF00ULL;
+   result |= ((mask & 0x0200) ? src : dst) & 0x0000000000FF0000ULL;
+   result |= ((mask & 0x0400) ? src : dst) & 0x00000000FF000000ULL;
+   result |= ((mask & 0x0800) ? src : dst) & 0x000000FF00000000ULL;
+   result |= ((mask & 0x1000) ? src : dst) & 0x0000FF0000000000ULL;
+   result |= ((mask & 0x2000) ? src : dst) & 0x00FF000000000000ULL;
+   result |= ((mask & 0x4000) ? src : dst) & 0xFF00000000000000ULL;
+
+   return result;
+}
+
+/* ADD16SAT x4 — scalar reference
+ *
+ * Implements 4 parallel 16-bit saturating adds using the Jaguar's
+ * segmented carry chain: low byte, mid nibble (bits 11:8), high
+ * nibble (bits 15:12), with conditional carry propagation.
+ */
+static BLITTER_SIMD_INLINE
+void blitter_simd_add16sat_x4(uint16_t *addq, uint8_t *co,
+                                const uint16_t *adda, const uint16_t *addb,
+                                const uint8_t *cin,
+                                bool sat, bool eightbit, bool hicinh)
+{
+   int i;
+   for (i = 0; i < 4; i++)
+   {
+      uint16_t a = adda[i];
+      uint16_t b = addb[i];
+      uint8_t carry0, carry1, carry2, carry3;
+      uint8_t btop, ctop;
+      bool saturate, hisaturate;
+      uint32_t qt;
+      uint16_t q;
+
+      qt      = (a & 0xFF) + (b & 0xFF) + cin[i];
+      q       = qt & 0x00FF;
+      carry0  = ((qt & 0x0100) ? 1 : 0);
+      carry1  = (carry0 && !eightbit ? carry0 : 0);
+      qt      = (a & 0x0F00) + (b & 0x0F00) + (carry1 << 8);
+      carry2  = ((qt & 0x1000) ? 1 : 0);
+      q      |= qt & 0x0F00;
+      carry3  = (carry2 && !hicinh ? carry2 : 0);
+      qt      = (a & 0xF000) + (b & 0xF000) + (carry3 << 12);
+      co[i]   = ((qt & 0x10000) ? 1 : 0);
+      q      |= qt & 0xF000;
+
+      if (eightbit)
+      {
+         btop = (b & 0x0080) >> 7;
+         ctop = carry0;
+      }
+      else
+      {
+         btop = (b & 0x8000) >> 15;
+         ctop = co[i];
+      }
+
+      saturate   = sat && (btop ^ ctop);
+      hisaturate = saturate && !eightbit;
+
+      addq[i]  = (saturate ? (ctop ? 0x00FF : 0x0000) : q & 0x00FF);
+      addq[i] |= (hisaturate ? (ctop ? 0xFF00 : 0x0000) : q & 0xFF00);
+   }
+}
+
+#endif /* BLITTER_SIMD_SCALAR_H */

--- a/src/tom/blitter_simd_sse2.c
+++ b/src/tom/blitter_simd_sse2.c
@@ -1,327 +1,47 @@
 /*
- * Blitter SIMD ops — x86/x64 SSE2 implementation
+ * Blitter SIMD ops -- out-of-line sse2 vtable.
  *
- * SSE2 is baseline for all x86_64 processors and available on x86
- * since Pentium 4 (2001). No runtime feature detection needed.
- *
- * Operations work on 64-bit values loaded into 128-bit SSE registers
- * (upper 64 bits unused or zeroed).
+ * The implementations themselves live in blitter_simd_sse2.h so that
+ * blitter.c can inline them (see blitter_simd.h).  This file only
+ * provides the function-pointer table, which test/test_blitter_simd.c
+ * uses to exercise the very same code the core runs.
  */
 
 #include "blitter_simd.h"
-#include <emmintrin.h>  /* SSE2 */
-#include <string.h>     /* memcpy for type-punning extract */
+#include "blitter_simd_sse2.h"
 
-/* _mm_set_epi64x doesn't exist in MSVC 2010 and earlier.
- * Build from two 32-bit halves instead (pure SSE2). */
-#if defined(_MSC_VER) && _MSC_VER < 1700
-#define SSE2_SET64(hi, lo) \
-   _mm_set_epi32((int)((uint64_t)(hi) >> 32), (int)(hi), \
-                 (int)((uint64_t)(lo) >> 32), (int)(lo))
-#else
-#define SSE2_SET64(hi, lo) _mm_set_epi64x((int64_t)(hi), (int64_t)(lo))
-#endif
-
-static uint64_t sse2_extract_u64(__m128i v)
+static uint64_t ops_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
 {
-   uint64_t r;
-   memcpy(&r, &v, sizeof(r));
-   return r;
+   return blitter_simd_lfu(srcd, dstd, lfu_func);
 }
 
-/* Logic Function Unit — SSE2
- *
- * The truth table has 4 terms, each gated by one bit of lfu_func.
- * We broadcast each gate to all 64 bits, then AND/OR in registers.
- */
-static uint64_t sse2_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
+static uint8_t ops_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
 {
-   /* Build 64-bit masks from each lfu_func bit */
-   uint64_t func0 = (lfu_func & 0x01) ? 0xFFFFFFFFFFFFFFFFULL : 0;
-   uint64_t func1 = (lfu_func & 0x02) ? 0xFFFFFFFFFFFFFFFFULL : 0;
-   uint64_t func2 = (lfu_func & 0x04) ? 0xFFFFFFFFFFFFFFFFULL : 0;
-   uint64_t func3 = (lfu_func & 0x08) ? 0xFFFFFFFFFFFFFFFFULL : 0;
-
-   __m128i vs   = SSE2_SET64(0, srcd);
-   __m128i vd   = SSE2_SET64(0, dstd);
-   __m128i vns  = _mm_andnot_si128(vs, _mm_set1_epi32(-1)); /* ~srcd */
-   __m128i vnd  = _mm_andnot_si128(vd, _mm_set1_epi32(-1)); /* ~dstd */
-
-   __m128i vf0  = SSE2_SET64(0, func0);
-   __m128i vf1  = SSE2_SET64(0, func1);
-   __m128i vf2  = SSE2_SET64(0, func2);
-   __m128i vf3  = SSE2_SET64(0, func3);
-
-   /* (~s & ~d & f0) | (~s & d & f1) | (s & ~d & f2) | (s & d & f3) */
-   __m128i t0 = _mm_and_si128(_mm_and_si128(vns, vnd), vf0);
-   __m128i t1 = _mm_and_si128(_mm_and_si128(vns, vd),  vf1);
-   __m128i t2 = _mm_and_si128(_mm_and_si128(vs,  vnd), vf2);
-   __m128i t3 = _mm_and_si128(_mm_and_si128(vs,  vd),  vf3);
-
-   __m128i result = _mm_or_si128(_mm_or_si128(t0, t1), _mm_or_si128(t2, t3));
-   return sse2_extract_u64(result);
+   return blitter_simd_dcomp(patd, srcd, dstd, cmpdst);
 }
 
-/* Data Comparator — SSE2
- *
- * XOR the two 64-bit values, then check each byte for zero.
- * _mm_cmpeq_epi8 + _mm_movemask_epi8 gives us all 8 byte-equality
- * bits in one shot.
- */
-static uint8_t sse2_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
+static uint8_t ops_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
 {
-   uint64_t other = cmpdst ? dstd : srcd;
-   __m128i vp = SSE2_SET64(0, patd);
-   __m128i vo = SSE2_SET64(0, other);
-   __m128i vxor = _mm_xor_si128(vp, vo);
-
-   /* Compare each byte against zero */
-   __m128i vzero = _mm_setzero_si128();
-   __m128i vcmp = _mm_cmpeq_epi8(vxor, vzero);
-
-   /* movemask gives us 16 bits (one per byte of 128-bit reg).
-    * We only care about the low 8 bytes. */
-   return (uint8_t)(_mm_movemask_epi8(vcmp) & 0xFF);
+   return blitter_simd_zcomp(srcz, dstz, zmode);
 }
 
-/* Z-buffer Comparator — SSE2
- *
- * 4 packed 16-bit comparisons. SSE2 has _mm_cmpeq_epi16 and
- * _mm_cmpgt_epi16 (signed), but Z values are unsigned. We handle
- * this by biasing both operands by -32768 before signed compare.
- */
-static uint8_t sse2_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
+static uint64_t ops_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
 {
-   uint8_t result = 0;
-   uint8_t packed = 0;
-
-   __m128i vs = SSE2_SET64(0, srcz);
-   __m128i vd = SSE2_SET64(0, dstz);
-
-   /* Bias for unsigned comparison via signed instructions */
-   __m128i bias = _mm_set1_epi16((short)0x8000);
-   __m128i vs_biased = _mm_sub_epi16(vs, bias);
-   __m128i vd_biased = _mm_sub_epi16(vd, bias);
-
-   /* EQ: src == dst */
-   if (zmode & 0x02)
-   {
-      __m128i veq = _mm_cmpeq_epi16(vs, vd);
-      result |= (uint8_t)(_mm_movemask_epi8(veq) & 0xFF);
-   }
-
-   /* LT: src < dst (signed compare after bias = unsigned compare) */
-   if (zmode & 0x01)
-   {
-      __m128i vlt = _mm_cmplt_epi16(vs_biased, vd_biased);
-      result |= (uint8_t)(_mm_movemask_epi8(vlt) & 0xFF);
-   }
-
-   /* GT: src > dst */
-   if (zmode & 0x04)
-   {
-      __m128i vgt = _mm_cmpgt_epi16(vs_biased, vd_biased);
-      result |= (uint8_t)(_mm_movemask_epi8(vgt) & 0xFF);
-   }
-
-   /* movemask gives 2 bits per 16-bit lane (one per byte).
-    * Convert to 1 bit per lane: lanes at positions 0,2,4,6 */
-   if (result & 0x03) packed |= 0x01;  /* lane 0: bytes 0-1 */
-   if (result & 0x0C) packed |= 0x02;  /* lane 1: bytes 2-3 */
-   if (result & 0x30) packed |= 0x04;  /* lane 2: bytes 4-5 */
-   if (result & 0xC0) packed |= 0x08;  /* lane 3: bytes 6-7 */
-
-   return packed;
+   return blitter_simd_byte_merge(src, dst, mask);
 }
 
-/* Byte Mask Merge — SSE2
- *
- * Byte 0 is per-bit blended, bytes 1-7 are whole-byte selected.
- * We build a byte-level mask from the 16-bit input, then use
- * AND/ANDNOT/OR to blend.
- */
-static uint64_t sse2_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
+static void ops_add16sat_x4(uint16_t *addq, uint8_t *co,
+                            const uint16_t *adda, const uint16_t *addb,
+                            const uint8_t *cin,
+                            bool sat, bool eightbit, bool hicinh)
 {
-   /* Build an 8-byte selection mask directly via bit arithmetic.
-    * Byte 0 = low 8 bits of mask (per-bit blend).
-    * Bytes 1-7 = 0xFF or 0x00 from mask bits 8-14 (whole-byte select).
-    * We expand each bit to a full 0xFF byte using sign-extension. */
-   uint64_t sel64 = (uint64_t)(mask & 0xFF);  /* byte 0: per-bit */
-   __m128i vmask, vsrc, vdst, r;
-
-   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 8)  & 1))) << 8;
-   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 9)  & 1))) << 16;
-   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 10) & 1))) << 24;
-   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 11) & 1))) << 32;
-   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 12) & 1))) << 40;
-   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 13) & 1))) << 48;
-   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 14) & 1))) << 56;
-
-   vmask = SSE2_SET64(0, sel64);
-   vsrc  = SSE2_SET64(0, src);
-   vdst  = SSE2_SET64(0, dst);
-
-   /* result = (src & mask) | (dst & ~mask) */
-   r = _mm_or_si128(
-      _mm_and_si128(vsrc, vmask),
-      _mm_andnot_si128(vmask, vdst)
-   );
-
-   return sse2_extract_u64(r);
-}
-
-/* ADD16SAT x4 — SSE2
- *
- * Processes all four 16-bit lanes in parallel using SSE2 vectors.
- * The Jaguar's segmented carry chain (low byte / mid nibble / high nibble)
- * is replicated across all 4 lanes simultaneously.
- *
- * Uses the low 64 bits of 128-bit SSE registers (4 x 16-bit lanes).
- */
-static void sse2_add16sat_x4(uint16_t *addq, uint8_t *co,
-                              const uint16_t *adda, const uint16_t *addb,
-                              const uint8_t *cin,
-                              bool sat, bool eightbit, bool hicinh)
-{
-   /* Load operands — only low 4 lanes used (64 bits) */
-   __m128i va = _mm_loadl_epi64((const __m128i *)adda);
-   __m128i vb = _mm_loadl_epi64((const __m128i *)addb);
-
-   /* Expand cin[0..3] from uint8_t to 16-bit lanes */
-   __m128i vcin;
-   __m128i mask_lo, mask_mid, mask_hi, mask_0100, mask_1000;
-   __m128i va_lo, vb_lo, sum1, q_lo, carry0, carry1;
-   __m128i va_mid, vb_mid, sum2, q_mid, carry2, carry3;
-   __m128i va_hi, vb_hi, sum3, q_hi;
-   __m128i q;
-   uint32_t s0, s1, s2, s3;
-   uint16_t c3_0, c3_1, c3_2, c3_3;
-   uint16_t carry3_buf[8];
-
-   {
-      uint16_t cin16[8] = { 0 };
-      cin16[0] = cin[0]; cin16[1] = cin[1]; cin16[2] = cin[2]; cin16[3] = cin[3];
-      vcin = _mm_loadu_si128((const __m128i *)cin16);
-   }
-
-   mask_lo   = _mm_set1_epi16(0x00FF);
-   mask_mid  = _mm_set1_epi16(0x0F00);
-   mask_hi   = _mm_set1_epi16((short)0xF000);
-   mask_0100 = _mm_set1_epi16(0x0100);
-   mask_1000 = _mm_set1_epi16(0x1000);
-
-   /* Stage 1: low byte add */
-   va_lo = _mm_and_si128(va, mask_lo);
-   vb_lo = _mm_and_si128(vb, mask_lo);
-   sum1  = _mm_add_epi16(_mm_add_epi16(va_lo, vb_lo), vcin);
-   q_lo  = _mm_and_si128(sum1, mask_lo);
-
-   /* carry0 = (sum1 >> 8) & 1 */
-   carry0 = _mm_srli_epi16(_mm_and_si128(sum1, mask_0100), 8);
-
-   /* carry1 = eightbit ? 0 : carry0 */
-   carry1 = eightbit ? _mm_setzero_si128() : carry0;
-
-   /* Stage 2: mid nibble add */
-   va_mid = _mm_and_si128(va, mask_mid);
-   vb_mid = _mm_and_si128(vb, mask_mid);
-   sum2   = _mm_add_epi16(_mm_add_epi16(va_mid, vb_mid), _mm_slli_epi16(carry1, 8));
-   q_mid  = _mm_and_si128(sum2, mask_mid);
-
-   /* carry2 = (sum2 >> 12) & 1 */
-   carry2 = _mm_srli_epi16(_mm_and_si128(sum2, mask_1000), 12);
-
-   /* carry3 = hicinh ? 0 : carry2 */
-   carry3 = hicinh ? _mm_setzero_si128() : carry2;
-
-   /* Stage 3: high nibble add */
-   va_hi = _mm_and_si128(va, mask_hi);
-   vb_hi = _mm_and_si128(vb, mask_hi);
-   sum3  = _mm_add_epi16(_mm_add_epi16(va_hi, vb_hi), _mm_slli_epi16(carry3, 12));
-   q_hi  = _mm_and_si128(sum3, mask_hi);
-
-   /* co[i]: detect carry out of bit 15.  16-bit lanes lose bit 16,
-    * so widen to 32-bit to capture the overflow. */
-   _mm_storeu_si128((__m128i *)carry3_buf, carry3);
-   c3_0 = carry3_buf[0]; c3_1 = carry3_buf[1];
-   c3_2 = carry3_buf[2]; c3_3 = carry3_buf[3];
-
-   s0 = (uint32_t)(adda[0] & 0xF000) + (addb[0] & 0xF000) + ((uint32_t)c3_0 << 12);
-   s1 = (uint32_t)(adda[1] & 0xF000) + (addb[1] & 0xF000) + ((uint32_t)c3_1 << 12);
-   s2 = (uint32_t)(adda[2] & 0xF000) + (addb[2] & 0xF000) + ((uint32_t)c3_2 << 12);
-   s3 = (uint32_t)(adda[3] & 0xF000) + (addb[3] & 0xF000) + ((uint32_t)c3_3 << 12);
-   co[0] = (s0 & 0x10000) ? 1 : 0;
-   co[1] = (s1 & 0x10000) ? 1 : 0;
-   co[2] = (s2 & 0x10000) ? 1 : 0;
-   co[3] = (s3 & 0x10000) ? 1 : 0;
-
-   /* Combine low + mid + high */
-   q = _mm_or_si128(_mm_or_si128(q_lo, q_mid), q_hi);
-
-   /* Saturation logic */
-   if (sat)
-   {
-      __m128i btop, ctop, do_saturate, do_hi_saturate;
-      __m128i sat_lo_fill, sat_hi_fill;
-      __m128i sat_mask, hi_sat_mask;
-      __m128i result_lo, result_hi;
-      uint16_t co16[8] = { 0 };
-      __m128i vco;
-
-      co16[0] = co[0]; co16[1] = co[1]; co16[2] = co[2]; co16[3] = co[3];
-      vco = _mm_loadu_si128((const __m128i *)co16);
-
-      if (eightbit)
-      {
-         btop = _mm_srli_epi16(_mm_and_si128(vb, _mm_set1_epi16(0x0080)), 7);
-         ctop = carry0;
-      }
-      else
-      {
-         btop = _mm_srli_epi16(vb, 15);
-         ctop = vco;
-      }
-
-      /* do_saturate = btop ^ ctop (non-zero lanes saturate) */
-      do_saturate = _mm_xor_si128(btop, ctop);
-
-      /* do_hi_saturate = eightbit ? 0 : do_saturate */
-      do_hi_saturate = eightbit ? _mm_setzero_si128() : do_saturate;
-
-      /* Build saturated fill: ctop ? 0x00FF/0xFF00 : 0x0000 */
-      /* ctop is 0 or 1 in each lane. Expand to mask: cmpeq with 1 gives 0xFFFF where ctop=1 */
-      {
-         __m128i vone = _mm_set1_epi16(1);
-         __m128i ctop_mask = _mm_cmpeq_epi16(ctop, vone);
-         sat_lo_fill = _mm_and_si128(ctop_mask, mask_lo);   /* 0x00FF where ctop=1 */
-         sat_hi_fill = _mm_and_si128(ctop_mask, _mm_set1_epi16((short)0xFF00));
-
-         /* Expand do_saturate/do_hi_saturate to masks */
-         sat_mask    = _mm_cmpeq_epi16(do_saturate, vone);
-         hi_sat_mask = _mm_cmpeq_epi16(do_hi_saturate, vone);
-      }
-
-      /* Select: if saturating use fill, else use q */
-      result_lo = _mm_or_si128(
-         _mm_and_si128(sat_mask, sat_lo_fill),
-         _mm_andnot_si128(sat_mask, _mm_and_si128(q, mask_lo))
-      );
-      result_hi = _mm_or_si128(
-         _mm_and_si128(hi_sat_mask, sat_hi_fill),
-         _mm_andnot_si128(hi_sat_mask, _mm_and_si128(q, _mm_set1_epi16((short)0xFF00)))
-      );
-
-      q = _mm_or_si128(result_lo, result_hi);
-   }
-
-   /* Store result — only low 4 lanes (64 bits) */
-   _mm_storel_epi64((__m128i *)addq, q);
+   blitter_simd_add16sat_x4(addq, co, adda, addb, cin, sat, eightbit, hicinh);
 }
 
 const blitter_simd_ops_t blitter_simd_ops = {
-   sse2_lfu,
-   sse2_dcomp,
-   sse2_zcomp,
-   sse2_byte_merge,
-   sse2_add16sat_x4
+   ops_lfu,
+   ops_dcomp,
+   ops_zcomp,
+   ops_byte_merge,
+   ops_add16sat_x4
 };

--- a/src/tom/blitter_simd_sse2.c
+++ b/src/tom/blitter_simd_sse2.c
@@ -7,6 +7,16 @@
  * uses to exercise the very same code the core runs.
  */
 
+/* Select our own arch before blitter_simd.h picks one.  This file IS
+ * the sse2 implementation, so it must get the sse2 inline set even when
+ * compiled standalone without the Makefile's -DBLITTER_SIMD_SSE2 --
+ * as .github/workflows/c-cpp.yml does when it builds
+ * test_blitter_simd by hand.  Without this the header chain pulled in
+ * the scalar set as well and the two collided. */
+#ifndef BLITTER_SIMD_SSE2
+#define BLITTER_SIMD_SSE2 1
+#endif
+
 #include "blitter_simd.h"
 #include "blitter_simd_sse2.h"
 

--- a/src/tom/blitter_simd_sse2.h
+++ b/src/tom/blitter_simd_sse2.h
@@ -1,0 +1,340 @@
+#ifndef BLITTER_SIMD_SSE2_H
+#define BLITTER_SIMD_SSE2_H
+
+/* Included by blitter_simd.h once the arch has been selected.
+ * Do not include directly -- BLITTER_SIMD_INLINE comes from there. */
+#ifndef BLITTER_SIMD_INLINE
+#error "include blitter_simd.h, not blitter_simd_sse2.h"
+#endif
+
+#include <stdint.h>
+#include <boolean.h>
+#include <emmintrin.h>  /* SSE2 */
+#include <string.h>     /* memcpy for type-punning extract */
+
+/*
+ * Blitter SIMD ops — x86/x64 SSE2 implementation
+ *
+ * SSE2 is baseline for all x86_64 processors and available on x86
+ * since Pentium 4 (2001). No runtime feature detection needed.
+ *
+ * Operations work on 64-bit values loaded into 128-bit SSE registers
+ * (upper 64 bits unused or zeroed).
+ */
+
+
+
+
+/* _mm_set_epi64x doesn't exist in MSVC 2010 and earlier.
+ * Build from two 32-bit halves instead (pure SSE2). */
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#define SSE2_SET64(hi, lo) \
+   _mm_set_epi32((int)((uint64_t)(hi) >> 32), (int)(hi), \
+                 (int)((uint64_t)(lo) >> 32), (int)(lo))
+#else
+#define SSE2_SET64(hi, lo) _mm_set_epi64x((int64_t)(hi), (int64_t)(lo))
+#endif
+
+static BLITTER_SIMD_INLINE
+uint64_t blitter_simd_sse2_extract_u64(__m128i v)
+{
+   uint64_t r;
+   memcpy(&r, &v, sizeof(r));
+   return r;
+}
+
+/* Logic Function Unit — SSE2
+ *
+ * The truth table has 4 terms, each gated by one bit of lfu_func.
+ * We broadcast each gate to all 64 bits, then AND/OR in registers.
+ */
+static BLITTER_SIMD_INLINE
+uint64_t blitter_simd_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
+{
+   /* Build 64-bit masks from each lfu_func bit */
+   uint64_t func0 = (lfu_func & 0x01) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+   uint64_t func1 = (lfu_func & 0x02) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+   uint64_t func2 = (lfu_func & 0x04) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+   uint64_t func3 = (lfu_func & 0x08) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+
+   __m128i vs   = SSE2_SET64(0, srcd);
+   __m128i vd   = SSE2_SET64(0, dstd);
+   __m128i vns  = _mm_andnot_si128(vs, _mm_set1_epi32(-1)); /* ~srcd */
+   __m128i vnd  = _mm_andnot_si128(vd, _mm_set1_epi32(-1)); /* ~dstd */
+
+   __m128i vf0  = SSE2_SET64(0, func0);
+   __m128i vf1  = SSE2_SET64(0, func1);
+   __m128i vf2  = SSE2_SET64(0, func2);
+   __m128i vf3  = SSE2_SET64(0, func3);
+
+   /* (~s & ~d & f0) | (~s & d & f1) | (s & ~d & f2) | (s & d & f3) */
+   __m128i t0 = _mm_and_si128(_mm_and_si128(vns, vnd), vf0);
+   __m128i t1 = _mm_and_si128(_mm_and_si128(vns, vd),  vf1);
+   __m128i t2 = _mm_and_si128(_mm_and_si128(vs,  vnd), vf2);
+   __m128i t3 = _mm_and_si128(_mm_and_si128(vs,  vd),  vf3);
+
+   __m128i result = _mm_or_si128(_mm_or_si128(t0, t1), _mm_or_si128(t2, t3));
+   return blitter_simd_sse2_extract_u64(result);
+}
+
+/* Data Comparator — SSE2
+ *
+ * XOR the two 64-bit values, then check each byte for zero.
+ * _mm_cmpeq_epi8 + _mm_movemask_epi8 gives us all 8 byte-equality
+ * bits in one shot.
+ */
+static BLITTER_SIMD_INLINE
+uint8_t blitter_simd_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
+{
+   uint64_t other = cmpdst ? dstd : srcd;
+   __m128i vp = SSE2_SET64(0, patd);
+   __m128i vo = SSE2_SET64(0, other);
+   __m128i vxor = _mm_xor_si128(vp, vo);
+
+   /* Compare each byte against zero */
+   __m128i vzero = _mm_setzero_si128();
+   __m128i vcmp = _mm_cmpeq_epi8(vxor, vzero);
+
+   /* movemask gives us 16 bits (one per byte of 128-bit reg).
+    * We only care about the low 8 bytes. */
+   return (uint8_t)(_mm_movemask_epi8(vcmp) & 0xFF);
+}
+
+/* Z-buffer Comparator — SSE2
+ *
+ * 4 packed 16-bit comparisons. SSE2 has _mm_cmpeq_epi16 and
+ * _mm_cmpgt_epi16 (signed), but Z values are unsigned. We handle
+ * this by biasing both operands by -32768 before signed compare.
+ */
+static BLITTER_SIMD_INLINE
+uint8_t blitter_simd_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
+{
+   uint8_t result = 0;
+   uint8_t packed = 0;
+
+   __m128i vs = SSE2_SET64(0, srcz);
+   __m128i vd = SSE2_SET64(0, dstz);
+
+   /* Bias for unsigned comparison via signed instructions */
+   __m128i bias = _mm_set1_epi16((short)0x8000);
+   __m128i vs_biased = _mm_sub_epi16(vs, bias);
+   __m128i vd_biased = _mm_sub_epi16(vd, bias);
+
+   /* EQ: src == dst */
+   if (zmode & 0x02)
+   {
+      __m128i veq = _mm_cmpeq_epi16(vs, vd);
+      result |= (uint8_t)(_mm_movemask_epi8(veq) & 0xFF);
+   }
+
+   /* LT: src < dst (signed compare after bias = unsigned compare) */
+   if (zmode & 0x01)
+   {
+      __m128i vlt = _mm_cmplt_epi16(vs_biased, vd_biased);
+      result |= (uint8_t)(_mm_movemask_epi8(vlt) & 0xFF);
+   }
+
+   /* GT: src > dst */
+   if (zmode & 0x04)
+   {
+      __m128i vgt = _mm_cmpgt_epi16(vs_biased, vd_biased);
+      result |= (uint8_t)(_mm_movemask_epi8(vgt) & 0xFF);
+   }
+
+   /* movemask gives 2 bits per 16-bit lane (one per byte).
+    * Convert to 1 bit per lane: lanes at positions 0,2,4,6 */
+   if (result & 0x03) packed |= 0x01;  /* lane 0: bytes 0-1 */
+   if (result & 0x0C) packed |= 0x02;  /* lane 1: bytes 2-3 */
+   if (result & 0x30) packed |= 0x04;  /* lane 2: bytes 4-5 */
+   if (result & 0xC0) packed |= 0x08;  /* lane 3: bytes 6-7 */
+
+   return packed;
+}
+
+/* Byte Mask Merge — SSE2
+ *
+ * Byte 0 is per-bit blended, bytes 1-7 are whole-byte selected.
+ * We build a byte-level mask from the 16-bit input, then use
+ * AND/ANDNOT/OR to blend.
+ */
+static BLITTER_SIMD_INLINE
+uint64_t blitter_simd_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
+{
+   /* Build an 8-byte selection mask directly via bit arithmetic.
+    * Byte 0 = low 8 bits of mask (per-bit blend).
+    * Bytes 1-7 = 0xFF or 0x00 from mask bits 8-14 (whole-byte select).
+    * We expand each bit to a full 0xFF byte using sign-extension. */
+   uint64_t sel64 = (uint64_t)(mask & 0xFF);  /* byte 0: per-bit */
+   __m128i vmask, vsrc, vdst, r;
+
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 8)  & 1))) << 8;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 9)  & 1))) << 16;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 10) & 1))) << 24;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 11) & 1))) << 32;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 12) & 1))) << 40;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 13) & 1))) << 48;
+   sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 14) & 1))) << 56;
+
+   vmask = SSE2_SET64(0, sel64);
+   vsrc  = SSE2_SET64(0, src);
+   vdst  = SSE2_SET64(0, dst);
+
+   /* result = (src & mask) | (dst & ~mask) */
+   r = _mm_or_si128(
+      _mm_and_si128(vsrc, vmask),
+      _mm_andnot_si128(vmask, vdst)
+   );
+
+   return blitter_simd_sse2_extract_u64(r);
+}
+
+/* ADD16SAT x4 — SSE2
+ *
+ * Processes all four 16-bit lanes in parallel using SSE2 vectors.
+ * The Jaguar's segmented carry chain (low byte / mid nibble / high nibble)
+ * is replicated across all 4 lanes simultaneously.
+ *
+ * Uses the low 64 bits of 128-bit SSE registers (4 x 16-bit lanes).
+ */
+static BLITTER_SIMD_INLINE
+void blitter_simd_add16sat_x4(uint16_t *addq, uint8_t *co,
+                              const uint16_t *adda, const uint16_t *addb,
+                              const uint8_t *cin,
+                              bool sat, bool eightbit, bool hicinh)
+{
+   /* Load operands — only low 4 lanes used (64 bits) */
+   __m128i va = _mm_loadl_epi64((const __m128i *)adda);
+   __m128i vb = _mm_loadl_epi64((const __m128i *)addb);
+
+   /* Expand cin[0..3] from uint8_t to 16-bit lanes */
+   __m128i vcin;
+   __m128i mask_lo, mask_mid, mask_hi, mask_0100, mask_1000;
+   __m128i va_lo, vb_lo, sum1, q_lo, carry0, carry1;
+   __m128i va_mid, vb_mid, sum2, q_mid, carry2, carry3;
+   __m128i va_hi, vb_hi, sum3, q_hi;
+   __m128i q;
+   uint32_t s0, s1, s2, s3;
+   uint16_t c3_0, c3_1, c3_2, c3_3;
+   uint16_t carry3_buf[8];
+
+   {
+      uint16_t cin16[8] = { 0 };
+      cin16[0] = cin[0]; cin16[1] = cin[1]; cin16[2] = cin[2]; cin16[3] = cin[3];
+      vcin = _mm_loadu_si128((const __m128i *)cin16);
+   }
+
+   mask_lo   = _mm_set1_epi16(0x00FF);
+   mask_mid  = _mm_set1_epi16(0x0F00);
+   mask_hi   = _mm_set1_epi16((short)0xF000);
+   mask_0100 = _mm_set1_epi16(0x0100);
+   mask_1000 = _mm_set1_epi16(0x1000);
+
+   /* Stage 1: low byte add */
+   va_lo = _mm_and_si128(va, mask_lo);
+   vb_lo = _mm_and_si128(vb, mask_lo);
+   sum1  = _mm_add_epi16(_mm_add_epi16(va_lo, vb_lo), vcin);
+   q_lo  = _mm_and_si128(sum1, mask_lo);
+
+   /* carry0 = (sum1 >> 8) & 1 */
+   carry0 = _mm_srli_epi16(_mm_and_si128(sum1, mask_0100), 8);
+
+   /* carry1 = eightbit ? 0 : carry0 */
+   carry1 = eightbit ? _mm_setzero_si128() : carry0;
+
+   /* Stage 2: mid nibble add */
+   va_mid = _mm_and_si128(va, mask_mid);
+   vb_mid = _mm_and_si128(vb, mask_mid);
+   sum2   = _mm_add_epi16(_mm_add_epi16(va_mid, vb_mid), _mm_slli_epi16(carry1, 8));
+   q_mid  = _mm_and_si128(sum2, mask_mid);
+
+   /* carry2 = (sum2 >> 12) & 1 */
+   carry2 = _mm_srli_epi16(_mm_and_si128(sum2, mask_1000), 12);
+
+   /* carry3 = hicinh ? 0 : carry2 */
+   carry3 = hicinh ? _mm_setzero_si128() : carry2;
+
+   /* Stage 3: high nibble add */
+   va_hi = _mm_and_si128(va, mask_hi);
+   vb_hi = _mm_and_si128(vb, mask_hi);
+   sum3  = _mm_add_epi16(_mm_add_epi16(va_hi, vb_hi), _mm_slli_epi16(carry3, 12));
+   q_hi  = _mm_and_si128(sum3, mask_hi);
+
+   /* co[i]: detect carry out of bit 15.  16-bit lanes lose bit 16,
+    * so widen to 32-bit to capture the overflow. */
+   _mm_storeu_si128((__m128i *)carry3_buf, carry3);
+   c3_0 = carry3_buf[0]; c3_1 = carry3_buf[1];
+   c3_2 = carry3_buf[2]; c3_3 = carry3_buf[3];
+
+   s0 = (uint32_t)(adda[0] & 0xF000) + (addb[0] & 0xF000) + ((uint32_t)c3_0 << 12);
+   s1 = (uint32_t)(adda[1] & 0xF000) + (addb[1] & 0xF000) + ((uint32_t)c3_1 << 12);
+   s2 = (uint32_t)(adda[2] & 0xF000) + (addb[2] & 0xF000) + ((uint32_t)c3_2 << 12);
+   s3 = (uint32_t)(adda[3] & 0xF000) + (addb[3] & 0xF000) + ((uint32_t)c3_3 << 12);
+   co[0] = (s0 & 0x10000) ? 1 : 0;
+   co[1] = (s1 & 0x10000) ? 1 : 0;
+   co[2] = (s2 & 0x10000) ? 1 : 0;
+   co[3] = (s3 & 0x10000) ? 1 : 0;
+
+   /* Combine low + mid + high */
+   q = _mm_or_si128(_mm_or_si128(q_lo, q_mid), q_hi);
+
+   /* Saturation logic */
+   if (sat)
+   {
+      __m128i btop, ctop, do_saturate, do_hi_saturate;
+      __m128i sat_lo_fill, sat_hi_fill;
+      __m128i sat_mask, hi_sat_mask;
+      __m128i result_lo, result_hi;
+      uint16_t co16[8] = { 0 };
+      __m128i vco;
+
+      co16[0] = co[0]; co16[1] = co[1]; co16[2] = co[2]; co16[3] = co[3];
+      vco = _mm_loadu_si128((const __m128i *)co16);
+
+      if (eightbit)
+      {
+         btop = _mm_srli_epi16(_mm_and_si128(vb, _mm_set1_epi16(0x0080)), 7);
+         ctop = carry0;
+      }
+      else
+      {
+         btop = _mm_srli_epi16(vb, 15);
+         ctop = vco;
+      }
+
+      /* do_saturate = btop ^ ctop (non-zero lanes saturate) */
+      do_saturate = _mm_xor_si128(btop, ctop);
+
+      /* do_hi_saturate = eightbit ? 0 : do_saturate */
+      do_hi_saturate = eightbit ? _mm_setzero_si128() : do_saturate;
+
+      /* Build saturated fill: ctop ? 0x00FF/0xFF00 : 0x0000 */
+      /* ctop is 0 or 1 in each lane. Expand to mask: cmpeq with 1 gives 0xFFFF where ctop=1 */
+      {
+         __m128i vone = _mm_set1_epi16(1);
+         __m128i ctop_mask = _mm_cmpeq_epi16(ctop, vone);
+         sat_lo_fill = _mm_and_si128(ctop_mask, mask_lo);   /* 0x00FF where ctop=1 */
+         sat_hi_fill = _mm_and_si128(ctop_mask, _mm_set1_epi16((short)0xFF00));
+
+         /* Expand do_saturate/do_hi_saturate to masks */
+         sat_mask    = _mm_cmpeq_epi16(do_saturate, vone);
+         hi_sat_mask = _mm_cmpeq_epi16(do_hi_saturate, vone);
+      }
+
+      /* Select: if saturating use fill, else use q */
+      result_lo = _mm_or_si128(
+         _mm_and_si128(sat_mask, sat_lo_fill),
+         _mm_andnot_si128(sat_mask, _mm_and_si128(q, mask_lo))
+      );
+      result_hi = _mm_or_si128(
+         _mm_and_si128(hi_sat_mask, sat_hi_fill),
+         _mm_andnot_si128(hi_sat_mask, _mm_and_si128(q, _mm_set1_epi16((short)0xFF00)))
+      );
+
+      q = _mm_or_si128(result_lo, result_hi);
+   }
+
+   /* Store result — only low 4 lanes (64 bits) */
+   _mm_storel_epi64((__m128i *)addq, q);
+}
+
+#endif /* BLITTER_SIMD_SSE2_H */


### PR DESCRIPTION
## Summary

Investigating a user report that the **accurate blitter is much slower than Fast in Tempest 2000** turned up a general defect: the SIMD helpers were reached through a **function-pointer table in a separate translation unit**, with no LTO on any desktop target — so nothing could be inlined or devirtualised.

Profiling (macOS `sample`, T2K accurate): `BlitterMidsummer2` ~59% self-time, and **20.6% of total runtime in five tiny SIMD leaf functions** (`neon_add16sat_x4` alone 13.6%). Disassembly showed `blr x8` / `blr x24` — indirect calls. `add16sat_x4` takes three 4-element arrays by pointer, so every call spilled `adda`/`addb`/`cin` to stack for the callee to reload, and the indirection discarded the per-call-site specialisation `ADDARRAY`'s `BLITTER_ALWAYS_INLINE` exists to create (`sat`/`eightbit`/`hicinh` are compile-time constants at its four call sites).

## Change

Implementations move into `blitter_simd_<arch>.h` as `static` always-inline functions, selected by `-DBLITTER_SIMD_{NEON,SSE2,SCALAR}` from the same `Makefile.common` block that already picks the `.c`. Each `.c` keeps `blitter_simd_ops`, now thin wrappers around those same inline functions — so `test/test_blitter_simd.c` still validates exactly the code the core runs, and a `-D`/`.c` mismatch becomes a duplicate-definition **compile error** rather than a silent slow path.

## Measured (arm64 macOS, NEON; best of 5–7 interleaved A/B, 600 frames after 120 warmup)

| Title | fast | accurate before | accurate after |
|---|---|---|---|
| Tempest 2000 | 259.4 | 125.9 | **146.3 (+16.2%)** |
| yarc | 282.2 | 253.8 | **269.5 (+6.2%)** |
| jagniccc | ~283 | 296.0 | **313.4 (+5.9%)** |

Fast blitter unchanged (±2% noise). Notably **the dispatch overhead removed was larger than the SIMD-over-scalar win it was carrying** (SIMD vs scalar measures only 5–9%).

## On the original report

**T2K is not uniquely broken — it is uniquely blit-heavy.** `BENCH_PROFILE=1`: **99,030 blitter inner-loop iterations/frame** vs yarc 15,988 and jagniccc 11,694, at a near-identical blit *count* (~171 vs ~174 calls/frame) — its blits are ~6x larger. This PR does **not** close the fast-vs-accurate gap (still ~1.8x on T2K); the residual is blit volume, which is inherent to what the accurate path does.

## Correctness

- **`test_blitter_compare` on Tempest 2000: 132,912 blits, 0 differences, `IDENTICAL`** (re-run by me post-rebase)
- `fb_ab_sweep` 1200 frames × 5 titles (T2K, AvP, Atari Karts, yarc, jagniccc): `changed_frames=0` — bit-identical framebuffers
- `make TEST_EXPORTS=1 test` exit 0, **opcode sweep 56,103/56,103**, audio pair by name, "Skipped checks: none"
- `test_blitter_simd` passes natively (NEON) and cross-built `-arch x86_64` under Rosetta for SSE2 — bit-exact
- c89-lint clean; all three `BLITTER_SIMD=` values build

## Platform caveats

Measured on **arm64/NEON**; no Intel host available. Static evidence for x86_64: compiling `blitter.c` with `-DBLITTER_SIMD_SSE2`, `BlitterMidsummer2` goes from **zero** SSE2 instructions to 300+ inline, calls 65→42, stack frame +272 bytes — proportionate, no spill blowup from the smaller register file. Worth an Intel confirmation via `make benchmark BENCH_ROM=<T2K> BENCH_BLITTER=accurate`.

Separately noted (not fixed here, tracked on its own): **MSVC x64/x86 and all Android ABIs fall through to `blitter_simd_scalar.c`** — real, but only a 5–9% effect, so not the reported slowdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
