### PR TITLE
fix(timing): charge bus latencies in wall time under clock scales (#318)

### DIFF
--- a/exports-test.list
+++ b/exports-test.list
@@ -18,6 +18,7 @@ _Halfline*
 _jaguarMainRAM
 _jaguarMainROM
 _jagMemSpace
+_busArbiter
 _pcQueue
 _pcQPtr
 _a6Queue

--- a/libretro.c
+++ b/libretro.c
@@ -37,6 +37,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "joystick.h"
 #include "settings.h"
 #include "tom.h"
+#include "gpu.h"
 #include "eeprom.h"
 #include "memtrack.h"
 #include "jaggd.h"
@@ -595,6 +596,9 @@ static void check_variables(void)
       else if (strcmp(var.value, "2x") == 0)
          riscClockScalePct = 200;
    }
+   /* Drop the GPU's sub-cycle bus-stall remainder when the RISC scale
+    * (possibly) changed — mirrors M68KClockScaleReset() above. */
+   GPUClockScaleReset();
 
    if (m68kClockScalePct != 100 || riscClockScalePct != 100)
       LOG_INF("[CLOCK] Non-stock clock scales active: M68K %u%%, RISC %u%% (enhancement mode; timing-sensitive bug reports are only valid at 1x)\n",

--- a/link-test.T
+++ b/link-test.T
@@ -21,6 +21,7 @@
       jaguarMainRAM;
       jaguarMainROM;
       jagMemSpace;
+      busArbiter;
       pcQueue;
       pcQPtr;
       a6Queue;

--- a/src/core/bus_arbiter.c
+++ b/src/core/bus_arbiter.c
@@ -133,7 +133,8 @@ uint32_t bus_arbiter_charge_access(int master, uint32_t addr)
     return cost;
 }
 
-uint32_t bus_arbiter_m68k_access(uint32_t addr, uint32_t naccesses)
+uint32_t bus_arbiter_m68k_access(uint32_t addr, uint32_t naccesses,
+                                 uint32_t scale_pct)
 {
     uint32_t per_access, sysclks, cycles;
 
@@ -170,9 +171,16 @@ uint32_t bus_arbiter_m68k_access(uint32_t addr, uint32_t naccesses)
     sysclks = per_access * naccesses;
     if (sysclks == 0)
         return 0;
-    busArbiter.m68k_sysclk_carry += sysclks;
-    cycles = busArbiter.m68k_sysclk_carry >> 1;
-    busArbiter.m68k_sysclk_carry &= 1;
+
+    /* Wall sysclks -> the 68K's scaled cycle domain (cycle-domain
+     * contract, bus_arbiter.h): a stock 68K cycle is 2 sysclks and the
+     * budget holds scale_pct/100 cycles per stock cycle, so
+     * cycles = sysclks * scale_pct / 200, remainder carried.  At
+     * scale_pct == 100 this reduces exactly to the old system/2
+     * conversion (carry 0/100 instead of 0/1). */
+    busArbiter.m68k_sysclk_carry += sysclks * scale_pct;
+    cycles = busArbiter.m68k_sysclk_carry / 200u;
+    busArbiter.m68k_sysclk_carry %= 200u;
     return cycles;
 }
 

--- a/src/core/bus_arbiter.h
+++ b/src/core/bus_arbiter.h
@@ -22,6 +22,37 @@
  * blitter busy-time, 68K arbitration done right) can grow back around
  * it.
  *
+ * CYCLE-DOMAIN CONTRACT (issue #318).  Every charge in this model is a
+ * memory-system latency, and memory-system latencies are WALL TIME:
+ * they come from DRAM/ROM silicon, which does not speed up when a core
+ * option overclocks a processor.  Instruction costs (gpu_opcode_cycles,
+ * the UAE 68K's published timings) are CORE TIME and scale with their
+ * processor's clock.  Concretely, per charge:
+ *
+ *   68K per-access wait states  computed in sysclks here, converted to
+ *     the 68K's SCALED cycle domain by bus_arbiter_m68k_access() (the
+ *     caller passes its clock-scale percent) so the wall time of a wait
+ *     state is invariant under the m68k_clock_scale enhancement.
+ *   GPU per-access self-cost    returned in sysclks by
+ *     bus_arbiter_charge_access(); gpu.c converts to the GPU's scaled
+ *     cycle domain at the point it deducts from the slice budget.
+ *   OP fetch / row-change / DRAM refresh  charged to the 68K as
+ *     m68k_pending_stall and drained by M68KExecuteWithStalls() BEFORE
+ *     the 68K clock scale is applied — already wall time.
+ *   DSP external accesses       currently pay NOTHING (no charge hook
+ *     in dsp.c).  Known asymmetry; the pipeline-hazard work (#313) is
+ *     expected to add the DSP-side hook and must place its charges in
+ *     this same wall-time domain.
+ *
+ * One deliberate simplification: the 68K wait-state THRESHOLD
+ * (M68K_BUS_CYCLE_SYSCLKS, the stock 8-sysclk bus cycle an access must
+ * exceed before it costs anything) stays defined against the STOCK bus
+ * cycle even when the 68K is overclocked.  A hypothetical overclocked
+ * 68000 would have a shorter bus cycle and see more wait states; the
+ * clock scales are enhancement levers documented as "bug reports only
+ * valid at 1x", so the model keeps the stock threshold and only makes
+ * the charged excess wall-time invariant.
+ *
  * MEMCON1 default on Jaguar: 0x1861
  *   Bits 3-4 (ROMSPEED): 0b00 = 10 system clocks per ROM access
  *     (JTRM: 0=10, 1=8, 2=6, 3=5; bit 7 FASTROM overrides to 2, test-only)
@@ -85,8 +116,12 @@ struct BusArbiter {
      * handoff) is being pinned down against measured game pace. */
     uint8_t contention_scale;
 
-    /* 68K self-cost carry: system clocks not yet converted to a whole
-     * 68K cycle (68K runs at system/2, so 0 or 1).  Savestate field. */
+    /* 68K self-cost carry: sub-cycle remainder from converting wall
+     * sysclks into scaled 68K cycles.  Units are sysclk-hundredths
+     * (sysclks x scale_pct), remainder modulo 200 — at stock scale
+     * (100) this is exactly the old odd-sysclk carry with values
+     * 0/100 instead of 0/1.  Savestate field; an old state's 0/1
+     * value loads as a sub-cycle epsilon, which is harmless. */
     uint32_t m68k_sysclk_carry;
 
     /* Elapsed system clocks not yet folded into a refresh request
@@ -132,11 +167,17 @@ uint32_t bus_arbiter_refresh_clocks(uint32_t elapsed_sysclks);
 uint32_t bus_arbiter_charge_access(int master, uint32_t addr);
 
 /* 68K self-cost: whole 68K cycles to charge for `naccesses` 16-bit
- * bus cycles at `addr` (a longword access passes 2).  Converts system
- * clocks to 68K cycles (system/2), carrying the odd clock in
- * busArbiter.m68k_sysclk_carry.  Does not check busArbiter.enabled —
- * call sites gate, same as the GPU half. */
-uint32_t bus_arbiter_m68k_access(uint32_t addr, uint32_t naccesses);
+ * bus cycles at `addr` (a longword access passes 2).  Converts wall
+ * system clocks into the 68K's cycle domain at `scale_pct` (the
+ * m68k_clock_scale percent, 100 = stock): cycles = sysclks x
+ * scale_pct / 200, sub-cycle remainder carried in
+ * busArbiter.m68k_sysclk_carry.  At 100 this is exactly the old
+ * system/2 conversion.  Wall time of a wait state is thus invariant
+ * under the clock scale — see the cycle-domain contract above.  Does
+ * not check busArbiter.enabled — call sites gate, same as the GPU
+ * half. */
+uint32_t bus_arbiter_m68k_access(uint32_t addr, uint32_t naccesses,
+                                 uint32_t scale_pct);
 
 #ifdef __cplusplus
 }

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -404,7 +404,7 @@ static int m68kBusNoCharge = 0;
 #define M68K_BUS_CHARGE(addr, naccesses) \
    do { \
       if (busArbiter.enabled && !m68kBusNoCharge) \
-         regs.remainingCycles -= (int32_t)bus_arbiter_m68k_access((addr), (naccesses)); \
+         regs.remainingCycles -= (int32_t)bus_arbiter_m68k_access((addr), (naccesses), m68kClockScalePct); \
    } while (0)
 
 unsigned int m68k_read_memory_8(unsigned int address)

--- a/src/core/jaguar.h
+++ b/src/core/jaguar.h
@@ -63,12 +63,15 @@ extern uint32_t jaguarLoadedRAMStart, jaguarLoadedRAMEnd;
  * rate (100 = stock).  Config, not state: set from the core options in
  * libretro.c::check_variables(), never serialized.  Applied ONLY where
  * execution budgets are handed out (JaguarExecuteNew() timeslices and
- * the 68K->GPU 2:1 coupling in GPUSyncToM68K()) -- bus costs
- * (bus_arbiter_m68k_access() DRAM latencies, OP-fetch/refresh occupancy,
- * blitter occupancy) and all event scheduling (video, PIT, UART, I2S)
- * stay on the real, unscaled sysclock.  At 100 the integer arithmetic
- * (c * 100 / 100) is an exact identity, so 1x is bit-identical to the
- * unscaled build. */
+ * the 68K->GPU 2:1 coupling in GPUSyncToM68K()) -- bus costs and all
+ * event scheduling (video, PIT, UART, I2S) stay on the real, unscaled
+ * sysclock.  For the per-access charges that are deducted from a
+ * SCALED budget (bus_arbiter_m68k_access() wait states, the GPU bus
+ * stall in gpu.c) wall-time invariance is enforced by converting the
+ * sysclk charge into the consumer's scaled cycle domain -- see the
+ * cycle-domain contract in bus_arbiter.h (issue #318).  At 100 the
+ * integer arithmetic (c * 100 / 100) is an exact identity, so 1x is
+ * bit-identical to the unscaled build. */
 extern uint32_t m68kClockScalePct;
 void M68KClockScaleReset(void);
 extern uint32_t riscClockScalePct;

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -46,6 +46,13 @@
  * Units: system clocks (same as bus_arbiter charges). */
 static uint32_t gpu_bus_stall;
 
+/* Sub-cycle remainder from converting wall-sysclk bus stalls into the
+ * GPU's scaled cycle domain (cycle-domain contract, bus_arbiter.h).
+ * Units: sysclk-hundredths, remainder modulo 100.  Always 0 at stock
+ * scale.  Not serialized — same precedent as m68kScaleAccum (a bounded
+ * sub-cycle epsilon); reset alongside the scale in GPUClockScaleReset(). */
+static uint32_t gpu_stall_scale_accum;
+
 /* Charge an external memory access and accumulate the stall.
  * addr is the target address — GPU local RAM (0xF03000-0xF03FFF)
  * costs nothing; external addresses cost DRAM access time. */
@@ -846,6 +853,15 @@ void GPUDone(void)
    branch_condition_table = NULL;
 }
 
+/* Drop the sub-cycle bus-stall remainder when the RISC clock scale
+ * (possibly) changed, so a new scale starts from a clean accumulator.
+ * Mirrors M68KClockScaleReset() for m68kScaleAccum. */
+void GPUClockScaleReset(void)
+{
+   gpu_stall_scale_accum = 0;
+}
+
+
 void GPUReset(void)
 {
    unsigned i;
@@ -1040,7 +1056,22 @@ void GPUExec(int32_t cycles)
        executeOpcode(index);
 #endif
 
-      cycles -= gpu_opcode_cycles[index] + (int32_t)gpu_bus_stall;
+      /* Bus stalls are wall time (sysclks); the slice budget is in the
+       * GPU's scaled cycle domain.  Convert so a DRAM wait costs the
+       * same wall time at any RISC clock scale (bus_arbiter.h contract):
+       * at 2x the budget holds twice the cycles per wall second, so the
+       * same stall must consume twice the cycles.  Stock scale takes
+       * the identity branch — bit-exact pre-#318 behavior. */
+      if (riscClockScalePct != 100u && gpu_bus_stall != 0)
+      {
+         uint32_t stall_scaled;
+         gpu_stall_scale_accum += gpu_bus_stall * riscClockScalePct;
+         stall_scaled = gpu_stall_scale_accum / 100u;
+         gpu_stall_scale_accum %= 100u;
+         cycles -= gpu_opcode_cycles[index] + (int32_t)stall_scaled;
+      }
+      else
+         cycles -= gpu_opcode_cycles[index] + (int32_t)gpu_bus_stall;
 
       /* Single-step barrier (G_CTRL SINGLE_STEP, bit 3): a running RISC core
        * that has just set SINGLE_STEP has entered single-step mode and stops

--- a/src/tom/gpu.h
+++ b/src/tom/gpu.h
@@ -17,6 +17,7 @@ extern "C" {
 void GPUInit(void);
 void GPUDone(void);
 void GPUReset(void);
+void GPUClockScaleReset(void);
 void GPUExec(int32_t);
 /* Slice bookkeeping for the 68K->GPU-local-RAM sync; see the comment on
  * gpuSliceBudget in gpu.c.  GPUBeginSlice() declares the RISC cycles the

--- a/test/test_dram_timing.c
+++ b/test/test_dram_timing.c
@@ -103,41 +103,67 @@ int main(void)
     /* Main DRAM at MEMCON1 0x1861 costs 5 sysclks -- FASTER than the
      * CPU's own bus cycle, so the 68K never waits on it. */
     busArbiter.m68k_sysclk_carry = 0;
-    check(bus_arbiter_m68k_access(0x00080000, 1) == 0,
+    check(bus_arbiter_m68k_access(0x00080000, 1, 100) == 0,
           "DRAM (5 sysclks) is faster than a 68K bus cycle: no stall");
     check(busArbiter.m68k_sysclk_carry == 0,
           "no carry from a free access");
-    check(bus_arbiter_m68k_access(0x00080000, 2) == 0,
+    check(bus_arbiter_m68k_access(0x00080000, 2, 100) == 0,
           "longword to DRAM still free");
 
     /* I/O bus (2 sysclks) likewise costs the 68K nothing. */
-    check(bus_arbiter_m68k_access(0x00F00050, 1) == 0,
+    check(bus_arbiter_m68k_access(0x00F00050, 1, 100) == 0,
           "I/O (2 sysclks) does not stall the 68K");
 
     /* Cart ROM at ROMSPEED=0 costs 10 sysclks: 2 over the baseline,
      * i.e. 1 68K cycle.  This is the only thing that stalls the CPU at
      * the reset MEMCON1 -- and it is why 68K code executing from cart
      * ROM runs measurably slower than its datasheet cycle counts. */
-    check(bus_arbiter_m68k_access(0x00800000, 1) == 1,
+    check(bus_arbiter_m68k_access(0x00800000, 1, 100) == 1,
           "cart ROM (10 sysclks) stalls 1 68K cycle per access");
     check(busArbiter.m68k_sysclk_carry == 0,
           "even wait leaves no carry");
-    check(bus_arbiter_m68k_access(0x00800000, 2) == 2,
+    check(bus_arbiter_m68k_access(0x00800000, 2, 100) == 2,
           "longword from cart ROM stalls 2 68K cycles");
 
     /* Odd waits carry.  DRAMSPEED=0 gives row-miss 7, so DRAM costs
-     * 2 + 7 = 9 sysclks -- 1 over the baseline, an odd number. */
+     * 2 + 7 = 9 sysclks -- 1 over the baseline, an odd number.  Carry
+     * units are sysclk-hundredths (sysclks x scale_pct, modulo 200), so
+     * the carried odd clock reads as 100, not 1. */
     bus_arbiter_update_memcon((uint16_t)(0x1861 & ~0x0060));
     busArbiter.m68k_sysclk_carry = 0;
-    check(bus_arbiter_m68k_access(0x00080000, 1) == 0,
+    check(bus_arbiter_m68k_access(0x00080000, 1, 100) == 0,
           "slow DRAM: 1 sysclk of wait is less than one 68K cycle");
-    check(busArbiter.m68k_sysclk_carry == 1,
-          "odd system clock carried");
-    check(bus_arbiter_m68k_access(0x00080000, 1) == 1,
+    check(busArbiter.m68k_sysclk_carry == 100,
+          "odd system clock carried (100 hundredths)");
+    check(bus_arbiter_m68k_access(0x00080000, 1, 100) == 1,
           "carry + 1 sysclk completes a 68K cycle");
     check(busArbiter.m68k_sysclk_carry == 0,
           "carry drained");
     bus_arbiter_update_memcon(0x1861);
+
+    /* --- Cycle-domain contract under m68k_clock_scale (#318) --------
+     * Wait states are wall time: an overclocked 68K's budget holds
+     * scale/100 cycles per stock cycle, so the SAME wall wait must
+     * consume scale/100 times the cycles.  cycles = sysclks*pct/200. */
+
+    /* 2x: cart ROM's 2-sysclk wait = 1 stock cycle = 2 scaled cycles. */
+    busArbiter.m68k_sysclk_carry = 0;
+    check(bus_arbiter_m68k_access(0x00800000, 1, 200) == 2,
+          "2x scale: cart ROM wait charges 2 scaled cycles (same wall time)");
+    check(busArbiter.m68k_sysclk_carry == 0,
+          "2x scale: even conversion leaves no carry");
+
+    /* 0.5x: the same wait is half a scaled cycle -- carried, then
+     * completed by the next access. */
+    busArbiter.m68k_sysclk_carry = 0;
+    check(bus_arbiter_m68k_access(0x00800000, 1, 50) == 0,
+          "0.5x scale: one ROM wait is sub-cycle, carried");
+    check(busArbiter.m68k_sysclk_carry == 100,
+          "0.5x scale: half a scaled cycle in the carry");
+    check(bus_arbiter_m68k_access(0x00800000, 1, 50) == 1,
+          "0.5x scale: second ROM wait completes a scaled cycle");
+    check(busArbiter.m68k_sysclk_carry == 0,
+          "0.5x scale: carry drained");
 
     /* --- DRAM refresh model (MEMCON2 REFRATE) --------------------- */
     bus_arbiter_update_memcon(0x1861);   /* DRAMSPEED=3 */


### PR DESCRIPTION
Part 1 of #318: settle the cycle-domain contract for every `dram_timing` charge.

**Rule** (now documented in `bus_arbiter.h`): a memory-system latency is wall time — DRAM/ROM silicon does not speed up when a core option overclocks a processor. Instruction costs are core time and scale with their processor's clock.

**Two charges violated it, both invisible at stock scale:**

- **GPU per-access self-cost** — sysclk-valued stalls were deducted from the RISC-scaled slice budget without conversion, so at `risc=2x` a DRAM wait consumed half its real wall time (#316's caveat). Now converted into the scaled domain with an error-diffusion accumulator.
- **68K per-access wait states** — same class. `bus_arbiter_m68k_access()` now takes the caller's scale percent; `cycles = sysclks × pct / 200`, remainder carried. At 100 this reduces exactly to the old `system/2` conversion.

OP fetch / row-change / refresh were already drained pre-scale (wall time) and are unchanged. The DSP's missing charge hook is documented as #313's insertion point. The 68K wait-state threshold deliberately stays at the stock 8-sysclk bus cycle under overclock — decision recorded in the header.

**Validation**

- **1x identity gate:** 1800-frame framebuffer-hash CSVs (`test/tools/frame_hash_ab`, from a Battle Morph gameplay save state) are **byte-identical** to the pre-change build with `dram_timing` on *and* off.
- **Semantic fix visible at 2x+dram:** pace ratio vs 1x moves 0.840 → 0.877 — overclock buys less speedup because DRAM latency keeps its wall time.
- `test_dram_timing` gains scaled-domain coverage (2x doubles the charge, 0.5x carries the half-cycle).
- Full suite green; both audio tests pass (presence also asserted at `risc=2x`); acid 140/143 with **zero regressions** vs baseline; benchmark p50 3.38 ms unchanged.
- Audio note: `dac.c`/`dsp.c` untouched, DSP pays no bus charges; stock audio behavior is bit-identical per the identity gate.

Unblocks #313, whose `max(bus latency, consumer distance)` stall arithmetic needs each charge to have a declared domain. Part 2 of #318 (demo-stutter root cause) is a separate investigation.

Context: `docs/battle-morph-pace-calibration.md` (measured on the same save state) — `dram_timing` moves BM gameplay pace by +18.8%, so this option's correctness now demonstrably matters beyond Doom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)