### PR TITLE
fix(core): program VI like the boot ROM in HLE fast-boot (Raiden black screen)

### DIFF
--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -218,6 +218,8 @@ extern uint8_t jagMemSpace[];
 #define TOM_OLP_HI              0x22
 #define TOM_BORD1               0x2A
 #define TOM_BORD2               0x2C
+#define TOM_VDE                 0x48
+#define TOM_VI                  0x4E
 #define TOM_INT                 0xF000E0
 #define TOM_INT_CLR_ALL         0x1F00
 
@@ -1188,6 +1190,15 @@ void JaguarReset(void)
       /* --- Clear border color --- */
       SET16(tomRam8, TOM_BORD1, 0x0000);
       SET16(tomRam8, TOM_BORD2, 0x0000);
+
+      /* --- Vertical interrupt line ---
+       * The boot ROM programs VI to the first VBlank halfline (VDE+1,
+       * measured $207 on the retail BIOS) before jumping to the cart.
+       * Carts may enable the INT1 VI bit without ever writing VI
+       * (Raiden does), relying on this value; with VI left 0 the
+       * compare never fires and the game spins waiting for its VBlank
+       * ISR. */
+      SET16(tomRam8, TOM_VI, (uint16_t)(GET16(tomRam8, TOM_VDE) + 1));
 
       /* --- Interrupts: clear all pending, disable all enables --- */
       TOMWriteWord(TOM_INT, TOM_INT_CLR_ALL, M68K);

--- a/test/test_hle_bios.c
+++ b/test/test_hle_bios.c
@@ -1698,7 +1698,11 @@ static void test_tom_video_registers(void)
    CHECK_TOM("VDE",  TOM_VDE,  518);
    CHECK_TOM("VEB",  TOM_VEB,  ntsc ? 511 : 613);
    CHECK_TOM("VEE",  TOM_VEE,  6);
-   CHECK_TOM("VI",   TOM_VI,   0);  /* left at 0; (vc>0) guard disables until game sets it */
+   /* The real boot ROM programs VI to the first VBlank halfline (VDE+1)
+    * before jumping to the cart; carts like Raiden enable the INT1 VI
+    * bit without ever writing VI and hang without this (issue class:
+    * "works only with real BIOS"). Measured $207 on the retail BIOS. */
+   CHECK_TOM("VI",   TOM_VI,   519);
    CHECK_TOM("HEQ",  TOM_HEQ,  ntsc ? 784 : 787);
    CHECK_TOM("BG",   TOM_BG,   0);
    CHECK_TOM("VMODE", TOM_VMODE, 0x06C1);


### PR DESCRIPTION
## Problem
Raiden boots to a permanent black screen with no audio in HLE (fast-boot) mode and has always required the real-BIOS core option (reported as far back as #20/#70).

## Root cause
Wedge-probe evidence: the 68K spins at $18014A (`tst.b $2C7(a4)` / `beq.s`) waiting for its VBlank ISR to set a frame flag at $180679. The ISR is installed (L2 autovector → $404) and enabled (INT1=$0101), but TOM's VI halfline-compare register is 0 — Raiden never writes VI, relying on the boot ROM's value, and our HLE fabrication block never programmed it. On hardware a cart can never observe VI=0 because the BIOS always runs first (measured: retail BIOS leaves VI=$207 = VDE+1).

## Fix
Program `VI = VDE+1` in the HLE post-boot fabrication block in `JaguarReset()`, next to the other boot-ROM state replication. Strictly more hardware-accurate; games that program their own VI simply overwrite it, and stray VI interrupts land on the existing RTE stub vectors exactly as they would post-BIOS on hardware.

## Testing
- TDD: `test_hle_bios` had codified the bug (`CHECK_TOM("VI", 0)`); expectation flipped to 519, failed before the fix, 219/219 after (NTSC+PAL, mode-invariance checks included).
- `make TEST_EXPORTS=1 test` exit 0, zero skipped checks.
- Raiden headless HLE: black/silent → renders gameplay (66–94% nonblack, sustained motion), audio onset frame 724; screenshot-verified imagery.
- `scripts/c89-lint.sh` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)