### PR TITLE
build(android): give ndk-build a real blitter SIMD arch

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -95,24 +95,28 @@ jobs:
             os: ubuntu-latest
             android: true
             android_abi: 'arm64-v8a'
+            android_simd: 'neon'
 
           - displayTargetName: 'Android armeabi-v7a'
             artifact: 'libs/armeabi-v7a/libretro.so'
             os: ubuntu-latest
             android: true
             android_abi: 'armeabi-v7a'
+            android_simd: 'neon'
 
           - displayTargetName: 'Android x86_64'
             artifact: 'libs/x86_64/libretro.so'
             os: ubuntu-latest
             android: true
             android_abi: 'x86_64'
+            android_simd: 'sse2'
 
           - displayTargetName: 'Android x86'
             artifact: 'libs/x86/libretro.so'
             os: ubuntu-latest
             android: true
             android_abi: 'x86'
+            android_simd: 'sse2'
 
           # iOS / tvOS
           - displayTargetName: 'iOS arm64'
@@ -181,8 +185,39 @@ jobs:
         # ndk-build uses jni/Android.mk (not the project Makefile),
         # so the parse-time version.h regen in Makefile doesn't run.
         bash scripts/gen-version-h.sh
-        ${{ steps.setup-ndk.outputs.ndk-path }}/ndk-build \
-          APP_ABI=${{ matrix.config.android_abi }} -j4
+
+        NDK="${{ steps.setup-ndk.outputs.ndk-path }}"
+        ABI="${{ matrix.config.android_abi }}"
+        SIMD="${{ matrix.config.android_simd }}"
+        UPPER=$(echo "$SIMD" | tr '[:lower:]' '[:upper:]')
+
+        # Dry run first, while nothing is built, so make actually prints
+        # the compile lines. blitter.c MUST carry -DBLITTER_SIMD_<ARCH>:
+        # without it blitter.c inlines the scalar ops and still links
+        # happily against the neon/sse2 vtable, so a missing define is a
+        # silent slow path that no build failure would reveal.
+        "$NDK/ndk-build" APP_ABI="$ABI" -n > ndk-dry.log 2>&1
+        BLIT_LINES=$(grep -c '[/ ]blitter\.c' ndk-dry.log || true)
+        if [ "$BLIT_LINES" = "0" ]; then
+          echo "::error::ndk-build -n printed no compile line for blitter.c; this check needs rework"
+          exit 1
+        fi
+        if ! grep '[/ ]blitter\.c' ndk-dry.log | grep -q -- "-DBLITTER_SIMD_${UPPER}"; then
+          echo "::error::blitter.c is not compiled with -DBLITTER_SIMD_${UPPER} on ${ABI}"
+          grep '[/ ]blitter\.c' ndk-dry.log | head -3
+          exit 1
+        fi
+        echo "==> ${ABI}: blitter.c carries -DBLITTER_SIMD_${UPPER}"
+
+        "$NDK/ndk-build" APP_ABI="$ABI" -j4
+
+        # And the arch .c that define has to agree with.
+        FOUND=$(find "obj/local/$ABI" -name 'blitter_simd_*.o' -exec basename {} \; | sort | tr '\n' ' ')
+        if [ "$FOUND" != "blitter_simd_${SIMD}.o " ]; then
+          echo "::error::expected blitter_simd_${SIMD}.o on ${ABI}, found: ${FOUND:-<none>}"
+          exit 1
+        fi
+        echo "==> ${ABI}: built ${FOUND}"
 
     # Mach-O symbol gating: production builds must export retro_* only.
     # Runs before the test step (which would relink with TEST_EXPORTS=1

--- a/Makefile.common
+++ b/Makefile.common
@@ -139,13 +139,18 @@ SOURCES_C += $(BLITTER_SIMD_SRC)
 # blitter.c.  This must agree with the .c file selected above; if it
 # doesn't, that .c fails to compile (duplicate definitions) instead of
 # quietly running one impl while the vtable test validates another.
+#
+# Kept in its own variable because jni/Android.mk builds its own flag
+# set from scratch (COREFLAGS) and never sees $(CFLAGS) -- it needs this
+# define and nothing else from here.
 ifeq ($(BLITTER_SIMD_SRC),$(CORE_DIR)/src/tom/blitter_simd_sse2.c)
-   CFLAGS += -DBLITTER_SIMD_SSE2
+   BLITTER_SIMD_DEFINE := -DBLITTER_SIMD_SSE2
 else ifeq ($(BLITTER_SIMD_SRC),$(CORE_DIR)/src/tom/blitter_simd_neon.c)
-   CFLAGS += -DBLITTER_SIMD_NEON
+   BLITTER_SIMD_DEFINE := -DBLITTER_SIMD_NEON
 else
-   CFLAGS += -DBLITTER_SIMD_SCALAR
+   BLITTER_SIMD_DEFINE := -DBLITTER_SIMD_SCALAR
 endif
+CFLAGS += $(BLITTER_SIMD_DEFINE)
 
 # Add -msse2 flag for all GCC/Clang SSE2 builds. No-op on x86_64 (baseline),
 # required on i686 / gcc -m32. Skip for MSVC (uses /arch:SSE2, not -msse2).

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -2,9 +2,43 @@ LOCAL_PATH := $(call my-dir)/..
 
 CORE_DIR := $(LOCAL_PATH)
 
+# Blitter SIMD arch, picked from the ABI ndk-build is currently building.
+# Makefile.common's own detection can't do it here: `platform` and `ARCH`
+# are unset under ndk-build and $(CC) isn't a cross-compiler triple it
+# recognises, so every Android ABI -- including x86_64 -- silently landed
+# on the scalar blitter.
+#
+# Reset first. With APP_ABI=all, ndk-build re-includes this file once per
+# ABI in the same make process, so a stale value from the previous ABI
+# would leak (arm64-v8a then riscv64 would try to build the NEON source
+# for RISC-V).
+#
+# Why each mapping is safe:
+#   arm64-v8a    -- NEON is mandatory in ARMv8-A.
+#   armeabi-v7a  -- NDK r21+ builds armeabi-v7a with NEON by default and
+#                   r26 dropped non-NEON ARMv7 entirely; CI pins r26d.
+#   x86 / x86_64 -- the NDK x86 ABI baseline is SSSE3, which subsumes
+#                   SSE2, so no -msse2 is needed on either.
+# Anything else (riscv64, ...) leaves BLITTER_SIMD empty and falls
+# through to Makefile.common's scalar default.
+BLITTER_SIMD :=
+ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+   BLITTER_SIMD := neon
+else ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+   BLITTER_SIMD := neon
+else ifeq ($(TARGET_ARCH_ABI),x86_64)
+   BLITTER_SIMD := sse2
+else ifeq ($(TARGET_ARCH_ABI),x86)
+   BLITTER_SIMD := sse2
+endif
+
 include $(CORE_DIR)/Makefile.common
 
-COREFLAGS := -DINLINE="inline" -D__LIBRETRO__ $(INCFLAGS)
+# $(BLITTER_SIMD_DEFINE) is what makes blitter.c inline the same ops the
+# arch .c compiles. Without it blitter.c falls back to the scalar inline
+# set -- which links fine against the neon/sse2 vtable and just runs
+# slower, so nothing would catch its absence at build time.
+COREFLAGS := -DINLINE="inline" -D__LIBRETRO__ $(INCFLAGS) $(BLITTER_SIMD_DEFINE)
 
 # libretro.c includes the generated src/core/version.h.  Generate it
 # at parse time -- ndk-build doesn't go through the project Makefile,


### PR DESCRIPTION
The Android half of the same problem as #334: a build path that never reached the SIMD selection logic and silently got the scalar blitter.

## The bug

`jni/Android.mk` builds its flag set from scratch (`COREFLAGS := -DINLINE=… -D__LIBRETRO__ $(INCFLAGS)`) and never passes `$(CFLAGS)`. Under ndk-build none of `Makefile.common`'s detection inputs exist either — no `platform`, no `ARCH`, and `$(CC)` isn't a triple it recognises. So **every** Android ABI, `x86_64` included, fell through to `blitter_simd_scalar.c`, and `-DBLITTER_SIMD_<ARCH>` never reached the compiler.

Define and source agreed, so nothing was broken — just slow on every Android build.

## The fix

Map `TARGET_ARCH_ABI` to an arch before the include:

| ABI | Arch | Why it's safe |
|---|---|---|
| `arm64-v8a` | neon | NEON is mandatory in ARMv8-A |
| `armeabi-v7a` | neon | NDK r21+ builds armeabi-v7a with NEON by default; r26 dropped non-NEON ARMv7 entirely, and CI pins r26d |
| `x86`, `x86_64` | sse2 | the NDK x86 ABI baseline is SSSE3, which subsumes SSE2 — so no `-msse2` on either |
| anything else | *(unset)* | falls through to `Makefile.common`'s scalar default |

`BLITTER_SIMD` is reset before the chain: with `APP_ABI=all`, ndk-build re-includes `Android.mk` once per ABI in one make process, so a stale `neon` would otherwise try to build the NEON source for riscv64. (`SOURCES_C` and `BLITTER_SIMD_SRC` already self-reset, so nothing else leaks across ABIs.)

`Makefile.common` now keeps the define in `BLITTER_SIMD_DEFINE` and folds that into `CFLAGS`, so `Android.mk` can take the one thing it needs without inheriting host flags. No `LOCAL_ARM_NEON` — it's a no-op on r26d, and the `ndk-version: r26d` pin is what defines the contract.

## Verification

The CI Android rows now assert **both** halves, and both asserts were observed firing:

```
==> x86_64: blitter.c carries -DBLITTER_SIMD_SSE2
==> x86_64: built blitter_simd_sse2.o
```

- The arch `.c` is checked by name in `obj/local/<abi>`.
- `blitter.c`'s compile line is checked for `-DBLITTER_SIMD_<ARCH>` via `ndk-build -n`, with a guard that fails loudly if the dry run prints no `blitter.c` line at all rather than passing vacuously.

The second check is the load-bearing one. Since each arch `.c` self-selects its own macro (27c59f2), a missing define doesn't fail the build — `blitter.c` just inlines the scalar ops and links happily against the neon/sse2 vtable. Nothing would go red; it would only be slow. That is exactly the failure mode this PR fixes, so it needed an assert that can see it.

**Full C/C++ CI green** ([run 31071191071](https://github.com/libretro/virtualjaguar-libretro/actions/runs/31071191071)) — all four Android ABIs plus every other row.

## Interaction with #334

Both touch `Makefile.common` and `c-cpp.yml`, in different regions; `git merge-tree` confirms they combine cleanly. Whoever merges these second may want to confirm `CFLAGS += $(BLITTER_SIMD_DEFINE)` still reaches the MSVC targets — it does, that line is a straight substitution for the three `CFLAGS += -DBLITTER_SIMD_*` branches it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)