### PR TITLE
docs(site): true-color has merged, not in review

### DIFF
--- a/site/pages/enhancements.html
+++ b/site/pages/enhancements.html
@@ -16,7 +16,7 @@
   core</a>.
 </p>
 
-<h2>True-color rendering <span class="badge review">in review — PR #341</span></h2>
+<h2>True-color rendering <span class="badge review">merged — PR #341</span></h2>
 <p>
   The Jaguar's blitter computes Gouraud-shaded intensity with <em>16 fraction
   bits</em> of precision — and then throws them away when it writes a 16-bit CRY
@@ -57,8 +57,9 @@
   engines (fast and accurate) agree exactly; with the option <em>off</em>, 600
   frames across three cartridge titles hash bit-identical to develop. CRY 16bpp
   only, default off, ~8&nbsp;MB allocated only when enabled.
-  Status: <em>in review</em> &mdash;
+  Status: <em>merged to develop</em> &mdash;
   <a href="{{REPO}}/pull/341">PR #341</a>, design doc committed with the PR.
+  Available in nightly builds; not yet in a tagged release.
 </div>
 
 <h2>Overclocking that doesn't break the game</h2>

--- a/site/pages/why-this-core.html
+++ b/site/pages/why-this-core.html
@@ -96,8 +96,8 @@
 <p>
   We know of no other Atari Jaguar emulator offering a true-color rendering mode
   or an internal-resolution upscaling track like the one described on the
-  <a href="enhancements.html">enhancements page</a> (true-color is in review,
-  hi-res is in design — labeled as such there). If we're wrong, we'd genuinely
+  <a href="enhancements.html">enhancements page</a> (true-color has merged and
+  ships in nightlies, hi-res is in design — labeled as such there). If we're wrong, we'd genuinely
   like to know: <a href="{{REPO}}/discussions">tell us in Discussions</a> and this
   page gets corrected.
 </p>


### PR DESCRIPTION
PR #341 merged to develop after the v3.1.0 tag, so the site's "in review" badges are stale. Relabels them "merged" and states plainly that it ships in nightlies but is not yet in a tagged release — matching the README's status wording so the two surfaces can't disagree.

Verified with `scripts/build_site.py` + `scripts/check_site.py` (OK — 4 pages, sitemap and robots.txt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)