### PR TITLE
test(jlink): fix coverage-job flake — test ports sat inside the ephemeral range

### DIFF
--- a/src/jerry/jlink_tcp.c
+++ b/src/jerry/jlink_tcp.c
@@ -350,6 +350,20 @@ int JLinkTCPConnected(void)
    return 0;
 }
 
+int JLinkTCPPeerCount(void)
+{
+   int i;
+   int n = 0;
+   if (!tcpPeersInit)
+      return 0;
+   if (tcpIsClient)
+      return (jlink_sock_valid(tcpPeers[0].sock) && !tcpConnecting) ? 1 : 0;
+   for (i = 0; i < JLINK_TCP_MAX_PEERS; i++)
+      if (jlink_sock_valid(tcpPeers[i].sock))
+         n++;
+   return n;
+}
+
 static void jlink_tcp_queue_pending(jlink_peer_t *p, uint8_t b)
 {
    uint32_t tail;
@@ -545,6 +559,7 @@ int JLinkTCPOpen(int is_server, const char *host, int port)
 }
 void JLinkTCPClose(void) {}
 int JLinkTCPConnected(void) { return 0; }
+int JLinkTCPPeerCount(void) { return 0; }
 void JLinkTCPSend(uint8_t b) { (void)b; }
 int JLinkTCPRecv(uint8_t *b) { (void)b; return 0; }
 void JLinkTCPPoll(void) {}

--- a/src/jerry/jlink_tcp.h
+++ b/src/jerry/jlink_tcp.h
@@ -19,6 +19,12 @@ int  JLinkTCPOpen(int is_server, const char *host, int port);
 void JLinkTCPClose(void);
 int  JLinkTCPConnected(void);
 
+/* Number of live peer connections: accepted clients in server mode,
+   0/1 in client mode (0 while the connect is still in flight).  Lets a
+   hub caller (tests, future OSD) wait on "N peers present" instead of
+   sleeping a fixed interval and hoping the accept happened. */
+int  JLinkTCPPeerCount(void);
+
 /* Nonblocking send; on partial send / EAGAIN the byte parks in a small
    pending ring flushed by JLinkTCPPoll.  Silently drops when no peer. */
 void JLinkTCPSend(uint8_t b);

--- a/test/test_jlink_tcp.c
+++ b/test/test_jlink_tcp.c
@@ -33,12 +33,23 @@ static int failures = 0;
 
 /* 17000-20999: above the well-known/registered services that actually
    run anywhere, below the ephemeral floor of every OS we test on.
-   VJ_TEST_PORT_BASE pins the base for deterministic reproduction. */
+   VJ_TEST_PORT_BASE pins the base for deterministic reproduction; it
+   must leave room for the retry walk (offset 200 + 31 attempts), so
+   out-of-range values fall back to the PID-spread default instead of
+   silently leaving JLinkSetTCPEndpoint on a stale port. */
 static int test_port_base(void)
 {
     const char *e = getenv("VJ_TEST_PORT_BASE");
-    if (e && atoi(e) > 0)
-        return atoi(e);
+    if (e)
+    {
+        int p = atoi(e);
+        if (p >= 1024 && p <= 65535 - 200 - 32)
+            return p;
+        if (p != 0)
+            fprintf(stderr, "note: VJ_TEST_PORT_BASE '%s' out of range "
+                            "(1024..%d), using PID default\n",
+                    e, 65535 - 200 - 32);
+    }
     return 17000 + (int)(getpid() % 4000);
 }
 
@@ -172,6 +183,7 @@ static void test_client_mode(void)
     int i;
 
     lsock = socket(AF_INET, SOCK_STREAM, 0);
+    CHECK(lsock >= 0, "client: test listener socket created");
     {
         int one = 1;
         setsockopt(lsock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
@@ -183,7 +195,8 @@ static void test_client_mode(void)
     CHECK(bind(lsock, (struct sockaddr *)&sa, sizeof(sa)) == 0,
           "client: test listener binds");
     salen = (socklen_t)sizeof(sa);
-    getsockname(lsock, (struct sockaddr *)&sa, &salen);
+    CHECK(getsockname(lsock, (struct sockaddr *)&sa, &salen) == 0
+          && ntohs(sa.sin_port) != 0, "client: kernel assigned a port");
     port = (int)ntohs(sa.sin_port);
     listen(lsock, 1);
     fcntl(lsock, F_SETFL, O_NONBLOCK);

--- a/test/test_jlink_tcp.c
+++ b/test/test_jlink_tcp.c
@@ -1,6 +1,16 @@
 /* test_jlink_tcp.c — unit test for the TCP link backend.  The test acts
    as the remote peer with its own plain sockets, so both endpoints live
-   in one process without sharing any jlink state. */
+   in one process without sharing any jlink state.
+
+   Ports are NOT hard-coded.  The old fixed base (42371) sat inside the
+   Linux ephemeral range (32768-60999), and on CI runners a transient
+   outgoing connection (runner agent, pip, codecov) would occasionally
+   hold that exact port — bind() then fails EADDRINUSE, JLinkOpen()
+   returns 0, and every downstream hub check cascades into FAIL (the
+   coverage-job "hub" flake).  Server-mode ports are now picked from a
+   PID-spread band BELOW every OS's ephemeral floor (Linux 32768, macOS
+   49152) with a retry walk on bind failure; the client-mode listener
+   just binds port 0 and asks the kernel what it got. */
 #define _DEFAULT_SOURCE 1   /* usleep/MSG_DONTWAIT under -std=c99 on glibc */
 #include <stdio.h>
 #include <stdint.h>
@@ -11,9 +21,9 @@
 #include <fcntl.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include "src/jerry/jlink.h"
+#include "src/jerry/jlink_tcp.h"
 
 static int failures = 0;
 
@@ -21,9 +31,42 @@ static int failures = 0;
     do { if (cond) printf("PASS %s\n", msg); \
          else { printf("FAIL %s\n", msg); failures++; } } while (0)
 
-#define TEST_PORT_BASE 42371
+/* 17000-20999: above the well-known/registered services that actually
+   run anywhere, below the ephemeral floor of every OS we test on.
+   VJ_TEST_PORT_BASE pins the base for deterministic reproduction. */
+static int test_port_base(void)
+{
+    const char *e = getenv("VJ_TEST_PORT_BASE");
+    if (e && atoi(e) > 0)
+        return atoi(e);
+    return 17000 + (int)(getpid() % 4000);
+}
 
-/* Poll the jlink side + give the kernel a moment, up to ~2 s. */
+/* Open a jlink TCP server on the first free port at-or-after
+   base + off.  Returns the port, or -1 with diagnostics.  A busy slot
+   is expected occasionally (another service, a concurrent suite);
+   walking forward keeps the test independent of any one port. */
+static int open_jlink_server(int off)
+{
+    int attempt;
+    for (attempt = 0; attempt < 32; attempt++)
+    {
+        int port = test_port_base() + off + attempt;
+        errno = 0;
+        JLinkSetTCPEndpoint(NULL, port);
+        if (JLinkOpen(JLINK_MODE_TCP_SERVER) == 1)
+            return port;
+        fprintf(stderr, "note: JLinkOpen(server) port %d failed (%s), "
+                        "trying next\n", port, strerror(errno));
+    }
+    fprintf(stderr, "error: no bindable port in %d..%d\n",
+            test_port_base() + off, test_port_base() + off + 31);
+    return -1;
+}
+
+/* Poll the jlink side + give the kernel a moment.  Deadline-bounded
+   (iters x 10 ms), returns early on success — generous iters cost
+   nothing on the passing path, so waits use ~5 s not ~2 s. */
 static int wait_for(int (*pred)(void), int iters)
 {
     int i;
@@ -37,118 +80,15 @@ static int wait_for(int (*pred)(void), int iters)
     return 0;
 }
 
+#define WAIT_ITERS 500   /* x 10 ms = 5 s deadline */
+
 static int pred_connected(void) { return JLinkConnected(); }
+static int pred_not_connected(void) { return !JLinkConnected(); }
 static int pred_rx_pending(void) { return JLinkRxPending() > 0; }
+static int pred_two_peers(void) { return JLinkTCPPeerCount() >= 2; }
+static int pred_one_peer(void) { return JLinkTCPPeerCount() == 1; }
 
-/* ---- server-mode: jlink listens, test connects ---- */
-static void test_server_mode(void)
-{
-    int port = TEST_PORT_BASE;
-    int peer;
-    struct sockaddr_in sa;
-    uint8_t b = 0;
-    ssize_t n;
-    char buf[4];
-
-    JLinkSetTCPEndpoint(NULL, port);
-    CHECK(JLinkOpen(JLINK_MODE_TCP_SERVER) == 1, "server: open listens");
-    CHECK(!JLinkConnected(), "server: not connected before peer");
-
-    peer = socket(AF_INET, SOCK_STREAM, 0);
-    memset(&sa, 0, sizeof(sa));
-    sa.sin_family = AF_INET;
-    sa.sin_port = htons((uint16_t)port);
-    sa.sin_addr.s_addr = inet_addr("127.0.0.1");
-    CHECK(connect(peer, (struct sockaddr *)&sa, sizeof(sa)) == 0,
-          "server: test peer connects");
-
-    CHECK(wait_for(pred_connected, 200), "server: accept completes");
-
-    /* jlink -> peer */
-    JLinkSendByte(0xAA);
-    JLinkPoll();
-    n = recv(peer, buf, 1, 0);
-    CHECK(n == 1 && (uint8_t)buf[0] == 0xAA, "server: TX byte reaches peer");
-
-    /* peer -> jlink */
-    buf[0] = (char)0x55;
-    send(peer, buf, 1, 0);
-    CHECK(wait_for(pred_rx_pending, 200), "server: RX byte arrives");
-    CHECK(JLinkRecvByte(&b) == 1 && b == 0x55, "server: RX byte value");
-
-    /* disconnect detection */
-    close(peer);
-    {
-        int i, gone = 0;
-        for (i = 0; i < 200; i++)
-        {
-            JLinkPoll();
-            if (!JLinkConnected()) { gone = 1; break; }
-            usleep(10000);
-        }
-        CHECK(gone, "server: peer close detected");
-    }
-    JLinkClose();
-}
-
-/* ---- client-mode: test listens, jlink connects ---- */
-static void test_client_mode(void)
-{
-    int port = TEST_PORT_BASE + 1;
-    int lsock, peer = -1;
-    struct sockaddr_in sa;
-    uint8_t b = 0;
-    ssize_t n;
-    char buf[4];
-    int i;
-
-    lsock = socket(AF_INET, SOCK_STREAM, 0);
-    {
-        int one = 1;
-        setsockopt(lsock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
-    }
-    memset(&sa, 0, sizeof(sa));
-    sa.sin_family = AF_INET;
-    sa.sin_port = htons((uint16_t)port);
-    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    CHECK(bind(lsock, (struct sockaddr *)&sa, sizeof(sa)) == 0,
-          "client: test listener binds");
-    listen(lsock, 1);
-    fcntl(lsock, F_SETFL, O_NONBLOCK);
-
-    JLinkSetTCPEndpoint("127.0.0.1", port);
-    CHECK(JLinkOpen(JLINK_MODE_TCP_CLIENT) == 1, "client: open starts connect");
-
-    for (i = 0; i < 200 && peer < 0; i++)
-    {
-        JLinkPoll();
-        peer = accept(lsock, NULL, NULL);
-        if (peer < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
-            usleep(10000);
-    }
-    CHECK(peer >= 0, "client: jlink connected to test listener");
-    CHECK(wait_for(pred_connected, 200), "client: JLinkConnected reports up");
-
-    /* jlink -> peer */
-    JLinkSendByte(0x42);
-    JLinkPoll();
-    n = recv(peer, buf, 1, 0);
-    if (n < 0) { usleep(50000); n = recv(peer, buf, 1, 0); }
-    CHECK(n == 1 && (uint8_t)buf[0] == 0x42, "client: TX byte reaches peer");
-
-    /* peer -> jlink */
-    buf[0] = (char)0x24;
-    send(peer, buf, 1, 0);
-    CHECK(wait_for(pred_rx_pending, 200), "client: RX byte arrives");
-    CHECK(JLinkRecvByte(&b) == 1 && b == 0x24, "client: RX byte value");
-
-    close(peer);
-    close(lsock);
-    JLinkClose();
-}
-
-/* ---- hub mode: two peers on one jlink server, bus semantics ---- */
-static int hub_connect_peer(int port)
+static int connect_peer(int port)
 {
     int s = socket(AF_INET, SOCK_STREAM, 0);
     struct sockaddr_in sa;
@@ -166,7 +106,9 @@ static int hub_connect_peer(int port)
     return s;
 }
 
-static int hub_recv_byte(int s, uint8_t *b, int iters)
+/* Pump jlink and read one byte from a plain test socket; deadline-
+   bounded like wait_for. */
+static int peer_recv_byte(int s, uint8_t *b, int iters)
 {
     int i;
     for (i = 0; i < iters; i++)
@@ -180,50 +122,146 @@ static int hub_recv_byte(int s, uint8_t *b, int iters)
     return 0;
 }
 
+/* ---- server-mode: jlink listens, test connects ---- */
+static void test_server_mode(void)
+{
+    int port;
+    int peer;
+    uint8_t b = 0;
+    ssize_t n;
+    char buf[4];
+
+    port = open_jlink_server(0);
+    CHECK(port > 0, "server: open listens");
+    CHECK(!JLinkConnected(), "server: not connected before peer");
+
+    peer = connect_peer(port);
+    CHECK(peer >= 0, "server: test peer connects");
+
+    CHECK(wait_for(pred_connected, WAIT_ITERS), "server: accept completes");
+
+    /* jlink -> peer */
+    JLinkSendByte(0xAA);
+    JLinkPoll();
+    n = recv(peer, buf, 1, 0);
+    CHECK(n == 1 && (uint8_t)buf[0] == 0xAA, "server: TX byte reaches peer");
+
+    /* peer -> jlink */
+    buf[0] = (char)0x55;
+    send(peer, buf, 1, 0);
+    CHECK(wait_for(pred_rx_pending, WAIT_ITERS), "server: RX byte arrives");
+    CHECK(JLinkRecvByte(&b) == 1 && b == 0x55, "server: RX byte value");
+
+    /* disconnect detection */
+    close(peer);
+    CHECK(wait_for(pred_not_connected, WAIT_ITERS),
+          "server: peer close detected");
+    JLinkClose();
+}
+
+/* ---- client-mode: test listens, jlink connects ---- */
+static void test_client_mode(void)
+{
+    int port;
+    int lsock, peer = -1;
+    struct sockaddr_in sa;
+    socklen_t salen;
+    uint8_t b = 0;
+    ssize_t n;
+    char buf[4];
+    int i;
+
+    lsock = socket(AF_INET, SOCK_STREAM, 0);
+    {
+        int one = 1;
+        setsockopt(lsock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    }
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family = AF_INET;
+    sa.sin_port = 0;              /* kernel picks: collision-proof */
+    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    CHECK(bind(lsock, (struct sockaddr *)&sa, sizeof(sa)) == 0,
+          "client: test listener binds");
+    salen = (socklen_t)sizeof(sa);
+    getsockname(lsock, (struct sockaddr *)&sa, &salen);
+    port = (int)ntohs(sa.sin_port);
+    listen(lsock, 1);
+    fcntl(lsock, F_SETFL, O_NONBLOCK);
+
+    JLinkSetTCPEndpoint("127.0.0.1", port);
+    CHECK(JLinkOpen(JLINK_MODE_TCP_CLIENT) == 1, "client: open starts connect");
+
+    for (i = 0; i < WAIT_ITERS && peer < 0; i++)
+    {
+        JLinkPoll();
+        peer = accept(lsock, NULL, NULL);
+        if (peer < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            usleep(10000);
+    }
+    CHECK(peer >= 0, "client: jlink connected to test listener");
+    CHECK(wait_for(pred_connected, WAIT_ITERS),
+          "client: JLinkConnected reports up");
+
+    /* jlink -> peer */
+    JLinkSendByte(0x42);
+    JLinkPoll();
+    n = recv(peer, buf, 1, 0);
+    if (n < 0) { usleep(50000); n = recv(peer, buf, 1, 0); }
+    CHECK(n == 1 && (uint8_t)buf[0] == 0x42, "client: TX byte reaches peer");
+
+    /* peer -> jlink */
+    buf[0] = (char)0x24;
+    send(peer, buf, 1, 0);
+    CHECK(wait_for(pred_rx_pending, WAIT_ITERS), "client: RX byte arrives");
+    CHECK(JLinkRecvByte(&b) == 1 && b == 0x24, "client: RX byte value");
+
+    close(peer);
+    close(lsock);
+    JLinkClose();
+}
+
+/* ---- hub mode: two peers on one jlink server, bus semantics ---- */
 static void test_hub_mode(void)
 {
-    int port = TEST_PORT_BASE + 3;
+    int port;
     int p1, p2;
     uint8_t b = 0;
     char c;
 
-    JLinkSetTCPEndpoint(NULL, port);
-    CHECK(JLinkOpen(JLINK_MODE_TCP_SERVER) == 1, "hub: open listens");
+    port = open_jlink_server(100);
+    CHECK(port > 0, "hub: open listens");
 
-    p1 = hub_connect_peer(port);
+    p1 = connect_peer(port);
     CHECK(p1 >= 0, "hub: peer1 connects");
-    CHECK(wait_for(pred_connected, 200), "hub: peer1 accepted");
-    p2 = hub_connect_peer(port);
+    CHECK(wait_for(pred_connected, WAIT_ITERS), "hub: peer1 accepted");
+    p2 = connect_peer(port);
     CHECK(p2 >= 0, "hub: peer2 connects");
-    /* second accept happens on a later poll */
-    {
-        int i;
-        for (i = 0; i < 100; i++) { JLinkPoll(); usleep(5000); }
-    }
+    /* The second accept happens on a later poll: wait for the observable
+       condition (2 live peers), not a fixed number of sleeps. */
+    CHECK(wait_for(pred_two_peers, WAIT_ITERS), "hub: peer2 accepted");
 
     /* local TX reaches BOTH peers */
     JLinkSendByte(0xA1);
     JLinkPoll();
-    CHECK(hub_recv_byte(p1, &b, 100) && b == 0xA1, "hub: TX to peer1");
-    CHECK(hub_recv_byte(p2, &b, 100) && b == 0xA1, "hub: TX to peer2");
+    CHECK(peer_recv_byte(p1, &b, WAIT_ITERS) && b == 0xA1, "hub: TX to peer1");
+    CHECK(peer_recv_byte(p2, &b, WAIT_ITERS) && b == 0xA1, "hub: TX to peer2");
 
     /* peer1 byte reaches the local ring AND peer2 (bus forward) */
     c = (char)0xB2;
     send(p1, &c, 1, 0);
-    CHECK(wait_for(pred_rx_pending, 200), "hub: peer1 byte in local ring");
+    CHECK(wait_for(pred_rx_pending, WAIT_ITERS), "hub: peer1 byte in local ring");
     CHECK(JLinkRecvByte(&b) == 1 && b == 0xB2, "hub: local ring value");
-    CHECK(hub_recv_byte(p2, &b, 100) && b == 0xB2, "hub: forwarded to peer2");
+    CHECK(peer_recv_byte(p2, &b, WAIT_ITERS) && b == 0xB2,
+          "hub: forwarded to peer2");
 
     /* peer2 drop: session continues with peer1 */
     close(p2);
-    {
-        int i;
-        for (i = 0; i < 100; i++) { JLinkPoll(); usleep(5000); }
-    }
+    CHECK(wait_for(pred_one_peer, WAIT_ITERS), "hub: peer2 drop detected");
     CHECK(JLinkConnected(), "hub: still connected after peer2 drop");
     JLinkSendByte(0xC3);
     JLinkPoll();
-    CHECK(hub_recv_byte(p1, &b, 100) && b == 0xC3, "hub: peer1 flows after drop");
+    CHECK(peer_recv_byte(p1, &b, WAIT_ITERS) && b == 0xC3,
+          "hub: peer1 flows after drop");
 
     close(p1);
     JLinkClose();
@@ -231,8 +269,8 @@ static void test_hub_mode(void)
 
 static void test_unconnected_send_harmless(void)
 {
-    JLinkSetTCPEndpoint(NULL, TEST_PORT_BASE + 2);
-    CHECK(JLinkOpen(JLINK_MODE_TCP_SERVER) == 1, "orphan: open ok");
+    int port = open_jlink_server(200);
+    CHECK(port > 0, "orphan: open ok");
     JLinkSendByte(0x77);           /* no peer: must not crash or queue */
     JLinkPoll();
     CHECK(JLinkRxPending() == 0, "orphan: nothing echoes");

--- a/test/tools/netlink_latency_test.sh
+++ b/test/tools/netlink_latency_test.sh
@@ -85,9 +85,15 @@ skip()
     exit 0
 }
 
-out_off="$(run_case "control disabled" 42751 42761 disabled)" || {
+# Ports: PID-spread inside 21000-24999, below every OS's ephemeral
+# floor (Linux 32768, macOS 49152).  Fixed ports in the ephemeral range
+# collide with the runner's own transient connections and flake the
+# suite (see netlink_pair_test.sh / test_jlink_tcp.c).
+PORT_BASE=$(( 21000 + ($$ % 4000) ))
+
+out_off="$(run_case "control disabled" "$PORT_BASE" "$((PORT_BASE + 10))" disabled)" || {
     echo "netlink_latency_test: FAIL (control case errored)"; exit 1; }
-out_on="$(run_case "fixed enabled" 42752 42762 enabled)" || {
+out_on="$(run_case "fixed enabled" "$((PORT_BASE + 1))" "$((PORT_BASE + 11))" enabled)" || {
     echo "netlink_latency_test: FAIL (enabled case errored)"; exit 1; }
 read -r rate_off fps_off <<<"$out_off"
 read -r rate_on  fps_on  <<<"$out_on"

--- a/test/tools/netlink_pair.c
+++ b/test/tools/netlink_pair.c
@@ -14,6 +14,7 @@
 #include <stdint.h>
 #include <unistd.h>
 #include "../harness/harness.h"
+#include "jlink.h"   /* JLINK_MODE_* values for the fast-fail check */
 
 typedef void     (*jerry_ww_t)(uint32_t, uint16_t, uint32_t);
 typedef uint16_t (*jerry_rw_t)(uint32_t, uint32_t);
@@ -144,6 +145,20 @@ int main(int argc, char **argv)
     {
         fprintf(stderr, "[%s] symbols missing -- build with TEST_EXPORTS=1\n", role);
         return 1;
+    }
+
+    /* Server bind failures (EADDRINUSE: something else on the runner
+       holds the port) leave the mode DISABLED after load.  Exit fast
+       with a distinct code so the driver script can retry on another
+       port instead of burning the full 15 s rendezvous and reporting a
+       generic FAIL. */
+    if (!strcmp(role, "server") && jlink_mode
+        && jlink_mode() == JLINK_MODE_DISABLED)
+    {
+        fprintf(stderr, "[%s] FAIL: netlink server did not open "
+                        "(port %s busy?)\n", role, port);
+        harness_shutdown(&cfg);
+        return 2;
     }
 
     /* Slow baud (~27 ms per character frame): this test only reads

--- a/test/tools/netlink_pair_test.sh
+++ b/test/tools/netlink_pair_test.sh
@@ -17,7 +17,13 @@
 set -u
 
 CORE="${1:?usage: netlink_pair_test.sh <core> [port]}"
-PORT="${2:-${VJ_NETLINK_PORT:-42171}}"
+# Default port: PID-spread inside 17000-20999 — BELOW the ephemeral
+# range of every CI OS (Linux 32768+, macOS 49152+).  The old fixed
+# 42171 sat inside Linux's ephemeral range, and a transient outgoing
+# connection on the runner occasionally held it: the server's bind
+# failed and the pair test flaked.  Explicit [port] / VJ_NETLINK_PORT
+# still override.
+PORT="${2:-${VJ_NETLINK_PORT:-$(( 17000 + ($$ % 4000) ))}}"
 BIN="$(dirname "$0")/netlink_pair"
 
 if [ ! -x "$BIN" ]; then
@@ -44,12 +50,31 @@ run_pair() {
         echo "netlink_pair_test: PASS ($label, host=$host, port $port)"
         return 0
     fi
+    # Server exit 2 = bind failed (port held by something else on the
+    # machine): the caller retries on a different port.
+    if [ "$server_rc" -eq 2 ]; then
+        return 2
+    fi
     echo "netlink_pair_test: FAIL ($label, host=$host, server=$server_rc client=$client_rc)" >&2
     return 1
 }
 
-run_pair "127.0.0.1" "by IP" "$PORT" || exit 1
+# run_pair, retrying on a shifted port when the server's bind fails.
+run_pair_retry() {
+    local host="$1" label="$2" port="$3" attempt rc
+    for attempt in 1 2 3; do
+        run_pair "$host" "$label" "$port"
+        rc=$?
+        [ "$rc" -ne 2 ] && return "$rc"
+        port=$((port + 211))
+        echo "netlink_pair_test: port busy, retrying $label on $port" >&2
+    done
+    echo "netlink_pair_test: FAIL ($label — no bindable port after 3 tries)" >&2
+    return 1
+}
+
+run_pair_retry "127.0.0.1" "by IP" "$PORT" || exit 1
 # Second round on the next port: the first server may still be in
 # TIME_WAIT, and SO_REUSEADDR does not cover a listener that raced.
-run_pair "localhost" "by name" "$((PORT + 1))" || exit 1
+run_pair_retry "localhost" "by name" "$((PORT + 1))" || exit 1
 exit 0


### PR DESCRIPTION
## Root cause

The intermittent hub-test failures in the **Code coverage (gcov + codecov)** job ([run 31287566215](https://github.com/libretro/virtualjaguar-libretro/actions/runs/31287566215): `FAIL hub: open listens` + 10 cascading FAILs, `FAILED (11)`) were **not** a slow-build timing problem. The first failing check is `JLinkOpen(JLINK_MODE_TCP_SERVER)` returning 0 — `bind()` failed with `EADDRINUSE` — and everything after it is cascade. Build slowness cannot make `bind()` fail.

The real defect: the hard-coded test ports (42371–42374 in `test_jlink_tcp`, 42171 in the pair test, 42751–42762 in the latency test) sit **inside Linux's ephemeral port range (32768–60999)**. Any transient outgoing connection on the runner — the actions agent, `pip install gcovr` (which the coverage job runs right before the tests), codecov — can hold that exact port as its local port at bind time. macOS's ephemeral floor is 49152, which is why this never reproduced locally.

Reproduced deterministically by pre-occupying the hub port: identical FAIL-cascade signature, and the two earlier waves of `wait_for` checks pass just like in the CI log.

## Fix

- **test_jlink_tcp.c** — server ports come from a PID-spread band (17000–20999, below every OS's ephemeral floor) with a retry walk on bind failure that logs `strerror(errno)`; the client-mode listener binds port 0 and reads the kernel-assigned port back. `VJ_TEST_PORT_BASE` pins the base for reproduction.
- **Condition-based hub waits** — new `JLinkTCPPeerCount()` (src/jerry/jlink_tcp.c) lets the test wait on "2 peers accepted" / "peer dropped" directly instead of fixed 0.5 s sleep loops; all deadlines are a generous 5 s with early exit (no added cost on the passing path).
- **netlink_pair.c** — the server exits with a distinct code 2 when the netlink open left the mode DISABLED (bind failed), so the driver retries on a shifted port instead of burning the 15 s rendezvous; **netlink_pair_test.sh** picks a PID-spread default port and retries up to 3× on exit 2.
- **netlink_latency_test.sh** — same PID-spread scheme (21000–24999).

## Verification

- Full suite green under a `COVERAGE=1 TEST_EXPORTS=1` instrumented build (the CI gcov configuration); latency test correctly SKIPs (instrumented builds run below realtime, documented behavior).
- `test_jlink_tcp` 60/60 green under the instrumented build.
- Adversarial runs with the chosen ports pre-occupied: the unit test walks to the next port (`note: JLinkOpen(server) port N failed (Address already in use), trying next`) and passes; the pair script retries (`port busy, retrying by IP on …`) and passes.
- `scripts/c89-lint.sh` clean on all changed C files; production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)