### PR TITLE
build(msvc): select the SSE2 blitter for MSVC 2015/2017 x64 and x86

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -209,10 +209,13 @@ jobs:
       run: |
         ARCH=$(uname -m)
         CC="${{ matrix.config.cc }}"
+        # -DBLITTER_SIMD_<ARCH> is not optional: blitter_simd.h inlines
+        # the matching arch header, so an arch .c compiled without its
+        # define pulls in the scalar ops and then redefines every one.
         case "$ARCH" in
-          x86_64|i686|i386)  SIMD_SRC=src/tom/blitter_simd_sse2.c; EXTRA="-msse2" ;;
-          aarch64|arm64)     SIMD_SRC=src/tom/blitter_simd_neon.c;  EXTRA="" ;;
-          *)                 SIMD_SRC=src/tom/blitter_simd_scalar.c; EXTRA="" ;;
+          x86_64|i686|i386)  SIMD_SRC=src/tom/blitter_simd_sse2.c; EXTRA="-msse2 -DBLITTER_SIMD_SSE2" ;;
+          aarch64|arm64)     SIMD_SRC=src/tom/blitter_simd_neon.c;  EXTRA="-DBLITTER_SIMD_NEON" ;;
+          *)                 SIMD_SRC=src/tom/blitter_simd_scalar.c; EXTRA="-DBLITTER_SIMD_SCALAR" ;;
         esac
 
         echo "==> Testing ${SIMD_SRC}..."
@@ -221,7 +224,7 @@ jobs:
         ./test_blitter_simd
 
         echo "==> Cross-checking against scalar..."
-        $CC -O2 -Wall -I src -I src/core -I src/tom \
+        $CC -O2 -Wall -DBLITTER_SIMD_SCALAR -I src -I src/core -I src/tom \
           -o test_blitter_scalar test/test_blitter_simd.c src/tom/blitter_simd_scalar.c
         ./test_blitter_scalar
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -323,12 +323,22 @@ jobs:
       shell: bash
       run: bash scripts/gen-version-h.sh
 
-    - name: Compile all sources with cl.exe
+    # Sources are .c, so cl.exe compiles them in C mode -- deliberately.
+    # That is what the buildbot does, and it is what makes this job a
+    # useful C89/MSVC check. Do not "fix" it to /TP. Do not add /Za
+    # either: it breaks <emmintrin.h> and the Windows SDK headers.
+    #
+    # Exactly one BLITTER_SIMD_<ARCH> may be defined per translation
+    # unit -- blitter_simd.h inlines the matching blitter_simd_<arch>.h,
+    # and any arch .c compiled under a different (or absent) define
+    # redefines every op. So the SIMD arches get one cl.exe run each,
+    # mirroring how Makefile.common builds exactly one of them.
+    - name: Compile all sources with cl.exe (scalar blitter SIMD)
       shell: cmd
       run: |
         cl.exe /c /W3 /O2 /DNDEBUG /D_CRT_SECURE_NO_DEPRECATE ^
           /I. /Isrc /Isrc\core /Isrc\tom /Isrc\jerry /Isrc\cd /Isrc\bios /Isrc\m68000 /Ilibretro-common\include ^
-          /D__LIBRETRO__ /DINLINE="_inline" ^
+          /D__LIBRETRO__ /DINLINE="_inline" /DBLITTER_SIMD_SCALAR ^
           libretro.c ^
           src\tom\blitter.c src\tom\blitter_compare.c src\tom\blitter_mmio.c src\jerry\dac.c src\jerry\dsp.c src\core\file.c ^
           src\tom\gpu.c src\core\jaguar.c src\jerry\jerry.c src\tom\tom.c src\tom\op.c ^
@@ -339,9 +349,26 @@ jobs:
           src\bios\jagbios.c ^
           src\bios\jagcdbios.c src\bios\jagdevcdbios.c ^
           src\m68000\m68kinterface.c ^
-          src\tom\blitter_simd_scalar.c ^
-          src\tom\blitter_simd_sse2.c
+          src\tom\blitter_simd_scalar.c
         echo MSVC compilation check passed
+
+    # The shape Makefile.common now selects for windows_msvc2015/2017
+    # x64 and x86: blitter.c inlines blitter_simd_sse2.h, so cl.exe
+    # compiles <emmintrin.h> intrinsics inside blitter.c itself -- not
+    # just inside the lint-exempt blitter_simd_sse2.c. That is the whole
+    # risk of enabling SSE2 for MSVC, and this step is what verifies it.
+    # Objects go to a subdir so they don't collide with the run above.
+    - name: Compile blitter with cl.exe (SSE2 blitter SIMD)
+      shell: cmd
+      run: |
+        mkdir msvc-sse2
+        cl.exe /c /W3 /O2 /DNDEBUG /D_CRT_SECURE_NO_DEPRECATE ^
+          /I. /Isrc /Isrc\core /Isrc\tom /Isrc\jerry /Isrc\cd /Isrc\bios /Isrc\m68000 /Ilibretro-common\include ^
+          /D__LIBRETRO__ /DINLINE="_inline" /DBLITTER_SIMD_SSE2 ^
+          /Fomsvc-sse2\ ^
+          src\tom\blitter.c ^
+          src\tom\blitter_simd_sse2.c
+        echo MSVC SSE2 blitter compilation check passed
 
   vita-build:
     name: build-PS Vita

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -529,8 +529,17 @@ jobs:
           # --diff-filter=d drops deleted paths: clang-tidy cannot lint a
           # file that no longer exists and fails the whole job with
           # "no input files" / "expected exactly one compiler job".
+          #
+          # blitter_simd_<arch>.{c,h} are all excluded. Only one arch is
+          # ever built, so the other two .c files aren't in
+          # compile_commands.json; and the .h files are include-only
+          # fragments that refuse to be compiled standalone (they
+          # #error unless blitter_simd.h pulled them in), so linting one
+          # directly is guaranteed to fail. They are covered instead by
+          # c89-lint's per-arch pass, which compiles them the way the
+          # build does.
           FILES=$(git diff --name-only --diff-filter=d "$BASE"...HEAD -- '*.c' '*.h' \
-            | grep -Ev '^(src/m68000/|src/bios/jag.*\.c$|libretro-common/|src/core/version\.h$|src/tom/blitter_simd_(neon|sse2)\.c$)' \
+            | grep -Ev '^(src/m68000/|src/bios/jag.*\.c$|libretro-common/|src/core/version\.h$|src/tom/blitter_simd_(neon|sse2|scalar)\.(c|h)$)' \
             | grep -E '^(src/|libretro\.c$)' || true)
           if [ -z "$FILES" ]; then
             echo "No relevant C files changed; skipping clang-tidy."

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -350,7 +350,6 @@ jobs:
           src\bios\jagcdbios.c src\bios\jagdevcdbios.c ^
           src\m68000\m68kinterface.c ^
           src\tom\blitter_simd_scalar.c
-        echo MSVC compilation check passed
 
     # The shape Makefile.common now selects for windows_msvc2015/2017
     # x64 and x86: blitter.c inlines blitter_simd_sse2.h, so cl.exe
@@ -358,6 +357,11 @@ jobs:
     # just inside the lint-exempt blitter_simd_sse2.c. That is the whole
     # risk of enabling SSE2 for MSVC, and this step is what verifies it.
     # Objects go to a subdir so they don't collide with the run above.
+    #
+    # No trailing `echo` in either step: `shell: cmd` has no `set -e`,
+    # so the step's exit code is the LAST command's. A closing echo
+    # would return 0 over any cl.exe failure and make this whole job
+    # green-but-inert. Let cl.exe be the last command.
     - name: Compile blitter with cl.exe (SSE2 blitter SIMD)
       shell: cmd
       run: |
@@ -368,7 +372,6 @@ jobs:
           /Fomsvc-sse2\ ^
           src\tom\blitter.c ^
           src\tom\blitter_simd_sse2.c
-        echo MSVC SSE2 blitter compilation check passed
 
   vita-build:
     name: build-PS Vita

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,9 @@ test/tools/netlink_delay_proxy
 
 # Skip ledger written by `make test` (scripts/test-skip.sh)
 test/.skipped-checks
+
+# Created by `make platform=windows_msvc*` on a non-Windows host:
+# those blocks run `reg query ... 2>nul`, and outside cmd.exe `nul`
+# is a plain file. Committing it makes every Windows checkout fail
+# with "error: invalid path 'nul'".
+/nul

--- a/Makefile.common
+++ b/Makefile.common
@@ -109,6 +109,31 @@ ifneq (,$(filter MINGW64% MINGW32%,$(MSYSTEM)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/tom/blitter_simd_sse2.c
 endif
 
+# MSVC.  None of the matches above ever fire for these -- the platform
+# strings are windows_msvc*, ARCH is unset -- so every MSVC core used
+# to fall through to scalar.  x64 has SSE2 in the ABI baseline, and
+# MSVC 2015/2017 x86 already compiles to /arch:SSE2 by default, so
+# neither adds a runtime CPU requirement.
+#
+# Spelled out one platform at a time rather than matched with
+# findstring: several MSVC platform names must NOT land here.
+#   windows_msvc2017_*_arm, *_arm64  -- no x86 intrinsics at all
+#   xbox1_msvc2003                   -- Pentium III: SSE, but no SSE2
+#   windows_msvc2010_*,              -- C89-only C mode plus the
+#   windows_msvc2005_x86,               _MSC_VER < 1700 SSE2_SET64
+#   windows_msvc2003_x86                path; the msvc-check CI job
+#                                       runs VS2022 and cannot verify
+#                                       either, so they stay scalar.
+# No -msse2 for any of these -- cl.exe doesn't take it; see the flag
+# block below.
+MSVC_SSE2_PLATFORMS := \
+   windows_msvc2017_desktop_x64 windows_msvc2017_desktop_x86 \
+   windows_msvc2017_uwp_x64     windows_msvc2017_uwp_x86 \
+   windows_msvc2015_x64         windows_msvc2015_x86
+ifneq (,$(filter $(MSVC_SSE2_PLATFORMS),$(platform)))
+   BLITTER_SIMD_SRC := $(CORE_DIR)/src/tom/blitter_simd_sse2.c
+endif
+
 # Native build fallback: auto-detect from host architecture, but only for
 # native-build platforms (unix/osx/win). Cross-compile targets (vita, ps3,
 # libnx, etc.) set platform explicitly and should not use host detection.

--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -23,6 +23,10 @@ skip_file() {
     case "$1" in
         src/m68000/cpu*.c|src/m68000/read*.c) return 0 ;;
         src/bios/jag*bios*.c) return 0 ;;
+        # Skipped only by the default pass, which has no BLITTER_SIMD_<ARCH>
+        # define and so cannot compile them (blitter_simd.h would inline the
+        # scalar ops and the arch header would redefine every one). They are
+        # checked, with the right define and target, by check_simd_arch below.
         src/tom/blitter_simd_neon.c|src/tom/blitter_simd_sse2.c) return 0 ;;
         # Depends on rcheevos headers fetched at runtime by the e2e shell wrapper.
         test/tools/test_rcheevos_e2e.c) return 0 ;;
@@ -42,15 +46,83 @@ else
     FILES="libretro.c $(find src -name '*.c')"
 fi
 
+CHECK_SIMD=0
+
 for f in $FILES; do
     [ -f "$f" ] || continue
     case "$f" in *.c) ;; *) continue ;; esac
+    case "$f" in src/tom/blitter.c|src/tom/blitter_simd_*.c) CHECK_SIMD=1 ;; esac
     if skip_file "$f"; then continue; fi
 
     if ! $CC $CFLAGS $INCLUDES $DEFINES "$f" 2>&1; then
         FAILED=1
     fi
 done
+
+# --------------------------------------------------------------------
+# Per-arch SIMD pass.
+#
+# blitter.c includes blitter_simd.h, which inlines whichever
+# blitter_simd_<arch>.h the build selected.  The loop above runs with no
+# BLITTER_SIMD_<ARCH> define, so it only ever sees the scalar header --
+# yet the buildbot compiles the sse2 one inside blitter.c on every MSVC
+# and x86 target, and the neon one on every ARM target.  A C99-ism in
+# either arch header would sail past the lint and break there instead.
+#
+# Re-check blitter.c (and the arch's own .c) once per arch, cross-
+# targeting when the host can't do it natively.  A host that can't
+# cross-target says so out loud rather than passing silently.
+check_simd_arch() {
+    arch="$1"      # sse2 | neon
+    define="$2"    # BLITTER_SIMD_SSE2 | BLITTER_SIMD_NEON
+    target="$3"    # extra flags, may be empty
+    probe="$4"     # intrinsics header to probe for
+
+    probe_c="${TMPDIR:-/tmp}/c89lint_probe_$$.c"
+    echo "#include <$probe>" > "$probe_c"
+    echo "int main(void) { return 0; }" >> "$probe_c"
+    if ! $CC $CFLAGS $target "$probe_c" >/dev/null 2>&1; then
+        rm -f "$probe_c"
+        echo "C89 lint: SKIP $arch — $CC cannot target it here ($probe unavailable)"
+        echo "C89 lint:      the $arch header is NOT checked on this host; CI covers it."
+        return 0
+    fi
+    rm -f "$probe_c"
+
+    arch_failed=0
+    for f in src/tom/blitter.c "src/tom/blitter_simd_$arch.c"; do
+        [ -f "$f" ] || continue
+        if ! $CC $CFLAGS $target $INCLUDES $DEFINES "-D$define" "$f" 2>&1; then
+            echo "C89 lint: $arch pass failed on $f"
+            arch_failed=1
+            FAILED=1
+        fi
+    done
+    [ "$arch_failed" = "0" ] && echo "C89 lint: $arch pass OK"
+    return 0
+}
+
+# Only worth running when blitter.c is actually in scope.
+case "$CHECK_SIMD" in
+    1)
+        case "$(uname -m)" in
+            x86_64|amd64|i686|i386) SSE2_TARGET="-msse2" ;;
+            *) case "$(uname -s)" in
+                   Darwin) SSE2_TARGET="--target=x86_64-apple-macos11 -msse2" ;;
+                   *)      SSE2_TARGET="--target=x86_64-linux-gnu -msse2" ;;
+               esac ;;
+        esac
+        case "$(uname -m)" in
+            aarch64|arm64) NEON_TARGET="" ;;
+            *) case "$(uname -s)" in
+                   Darwin) NEON_TARGET="--target=arm64-apple-macos11" ;;
+                   *)      NEON_TARGET="--target=aarch64-linux-gnu" ;;
+               esac ;;
+        esac
+        check_simd_arch sse2 BLITTER_SIMD_SSE2 "$SSE2_TARGET" emmintrin.h
+        check_simd_arch neon BLITTER_SIMD_NEON "$NEON_TARGET" arm_neon.h
+        ;;
+esac
 
 if [ "$FAILED" = "1" ]; then
     echo "C89 lint FAILED — fix mid-block declarations"

--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -78,12 +78,17 @@ check_simd_arch() {
     target="$3"    # extra flags, may be empty
     probe="$4"     # intrinsics header to probe for
 
+    cc="$CC"
+    case "$target" in
+        *--target=*) command -v clang >/dev/null 2>&1 && cc=clang ;;
+    esac
+
     probe_c="${TMPDIR:-/tmp}/c89lint_probe_$$.c"
     echo "#include <$probe>" > "$probe_c"
     echo "int main(void) { return 0; }" >> "$probe_c"
-    if ! $CC $CFLAGS $target "$probe_c" >/dev/null 2>&1; then
+    if ! $cc $CFLAGS $target "$probe_c" >/dev/null 2>&1; then
         rm -f "$probe_c"
-        echo "C89 lint: SKIP $arch — $CC cannot target it here ($probe unavailable)"
+        echo "C89 lint: SKIP $arch — $cc cannot target it here ($probe unavailable)"
         echo "C89 lint:      the $arch header is NOT checked on this host; CI covers it."
         return 0
     fi
@@ -92,7 +97,7 @@ check_simd_arch() {
     arch_failed=0
     for f in src/tom/blitter.c "src/tom/blitter_simd_$arch.c"; do
         [ -f "$f" ] || continue
-        if ! $CC $CFLAGS $target $INCLUDES $DEFINES "-D$define" "$f" 2>&1; then
+        if ! $cc $CFLAGS $target $INCLUDES $DEFINES "-D$define" "$f" 2>&1; then
             echo "C89 lint: $arch pass failed on $f"
             arch_failed=1
             FAILED=1

--- a/src/tom/blitter_simd_neon.h
+++ b/src/tom/blitter_simd_neon.h
@@ -95,6 +95,7 @@ uint8_t blitter_simd_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
    uint16x4_t vs = vreinterpret_u16_u64(vcreate_u64(srcz));
    uint16x4_t vd = vreinterpret_u16_u64(vcreate_u64(dstz));
    uint16x4_t vresult = vdup_n_u16(0);
+   uint8_t result = 0;
 
    if (zmode & 0x01)  /* LT */
       vresult = vorr_u16(vresult, vclt_u16(vs, vd));
@@ -107,7 +108,6 @@ uint8_t blitter_simd_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
     * vresult lanes are 0xFFFF or 0x0000. Narrow and extract. */
    /* Shift each lane: lane0 >> 0, lane1 >> 1, lane2 >> 2, lane3 >> 3
     * But easier: just read each lane */
-   uint8_t result = 0;
    if (vget_lane_u16(vresult, 0)) result |= 0x01;
    if (vget_lane_u16(vresult, 1)) result |= 0x02;
    if (vget_lane_u16(vresult, 2)) result |= 0x04;

--- a/src/tom/blitter_simd_sse2.h
+++ b/src/tom/blitter_simd_sse2.h
@@ -25,9 +25,11 @@
 
 
 
-/* _mm_set_epi64x doesn't exist in MSVC 2010 and earlier.
- * Build from two 32-bit halves instead (pure SSE2). */
-#if defined(_MSC_VER) && _MSC_VER < 1700
+/* _mm_set_epi64x doesn't exist in MSVC 2010 and earlier, and its
+ * availability on 32-bit MSVC targets varies by version.  Build from
+ * two 32-bit halves instead (pure SSE2, and what cl.exe lowers the
+ * 64-bit form to on x86 anyway) whenever either applies. */
+#if defined(_MSC_VER) && (_MSC_VER < 1700 || !defined(_M_X64))
 #define SSE2_SET64(hi, lo) \
    _mm_set_epi32((int)((uint64_t)(hi) >> 32), (int)(hi), \
                  (int)((uint64_t)(lo) >> 32), (int)(lo))


### PR DESCRIPTION
The inline-SIMD work this branch was named for already landed on `develop` via #332. What's left here is #333, which was merged into this branch and never had a route onward — this PR is that route. After it merges, `perf/blitter-t2k` can be deleted.

## The bug

`Makefile.common`'s SIMD selection block never matched a single MSVC platform name — they are all `windows_msvc*`, and `ARCH` is unset — so every libretro-buildbot MSVC core fell through to `blitter_simd_scalar.c`. Measured cost of the scalar fallback (NEON vs scalar, accurate blitter, Tempest 2000) is ~5% post-inlining, ~9% pre-inlining. The repo's own release matrix is unaffected: Windows there is MSYS2/MinGW, which already selected sse2.

## The fix

An explicit allowlist rather than `findstring msvc`, because three groups of MSVC platform names must **not** match:

| Excluded | Why |
|---|---|
| `windows_msvc2017_*_arm`, `*_arm64` | no x86 intrinsics at all |
| `xbox1_msvc2003` | Pentium III — SSE, but no SSE2 |
| `windows_msvc2010_*`, `2005_x86`, `2003_x86` | C89-only C mode plus the `_MSC_VER < 1700` `SSE2_SET64` path; `msvc-check` runs VS2022 and can verify neither |

Enabled: `windows_msvc2017_desktop_x64/_x86`, `windows_msvc2017_uwp_x64/_x86`, `windows_msvc2015_x64/_x86`. x64 has SSE2 in the ABI baseline; MSVC 2015/2017 x86 already compiles to `/arch:SSE2` by default. Neither adds a runtime CPU requirement. No `-msse2` — the existing flag block already gates it off for MSVC.

`SSE2_SET64` now takes the two-halves `_mm_set_epi32` form on 32-bit MSVC as well as on `_MSC_VER < 1700`. `_mm_set_epi64x`'s availability on x86 varies by MSVC version, and cl.exe lowers the 64-bit form to the same thing there anyway.

## Verification

This puts `<emmintrin.h>` intrinsics inside `blitter.c` on MSVC for the first time, so verification is the point, not a footnote.

- **Full C/C++ CI green** ([run 31068946305](https://github.com/libretro/virtualjaguar-libretro/actions/runs/31068946305)), including *MSVC x64* and *MSVC x86*, with the new SSE2 step listed `success` — not skipped.
- `msvc-check` split into one cl.exe run per arch. The SSE2 run compiles `blitter.c` with `/DBLITTER_SIMD_SSE2`, so the x64 leg exercises `_mm_set_epi64x` and the x86 leg exercises the `_mm_set_epi32` fallback.
- `c89-lint` gained a per-arch pass: re-checks `blitter.c` + `blitter_simd_<arch>.c` under `-std=gnu89 -Werror=declaration-after-statement` with the matching define, cross-targeting when the host can't do it natively. A host that can't prints a loud SKIP rather than passing silently. Failure path confirmed by injecting a mid-block declaration: exit 1, no false "pass OK".
- `make platform=… print-BLITTER_SIMD_SRC`: sse2 for all six allowlisted targets, scalar for `uwp_arm64` / `msvc2010_x64` / `msvc2005_x86` / `xbox1_msvc2003`.
- `test_blitter_simd` 56103/56103 on arm64 (NEON) and `-arch x86_64` (SSE2).

## Two pre-existing CI breaks fixed along the way

Both were blocking that verification:

- **`msvc-check` could not go red.** Its steps ended with `echo … passed`; `shell: cmd` has no `set -e`, so the step's exit code was the echo's. Dropped the echoes.
- **"Run SIMD blitter tests" compiled `blitter_simd_<arch>.c` with no `BLITTER_SIMD_<ARCH>`**, failing on all seven native build rows. Fixed from the source side in 27c59f2 (already on develop); the define is also passed from CI here, which documents the requirement at the call site.

`c2206a2` also caught a real C99-ism in `blitter_simd_neon.h` — zcomp's `result` was declared mid-block, reachable from `blitter.c` on every ARM target. Moved to the top of the block; no behaviour change.

## Also in here

`/nul` added to `.gitignore`. The `windows_msvc*` Makefile blocks run `reg query … 2>nul`, which on a non-Windows host creates a file literally named `nul`. Commit one and every Windows checkout dies with `error: invalid path 'nul'` before compiling anything.

`6bef13d` is a Copilot Autofix on `scripts/c89-lint.sh` applied during #333's review.

A `clang-tidy` fix too: that job lints PR-changed files directly, and this is the first PR to touch `blitter_simd_{neon,sse2}.h` since the ops moved into them. Those headers are include-only fragments that `#error` unless `blitter_simd.h` pulled them in, so linting one standalone can only fail. The exclusion list already covered the arch `.c` files; extended it to the `.h` files (and to scalar for symmetry). `c89-lint`'s per-arch pass still covers all of them, compiled the way the build does.

## Follow-up

The Android half of this problem is #335.

Note that `windows_msvc2019_*` matches no block in this Makefile at all and falls through to the generic `else` — a missing platform block, not a SIMD-selection bug. Not added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

