### PR TITLE
docs(site): serve the site at jaguar.provenance-emu.com

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-# Build and deploy the GitHub Pages site (https://www.libretro.com/virtualjaguar-libretro/).
+# Build and deploy the GitHub Pages site (https://jaguar.provenance-emu.com/).
 #
 # The site is generated from committed repo data by scripts/build_site.py
 # (python3 stdlib only). It rebuilds on every push to develop that touches

--- a/docs/site-maintenance.md
+++ b/docs/site-maintenance.md
@@ -1,8 +1,25 @@
 # Site maintenance
 
-The project website (<https://www.libretro.com/virtualjaguar-libretro/>) is a
-static site generated from **committed repository data** — no CMS, no external
+The project website (<https://jaguar.provenance-emu.com/>) is a static site
+generated from **committed repository data** — no CMS, no external
 dependencies, no hand-maintained compatibility tables.
+
+## Where the site is hosted, and why
+
+The site is GitHub Pages on the **Provenance-Emu fork** with the verified
+custom domain `jaguar.provenance-emu.com` (DNS: a `CNAME` to
+`libretro.github.io`, proxy disabled so GitHub can see it and issue the
+certificate).
+
+It is not served from the `libretro` org repo because that org's Pages
+configuration redirects every project site to
+`www.libretro.com/<repo>/`, a host libretro serves elsewhere and which
+returns 404 for these paths. Only a libretro org owner can change that.
+If it is ever fixed, migrating is one variable: `SITE_BASE` in
+`scripts/build_site.py`, overridable at build time with `VJ_SITE_BASE`.
+Every absolute URL the site emits -- canonical, og:url, sitemap loc,
+robots -- derives from that single string, so they cannot drift apart.
+
 
 ## How the automation works
 

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -52,12 +52,20 @@ MAKEFILE = ROOT / "Makefile"
 
 REPO_URL = "https://github.com/libretro/virtualjaguar-libretro"
 
-# The org custom domain GitHub Pages reports for this repository.  Every
-# absolute URL the site emits is derived from this one string, and for a given
-# page the <link rel=canonical>, og:url and the sitemap <loc> must come out
+# The canonical base for every absolute URL the site emits; for a given page
+# the <link rel=canonical>, og:url and the sitemap <loc> must come out
 # byte-identical -- a mismatch between those three is the classic own-goal.
-# Keep the trailing slash.
-SITE_BASE = "https://www.libretro.com/virtualjaguar-libretro/"
+#
+# Default: jaguar.provenance-emu.com, GitHub Pages on the Provenance-Emu fork
+# with a verified custom domain.  The libretro org's own Pages routing sends
+# this repo's site to www.libretro.com/virtualjaguar-libretro/, which that
+# host does not serve (404) and only a libretro org owner can fix; if that
+# ever changes, migrate by flipping VJ_SITE_BASE.  Keep the trailing slash.
+import os as _os
+SITE_BASE = _os.environ.get(
+    "VJ_SITE_BASE", "https://jaguar.provenance-emu.com/")
+if not SITE_BASE.endswith("/"):
+    SITE_BASE += "/"
 SITE_NAME = "Virtual Jaguar libretro"
 
 # Official libretro documentation for this core: the canonical reference


### PR DESCRIPTION
The site built and deployed fine but 404'd: the libretro org's Pages configuration redirects every project site to `www.libretro.com/<repo>/`, a host libretro serves elsewhere (Cloudflare) which has no such path. Only a libretro org owner can change that, and `libretro.github.io/virtualjaguar-libretro/` just follows the same redirect.

Fix: serve from GitHub Pages on the **Provenance-Emu fork** with the verified custom domain `jaguar.provenance-emu.com` (DNS CNAME → `libretro.github.io`, unproxied so GitHub can verify it and issue the certificate).

- `SITE_BASE` defaults to the new domain and honours a `VJ_SITE_BASE` env override, so if libretro ever routes the path, migrating is one variable.
- Canonical, `og:url`, sitemap `<loc>` and `robots.txt` all still derive from that one string — verified they stay byte-identical to each other by `check_site.py`.
- Owning the domain root also fixes the `robots.txt`/sitemap auto-discovery limitation noted in `site-maintenance.md`.
- Rationale recorded in the maintenance doc so this isn't rediscovered later.

Verified: `build_site.py` + `check_site.py` pass on the new default and with the env override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)