### PR TITLE
docs: hi-res Stage 0 census — R1/R2 measured corpus-wide (GO)

### DIFF
--- a/docs/hires-stage0-census.md
+++ b/docs/hires-stage0-census.md
@@ -177,8 +177,11 @@ Notes:
 ## 4. OP scaler census (Stage 3 evidence)
 
 Per object-scanline call of `OPProcessScaledBitmap` with `render` and a
-non-zero `HSCALE`. "non-int" = `HSCALE` or `VSCALE` fraction bits ≠ 0
-(3.5 fixed point, `$20` = 1.0×). "h<1.0" / "h>1.0" split the histogram into
+non-zero `HSCALE`. "non-int" = `HSCALE` **or** `VSCALE` fraction bits ≠ 0
+(3.5 fixed point, `$20` = 1.0×). The "h<1.0" / "h>1.0" buckets are
+**HSCALE-only** — Towers II shows 0 in both because its HSCALE is exactly
+1.0 while its non-integer scaling is entirely in VSCALE. They split the
+histogram into
 minification (source detail exists beyond what 1x keeps — **real recovery**)
 and magnification (only step-placement smoothing).
 
@@ -231,7 +234,7 @@ in main RAM (all STORE variants, via the write funnels).
 |---|---|---|---|---|---|
 | Iron Soldier 1 (mission 1, from state) | 2400 | 11 | 5730 | 74849 | 3.52M |
 | Iron Soldier 2 (CD, city mission) | 12000 | 3688 | 9427 | 51214 | 40.24M |
-| Battlemorph (CD, menus+loadout) | 12000 | 308 | 149 | 59061 | 1.37M |
+| Battle Morph (CD, menus+loadout) | 12000 | 308 | 149 | 59061 | 1.37M |
 | Cybermorph (gameplay) | 2400 | 7 | 8366 | 220765 | 10.33M |
 | Doom (gameplay, contrast) | 2400 | 66 | 80818 | 39095 | 49.38M |
 | Checkered Flag (gameplay, contrast) | 2400 | 530 | 7185 | 86844 | 5.53M |
@@ -340,7 +343,8 @@ effectively nothing, so track 4's per-title enhancement DB remains a
 
 The instrumentation pattern (for re-running or extending):
 
-1. Counter struct + record function at `BlitterWriteWord` offset `0x3A`
+1. Counter struct + record function at `BlitterWriteWord`, firing when
+   `(offset & 0xFF) == 0x3A` (the B_CMD low-word write that launches a blit)
    (before engine dispatch) reading `blitter_ram` directly.
 2. `OPProcessFixedBitmap` / `OPProcessScaledBitmap` hooks after decode
    (`render` only): depth histogram, `HSCALE`/`VSCALE` histograms, 8 KB

--- a/docs/hires-stage0-census.md
+++ b/docs/hires-stage0-census.md
@@ -1,0 +1,355 @@
+# Hi-res upscaling Stage 0 — corpus-wide blit / OP census (R1 + R2)
+
+**Date:** 2026-08-07
+**Epic:** #338, track 1 ("internal resolution upscaling")
+**Design:** `docs/hires-upscaling-design.md` — this document executes **Stage 0**
+(§8) and resolves risks **R1** (is there a second beneficiary?) and **R2**
+(do IS-class titles rasterize with GPU stores?).
+**Status:** measurement report. **No product code.** The instrumentation was a
+throwaway compile-time patch and is not part of this commit.
+
+---
+
+## 0. Executive summary
+
+**R1 is resolved: the design's "Doom is the only qualifying title" premise was
+an artifact of the small first census, not of the hardware or the library.**
+With gameplay-reaching input across the corpus, **eight commercial titles**
+consume fractional source walks onto 16bpp CRY destinations at material rates —
+Doom, Missile Command 3D, Hover Strike (cart), Iron Soldier 2 (CD), Alien vs
+Predator, I-War, Skyhammer, and Towers II — plus one homebrew (CRZ Demo).
+The no-build condition in R1's decision rule is **not met**.
+
+**R2 is resolved: no measured title rasterizes its framebuffer with GPU
+stores.** Iron Soldier's famous "388 blits in 900 frames" was measured on a
+*menu*; in actual gameplay IS1 issues ~378 blits/frame (Z-buffered `PATDSEL`
+span fills through the blitter). GPU stores into OP-scanned framebuffer
+regions are 7–3,700 bytes/frame across the R2 set — HUD-scale, not
+rasterization-scale — while the blitter writes 39–220 KB/frame into the same
+regions. **No GPU-store shadow hook is needed.**
+
+The OP scaler census (Stage 3 evidence) additionally shows heavy non-integer
+`HSCALE`/`VSCALE` use in Primal Rage (its entire fighters), Val d'Isere (its
+entire renderer), Towers II, Atari Karts, Super Cross 3D, and Wolfenstein 3D.
+
+**Recommendation: GO** — see §6.
+
+---
+
+## 1. Method
+
+- **Instrumentation:** a throwaway counter block at the single blit-launch site
+  (`BlitterWriteWord`, `offset & 0xFF == 0x3A` in `src/tom/blitter_mmio.c` —
+  engine-independent: it fires before dispatch to either blitter), in the OP
+  bitmap processors (`OPProcessFixedBitmap` / `OPProcessScaledBitmap`), and in
+  the `JaguarWrite{Byte,Word,Long}` funnels (`who == GPU` / `who == BLITTER`,
+  main-RAM addresses only). Aggregates exposed via a dlsym-able struct read by
+  a small harness runner after each run. The patch was reverted before this
+  commit; only this document is committed.
+- **Per-blit record:** `B_CMD` flags (`GOURD`, `SRCSHADE`, Z bits, `DSTA2`,
+  `SRCEN`, `PATDSEL`, `UPDA1F`), destination pixel depth from the destination
+  walker's `A1_FLAGS`/`A2_FLAGS` (per `DSTA2`), OUTER count, phrase vs pixel
+  mode, and fractional-source-walk consumption.
+- **Fractional source walk** (the anti-inert-register definition from design
+  §2): counted only when A1 is the **source** (`DSTA2` set — A2 has no
+  fractional machinery), and either the inner walk consumes a fraction
+  (`XADDCTL = add-increment` **and** `A1_FINC` X-fraction ≠ 0) or the outer
+  walk does (`UPDA1F` set **and** `A1_FSTEP` X-fraction ≠ 0). A stale fraction
+  behind a phrase-mode `XADDCTL` does **not** count — the Cybermorph trap.
+- **Qualifying** = fractional source walk onto a 16bpp destination (the shape
+  Stage 2 as designed can reach). **Frac→CLUT** = same walk onto a 1/2/4/8bpp
+  destination (reachable only with a CLUT-destination extension).
+- **R2 classification:** main RAM is divided into 256 × 8 KB buckets. A bucket
+  is "framebuffer" if the OP fetched bitmap pixel data from it during the run
+  (object-list fetches are not marked). GPU-store and blitter-write bytes are
+  then split framebuffer vs non-framebuffer. Cumulative over the run, so a
+  menu-phase buffer stays marked — this over-approximates "framebuffer", which
+  is the conservative direction for R2 (it can only overstate, never hide,
+  GPU-store rasterization).
+- **Runs:** instrumented build of `libretro/develop` @ `28120cd` (wide test
+  ABI), headless via the shared harness. 2,400 frames per cart title (more
+  where menu navigation needed it, up to 12,000 for CD titles), scripted
+  `--press` input, per-title final-frame screenshots to verify the reached
+  scene. Identical runs are deterministic, so one run per title.
+- **Gameplay verification:** every row marked "gameplay" below had its
+  final-frame screenshot eyeballed (Doom in E1M1, IS1 in mission 1 cockpit,
+  IS2-CD in a city mission, AvP in a corridor as the Alien, Primal Rage
+  mid-fight, etc.). Rows marked "menu/attract" are lower bounds, not
+  negatives.
+
+## 2. Blit census — cartridge corpus
+
+Columns: total blits; shaded = `GOURD`+`SRCSHADE`; Z = any Z compare/write;
+dst16 / dstCLUT = blits by destination depth; frac src = fractional source
+walks (inner+outer); **QUALIFY16** = frac src onto 16bpp (Stage 2 reach);
+frac→CLUT = frac src onto CLUT dest (CLUT-extension reach).
+
+| Title | Frames | Blits | shaded | Z | dst16 | dstCLUT | frac src | QUALIFY16 | frac→CLUT | Scene reached |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Aircars | 2400 | 228.4k (95/f) | 114.7k | 115.0k | 123.6k | 25.2k | 16 | **8** | 0 | gameplay (terrain) |
+| Alien vs Predator | 4800 | 640.0k (133/f) | 544.3k | 0 | 615.2k | 19.3k | 405.8k | **405.8k** | 0 | gameplay (Alien, corridors) |
+| Atari Karts | 2400 | 159.7k (67/f) | 0 | 131.0k | 1 | 159.7k | 131.0k | **0** | 131.0k | gameplay (race, 7th) |
+| Attack of the Mutant Penguins | 2400 | 1.9k (1/f) | 0 | 30 | 1.2k | 607 | 16 | **0** | 16 | attract/menu |
+| Brutal Sports Football | 2400 | 1.3k (1/f) | 1.1k | 71 | 1.3k | 1 | 0 | **0** | 0 | attract |
+| Bubsy | 2400 | 919 (0/f) | 0 | 0 | 917 | 2 | 0 | **0** | 0 | attract/menu |
+| Cannon Fodder | 2400 | 2.2k (1/f) | 0 | 0 | 2 | 2.2k | 1.4k | **0** | 1.4k | menu |
+| Checkered Flag | 2400 | 1.67M (697/f) | 0 | 3.5k | 1.58M | 14 | 16 | **8** | 0 | gameplay (race) |
+| Club Drive | 2400 | 1.74M (724/f) | 0 | 4.0k | 1.70M | 38.7k | 626 | **314** | 0 | gameplay (driving) |
+| Cybermorph (1993) | 2400 | 1.74M (723/f) | 1.70M | 1.70M | 1.72M | 19.1k | 26 | **13** | 0 | gameplay (pods remaining HUD) |
+| Defender 2000 | 2400 | 16.0k (7/f) | 696 | 2.9k | 6.9k | 8.6k | 1.0k | **516** | 0 | attract/gameplay mix |
+| Doom | 2400 | 1.07M (445/f) | 1.07M | 0 | 1.07M | 2.4k | 1.04M | **1.04M** | 0 | gameplay (E1M1) |
+| Double Dragon V | 2400 | 1.6k (1/f) | 0 | 0 | 0 | 1.6k | 0 | **0** | 0 | menu |
+| Dragon | 2400 | 209 (0/f) | 0 | 0 | 209 | 0 | 0 | **0** | 0 | menu |
+| Evolution Dino Dudes | 2400 | 261 (0/f) | 0 | 0 | 0 | 261 | 0 | **0** | 0 | menu |
+| Fever Pitch Soccer | 2400 | 0 (0/f) | 0 | 0 | 0 | 0 | 0 | **0** | 0 | did not render |
+| Fight For Your Life | 2400 | 577.6k (241/f) | 0 | 0 | 577.5k | 0 | 0 | **0** | 0 | menu (BEGIN GAME; heaviest per-frame blit volume in corpus) |
+| Flashback | 2400 | 1.0k (0/f) | 0 | 0 | 495 | 553 | 0 | **0** | 0 | menu |
+| Flip Out | 2400 | 4 (0/f) | 0 | 0 | 1 | 0 | 0 | **0** | 0 | menu |
+| Hover Strike (cart) | 6000 | 4.02M (670/f) | 6.8k | 2.12M | 4.02M | 835 | 2.02M | **2.02M** | 0 | gameplay (mission approach, ALERT) |
+| I-War | 2400 | 2.58M (1076/f) | 1.85M | 2.56M | 2.58M | 0 | 441.4k | **441.4k** | 0 | gameplay (DAMAGE CRITICAL) |
+| Iron Soldier (v1.04, state+nav) | 2400 | 907.3k (378/f) | 3.1k | 868.1k | 883.7k | 21.2k | 15.6k | **11.6k** | 0 | gameplay (mission 1, verified) |
+| Iron Soldier 2 (cart) | 7200 | 329.2k (46/f) | 0 | 0 | 5.1k | 324.1k | 4.3k | **4.3k** | 0 | menus only (unit select; could not exit headlessly) |
+| Kasumi Ninja | 2400 | 1.07M (446/f) | 920.9k | 0 | 1.07M | 3.9k | 0 | **0** | 0 | 3D gauntlet walk (pre-fight) |
+| Missile Command 3D | 2400 | 5.73M (2386/f) | 3.96M | 1.27M | 5.73M | 0 | 4.48M | **4.48M** | 0 | gameplay (Original 3D mode) |
+| NBA Jam TE | 2400 | 1.4k (1/f) | 384 | 560 | 949 | 467 | 240 | **240** | 0 | attract/menu |
+| Pinball Fantasies | 2400 | 0 (0/f) | 0 | 0 | 0 | 0 | 0 | **0** | 0 | did not render |
+| Pitfall | 2400 | 20.5k (9/f) | 0 | 0 | 0 | 20.5k | 0 | **0** | 0 | attract |
+| Power Drive Rally | 2400 | 33.8k (14/f) | 198 | 0 | 9.3k | 22.9k | 0 | **0** | 0 | attract/menu |
+| Raiden | 2400 | 0 (0/f) | 0 | 0 | 0 | 0 | 0 | **0** | 0 | attract |
+| Rayman | 2400 | 8.8k (4/f) | 0 | 0 | 2.2k | 0 | 0 | **0** | 0 | menu |
+| Ruiner Pinball | 2400 | 9 (0/f) | 0 | 0 | 0 | 7 | 0 | **0** | 0 | menu |
+| Skyhammer | 2400 | 197.8k (82/f) | 176.4k | 0 | 195.8k | 110 | 169.3k | **169.3k** | 0 | gameplay (cockpit) |
+| Super Burnout | 2400 | 119.3k (50/f) | 0 | 0 | 0 | 141 | 0 | **0** | 0 | attract/gameplay |
+| Super Cross 3D | 2400 | 273.5k (114/f) | 0 | 0 | 2.4k | 271.0k | 173.6k | **0** | 173.6k | gameplay (race) |
+| Syndicate | 6000 | 1.98M (330/f) | 0 | 1.74M | 7 | 1.98M | 0 | **0** | 0 | mission brief (mouse-driven UI; gameplay unreachable headlessly) |
+| Tempest 2000 | 2400 | 1.75M (727/f) | 1.73M | 1.57M | 1.75M | 0 | 8.3k | **7.6k** | 0 | gameplay (web) |
+| Theme Park | 2400 | 43.4k (18/f) | 0 | 19 | 7 | 43.4k | 0 | **0** | 0 | menu |
+| Towers II | 7200 | 748.7k (104/f) | 0 | 0 | 735.6k | 0 | 234.4k | **234.4k** | 0 | gameplay (dungeon) |
+| Trevor McFur | 2400 | 73.6k (31/f) | 0 | 0 | 20.6k | 51.1k | 0 | **0** | 0 | attract |
+| Troy Aikman NFL | 2400 | 510 (0/f) | 0 | 0 | 0 | 508 | 0 | **0** | 0 | menu |
+| Ultra Vortek | 2400 | 2.5k (1/f) | 2 | 0 | 1.5k | 1.0k | 0 | **0** | 0 | attract |
+| Val d'Isere | 2400 | 1.5k (1/f) | 0 | 0 | 1 | 0 | 0 | **0** | 0 | gameplay (snowboarding) |
+| White Men Can't Jump | 2400 | 956 (0/f) | 768 | 1 | 770 | 181 | 0 | **0** | 0 | attract/menu |
+| Wolfenstein 3D | 2400 | 222.4k (93/f) | 0 | 107 | 1.7k | 220.6k | 215.3k | **0** | 215.3k | gameplay (in level) |
+| Zool 2 | 4800 | 1.7k (0/f) | 0 | 1.7k | 61 | 1.7k | 0 | **0** | 0 | stage intro |
+| Zoop | 2400 | 34.8k (14/f) | 0 | 0 | 0 | 34.8k | 0 | **0** | 0 | attract |
+
+PD/homebrew demos with zero-to-negligible blit activity are omitted from the
+table: 40+ demo/utility ROMs measured 0–5 blits in 2,400 frames (JagMania,
+Jaguar Server examples, BadCode series, Mandelbrot, Memory Dump, Gorf 2000,
+Phase Zero, JagFest, sound demos…). Two exceptions worth naming: **CRZ Demo**
+(1.96M blits, 1.90M gouraud, 57.8k qualifying onto 16bpp — a real, if small,
+homebrew beneficiary) and **DEMO1B/C + Ladybug + Asteroid + Native Demo +
+Jaguar Tetris**, which render via OP scaled objects (§4).
+
+## 3. Blit census — CD titles
+
+All CD runs used the default HLE boot path with the shared harness
+(`--system-dir` at the private ROM tree).
+
+| Title | Frames | Blits | shaded | Z | dst16 | dstCLUT | frac src | QUALIFY16 | frac→CLUT | Scene reached |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Battle Morph (CD) | 12000 | 21.3k (2/f) | 13.0k | 2.4k | 21.3k | 2 | 1.5k | **738** | 0 | menus + weapon select (see note) |
+| Iron Soldier 2 (CD) | 12000 | 7.00M (583/f) | 13.4k | 3.16M | 6.51M | 343.6k | 3.25M | **3.22M** | 0 | gameplay (city mission) |
+| Hover Strike: Unconquered Lands (CD) | 12000 | 252.0k (21/f) | 1 | 117 | 251.5k | 489 | 233 | **117** | 0 | mission-select cockpit (see note) |
+| Primal Rage (CD) | 9000 | 669 (0/f) | 0 | 0 | 0 | 669 | 0 | **0** | 0 | gameplay (fight, Sauron vs Diablo) |
+
+Notes:
+
+- **Iron Soldier 2 (CD) is the second-heaviest qualifying title by absolute
+  count (3.22M) and fourth by rate (268/frame)**: 583 blits/frame in-mission,
+  46% of them fractional source walks onto a 16bpp destination (textured,
+  Z-buffered spans). The cart release never got past its unit-select menu
+  headlessly; the CD row is the authoritative one.
+- **Battle Morph** could not be walked into a flight mission headlessly (name
+  pad → weapon bays → LAUNCH needs pixel-precise cursor work); the measured
+  segment (menus, briefing, loadout — 738 qualifying blits from briefing
+  scenes) is a lower bound and the row is marked accordingly. Its engine
+  lineage (Cybermorph sequel) predicts gouraud-span flight rendering — i.e.
+  the Cybermorph non-beneficiary result — but only a flight-mission run can
+  confirm that; its R2 numbers are still valid (§5).
+- **Hover Strike UL (CD)** parked on its mission-select cockpit; the **cart**
+  Hover Strike run did reach mission flight and is the representative row
+  (2.02M qualifying — the engine is a heavy fractional texture walker).
+- **Primal Rage** renders its fighters entirely through the OP scaler — 0.1
+  blits/frame mid-fight, 505k non-integer scaled-object calls (§4).
+
+## 4. OP scaler census (Stage 3 evidence)
+
+Per object-scanline call of `OPProcessScaledBitmap` with `render` and a
+non-zero `HSCALE`. "non-int" = `HSCALE` or `VSCALE` fraction bits ≠ 0
+(3.5 fixed point, `$20` = 1.0×). "h<1.0" / "h>1.0" split the histogram into
+minification (source detail exists beyond what 1x keeps — **real recovery**)
+and magnification (only step-placement smoothing).
+
+| Title (scene) | scaled calls | non-int | h<1.0 | h>1.0 | top HSCALE values |
+|---|---|---|---|---|---|
+| Towers II (dungeon) | 6.10M | 6.10M | 0 | 0 | $20:6.10M |
+| Val d'Isere (snowboarding) | 809.6k | 520.9k | 386.9k | 134.1k | $20:288.6k, $10:167.0k, $21:67.9k, $0D:44.0k |
+| Primal Rage (fight) | 504.9k | 504.9k | 504.9k | 0 | $1C:504.4k, $18:160, $14:136, $10:108 |
+| Jaguar Tetris (PD) | 477.1k | 0 | 0 | 477.1k | $40:477.1k |
+| Super Cross 3D (race) | 442.8k | 442.8k | 0 | 442.8k | $24:307.8k, $22:135.0k |
+| Defender 2000 | 361.6k | 239.1k | 54.3k | 306.8k | $40:122.8k, $3C:85.2k, $21:76.2k, $1E:1.9k |
+| Atari Karts (race) | 318.3k | 264.9k | 166.8k | 100.7k | $1F:51.5k, $20:50.8k, $08:24.7k, $07:19.1k |
+| Native Demo (PD) | 306.2k | 254.7k | 86.3k | 168.9k | $20:51.0k, $32:31.5k, $19:27.8k, $26:19.0k |
+| Missile Command 3D | 0 | 0 | 0 | 0 |  |
+| NBA Jam TE | 262.7k | 1.7k | 1.7k | 0 | $20:260.9k, $1E:217, $1C:203, $1A:188 |
+| Wolfenstein 3D | 127.6k | 127.6k | 43.0k | 84.5k | $24:65.0k, $1A:18.5k, $1E:11.6k, $25:4.3k |
+| Aircars (beta) | 65.8k | 65.8k | 65.8k | 0 | $10:65.8k |
+| IS2 (CD, mission) | 33.8k | 23.7k | 23.7k | 0 | $20:10.1k, $1F:9.7k, $1E:9.4k, $1D:304 |
+| Asteroid (PD) | 102.7k | 70.8k | 70.8k | 31.9k | $1E:61.7k, $40:31.9k, $1D:606, $1C:585 |
+| International Sensible Soccer | 249.8k | 73.0k | 18.6k | 55.8k | $20:175.4k, $1C:1.8k, $1E:1.5k, $1D:1.3k |
+| Iron Soldier (mission) | 7.3k | 4.8k | 4.8k | 0 | $20:2.5k, $1F:2.4k, $1E:2.3k |
+| Zool 2 | 51.5k | 51.5k | 0 | 0 | $20:51.5k |
+
+Readings:
+
+- **Primal Rage:** every fighter sprite is drawn at `$1C` (0.875×)
+  minification — the archetypal Stage 3 beneficiary, and it is a 2D title the
+  blitter path can never help.
+- **Val d'Isere:** the whole game is OP-scaled objects (809k calls, 521k
+  non-integer, dominant minification) with essentially zero blitting — the
+  "inconclusive" row in the design's first census is resolved: it is a Stage 3
+  title, not a Stage 2 one.
+- **Towers II:** all 6.1M calls at `HSCALE $20` / `VSCALE $22` — a constant
+  1.0625× vertical magnification (aspect correction). Smoothing-only.
+- **Atari Karts:** deep minification (`$02`–`$08` = 1/16×–1/4× for distant
+  karts) — real recovery, but its blit destinations are CLUT (§2), so the OP
+  CLUT resolve limitation (§6.5 of the design) applies to its sprites too.
+- **Wolfenstein 3D** scales its weapon/pickup sprites non-integer (`$24`,
+  `$1A`…) in addition to its CLUT wall columns.
+- Fixed (unscaled) bitmap objects dominate every other title; scaled-object
+  use is concentrated exactly where the table shows it.
+
+## 5. R2 — GPU-store probe
+
+Bytes/frame written by each engine into OP-fetched ("framebuffer") buckets vs
+elsewhere in main RAM. "GPU st events" = total GPU store instructions landing
+in main RAM (all STORE variants, via the write funnels).
+
+| Title (scene) | Frames | GPU→FB B/f | GPU→other B/f | Blitter→FB B/f | GPU st events |
+|---|---|---|---|---|---|
+| Iron Soldier 1 (mission 1, from state) | 2400 | 11 | 5730 | 74849 | 3.52M |
+| Iron Soldier 2 (CD, city mission) | 12000 | 3688 | 9427 | 51214 | 40.24M |
+| Battlemorph (CD, menus+loadout) | 12000 | 308 | 149 | 59061 | 1.37M |
+| Cybermorph (gameplay) | 2400 | 7 | 8366 | 220765 | 10.33M |
+| Doom (gameplay, contrast) | 2400 | 66 | 80818 | 39095 | 49.38M |
+| Checkered Flag (gameplay, contrast) | 2400 | 530 | 7185 | 86844 | 5.53M |
+
+Conclusions:
+
+1. **No measured title rasterizes via GPU stores.** The largest GPU→FB rate in
+   the R2 set (IS2-CD, ~3.7 KB/frame) is an order of magnitude below its own
+   blitter's ~51 KB/frame into the same regions, and is consistent with HUD /
+   radar element updates, not polygon filling. Iron Soldier 1 in gameplay:
+   **11 bytes/frame** of GPU stores into framebuffer buckets against 74.8
+   KB/frame of blitter writes.
+2. **The design's IS anomaly is explained.** The prior save state was the main
+   menu (verified by screenshot). In-mission, IS1 issues ~378 blits/frame:
+   Z-buffered `PATDSEL` flat spans onto a 16bpp destination with **integer**
+   walks — i.e. IS1 is a Cybermorph-class NN title (11.6k fractional blits in
+   2,400 frames is marginal), not an invisible-renderer. The 24bpp objects
+   noted in `src/tom/op.c` appear only on its menu/briefing screens; gameplay
+   scans 16bpp objects.
+3. **The shadow's two touch points (blitter stores + OP resolve) see every
+   pixel producer that matters.** No GPU-store hook is required; the
+   "structurally untouched write paths" guarantee of PR #341 carries to Nx
+   unweakened. Caveat: GPU→other traffic (e.g. Doom's 80.8 KB/frame) includes
+   game state and any GPU-written intermediate buffers; if such a buffer later
+   reaches the screen through a blit copy, the shadow sees the copy and
+   degrades that content to NN by tag mismatch — safe by construction, just
+   not supersampled. That is the design's intended failure mode, not a gap.
+
+## 6. Aggregate answers and recommendation
+
+**A1 — Titles qualifying for Stage 2 as designed (fractional source walk onto
+16bpp CRY, gameplay-verified, ≥ ~25 qualifying blits/frame):**
+
+| Title | qualifying blits/frame |
+|---|---|
+| Missile Command 3D | 1,865 |
+| Doom | 434 |
+| Hover Strike (cart, and by engine identity the CD release) | 336 |
+| Iron Soldier 2 (CD) | 268 |
+| I-War | 184 |
+| Alien vs Predator | 85 |
+| Skyhammer | 71 |
+| Towers II | 33 |
+| CRZ Demo (homebrew) | 24 |
+
+Marginal but non-zero: Tempest 2000 (3.2/f — its webs are gouraud; the
+fractional walks are its 3D interstitials), Iron Soldier 1 (4.8/f).
+**Answer: 8 commercial qualifying titles, not 1.**
+
+**A2 — Additional titles reachable only with a CLUT-destination extension:**
+
+| Title | frac→CLUT blits/frame |
+|---|---|
+| Wolfenstein 3D | 90 |
+| Super Cross 3D | 72 |
+| Atari Karts | 55 |
+
+**Answer: a CLUT extension adds 3 titles.** Worthwhile follow-on, no longer
+the make-or-break scope decision the design feared.
+
+**A3 — R2 / IS-class:** blitter-rendered everywhere measured; no GPU-store
+hook needed (§5).
+
+### Recommendation — against R1's decision rule
+
+R1's rule: *"if Stage 0 finds no second beneficiary, do not build Stage 1;
+either extend scope to CLUT destinations first, or close the track."* Stage 0
+found **eight** commercial second beneficiaries for Stage 2 as already
+specified, several of them heavier consumers of sub-pixel source information
+than Doom itself (Missile Command 3D at 4.3×, Hover Strike and IS2-CD
+comparable), and none of them requires the CLUT extension or a GPU-store hook.
+The rule's no-build condition is therefore not met: **GO — build Stage 1 (N=2
+plumbing) and Stage 2 exactly as designed.** The CLUT-destination extension is
+demoted from "possible prerequisite for a second beneficiary" to a follow-on
+stage that would add Wolfenstein 3D, Super Cross 3D and Atari Karts; Stage 3
+(OP scaled-object supersampling) is independently justified by Primal Rage,
+Val d'Isere and Atari Karts, and is the only stage that reaches 2D titles.
+Design §10's cost argument stands unchanged: Cybermorph, Checkered Flag, Club
+Drive, Kasumi Ninja, Tempest 2000 and Iron Soldier 1 pay the full N² cost for
+effectively nothing, so track 4's per-title enhancement DB remains a
+**shipping prerequisite** for default-on behaviour.
+
+## 7. Not measured, and why
+
+- **Homebrew Doom-engine mods were not in the corpus** — no such ROMs exist
+  under `test/roms/private/ROMS/`. Given stock Doom's numbers they are
+  presumed beneficiaries, but that is presumption, not measurement.
+- **24 PD/homebrew files failed to load headlessly** (raw `bin`/`rom`/BJL
+  variants of demos whose `.jag` counterparts did run: BadCode raw dumps,
+  Drumpad, Hubble, JDC demos, JSS demos, Painter bin, PAULA previews, PlaySFX,
+  Native bin, Chroma-Luma bin, one JagMania and one JagMarble build, AvP
+  Alpha). Their `.jag` siblings are in the data where they exist.
+- **BattleSphere Gold** ships only as a `.zip` in the tree — not measured.
+- **Menu-locked commercial titles** (marked in §2): Rayman, Flashback, Double
+  Dragon V, Dragon, Theme Park, Troy Aikman, Ruiner Pinball, Fever Pitch,
+  Pinball Fantasies, Fight For Your Life, Syndicate (mouse-driven UI), Zool 2
+  (stage card), Kasumi Ninja (pre-fight gauntlet), Iron Soldier 2 cart, Battle
+  Morph flight missions, Hover Strike UL (CD) missions. Their rows are lower
+  bounds. None of these is plausibly a hidden Stage 2 beneficiary of Doom's
+  class given what their engines showed in the measured scenes, but the rows
+  should not be quoted as negatives.
+- **Val d'Isere / DEMO1B / DEMO1C**: measured and active — via the OP scaler,
+  not the blitter (§4), consistent with the A/B-sweep tooling notes.
+
+## 8. Reproduction
+
+The instrumentation pattern (for re-running or extending):
+
+1. Counter struct + record function at `BlitterWriteWord` offset `0x3A`
+   (before engine dispatch) reading `blitter_ram` directly.
+2. `OPProcessFixedBitmap` / `OPProcessScaledBitmap` hooks after decode
+   (`render` only): depth histogram, `HSCALE`/`VSCALE` histograms, 8 KB
+   fetch-bucket marking from the object's data pointer.
+3. `JaguarWriteByte/Word/Long` main-RAM branches: bytes by `who` (GPU /
+   BLITTER) into 8 KB buckets.
+4. Frame counter in `retro_run`; struct exported through the wide test ABI and
+   read via `harness_dlsym` after `harness_run()`; per-title final-frame
+   screenshot via the harness video callback for scene verification.
+
+Budget observed: ~5 ms/frame instrumented; the whole corpus (~115 titles ×
+2,400 frames) measures in under an hour on one host.


### PR DESCRIPTION
Executes **Stage 0** of [`docs/hires-upscaling-design.md`](https://github.com/libretro/virtualjaguar-libretro/blob/develop/docs/hires-upscaling-design.md) (§8): the corpus-wide blit/OP census the design names as the **go/no-go for the whole track (R1)**, plus the GPU-store probe (**R2**). Deliverable is the data document only — the instrumentation was a throwaway compile-time patch (blit-launch site, OP bitmap processors, `JaguarWrite*` funnels, dlsym-able aggregate struct) and was reverted before commit.

## What was measured

- ~110 cartridge ROMs (every top-level `.jag`/`.j64` in the private tree that loads headlessly) + 4 CD titles (IS2, Battle Morph, Hover Strike UL, Primal Rage), 2,400–12,000 frames each, scripted `--press` input, **final-frame screenshot verification** for every row marked "gameplay" (Doom in E1M1, IS1 in mission-1 cockpit, IS2-CD in a city mission, AvP as the Alien in a corridor, Primal Rage mid-fight, …).
- Per blit: `B_CMD` flags, destination depth, OUTER, phrase/pixel mode, and **consumed** fractional source walks (XADDCTL-gated, so Cybermorph's inert stale fractions don't count).
- OP: `SCBITOBJ` call counts + full `HSCALE`/`VSCALE` histograms.
- R2: GPU-store vs blitter-write bytes into OP-fetched (framebuffer) 8 KB buckets.

## Aggregate answers

**R1 — qualifying titles for Stage 2 as designed** (fractional source walk onto 16bpp CRY, gameplay-verified): **eight commercial titles, not one** — Missile Command 3D (1,865 qualifying blits/frame), Doom (434), Hover Strike (336), Iron Soldier 2 CD (268), I-War (184), AvP (85), Skyhammer (71), Towers II (33), plus homebrew CRZ Demo (24). The design's "Doom is the sole beneficiary" premise was an artifact of the small first census with menu-bound input.

**CLUT extension reach**: +3 titles — Wolfenstein 3D (90/f), Super Cross 3D (72/f), Atari Karts (55/f). Worthwhile follow-on, no longer make-or-break.

**R2 — IS-class GPU stores**: no measured title rasterizes via GPU stores. IS1's "388 blits/900 frames" was measured **on a menu** (screenshot-verified); in-mission IS1 issues ~378 blits/frame of Z-buffered `PATDSEL` spans. GPU→framebuffer store traffic is 7–3,700 B/frame (HUD-scale) vs 39–220 KB/frame from the blitter. **No GPU-store shadow hook is needed.**

**Bonus (Stage 3 evidence)**: Primal Rage draws its fighters entirely through the OP scaler at 0.875× minification (505k non-integer scaled calls, ~0 blits); Val d'Isere's whole renderer is OP-scaled objects; Atari Karts minifies down to 1/16×.

## Recommendation — phrased against R1's decision rule

R1's rule: *"if Stage 0 finds no second beneficiary, do not build Stage 1; either extend scope to CLUT destinations first, or close the track."* Stage 0 found **eight** commercial second beneficiaries for Stage 2 exactly as specified — the no-build condition is **not met**: **GO** — build Stage 1 (N=2 plumbing) and Stage 2 as designed. CLUT extension demoted to follow-on; Stage 3 independently justified; track 4's per-title DB remains the shipping prerequisite (Cybermorph, Checkered Flag, Club Drive, Kasumi Ninja, IS1 still pay full N² cost for nothing).

## Caveats

- Homebrew Doom-engine mods were **not in the corpus** (none present in the ROM tree).
- 24 PD raw-dump files failed to load headlessly; menu-locked titles are marked as lower bounds, not negatives (full list in §7).
- Battle Morph flight missions were not reachable headlessly (name-pad + loadout cursor work); its row is menus/briefing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)