### PR TITLE
feat(tom): true-color shadow framebuffer — full-precision gouraud rendering (#338)

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -32,6 +32,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/jerry/jlink_netpacket.c \
 	$(CORE_DIR)/src/jerry/uart.c \
 	$(CORE_DIR)/src/tom/op.c \
+	$(CORE_DIR)/src/tom/shadowfb.c \
 	$(CORE_DIR)/src/tom/tom.c  \
 	$(CORE_DIR)/src/cd/cdintf.c \
 	$(CORE_DIR)/src/cd/cdrom.c \

--- a/docs/true-color-shadowfb-design.md
+++ b/docs/true-color-shadowfb-design.md
@@ -1,0 +1,119 @@
+# True-color internal rendering — shadow precision framebuffer
+
+**Date:** 2026-08-07
+**Epic:** #338 (enhancement suite), track 3 ("true-color internal rendering")
+**Status:** design approved in-session; awaiting spec review
+
+## Problem
+
+Jaguar 3D titles (Battlemorph, Iron Soldier 2, Checkered Flag) show visible
+banding in gouraud-shaded surfaces. The precision loss happens at **blitter
+write time**, not at the output stage: the blitter's gouraud iterator carries
+intensity with 16 fraction bits (`gd_i`), then discards them writing
+`(gd_c << 8) | (gd_i >> 16)` as a 16-bit CRY pixel into the game's framebuffer
+in main RAM. TOM's `CRY16ToRGB32` LUT at scanline time multiplies 4+4-bit
+chroma by the surviving 8-bit intensity — the fraction is gone. Output-stage
+filtering (BigPEmu's approach, RetroArch debanding shaders) can only smooth
+already-quantized data.
+
+## Goal
+
+Render gouraud-shaded pixels to the host framebuffer at full precision
+(chroma × 24-bit intensity) while the game-visible 16-bit framebuffer stays
+**bit-identical** to stock. Default off. Pace-neutral by construction (no
+timing code touched).
+
+## Non-goals (v1)
+
+- RGB16 (5-6-5) and 24bpp/mixed-mode rendering — stay stock.
+- Chroma interpolation — CRY gouraud interpolates intensity only; chroma
+  stays 4+4.
+- Performance optimization — correctness first (user decision); benchmark
+  recorded informationally, no gate.
+- Hi-res / Nx — this is deliberately the 1x prototype of the shadow-buffer
+  architecture that track 1 (shadow hi-res) will extend.
+
+## Architecture (approach A: shadow precision framebuffer)
+
+Two arrays mirror main RAM's 1M 16-bit pixel words, allocated lazily only
+when the core option is on (~8 MB total):
+
+- `shadowRGB[1M]` — packed RGB888 result of the full-precision conversion.
+- `shadowTag[1M]` — the 16-bit stock value the entry was derived from, plus
+  a valid bit (so zero-init never false-matches RAM zeros).
+
+**Coherence is by value-check at read time, not invalidation hooks.** A
+reader compares RAM's current 16-bit value with the entry's tag; mismatch →
+entry is stale → fall back to the stock LUT. No CPU/GPU/DSP/OP write path is
+touched, which keeps the stock pipeline provably intact and makes the
+bit-identity guarantee structural.
+
+False-positive staleness (RAM coincidentally equals a stale tag) paints a
+plausible full-precision pixel — cosmetic, self-healing on the next write.
+
+## Components and data flow
+
+1. **Blit time** (`src/tom/blitter.c`): the gouraud (`GOURD`/`GOURZ`) and
+   intensity-shade write paths, when the option is on, additionally compute
+   `rgb888 = cry_to_rgb_full(gd_c[i], gd_i[i])` (chroma tables × 24-bit
+   intensity) and call `shadow_store(dstAddr, stock16, rgb888)`. The stock
+   16-bit write is unchanged.
+2. **Scanline time** (`src/tom/op.c`): the OP's 16bpp bitmap paths (scaled
+   and unscaled), which read framebuffer phrases from RAM and write pixels
+   into the line buffer at `tomRam8[0x1800 + …]`, also resolve
+   `shadow_lookup(srcAddr, value16)` and write the result (hit → shadow
+   RGB888; miss → `CRY16ToRGB32[value16]`) into a parallel **shadow line
+   buffer** at the same line-buffer offset. Every other OP write site (CLUT,
+   BLEND_CR/BLEND_Y paths) stores the stock LUT conversion of the 16-bit
+   value it just wrote, so the shadow line buffer is always fully populated.
+   The per-line background fill / line-buffer clear that runs before object
+   processing initializes the shadow line buffer the same way (stock LUT of
+   the background value), so pixels no object touches render correctly.
+3. **Output** (`src/tom/tom.c`): `tom_render_16bpp_cry_scanline` copies the
+   shadow line buffer to the host backbuffer instead of running the LUT.
+4. **Module**: new `src/tom/shadowfb.{c,h}` owns the arrays,
+   alloc/free/clear, and the store/lookup inlines. C89, lint-clean.
+5. **Option**: `virtualjaguar_true_color` in `libretro_core_options.h`,
+   default `disabled`; runtime toggle allocates/clears or frees.
+
+## Lifecycle / edge cases
+
+- Shadow is a derived cache: never savestated; cleared on savestate load and
+  option toggle; freed and statics reset in `retro_deinit` (iOS static-reset
+  rule — cores can't dlclose there).
+- Allocation failure: log a warning, feature stays off, core runs stock.
+- Pixels from non-gouraud blits, GPU stores, or the 68K have no shadow entry
+  and render stock. Mixed-precision frames are fine — stock is banded, not
+  wrong.
+
+## Testing / validation
+
+- **Identity gate (OFF)**: `frame_hash_ab` across the A/B corpus must be
+  bit-identical to develop (same methodology that validated #337).
+- **Effect evidence (ON)**: unique-color count on shaded scenes
+  (Battlemorph, IS2, Checkered Flag) rises substantially vs stock;
+  screenshots via the visual-verify tooling; RetroArch check on a real game
+  (house rule — headless can't judge "looks right").
+- Full `make TEST_EXPORTS=1 test`, `bash scripts/c89-lint.sh` on new/touched
+  files, `make benchmark` recorded.
+- Pace-neutrality: structural (no timing code), spot-checked against the
+  BM/Doom calibration docs.
+
+## Strategic sequencing (user directive, 2026-08-07)
+
+The next track after this one must be something that **proves the core is
+better than BigPEmu for most users most of the time**. Assessment:
+
+- **Shadow hi-res blitter upscaling** (epic track 1) is the visible headline
+  BigPEmu structurally lacks (it filters at the output stage only). This
+  spec's shadow buffer, value-check coherence, and shadow line buffer are
+  its 1x prototype — hi-res generalizes the same interfaces to Nx.
+- **Ecosystem moat + "it just works"**: RetroAchievements, runahead-grade
+  determinism (already banked), every RetroArch platform, plus the
+  per-title enhancement defaults DB (track 4) so users never hand-tune.
+- **Compatibility breadth** is BigPEmu's actual crown; a corpus-driven
+  boot/compat audit against its title list should become its own epic track
+  feeding the per-title DB.
+
+Recommendation: true-color (this spec) → shadow hi-res (headline) with the
+compat audit running as a parallel background track.

--- a/docs/true-color-shadowfb-design.md
+++ b/docs/true-color-shadowfb-design.md
@@ -63,14 +63,23 @@ plausible full-precision pixel — cosmetic, self-healing on the next write.
    into the line buffer at `tomRam8[0x1800 + …]`, also resolve
    `shadow_lookup(srcAddr, value16)` and write the result (hit → shadow
    RGB888; miss → `CRY16ToRGB32[value16]`) into a parallel **shadow line
-   buffer** at the same line-buffer offset. Every other OP write site (CLUT,
-   BLEND_CR/BLEND_Y paths) stores the stock LUT conversion of the 16-bit
-   value it just wrote, so the shadow line buffer is always fully populated.
-   The per-line background fill / line-buffer clear that runs before object
-   processing initializes the shadow line buffer the same way (stock LUT of
-   the background value), so pixels no object touches render correctly.
-3. **Output** (`src/tom/tom.c`): `tom_render_16bpp_cry_scanline` copies the
-   shadow line buffer to the host backbuffer instead of running the LUT.
+   buffer** at the same line-buffer offset, tagged with the 16-bit value
+   written alongside it.
+
+   *Implemented refinement:* the shadow line buffer is **tag-checked at
+   render time** rather than exhaustively populated at every writer. The
+   original plan had each remaining OP write site (CLUT, BLEND_CR/BLEND_Y,
+   the per-line background fill) also store a stock LUT conversion so the
+   buffer would always be fully populated. That enumeration is not closed —
+   the GPU and 68K can write the line buffer directly through TOM memory
+   space — so a missed writer would leave a stale entry that renders as a
+   wrong pixel. Tagging instead makes any unenumerated path fall back to
+   stock rendering automatically: two touch points instead of ~20, and
+   mispopulation is impossible by construction rather than by review.
+3. **Output** (`src/tom/tom.c`): `tom_render_16bpp_cry_scanline` substitutes
+   the shadow line buffer's RGB888 **only where the entry's tag matches the
+   16-bit value actually in the line buffer**, and runs the stock
+   `CRY16ToRGB32` LUT everywhere else.
 4. **Module**: new `src/tom/shadowfb.{c,h}` owns the arrays,
    alloc/free/clear, and the store/lookup inlines. C89, lint-clean.
 5. **Option**: `virtualjaguar_true_color` in `libretro_core_options.h`,

--- a/libretro.c
+++ b/libretro.c
@@ -36,6 +36,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "uart.h"
 #include "joystick.h"
 #include "settings.h"
+#include "shadowfb.h"
 #include "tom.h"
 #include "gpu.h"
 #include "eeprom.h"
@@ -507,6 +508,13 @@ static void check_variables(void)
       else
          vjs.useFastBlitter = false;
    }
+
+   var.key = "virtualjaguar_true_color";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      ShadowFBSetEnabled(strcmp(var.value, "enabled") == 0);
+   else
+      ShadowFBSetEnabled(0);
 
    var.key = "virtualjaguar_crash_detect";
    var.value = NULL;
@@ -1153,6 +1161,11 @@ bool retro_unserialize(const void *data, size_t size)
    bus_arbiter_update_memcon2(TOMGetMEMCON2());
 
    JaguarApplyHLEBIOSState();
+
+   /* The true-color shadow framebuffer is a derived cache over RAM
+    * contents that were just replaced wholesale; drop every entry
+    * (never serialized -- see shadowfb.h). */
+   ShadowFBInvalidate();
 
    return true;
 }
@@ -1873,6 +1886,10 @@ void retro_deinit(void)
    if (sampleBuffer)
       free(sampleBuffer);
    sampleBuffer = NULL;
+
+   /* Free the true-color shadow buffers and reset all module statics
+    * (iOS cannot dlclose cores, so statics persist across loads). */
+   ShadowFBShutdown();
 
    eeprom_dirty_cb = NULL;
    mt_dirty_cb     = NULL;

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -141,6 +141,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "virtualjaguar_true_color",
+      "True Color (Gouraud Precision)",
+      NULL,
+      "Render gouraud-shaded pixels at full precision (chroma x 24-bit intensity) to reduce banding in 3D games. The game-visible 16-bit framebuffer is unchanged. Applies to CRY 16bpp video modes only.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "virtualjaguar_crash_detect",
       "Crash Detect",
       NULL,

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include "jaguar.h"
 #include "perf_counters.h"
+#include "shadowfb.h"
 #include "state.h"
 
 // Various conditional compilation goodies...
@@ -642,6 +643,35 @@ void blitter_generic(uint32_t cmd)
                WRITE_PIXEL(a1, REG(A1_FLAGS), writedata);
                if (DSTWRZ)
                   WRITE_ZDATA(a1, REG(A1_FLAGS), srczdata);
+
+               /* True-color shadow store (see shadowfb.h): record the
+                * full-precision intensity for gouraud / intensity-shade
+                * pixels written to a 16bpp destination.  The stock
+                * 16-bit write above is UNCHANGED; this is a parallel
+                * derived cache keyed by value-check at read time. */
+               if (shadowFBActive && !inhibit && (GOURD || SRCSHADE)
+                     && (((REG(A1_FLAGS) >> 3) & 0x07) == 4))
+               {
+                  uint16_t sfb_frac = 0;
+                  if (GOURD)
+                     sfb_frac = (uint16_t)(gd_i[colour_index] & 0xFFFF);
+                  else
+                  {
+                     /* SRCSHADE: 24-bit intensity = source intensity
+                      * plus the full (fraction-carrying) IINC.  Only
+                      * keep the fraction when the integer part agrees
+                      * with the stock write (clamp edges use 0). */
+                     int32_t sfb_i24 = ((int32_t)(srcdata & 0xFF) << 16) + gd_ia;
+                     if (sfb_i24 < 0)
+                        sfb_i24 = 0;
+                     if (sfb_i24 > 0x00FFFFFF)
+                        sfb_i24 = 0x00FFFFFF;
+                     if ((uint32_t)(sfb_i24 >> 16) == (writedata & 0xFF))
+                        sfb_frac = (uint16_t)(sfb_i24 & 0xFFFF);
+                  }
+                  ShadowFBStoreCry(a1_addr + (PIXEL_OFFSET_16(a1) << 1),
+                        (uint16_t)writedata, sfb_frac);
+               }
             }
          }
          else	// if (DSTA2) 							// Data movement: A1 -> A2
@@ -782,6 +812,28 @@ void blitter_generic(uint32_t cmd)
 
                if (DSTWRZ)
                   WRITE_ZDATA(a2, REG(A2_FLAGS), srczdata);
+
+               /* True-color shadow store, A2-destination twin of the
+                * A1 branch above (see shadowfb.h). */
+               if (shadowFBActive && !inhibit && (GOURD || SRCSHADE)
+                     && (((REG(A2_FLAGS) >> 3) & 0x07) == 4))
+               {
+                  uint16_t sfb_frac = 0;
+                  if (GOURD)
+                     sfb_frac = (uint16_t)(gd_i[colour_index] & 0xFFFF);
+                  else
+                  {
+                     int32_t sfb_i24 = ((int32_t)(srcdata & 0xFF) << 16) + gd_ia;
+                     if (sfb_i24 < 0)
+                        sfb_i24 = 0;
+                     if (sfb_i24 > 0x00FFFFFF)
+                        sfb_i24 = 0x00FFFFFF;
+                     if ((uint32_t)(sfb_i24 >> 16) == (writedata & 0xFF))
+                        sfb_frac = (uint16_t)(sfb_i24 & 0xFFFF);
+                  }
+                  ShadowFBStoreCry(a2_addr + (PIXEL_OFFSET_16(a2) << 1),
+                        (uint16_t)writedata, sfb_frac);
+               }
             }
          }
 
@@ -3290,6 +3342,32 @@ A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
                         blitter_write_word(address, wdata & 0x0000FFFF);
                      else
                         blitter_write_byte(address, wdata & 0x000000FF);
+                  }
+
+                  /* True-color shadow store for gouraud writes to a
+                   * 16bpp destination (see shadowfb.h).  In GOURD mode
+                   * the srcd1 register lanes carry the per-pixel
+                   * intensity fractions (JTRM: the source data
+                   * registers hold intensity fractions during gouraud).
+                   * Lanes that COMP_CTRL inhibited were byte-merged
+                   * from dstd, so their tag equals current RAM and the
+                   * value-check makes the entry a benign refinement of
+                   * the same 16-bit value; any fraction yields a color
+                   * within one stock quantization step (bounded by
+                   * construction, see ShadowFBCryRGB). */
+                  if (shadowFBActive && gourd && pixsize == 4)
+                  {
+                     if (phrase_mode)
+                     {
+                        int sfb_k;
+                        for (sfb_k = 0; sfb_k < 4; sfb_k++)
+                           ShadowFBStoreCry(address + ((uint32_t)sfb_k << 1),
+                                 (uint16_t)(wdata >> ((3 - sfb_k) << 4)),
+                                 (uint16_t)(srcd1 >> ((3 - sfb_k) << 4)));
+                     }
+                     else
+                        ShadowFBStoreCry(address, (uint16_t)wdata,
+                              (uint16_t)srcd1);
                   }
                }
 

--- a/src/tom/op.c
+++ b/src/tom/op.c
@@ -21,6 +21,7 @@
 #include "gpu.h"
 #include "jaguar.h"
 #include "m68000/m68kinterface.h"
+#include "shadowfb.h"
 #include "vjag_memory.h"
 #include "tom.h"
 
@@ -960,6 +961,9 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
       {
          // Fetch phrase...
          uint64_t pixels = ((uint64_t)JaguarReadLong(data, OP) << 32) | JaguarReadLong(data + 4, OP);
+         /* Source phrase address for the true-color shadow lookup;
+          * captured before the pitch advance below. */
+         uint32_t sfbPhrase = data;
          pixels <<= firstPix;
          data += pitch;
 
@@ -979,8 +983,18 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
             else
             {
                if (!flagRMW)
-                  *currentLineBuffer = bitsHi,
-                     *(currentLineBuffer + 1) = bitsLo;
+               {
+                  *currentLineBuffer = bitsHi;
+                  *(currentLineBuffer + 1) = bitsLo;
+                  /* True-color: resolve the source RAM word against the
+                   * shadow framebuffer and mirror it into the shadow
+                   * line buffer at the same pixel index (see shadowfb.h). */
+                  if (shadowFBActive)
+                     ShadowFBLineFromRAM(
+                           (int)((currentLineBuffer - &tomRam8[0x1800]) >> 1),
+                           sfbPhrase + (((uint32_t)(i - 1)) << 1),
+                           (uint16_t)(((uint16_t)bitsHi << 8) | bitsLo));
+               }
                else
                   *currentLineBuffer =
                      BLEND_CR(*currentLineBuffer, bitsHi),
@@ -1488,8 +1502,19 @@ void OPProcessScaledBitmap(uint64_t p0, uint64_t p1, uint64_t p2, bool render)
          else
          {
             if (!flagRMW)
-               *currentLineBuffer = bitsHi,
-                  *(currentLineBuffer + 1) = bitsLo;
+            {
+               *currentLineBuffer = bitsHi;
+               *(currentLineBuffer + 1) = bitsLo;
+               /* True-color: resolve the source RAM word against the
+                * shadow framebuffer and mirror it into the shadow line
+                * buffer at the same pixel index (see shadowfb.h).
+                * pixCount is the pixel index within the phrase at data. */
+               if (shadowFBActive)
+                  ShadowFBLineFromRAM(
+                        (int)((currentLineBuffer - &tomRam8[0x1800]) >> 1),
+                        data + ((uint32_t)pixCount << 1),
+                        (uint16_t)(((uint16_t)bitsHi << 8) | bitsLo));
+            }
             else
                *currentLineBuffer =
                   BLEND_CR(*currentLineBuffer, bitsHi),

--- a/src/tom/shadowfb.c
+++ b/src/tom/shadowfb.c
@@ -1,0 +1,125 @@
+/*
+ * shadowfb.c: True-color shadow precision framebuffer (epic #338 track 3)
+ *
+ * See shadowfb.h and docs/true-color-shadowfb-design.md for the
+ * architecture.  All state here is a derived cache: never savestated,
+ * cleared on savestate load / option toggle, fully reset in
+ * ShadowFBShutdown (iOS cannot dlclose cores).
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "shadowfb.h"
+#include "log.h"
+
+/* CRY chroma tables + stock LUT live in tom.c */
+extern uint8_t redcv[16][16];
+extern uint8_t greencv[16][16];
+extern uint8_t bluecv[16][16];
+extern uint32_t CRY16ToRGB32[0x10000];
+
+/* Main RAM is 2MB = 1M 16-bit words, mirrored through the bottom 8MB of
+ * the address space (see JaguarReadWord/JaguarWriteWord in jaguar.c). */
+#define SHADOWFB_WORDS 0x100000
+
+int shadowFBActive = 0;
+
+uint32_t shadowLineRGB[SHADOWFB_LINE_PIXELS];
+uint32_t shadowLineTag[SHADOWFB_LINE_PIXELS];
+
+static uint32_t *shadowRGB = NULL;
+static uint32_t *shadowTag = NULL;
+
+uint32_t ShadowFBCryRGB(uint16_t value16, uint16_t frac16)
+{
+   uint32_t cyan = ((uint32_t)value16 & 0xF000) >> 12;
+   uint32_t red  = ((uint32_t)value16 & 0x0F00) >> 8;
+   uint32_t i24  = (((uint32_t)value16 & 0x00FF) << 16) | frac16;
+   uint32_t r = ((uint32_t)redcv[cyan][red]   * i24) >> 24;
+   uint32_t g = ((uint32_t)greencv[cyan][red] * i24) >> 24;
+   uint32_t b = ((uint32_t)bluecv[cyan][red]  * i24) >> 24;
+   return (r << 16) | (g << 8) | b;
+}
+
+void ShadowFBStoreCry(uint32_t addr, uint16_t value16, uint16_t frac16)
+{
+   uint32_t idx;
+   if (!shadowFBActive)
+      return;
+   addr &= 0xFFFFFF;
+   if (addr >= 0x800000)
+      return;
+   idx = (addr & 0x1FFFFE) >> 1;
+   shadowRGB[idx] = ShadowFBCryRGB(value16, frac16);
+   shadowTag[idx] = (uint32_t)value16 | SHADOWFB_TAG_VALID;
+}
+
+int ShadowFBLookup(uint32_t addr, uint16_t current16, uint32_t *rgb888)
+{
+   uint32_t idx;
+   if (!shadowFBActive)
+      return 0;
+   addr &= 0xFFFFFF;
+   if (addr >= 0x800000)
+      return 0;
+   idx = (addr & 0x1FFFFE) >> 1;
+   if (shadowTag[idx] != ((uint32_t)current16 | SHADOWFB_TAG_VALID))
+      return 0;
+   *rgb888 = shadowRGB[idx];
+   return 1;
+}
+
+void ShadowFBLineFromRAM(int idx, uint32_t srcAddr, uint16_t value16)
+{
+   uint32_t rgb;
+   if (idx < 0 || idx >= SHADOWFB_LINE_PIXELS)
+      return;
+   if (!ShadowFBLookup(srcAddr, value16, &rgb))
+      rgb = CRY16ToRGB32[value16] & 0x00FFFFFF;
+   shadowLineRGB[idx] = rgb;
+   shadowLineTag[idx] = (uint32_t)value16 | SHADOWFB_TAG_VALID;
+}
+
+void ShadowFBInvalidate(void)
+{
+   if (shadowTag)
+      memset(shadowTag, 0, SHADOWFB_WORDS * sizeof(uint32_t));
+   memset(shadowLineTag, 0, sizeof(shadowLineTag));
+}
+
+void ShadowFBSetEnabled(int enable)
+{
+   if (enable)
+   {
+      if (shadowFBActive)
+         return;
+      if (!shadowRGB)
+         shadowRGB = (uint32_t *)malloc(SHADOWFB_WORDS * sizeof(uint32_t));
+      if (!shadowTag)
+         shadowTag = (uint32_t *)malloc(SHADOWFB_WORDS * sizeof(uint32_t));
+      if (!shadowRGB || !shadowTag)
+      {
+         LOG_WRN("[SHADOWFB] allocation failed (8MB); true-color disabled, running stock\n");
+         ShadowFBShutdown();
+         return;
+      }
+      ShadowFBInvalidate();
+      shadowFBActive = 1;
+   }
+   else
+      ShadowFBShutdown();
+}
+
+void ShadowFBShutdown(void)
+{
+   if (shadowRGB)
+      free(shadowRGB);
+   if (shadowTag)
+      free(shadowTag);
+   shadowRGB = NULL;
+   shadowTag = NULL;
+   shadowFBActive = 0;
+   memset(shadowLineRGB, 0, sizeof(shadowLineRGB));
+   memset(shadowLineTag, 0, sizeof(shadowLineTag));
+}

--- a/src/tom/shadowfb.h
+++ b/src/tom/shadowfb.h
@@ -1,0 +1,82 @@
+/*
+ * shadowfb.h: True-color shadow precision framebuffer (epic #338 track 3)
+ *
+ * Two lazily-allocated arrays mirror main RAM's 1M 16-bit pixel words:
+ *   shadowRGB[1M] -- packed RGB888 full-precision conversion of the pixel
+ *   shadowTag[1M] -- the stock 16-bit value the entry was derived from,
+ *                    OR'd with a valid bit (so zero-init never
+ *                    false-matches RAM zeros)
+ *
+ * Coherence is by value-check at READ time, never by invalidation hooks:
+ * a reader compares RAM's current 16-bit value with the entry's tag and
+ * falls back to the stock LUT on mismatch.  No CPU/GPU/DSP/OP write path
+ * is touched, so the stock pipeline stays provably intact.
+ *
+ * The shadow LINE buffer mirrors the OP line buffer at tomRam8[0x1800]
+ * (one entry per 16-bit pixel) and uses the same tag scheme, so the CRY
+ * scanline renderer only substitutes a full-precision pixel when the
+ * entry provably corresponds to the 16-bit value actually in the line
+ * buffer.
+ *
+ * Lifecycle: derived cache only.  Never savestated; invalidated on
+ * savestate load and option toggle; freed and all statics reset in
+ * retro_deinit (iOS cannot dlclose cores).
+ *
+ * See docs/true-color-shadowfb-design.md.
+ */
+#ifndef __SHADOWFB_H__
+#define __SHADOWFB_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SHADOWFB_LINE_PIXELS 720
+#define SHADOWFB_TAG_VALID   0x10000
+
+/* Nonzero when the core option is on AND the buffers are allocated.
+ * Hot paths gate on this before doing any shadow work. */
+extern int shadowFBActive;
+
+/* Shadow line buffer, parallel to tomRam8[0x1800..], one entry per
+ * 16-bit line-buffer pixel.  Tag = value16 | SHADOWFB_TAG_VALID. */
+extern uint32_t shadowLineRGB[SHADOWFB_LINE_PIXELS];
+extern uint32_t shadowLineTag[SHADOWFB_LINE_PIXELS];
+
+/* Option toggle: allocates+clears (on) or frees (off).  Allocation
+ * failure logs a warning and leaves the feature off (core runs stock). */
+void ShadowFBSetEnabled(int enable);
+
+/* Invalidate every entry (savestate load). */
+void ShadowFBInvalidate(void);
+
+/* Free buffers and reset ALL statics (retro_deinit / iOS reload). */
+void ShadowFBShutdown(void);
+
+/* Full-precision CRY -> RGB888 conversion: chroma tables x 24-bit
+ * intensity, where intensity24 = (value16 low byte << 16) | frac16.
+ * Any frac16 yields a color within one stock intensity quantization
+ * step of CRY16ToRGB32[value16], so results are structurally bounded. */
+uint32_t ShadowFBCryRGB(uint16_t value16, uint16_t frac16);
+
+/* Record a full-precision pixel for a main-RAM word address (blit time).
+ * Addresses outside the bottom-8MB RAM mirror window are ignored. */
+void ShadowFBStoreCry(uint32_t addr, uint16_t value16, uint16_t frac16);
+
+/* Value-checked lookup: returns nonzero and fills *rgb888 only when the
+ * entry's tag matches current16 (the value just read from RAM). */
+int ShadowFBLookup(uint32_t addr, uint16_t current16, uint32_t *rgb888);
+
+/* OP 16bpp write site helper: resolve srcAddr against the shadow RAM
+ * (hit -> shadow RGB888, miss -> stock CRY16ToRGB32 conversion) and
+ * store the result + tag into shadow line entry `idx`.  Out-of-range
+ * idx is ignored (renderer then falls back via tag mismatch). */
+void ShadowFBLineFromRAM(int idx, uint32_t srcAddr, uint16_t value16);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* __SHADOWFB_H__ */

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -262,6 +262,7 @@
 #include "gpu.h"
 #include "jaguar.h"
 #include "jerry.h"
+#include "shadowfb.h"
 #include "log.h"
 #include "m68000/m68kinterface.h"
 #include "op.h"
@@ -807,6 +808,33 @@ void tom_render_16bpp_cry_scanline(uint32_t * backbuffer)
 #endif
 
    width = tom_clamp_line_buffer_width(current_line_buffer, width, 2, pwidth_scale);
+
+   /* True-color path (see shadowfb.h): substitute the full-precision
+    * RGB888 from the shadow line buffer, but only when the entry's tag
+    * matches the 16-bit value actually in the line buffer -- any other
+    * write path (direct TOM writes, RMW blends, missed sites) then
+    * falls back to the stock LUT.  With the option off this block is
+    * never entered and output is bit-identical to stock. */
+   if (shadowFBActive)
+   {
+      int sfbIdx = (int)((current_line_buffer - &tomRam8[0x1800]) >> 1);
+      while (width >= pwidth_scale)
+      {
+         uint32_t out;
+         uint16_t color = (*current_line_buffer++) << 8;
+         color |= *current_line_buffer++;
+         out = CRY16ToRGB32[color];
+         if (sfbIdx >= 0 && sfbIdx < SHADOWFB_LINE_PIXELS
+               && shadowLineTag[sfbIdx] == ((uint32_t)color | SHADOWFB_TAG_VALID))
+            out = 0xFF000000 | shadowLineRGB[sfbIdx];
+         sfbIdx++;
+         for (s = 0; s < pwidth_scale; s++)
+            *backbuffer++ = out;
+         width -= pwidth_scale;
+      }
+      return;
+   }
+
    while (width >= pwidth_scale)
    {
       uint16_t color = (*current_line_buffer++) << 8;


### PR DESCRIPTION
First feature of the #338 enhancement suite: render gouraud-shaded pixels at full precision (CRY chroma × 24-bit intensity) while game-visible RAM stays bit-identical.

## Design
`docs/true-color-shadowfb-design.md` (committed here). Core idea: the blitter's gouraud iterator already computes 16 fraction bits (`gd_i`) and throws them away at the 16-bit CRY write. With `virtualjaguar_true_color=enabled`, the write sites also store the full-precision RGB888 in a shadow buffer keyed by RAM address; coherence is a value-check at read time (tag = stock 16-bit value + valid bit), so there are **zero invalidation hooks in any write path** — the stock pipeline is structurally untouched. The OP mirrors resolved pixels into a tagged shadow line buffer; the CRY scanline renderer substitutes only on tag match. Any stale-but-matching entry is bounded within one stock quantization step by construction. This is deliberately the 1x prototype of the shadow hi-res architecture (#338 track 1).

## Scope
CRY 16bpp only; both blitter engines (fast + accurate); default **off**; ~8 MB allocated only when enabled; never savestated (invalidated on state load, freed in `retro_deinit` per iOS static-reset rule).

## Validation
- Identity gate OFF: `frame_hash_ab` per-frame hashes bit-identical to develop `be95df3` over 600 frames on Checkered Flag, Iron Soldier, Doom.
- Effect ON (Cybermorph 3D, both engines agree exactly): unique colors 304→450 (max 423→702); frame-diff shows 45.9% of pixels refined with every channel delta exactly 1 — the predicted bounded sub-quantization refinement, no artifacts.
- `make TEST_EXPORTS=1 test` exit 0; c89-lint clean; benchmark unchanged with option off.
- Interesting corpus fact: Checkered Flag turns out not to use blitter GOURD (flat-shaded) — Cybermorph is the showcase title.

Remaining before merge: an on-device RetroArch eyeball pass with the option enabled (headless can't judge "looks right").

🤖 Generated with [Claude Code](https://claude.com/claude-code)