### PR TITLE
fix(jerry): EEPROM data-out must not shift on joystick reads (Raiden music death)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -826,6 +826,7 @@ clean:
 		test/test_irq_cascade test/test_boot_patterns test/test_audio_pipeline \
 		test/test_audio_clipping test/test_audio_presence test/test_pit_clock_rate \
 		test/test_blitter_mmio test/test_blitter_cmd test/test_eeprom_lifecycle \
+		test/test_eeprom_read_race \
 		test/test_tom_visible_window test/test_framebuffer_integrity \
 		test/test_butch_cd test/test_bios_config test/test_boot_config \
 		test/test_cart_format \
@@ -877,7 +878,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
 		test/test_audio_pipeline test/test_audio_clipping test/test_audio_presence test/test_pit_clock_rate \
-		test/test_blitter_mmio test/test_blitter_cmd test/test_eeprom_lifecycle test/test_tom_visible_window \
+		test/test_blitter_mmio test/test_blitter_cmd test/test_eeprom_lifecycle test/test_eeprom_read_race test/test_tom_visible_window \
 		test/test_framebuffer_integrity test/test_state_compat \
 		test/test_frontend_pacing test/test_jgd \
 		test/tools/test_runahead_determinism \
@@ -1126,6 +1127,9 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@$(CC) -O2 -Wall -o /tmp/gen_eeprom_test_rom test/tools/gen_eeprom_test_rom.c && \
 		/tmp/gen_eeprom_test_rom /tmp/eeprom_lifecycle_test.j64 && \
 		./test/test_eeprom_lifecycle ./$(TARGET) /tmp/eeprom_lifecycle_test.j64
+	@# EEPROM read-race test: joystick polls must not steal EEPROM DO bits
+	@# (Raiden background-music death regression).
+	./test/test_eeprom_read_race ./$(TARGET) /tmp/eeprom_lifecycle_test.j64
 	@echo ""
 	@echo "Note: test/test_cd_boot, test/test_cd_hle_boot, test/test_cd_bios_boot,"
 	@echo "test/test_cd_toc_contract (needs VJ_TOC_DISC=<image>),"
@@ -1309,6 +1313,13 @@ test/test_eeprom_lifecycle: test/test_eeprom_lifecycle.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_eeprom_lifecycle.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
+
+test/test_eeprom_read_race: test/test_eeprom_read_race.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_eeprom_read_race.c \
 		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 

--- a/src/jerry/eeprom.c
+++ b/src/jerry/eeprom.c
@@ -29,6 +29,7 @@ void (*eeprom_dirty_cb)(void) = NULL;
 static void EEPROMSave(void);
 static void eeprom_set_di(uint32_t state);
 static void eeprom_set_cs(uint32_t state);
+static void eeprom_clock(void);
 static uint32_t eeprom_get_do(void);
 
 enum { EE_STATE_START = 1, EE_STATE_OP_A, EE_STATE_OP_B, EE_STATE_0, EE_STATE_1,
@@ -102,6 +103,12 @@ uint8_t EepromReadByte(uint32_t offset)
 	case 0xF14001:
 		return eeprom_get_do();
 	case 0xF14801:
+		/* A read of the GPIO0 strobe ($F14800) is the EEPROM's serial
+		 * clock: the Atari-standard driver does `tst.w $F14800` before
+		 * sampling DO at $F14000 for each of the 16 data bits.  Only
+		 * this strobe advances the output shifter -- sampling DO does
+		 * not (see eeprom_get_do). */
+		eeprom_clock();
 		break;
 	case 0xF15001:
 		eeprom_set_cs(1);
@@ -319,6 +326,12 @@ static void eeprom_set_di(uint32_t data)
 		}
 
 		break;
+	case EE_STATE_2_0:
+		/* SK edge during the data-out phase of a READ: DI is ignored,
+		 * the edge just shifts the next bit onto DO (some drivers
+		 * clock reads by writing $F14800 instead of reading it). */
+		eeprom_clock();
+		break;
 	default:
 		jerry_ee_state = EE_STATE_OP_A;
 	}
@@ -338,6 +351,18 @@ static void eeprom_set_cs(uint32_t state)
 }
 
 
+/* Sample the DO (data out) line -- a read of $F14000/$F14001.
+ *
+ * Sampling must NOT advance the read shifter.  On the real 93-series
+ * part DO only changes on SK clock edges (the driver's `tst.w $F14800`
+ * strobe, see eeprom_clock); a read of the joystick register merely
+ * observes the pin.  The old model shifted one bit out per DO sample,
+ * so a joystick poll from the game's VBL/timer interrupt landing inside
+ * an in-flight READ transaction stole data bits: the shifter ran dry
+ * early and the mainline driver's remaining samples returned the idle
+ * DO level (1).  Raiden's game-over settings reload read its EEPROM
+ * music-enabled option as $FF that way and silenced the music sequencer
+ * for the rest of the session (SFX unaffected). */
 static uint32_t eeprom_get_do(void)
 {
 	uint16_t data = 1;
@@ -348,19 +373,38 @@ static uint32_t eeprom_get_do(void)
 		data = 1;
 		break;
 	case EE_STATE_BUSY:
+		/* Ready/busy handshake after a write/erase: DO reads busy (0)
+		 * once, then the part reports ready.  No clock involved. */
 		jerry_ee_state = EE_STATE_START;
 		data = 0;
 		break;
 	case EE_STATE_2_0:
-		jerry_ee_data_cnt--;
-		data = (eeprom_ram[jerry_ee_address_data] >> jerry_ee_data_cnt) & 0x01;
-
-		if (!jerry_ee_data_cnt)
-			jerry_ee_state = EE_STATE_START;
+		/* Data-out phase: DO presents a dummy 0 until the first clock
+		 * strobe, then the addressed word MSB-first (93C46 data sheet).
+		 * jerry_ee_data_cnt holds the bits not yet clocked out. */
+		if (jerry_ee_data_cnt >= 16)
+			data = 0;
+		else
+			data = (eeprom_ram[jerry_ee_address_data] >> jerry_ee_data_cnt) & 0x01;
 		break;
 	}
 
 	return data;
+}
+
+
+/* One SK clock edge without meaningful DI -- a read of $F14800.
+ * Advances the output shifter during the data-out phase of a READ
+ * transaction; ignored in every other state. */
+static void eeprom_clock(void)
+{
+	if (jerry_ee_state == EE_STATE_2_0)
+	{
+		if (jerry_ee_data_cnt)
+			jerry_ee_data_cnt--;
+		else
+			jerry_ee_state = EE_STATE_START;
+	}
 }
 
 #include "state.h"

--- a/src/jerry/eeprom.c
+++ b/src/jerry/eeprom.c
@@ -27,7 +27,7 @@ void (*eeprom_dirty_cb)(void) = NULL;
 
 // Private function prototypes
 static void EEPROMSave(void);
-static void eeprom_set_di(uint32_t state);
+static void eeprom_set_di(uint32_t data);
 static void eeprom_set_cs(uint32_t state);
 static void eeprom_clock(void);
 static uint32_t eeprom_get_do(void);

--- a/test/test_eeprom_read_race.c
+++ b/test/test_eeprom_read_race.c
@@ -1,0 +1,142 @@
+/*
+ * test/test_eeprom_read_race.c — EEPROM DO sampling vs clocking contract.
+ *
+ * Regression test for the Raiden background-music death: the 93-series
+ * EEPROM's DO line is sampled at $F14000 — the same address as the
+ * JOYSTICK register the game polls from its VBL/timer interrupt.  The
+ * old model shifted the read shifter on every DO sample, so a joystick
+ * poll preempting an in-flight READ transaction stole data bits and the
+ * mainline driver's remaining samples returned the idle level (1s).
+ * Raiden's game-over settings reload read its music-enabled EEPROM
+ * option back as $FF that way and muted the music sequencer for the
+ * rest of the session.
+ *
+ * Contract under test (93C46 data sheet + Atari-standard driver shape):
+ *   - Reading $F14800 (`tst.w $F14800`) is the serial clock: it shifts
+ *     the next bit onto DO during the data-out phase.
+ *   - Reading $F14000 samples DO without advancing anything.
+ *   - Therefore joystick polls interleaved with an EEPROM READ
+ *     transaction must not corrupt the value read.
+ *
+ * Build:  cc -O2 -Wall -std=c99 -I./test -Ilibretro-common/include \
+ *           -o test/test_eeprom_read_race test/test_eeprom_read_race.c \
+ *           test/harness/harness.c -ldl -lm
+ *
+ * Usage:  ./test/test_eeprom_read_race [core.dylib] <any_rom.j64>
+ *         (needs the wide test ABI: make TEST_EXPORTS=1)
+ */
+
+#include "harness/harness.h"
+
+#include <stdio.h>
+
+typedef uint16_t (*jrw_fn)(uint32_t, uint32_t);
+typedef void (*jww_fn)(uint32_t, uint16_t, uint32_t);
+
+static jrw_fn jrw;
+static jww_fn jww;
+
+#define WHO 0 /* UNKNOWN */
+
+static void cs_pulse(void)  { (void)jrw(0xF15000, WHO); }
+static void send_bit(int b) { jww(0xF14800, (uint16_t)(b & 1), WHO); }
+
+static void send_bits(uint32_t v, int n)
+{
+    int i;
+    for (i = n - 1; i >= 0; i--)
+        send_bit((int)((v >> i) & 1));
+}
+
+static int sample_do(void) { return jrw(0xF14000, WHO) & 1; }
+static void strobe(void)   { (void)jrw(0xF14800, WHO); }
+
+/* Atari-standard write: EWEN, WRITE addr+data, CS pulse, busy poll, EWDS */
+static void ee_write(int addr, uint16_t val)
+{
+    int i;
+    cs_pulse();
+    send_bits(0x130, 9);                     /* EWEN  %1 00 110000 */
+    cs_pulse();
+    send_bits(0x140 | (addr & 0x3F), 9);     /* WRITE %1 01 aaaaaa */
+    send_bits(val, 16);
+    cs_pulse();
+    for (i = 0; i < 100; i++)
+        if (sample_do())
+            break;
+    cs_pulse();
+    send_bits(0x100, 9);                     /* EWDS */
+}
+
+/* Atari-standard read (strobe then sample, 16 bits), optionally with a
+ * burst of joystick polls injected mid-transaction like an ISR pad scan. */
+static uint16_t ee_read(int addr, int inject_at, int inject_reads)
+{
+    uint16_t v = 0;
+    int i, j;
+    cs_pulse();
+    send_bits(0x180 | (addr & 0x3F), 9);     /* READ  %1 10 aaaaaa */
+    for (i = 0; i < 16; i++) {
+        if (i == inject_at)
+            for (j = 0; j < inject_reads; j++)
+                (void)jrw(0xF14000, WHO);    /* preempting pad scan */
+        strobe();                            /* tst.w $F14800 */
+        v = (uint16_t)((v << 1) | (uint16_t)sample_do());
+    }
+    return v;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    harness_result results[4];
+    unsigned n = 0;
+    uint16_t got;
+    int fails = 0;
+
+    cfg.frames = 1;
+    if (!harness_init_from_args(&cfg, argc, argv)) return 2;
+    if (!harness_load_rom(&cfg)) return 2;
+
+    jrw = (jrw_fn)harness_dlsym(&cfg, "JERRYReadWord");
+    jww = (jww_fn)harness_dlsym(&cfg, "JERRYWriteWord");
+    if (!jrw || !jww) {
+        fprintf(stderr, "FAIL: JERRYReadWord/JERRYWriteWord not exported "
+                        "(build with TEST_EXPORTS=1)\n");
+        return 2;
+    }
+
+    ee_write(3, 0xA5C3);
+
+    got = ee_read(3, -1, 0);
+    results[n].status = (got == 0xA5C3) ? "PASS" : "FAIL";
+    results[n].name = "clean_read";
+    results[n].detail = "uninterrupted READ returns the written word";
+    if (got != 0xA5C3) { fprintf(stderr, "clean read: got $%04X want $A5C3\n", got); fails++; }
+    n++;
+
+    got = ee_read(3, 8, 8);
+    results[n].status = (got == 0xA5C3) ? "PASS" : "FAIL";
+    results[n].name = "preempted_read";
+    results[n].detail = "8 joystick polls mid-READ must not steal DO bits";
+    if (got != 0xA5C3) { fprintf(stderr, "preempted read: got $%04X want $A5C3\n", got); fails++; }
+    n++;
+
+    got = ee_read(3, 0, 20);
+    results[n].status = (got == 0xA5C3) ? "PASS" : "FAIL";
+    results[n].name = "preempted_read_head";
+    results[n].detail = "20 joystick polls before first strobe must not steal bits";
+    if (got != 0xA5C3) { fprintf(stderr, "head-preempted read: got $%04X want $A5C3\n", got); fails++; }
+    n++;
+
+    got = ee_read(3, -1, 0);
+    results[n].status = (got == 0xA5C3) ? "PASS" : "FAIL";
+    results[n].name = "post_read";
+    results[n].detail = "transaction after the preempted one still reads clean";
+    if (got != 0xA5C3) { fprintf(stderr, "post read: got $%04X want $A5C3\n", got); fails++; }
+    n++;
+
+    harness_report(&cfg, results, n);
+    harness_shutdown(&cfg);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Symptom
Raiden's background music glitches and then stops for the rest of the session (SFX keep playing); it survives a savestate. Reported on device.

## Root cause — not a DSP bug at all
The DSP mixer was innocent: its wait loop at $F1B2E2 is the normal per-sample idle, SSI delivery was healthy (249 interrupts/frame), and gameplay FLAGS $20/$21/$24 are correct for that engine. What stopped were **music note-ons**: the 68K driver kept writing SFX voices 4–5 but never music voices 0–3.

The music tick (TOM-PIT, 50 Hz) is gated on `tst.b $482C3` — the game's EEPROM-backed **music on/off option**. In the broken state it reads $FF.

**Why it becomes $FF:** EEPROM DO is sampled at **$F14000 — the joystick register** (`jerry.c` merges `EepromReadWord` into every pad read), and our `eeprom_get_do()` was *destructive*: every call shifted one bit out of the read shifter. Measured on Raiden: **10,253 of 11,433 pad reads over 1800 gameplay frames come from interrupt context**. When the ISR's pad scan lands inside an in-flight EEPROM READ, it steals data bits; the shifter runs dry and the driver's remaining samples return the idle high level. Deterministic repro: **8 injected joystick polls mid-read turn a stored $0000 into $00FF** — bit-for-bit the value found in the user's savestate. Rare and timing-dependent, hence once-per-session; persistent because the game can save $FF back to EEPROM.

This is systemic, not Raiden-specific: any title polling the pad from an interrupt while reading EEPROM can lose bits.

## Fix (93C46-correct)
On a real 93-series part DO only changes on **SK clock edges**. Now: reading $F14000 is a pure sample (dummy 0 before the first clock, then MSB-first), reading $F14800 clocks the shifter (the Atari-standard driver's `tst.w $F14800` strobe), and a DI write during data-out clocks rather than resetting the state machine. Busy handshake unchanged; no savestate format change.

## Validation
- New `test/test_eeprom_read_race.c` (wired into `make test`): reproduces the corruption pre-fix ($00FF), all four cases return the written word post-fix.
- `make TEST_EXPORTS=1 test` exit 0 — including both audio gates (IS1 in envelope; Skyhammer RMS 3083, 0% saturation; IS2 clean).
- Raiden BIOS 7200-frame boot: LTXD 88.2%; 18000-frame scripted-gameplay soak: **99.5% healthy**.
- Tempest 2000 (EEPROM-heavy): 84.2% healthy. Raiden HLE behaves identically to unmodified develop (that path is fixed separately in #339).

**Note for affected users:** anyone already hit by this may have music=off persisted in their `.srm` — re-enable it in Raiden's options menu. Device confirmation still wanted per repo rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)