### PR TITLE
feat(video): hi-res Stage 2 — fractional-walk source supersampling (#338)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ test/acid/tests/**/*.jag
 /test/tools/frame_hash_ab
 /test/tools/hires_box_check
 /test/tools/hires_state_digest
+/test/tools/hires_shot
 test/tools/__pycache__/
 .link-mode
 

--- a/docs/hires-stage0-census.md
+++ b/docs/hires-stage0-census.md
@@ -268,6 +268,12 @@ Conclusions:
 **A1 — Titles qualifying for Stage 2 as designed (fractional source walk onto
 16bpp CRY, gameplay-verified, ≥ ~25 qualifying blits/frame):**
 
+> ⚠ **This table counts blit *shapes*, not supersampled pixels on screen.**
+> Three of the nine rows below measured **zero** on-screen benefit from the
+> shipped Stage 2, and a fourth could not be verified. Do not quote this
+> table as a beneficiary list — see **§9, "Stage 2 on-screen
+> verification"**, which measures what actually reaches the display.
+
 | Title | qualifying blits/frame |
 |---|---|
 | Missile Command 3D | 1,865 |
@@ -357,3 +363,227 @@ The instrumentation pattern (for re-running or extending):
 
 Budget observed: ~5 ms/frame instrumented; the whole corpus (~115 titles ×
 2,400 frames) measures in under an hour on one host.
+
+---
+
+## 9. Stage 2 on-screen verification (added 2026-08-09)
+
+**Date:** 2026-08-09 · **Build:** `feature/338-hires-stage2` @ `836baf6`
+(Stage 2 + the ADDDSEL review fix), clean tree, `VJ_EXPECT_BUILD` guard
+enabled on every run. **Tool:** `test/tools/hires_shot`.
+
+### 9.1 Why this section exists
+
+§2/§3/§6 counted **qualifying blit shapes**: a fractional A1 source walk
+onto a 16bpp CRY destination. That is the *shape* Stage 2 can reach — it
+is not the same thing as *supersampled pixels arriving on the display*.
+Three further conditions have to hold, and each one is a real filter:
+
+- **(a) pixel-mode destination writes.** The accurate engine's phrase-mode
+  `dwrite` path keeps Stage 1 box replication (a documented Stage 2
+  deviation). *Measured: not a filter for any title here* — see §9.4.
+- **(b) a source-dependent data path.** `GOURD` and `PATDSEL` produce
+  output that does not depend on the source sample, so re-sampling the
+  source cannot change anything; both engines exclude them.
+- **(c) the supersampled content must survive to the displayed
+  framebuffer.** If a title renders into an off-screen buffer and then
+  plain-copies that buffer to the display, the copy is an integer 1:1
+  walk: it replicates, and the sub-pixel content is discarded.
+
+And one condition the census could not see at all:
+
+- **(d) the source walk must MINIFY.** Stage 2 derives its extra samples
+  by re-reading the source at `pos + inc/2`. When the walk consumes less
+  than one source texel per destination pixel (magnification), the
+  half-step lands inside the *same texel* and returns the identical
+  value. A fractional walk is necessary but not sufficient — only
+  minification carries information the 1x sample threw away.
+
+### 9.2 The metric
+
+`hires_shot` reports, for each dumped 2x frame, the **percentage of 2×2
+output blocks whose four subpixels are not all equal**. This is a
+*coverage* number — the fraction of the screen carrying real sub-pixel
+detail. It is **not** "N% better image". Stage 1 replication and every
+non-beneficiary give exactly `0.0000`; a nonzero value is exactly where
+Stage 2 fired and survived. (The number is only meaningful at 2x; run at
+1x it just measures ordinary neighbouring-pixel variance.)
+
+### 9.3 Measured results
+
+Every "scene" below was screenshot-verified (PPM → PNG → eyeballed) at the
+frames measured — **not** inferred from a frame count. The census's own
+IS1 mistake (a "gameplay" row measured on a menu) is the reason.
+
+| Title | Scene (screenshot-verified) | Frames | Accurate (shipped default) | Fast | Verdict |
+|---|---|---|---|---|---|
+| **Alien vs Predator (1994)** | Alien, textured corridor, SCORE HUD | 5200 / 6000 | **30.63 / 30.62 %** | 30.63 / 30.62 % | **verified** |
+| **Skyhammer** | in-mission cockpit, city flight, weapons armed | 2000 / 2600 / 2900 | **10.01 / 17.74 / 3.40 %** | 10.01 / 17.74 / 3.40 % | **verified** |
+| **Skyhammer** | attract flight (same renderer + HUD) | 1200 / 1800 / 2400 | 22.68 / 18.05 / 3.67 % | 22.68 / 18.05 / 3.67 % | **verified** |
+| **Doom** | E1M1 gameplay | 900 | **8.68 %** | 8.68 % | **verified** |
+| **Missile Command 3D** | Original 3D gameplay | 1600 / 2000 / 2400 | **5.03 / 5.88 / 5.16 %** | 5.03 / 5.88 / 5.16 % | **verified** |
+| **Hover Strike (cart)** | mission cockpit, terrain + ALERT HUD | 2400 / 3200 / 4000 | **0.00 / 0.00 / 0.00 %** | 0.55 / 0.00 / 0.32 % | **zero** (§9.5) |
+| **I-War** | gameplay, "DAMAGE CRITICAL" | 2800 / 3200 / 3600 | **0.00 / 0.00 / 0.00 %** | 0.39 / 0.26 / 0.41 % | **zero** (§9.6) |
+| **Towers II** | first-person dungeon | 12000 / 13500 / 14800 | **0.00 / 0.00 %** | 0.00 / 0.00 / 0.00 % | **zero** |
+| **Iron Soldier 2 (CD)** | gameplay not reachable headlessly | — | — | — | **unverified** (§9.7) |
+| Checkered Flag / Cybermorph | gameplay (non-beneficiary controls) | — | 0.0000 % | 0.0000 % | zero, as designed |
+
+Notes on the table:
+
+- **Engine parity.** The harness leaves `vjs.useFastBlitter` at its init
+  value unless `--option virtualjaguar_usefastblitter=disabled` is passed,
+  so an unqualified harness run measures the **Fast** blitter while the
+  shipped core default is **Accurate**. Every row above was therefore run
+  on both. Doom, Skyhammer and AvP are bit-identical between engines. The
+  Fast column's small nonzero on Hover Strike and I-War comes from the
+  Fast engine's slightly wider Stage 2 predicate (`SRCSHADE || (!GOURD &&
+  !PATDSEL)`) versus the Accurate engine's (`!patdsel && !gourd &&
+  !adddsel`) — an engine-parity gap worth ~0.3–0.5 % of screen, noted in
+  §9.8.
+- **Skyhammer** is measured twice because its attract sequence drives the
+  full gameplay renderer and HUD; the in-mission row (reached with scripted
+  input, screenshot-verified in a mission cockpit) is the authoritative
+  one and both are strongly positive.
+
+### 9.4 Correction to a previously reported AvP result
+
+An earlier hand measurement circulated as "**AvP: 0.0000 % on both blitter
+engines**". **That is wrong.** On a clean `836baf6` tree with the
+build-identity guard enabled, AvP measures **30.63 %** — the *largest*
+on-screen benefit of any title measured, larger than Doom's. The scene
+(Alien, textured corridor, SCORE HUD, claw in frame) was screenshot-
+verified at both sampled frames on both engines. Instrumentation confirms
+why: 21.2 M of 22.2 M candidate shadow stores are accepted by the Stage 2
+predicate, 9.8 M of those blocks carry differing sub-samples, and 27.8 M
+block lookups at render time return non-uniform blocks.
+
+### 9.5 Hover Strike — detail is produced, then discarded downstream
+
+Hover Strike is **not** blocked by the Stage 2 predicate at all. Over 2,500
+frames of verified mission gameplay:
+
+| counter | value |
+|---|---|
+| candidate 16bpp shadow stores | 10,410,361 |
+| accepted by the Stage 2 predicate | 10,376,870 (99.7 %) |
+| accepted blocks carrying real sub-pixel detail | 9,056,918 (87 %) |
+| rejected: no fractional walk | 33,491 |
+| rejected: everything else (inhibit, no SRCEN, BCOMPEN, source depth, data path) | **0** |
+
+Yet the display shows ~0 %. The destination-address histogram explains it
+(64 KB buckets of main RAM; "render" = shadow-block lookups performed by
+the Nx renderer for displayed pixels):
+
+| bucket | Stage 2 stores | render lookups |
+|---|---|---|
+| `$000000`–`$040000` | 1,169,274 | 96.7 M |
+| `$050000`–`$0B0000` | 0 | 61.8 M |
+| **`$100000`** | **9,207,596 (89 %)** | **0** |
+
+89 % of the supersampled pixels land at `$100000`, a region the display
+**never reads**. Hover Strike renders its textured 3D view into an
+off-screen buffer and then copies that buffer to the displayed
+framebuffer; the copy is an integer 1:1 walk, so it replicates and the
+sub-pixel content is dropped. This is condition (c) above, and it is the
+one cheaply-fixable case found — see §9.8.
+
+### 9.6 I-War — the detail barely exists to begin with
+
+I-War is the opposite failure. Its Stage 2 stores and its display lookups
+share the same address buckets (`$0D0000`–`$160000`), so nothing is being
+discarded downstream. The content simply is not there:
+
+| counter | value |
+|---|---|
+| accepted by the Stage 2 predicate | 2,652,798 |
+| accepted blocks carrying real sub-pixel detail | 541,847 (20 %) |
+| qualifying walks with **< 1 source texel per destination pixel** | 2,151,841 (81 %) |
+| non-uniform blocks reaching the renderer | 604,757 |
+
+81 % of its fractional walks are **magnifying** — the `pos + inc/2`
+sub-sample lands inside the same source texel and returns the identical
+value, so the block is flat by construction. And the little detail that
+does exist *does* reach the screen (`604,757` non-uniform render hits ≈
+`541,847` detailed blocks). **This is information-theoretic, not a bug and
+not fixable within Stage 2**: there is no extra source information to
+recover. Towers II is the same class (its OP census in §4 already showed a
+constant `HSCALE $20` with only a 1.0625× vertical magnification —
+smoothing, not minification).
+
+**The rule to carry forward: Stage 2 recovers information only where the
+source walk minifies.** A fractional walk is necessary but not sufficient.
+Doom (43 % of its qualifying walks at ≥ 1 texel/pixel) and AvP benefit;
+I-War and Towers II cannot.
+
+### 9.7 Iron Soldier 2 (CD) — not verified
+
+Gameplay could not be reached headlessly in this session. The disc boots,
+plays its intro, and shows its `START GAME / LOAD GAME / OPTIONS` menu
+around frames 4,900–7,700 (screenshot-verified), but no button the shared
+harness can script (`a b c pause option up down 0–6`, including 30-frame
+holds and a per-button sweep) ever selects a menu entry — presses only
+shorten the menu's timeout and advance the attract story/credits loop. Its
+attract 3D city fly-through (same renderer) measured `0.0000 %` at frames
+8800/10400/12000, but **that is an attract scene, not gameplay, and is not
+counted as a result either way.** IS2-CD's on-screen benefit is
+**unknown**, not zero. Re-running this needs a gameplay savestate.
+
+### 9.8 Follow-on candidates (evidence only — not implemented)
+
+1. **Shadow-aware copy propagation** (contained; would recover Hover
+   Strike, and by engine identity Hover Strike: Unconquered Lands). Today a
+   blit whose source region is itself shadow-tracked still writes Stage 1
+   replicated blocks at the destination. Propagating the source's N×N
+   sub-blocks through such a copy instead would carry the 9.2 M
+   supersampled pixels at `$100000` into the displayed buffer. Evidence:
+   the bucket table in §9.5. Cost is a source-side shadow lookup on
+   qualifying copies; the risk to guard is tag/epoch coherence on the
+   source side.
+2. **Engine predicate parity** (small). The Fast engine supersamples
+   `SRCSHADE`-with-`GOURD` and `ADDDSEL` blits that the Accurate engine
+   rejects. Worth ~0.3–0.5 % of screen on Hover Strike / I-War — i.e.
+   cosmetic — but the two engines should not disagree about what Stage 2
+   covers.
+3. **Not** phrase-mode support. The Stage 2 design flags the accurate
+   engine's phrase-mode `dwrite` deviation as a known gap; it was
+   instrumented here and is **not** the blocker for any measured title —
+   Doom's accurate-engine run recorded `5,071,224` pixel-mode 16bpp
+   destination writes and **zero** phrase-mode ones, and Hover Strike's
+   rejection buckets are empty. Do not spend effort there on the strength
+   of this census.
+
+### 9.9 Reproduction
+
+```bash
+cc -O2 -Wall -std=c99 -I. -I./test/harness -I./libretro-common/include \
+   -o test/tools/hires_shot test/tools/hires_shot.c \
+   test/harness/harness.c -ldl -lm
+
+VJ_EXPECT_BUILD=$(bash scripts/build-id.sh) ./test/tools/hires_shot \
+  ./virtualjaguar_libretro.dylib "<rom-or-cue>" \
+  --option virtualjaguar_internal_resolution=2x \
+  [--option virtualjaguar_usefastblitter=disabled] \
+  --frames N --press F:BTN ... --shot F --out-prefix /tmp/shot --quiet
+```
+
+Scripted input used per title (all screenshot-verified):
+
+| Title | `--press` sequence | shots |
+|---|---|---|
+| Doom | `300:a 500:a 700:a` | 900 |
+| Missile Command 3D | `300:a 600:a 900:a 1200:a` | 1600 2000 2400 |
+| Alien vs Predator | `3300:a 3600:a 3900:a 4200:a 4500:a 5000:a` | 5200 6000 |
+| Skyhammer (mission) | `400:a 700:a 1000:a 1300:a` | 2000 2600 2900 |
+| Skyhammer (attract) | *(none)* | 1200 1800 2400 |
+| Hover Strike | `200:a 400:a 700:a 1000:a 1300:a 1600:a 1900:a 2200:a` | 2400 3200 4000 |
+| I-War | `300:a 1000:b 1400:a 1800:a 2200:a 2600:a` | 2800 3200 3600 |
+| Towers II | `7300:a 7700:a 8100:a 8500:a 8900:a 9300:a 10100:b 10500:b 10900:b 11300:b` | 12000 13500 14800 |
+
+Convert and inspect with `sips -s format png <prefix>_fNNNNN.ppm --out x.png`.
+
+The §9.5/§9.6 counter tables came from a throwaway instrumentation patch
+(rejection buckets at both engines' Stage 2 sites in `src/tom/blitter.c`,
+plus hit/miss/non-uniform and address buckets in
+`ShadowHiresLineFromRAM` in `src/tom/shadowfb.c`, exported through
+`exports-test.list` and read via `harness_dlsym`). It was reverted before
+this commit; only this document is committed. Same pattern as §8.

--- a/docs/hires-stage0-census.md
+++ b/docs/hires-stage0-census.md
@@ -269,10 +269,11 @@ Conclusions:
 16bpp CRY, gameplay-verified, ≥ ~25 qualifying blits/frame):**
 
 > ⚠ **This table counts blit *shapes*, not supersampled pixels on screen.**
-> Three of the nine rows below measured **zero** on-screen benefit from the
-> shipped Stage 2, and a fourth could not be verified. Do not quote this
-> table as a beneficiary list — see **§9, "Stage 2 on-screen
-> verification"**, which measures what actually reaches the display.
+> Of the nine rows below, four are verified on-screen beneficiaries, three
+> measured **zero**, one could not be verified, and one (CRZ Demo,
+> homebrew) was not measured. Do not quote this table as a beneficiary
+> list — see **§9, "Stage 2 on-screen verification"**, which measures what
+> actually reaches the display.
 
 | Title | qualifying blits/frame |
 |---|---|
@@ -424,8 +425,9 @@ IS1 mistake (a "gameplay" row measured on a menu) is the reason.
 | **Missile Command 3D** | Original 3D gameplay | 1600 / 2000 / 2400 | **5.03 / 5.88 / 5.16 %** | 5.03 / 5.88 / 5.16 % | **verified** |
 | **Hover Strike (cart)** | mission cockpit, terrain + ALERT HUD | 2400 / 3200 / 4000 | **0.00 / 0.00 / 0.00 %** | 0.55 / 0.00 / 0.32 % | **zero** (§9.5) |
 | **I-War** | gameplay, "DAMAGE CRITICAL" | 2800 / 3200 / 3600 | **0.00 / 0.00 / 0.00 %** | 0.39 / 0.26 / 0.41 % | **zero** (§9.6) |
-| **Towers II** | first-person dungeon | 12000 / 13500 / 14800 | **0.00 / 0.00 %** | 0.00 / 0.00 / 0.00 % | **zero** |
+| **Towers II** | first-person dungeon | Acc: 12000 / 14800 · Fast: 12000 / 13500 / 14800 | **0.00 / 0.00 %** | 0.00 / 0.00 / 0.00 % | **zero** |
 | **Iron Soldier 2 (CD)** | gameplay not reachable headlessly | — | — | — | **unverified** (§9.7) |
+| **CRZ Demo (homebrew)** | — | — | — | — | **not measured** |
 | Checkered Flag / Cybermorph | gameplay (non-beneficiary controls) | — | 0.0000 % | 0.0000 % | zero, as designed |
 
 Notes on the table:
@@ -444,6 +446,11 @@ Notes on the table:
   full gameplay renderer and HUD; the in-mission row (reached with scripted
   input, screenshot-verified in a mission cockpit) is the authoritative
   one and both are strongly positive.
+- **CRZ Demo** (the homebrew row in §6's A1 table) was not measured here.
+  §2 records that 1.90 M of its 1.96 M blits are gouraud, and both engines
+  exclude `GOURD` — so reason (b) predicts near-zero — but that is a
+  prediction, not a measurement, and the row is left open rather than
+  asserted.
 
 ### 9.4 Correction to a previously reported AvP result
 
@@ -455,7 +462,23 @@ on-screen benefit of any title measured, larger than Doom's. The scene
 verified at both sampled frames on both engines. Instrumentation confirms
 why: 21.2 M of 22.2 M candidate shadow stores are accepted by the Stage 2
 predicate, 9.8 M of those blocks carry differing sub-samples, and 27.8 M
-block lookups at render time return non-uniform blocks.
+block lookups at render time return non-uniform blocks. The earlier zero
+**could not be reproduced, and its cause was not established** — treat it
+as retracted rather than explained.
+
+**Pre-empting the obvious objection:** AvP's variance is near-constant
+across the sampled window (23,964 / 23,960 / 23,960 non-uniform blocks at
+frames 5200 / 5600 / 6000) and the run logs four `video_stall` lines, so
+it is fair to ask whether this is a frozen buffer rather than live
+rendering. It is not, and the shadow's own design proves it: the hi-res
+tag carries a frame epoch and an entry is trusted only if written within
+the last **16 presented frames** (`HIRES_EPOCH_WINDOW`, `shadowfb.c`). A
+framebuffer that stopped being rewritten would have every block fall out
+of the window and the measurement would decay to `0.0000`. A sustained
+30.6 % across 800 frames is only possible if the blitter is re-rendering
+those pixels continuously. The `video_stall` lines are the documented
+benign class — `crash_detect` hashes ~256 pixels per frame, and a
+visually near-static scene trips it.
 
 ### 9.5 Hover Strike — detail is produced, then discarded downstream
 
@@ -512,8 +535,8 @@ smoothing, not minification).
 
 **The rule to carry forward: Stage 2 recovers information only where the
 source walk minifies.** A fractional walk is necessary but not sufficient.
-Doom (43 % of its qualifying walks at ≥ 1 texel/pixel) and AvP benefit;
-I-War and Towers II cannot.
+Doom (44 % of its 4,936,831 qualifying walks at ≥ 1 texel/pixel) and AvP
+benefit; I-War and Towers II cannot.
 
 ### 9.7 Iron Soldier 2 (CD) — not verified
 

--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -37,6 +37,7 @@ skip_file() {
         test/tools/frame_hash_ab.c) return 0 ;;
         test/tools/hires_box_check.c) return 0 ;;
         test/tools/hires_state_digest.c) return 0 ;;
+        test/tools/hires_shot.c) return 0 ;;
     esac
     return 1
 }

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -447,6 +447,16 @@ static int32_t a1_clip_x, a1_clip_y;
 static int shadow_hires_read_src16_a1(int32_t sub_x, int32_t sub_y,
       uint32_t *out)
 {
+   /* PIXEL_OFFSET_16 token-pastes its argument into <arg>_x/_y/_width/
+    * _pitch, so PIXEL_OFFSET_16(sub) evaluates the STOCK A1 addressing
+    * formula over the explicit 16.16 (sub_x, sub_y) position and the
+    * locals below -- reusing the formula by construction rather than
+    * transcribing it. */
+   /* PIXEL_OFFSET_16 token-pastes its argument into <arg>_x/_y/_width/
+    * _pitch, so PIXEL_OFFSET_16(sub) evaluates the STOCK A1 addressing
+    * formula over the explicit 16.16 (sub_x, sub_y) parameters and the
+    * two locals below -- reusing that formula by construction instead
+    * of transcribing it. */
    int32_t sub_width = a1_width;
    int32_t sub_pitch = a1_pitch;
    uint32_t addr = (a1_addr + (PIXEL_OFFSET_16(sub) << 1)) & 0xFFFFFF;
@@ -485,13 +495,26 @@ static void shadow_hires_sub_fast(shadowfb_sub *out, uint32_t cmd,
    }
    if (ADDDSEL)
    {
-      /* Mirror of the DSTA2 ADDDSEL data path below. */
+      /* Exact mirror of the DSTA2 ADDDSEL data path below: signed
+       * saturated byte add when TOPBEN is clear (source sign-extended,
+       * clamped to [0,0xFF]), then the 12-bit MASK (not saturate) when
+       * TOPNEN is clear. */
       v = (s & 0xFF) + (dstdata & 0xFF);
-      if (!(TOPBEN) && v > 0xFF)
-         v = 0xFF;
+      if (!TOPBEN)
+      {
+         int16_t ss = (int16_t)((s & 0xFF) | ((s & 0x80) ? 0xFF00 : 0x0000));
+         int16_t dd = (int16_t)(dstdata & 0xFF);
+         int16_t sum = (int16_t)(ss + dd);
+         if (sum < 0)
+            v = 0x00;
+         else if (sum > 0xFF)
+            v = 0xFF;
+         else
+            v = (uint32_t)sum;
+      }
       v |= (s & 0xF00) + (dstdata & 0xF00);
-      if (!(TOPNEN) && v > 0xFFF)
-         v = 0xFFF;
+      if (!TOPNEN && v > 0xFFF)
+         v &= 0xFFF;
       v |= (s & 0xF000) + (dstdata & 0xF000);
    }
    else

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -426,6 +426,90 @@ static uint32_t z_i[4];
 
 static int32_t a1_clip_x, a1_clip_y;
 
+/* ==========================================================================
+ * Hi-res Stage 2 (fast engine): fractional-walk source supersampling.
+ * See docs/hires-upscaling-design.md sections 4/5 and section 8 Stage 2.
+ *
+ * When a DSTA2 blit's A1 source walk consumes a fraction (XADDINC with a
+ * fractional increment, or the XADD0 + fractional-FSTEP column scaler)
+ * onto a 16bpp CRY destination, the source bitmap holds more information
+ * than the single stock sample keeps.  These helpers sample the source
+ * at N*x density for the shadow surface ONLY: the stock walk, the stock
+ * write and every control decision (transparency, colour key, Z, clip,
+ * LFU selection) are untouched and made once at 1x; the shadow block
+ * carries content, never decisions.  All reads are side-effect-free
+ * (RAM mirrors + cart ROM; anything at/above BUTCH is refused).
+ * ========================================================================== */
+
+/* Read the 16bpp A1 source pixel at an explicit 16.16 position.
+ * Returns 0 (leaving *out untouched) when the address could carry a
+ * read side effect (BUTCH/TOM/JERRY space). */
+static int shadow_hires_read_src16_a1(int32_t sub_x, int32_t sub_y,
+      uint32_t *out)
+{
+   int32_t sub_width = a1_width;
+   int32_t sub_pitch = a1_pitch;
+   uint32_t addr = (a1_addr + (PIXEL_OFFSET_16(sub) << 1)) & 0xFFFFFF;
+   if (addr >= 0xDFFF00)
+      return 0;
+   *out = JaguarReadWord(addr, BLITTER);
+   return 1;
+}
+
+/* Derive one sub-sample {value16, frac16} from the source pixel at
+ * 16.16 position (x,y), applying the same data path the stock pixel
+ * took.  Only called for uninhibited pixels whose data path depends on
+ * the source (SRCSHADE, ADDDSEL or LFU); falls back to *stock when the
+ * source address is unreadable. */
+static void shadow_hires_sub_fast(shadowfb_sub *out, uint32_t cmd,
+      int32_t x, int32_t y, uint32_t dstdata, const shadowfb_sub *stock)
+{
+   uint32_t s;
+   uint32_t v;
+   *out = *stock;
+   if (!shadow_hires_read_src16_a1(x, y, &s))
+      return;
+   if (SRCSHADE)
+   {
+      /* 24-bit intensity = source intensity + full fraction-carrying
+       * IINC; integer part matches the stock formula's
+       * clamp((s & 0xFF) + (gd_ia >> 16), 0, 0xFF) exactly. */
+      int32_t i24 = ((int32_t)(s & 0xFF) << 16) + gd_ia;
+      if (i24 < 0)
+         i24 = 0;
+      if (i24 > 0x00FFFFFF)
+         i24 = 0x00FFFFFF;
+      out->value16 = (uint16_t)((s & 0xFF00) | ((uint32_t)i24 >> 16));
+      out->frac16  = (uint16_t)((uint32_t)i24 & 0xFFFF);
+      return;
+   }
+   if (ADDDSEL)
+   {
+      /* Mirror of the DSTA2 ADDDSEL data path below. */
+      v = (s & 0xFF) + (dstdata & 0xFF);
+      if (!(TOPBEN) && v > 0xFF)
+         v = 0xFF;
+      v |= (s & 0xF00) + (dstdata & 0xF00);
+      if (!(TOPNEN) && v > 0xFFF)
+         v = 0xFFF;
+      v |= (s & 0xF000) + (dstdata & 0xF000);
+   }
+   else
+   {
+      v = 0;
+      if (LFU_NAN)
+         v |= ~s & ~dstdata;
+      if (LFU_NA)
+         v |= ~s & dstdata;
+      if (LFU_AN)
+         v |= s & ~dstdata;
+      if (LFU_A)
+         v |= s & dstdata;
+   }
+   out->value16 = (uint16_t)v;
+   out->frac16  = 0;
+}
+
 // In the spirit of "get it right first, *then* optimize" I've taken the liberty
 // of removing all the unnecessary code caching. If it turns out to be a good way
 // to optimize the blitter, then we may revisit it in the future...
@@ -850,8 +934,65 @@ void blitter_generic(uint32_t cmd)
                      ShadowFBStoreCry(a2_addr + (PIXEL_OFFSET_16(a2) << 1),
                            (uint16_t)writedata, sfb_frac);
                   if (shadowHiresActive)
-                     ShadowHiresStoreCry(a2_addr + (PIXEL_OFFSET_16(a2) << 1),
-                           (uint16_t)writedata, sfb_frac);
+                  {
+                     /* Stage 2: when this blit's A1 source walk consumes
+                      * a fraction and the data path depends on the
+                      * source, fill the block with real sub-samples;
+                      * every other shape keeps Stage 1 replication. */
+                     int sh2 = 0;
+                     shadowfb_sub sblk[4];
+                     if (shadowHiresN == 2 && !inhibit && SRCEN && !BCOMPEN
+                           && (((REG(A1_FLAGS) >> 3) & 0x07) == 4)
+                           && (SRCSHADE || (!GOURD && !PATDSEL)))
+                     {
+                        int32_t hx = 0, hy = 0, vx = 0, vy = 0;
+                        int q_in = (xadd_a1_control == XADDINC
+                              && (((a1_xadd | a1_yadd) & 0xFFFF) != 0));
+                        int q_out = (xadd_a1_control == XADD0
+                              && a1_yadd == 0 && UPDA1F
+                              && (((a1_step_x | a1_step_y) & 0xFFFF) != 0));
+                        if (q_in)
+                        {
+                           hx = a1_xadd >> 1;
+                           hy = a1_yadd >> 1;
+                        }
+                        if (q_out)
+                        {
+                           vx = a1_step_x >> 1;
+                           vy = a1_step_y >> 1;
+                        }
+                        if (q_in || q_out)
+                        {
+                           sblk[0].value16 = (uint16_t)writedata;
+                           sblk[0].frac16  = sfb_frac;
+                           if (q_in)
+                              shadow_hires_sub_fast(&sblk[1], cmd,
+                                    a1_x + hx, a1_y + hy, dstdata, &sblk[0]);
+                           else
+                              sblk[1] = sblk[0];
+                           if (q_out)
+                              shadow_hires_sub_fast(&sblk[2], cmd,
+                                    a1_x + vx, a1_y + vy, dstdata, &sblk[0]);
+                           else
+                              sblk[2] = sblk[0];
+                           if (q_in && q_out)
+                              shadow_hires_sub_fast(&sblk[3], cmd,
+                                    a1_x + hx + vx, a1_y + hy + vy,
+                                    dstdata, &sblk[0]);
+                           else
+                              sblk[3] = (q_in ? sblk[1] : sblk[2]);
+                           sh2 = 1;
+                        }
+                     }
+                     if (sh2)
+                        ShadowHiresStoreCryBlock(
+                              a2_addr + (PIXEL_OFFSET_16(a2) << 1),
+                              (uint16_t)writedata, sblk);
+                     else
+                        ShadowHiresStoreCry(
+                              a2_addr + (PIXEL_OFFSET_16(a2) << 1),
+                              (uint16_t)writedata, sfb_frac);
+                  }
                }
             }
          }
@@ -1185,6 +1326,76 @@ static uint32_t addrgen_ya(uint16_t y, uint8_t width)
 		+ ((width & 0x02) ? y12 << 1 : 0)
 		+ ((width & 0x01) ? y12 : 0);
 	return (ytm << (width >> 2)) >> 2;
+}
+
+/* ==========================================================================
+ * Hi-res Stage 2 (accurate engine): fractional-walk source supersampling.
+ * See docs/hires-upscaling-design.md sections 4/5 and section 8 Stage 2,
+ * and the fast-engine twin above blitter_generic.  Shadow-only: the
+ * stock pipeline (reads, writes, comparators, ADDARRAY carry state) is
+ * untouched.
+ * ========================================================================== */
+
+/* Replicates lane 0 of the SRCSHADE ADDARRAY call (daddasel=4,
+ * daddbsel=5, daddmode=7, carry-in 0: 8-bit saturated add of the source
+ * intensity byte and the IINC integer byte; the colour byte passes
+ * through unchanged because the broadcast addend's high byte is zero).
+ * A direct ADDARRAY call would clobber its persistent carry-out state
+ * and diverge the stock pipeline, so the lane is reproduced here. */
+static uint16_t shadow_hires_shade16(uint16_t a, uint32_t iinc_masked)
+{
+	uint32_t b    = (iinc_masked >> 16) & 0xFF;
+	uint32_t qt   = (uint32_t)(a & 0xFF) + b;
+	uint32_t ctop = (qt >> 8) & 1;
+	uint32_t btop = (b >> 7) & 1;
+	uint32_t lo   = (btop ^ ctop) ? (ctop ? 0xFFu : 0x00u) : (qt & 0xFF);
+	return (uint16_t)(((uint32_t)a & 0xFF00) | lo);
+}
+
+/* 16-bit LFU, same truth-table convention as blitter_simd_lfu. */
+static uint16_t shadow_hires_lfu16(uint16_t s, uint16_t d, uint8_t lfu_func)
+{
+	uint16_t v = 0;
+	if (lfu_func & 0x01)
+		v |= (uint16_t)(~s & ~d);
+	if (lfu_func & 0x02)
+		v |= (uint16_t)(~s & d);
+	if (lfu_func & 0x04)
+		v |= (uint16_t)(s & ~d);
+	if (lfu_func & 0x08)
+		v |= (uint16_t)(s & d);
+	return v;
+}
+
+/* Derive one sub-sample {value16, frac16} for the accurate engine:
+ * read the 16bpp A1 source at 16.16 position (px, py) through the
+ * engine's own address generator and apply the pixel-mode data path
+ * (SRCSHADE then LFU) the stock pixel took.  Control decisions are NOT
+ * re-made -- the caller only invokes this for pixels that passed all
+ * comparators at 1x.  Falls back to *stock when the source address
+ * could carry a read side effect (BUTCH/TOM/JERRY space). */
+static void shadow_hires_sub_mid(shadowfb_sub *out, int32_t px, int32_t py,
+	uint32_t a1_base, uint8_t a1_pitch, uint8_t a1_pixsize, uint8_t a1_width,
+	bool srcshade_on, uint32_t iinc_masked, uint8_t lfu_func, uint16_t d16,
+	const shadowfb_sub *stock)
+{
+	uint32_t saddr, spixa;
+	uint16_t s;
+	uint16_t sx = (uint16_t)((uint32_t)px >> 16);
+	uint16_t sy = (uint16_t)((uint32_t)py >> 16);
+	*out = *stock;
+	ADDRGEN(&saddr, &spixa, false, false,
+		sx, sy, a1_base, a1_pitch, a1_pixsize, a1_width, 0,
+		0, 0, 0, 0, 0, 0, 0,
+		addrgen_ya(sy, a1_width), 0);
+	saddr &= 0xFFFFFF;
+	if (saddr >= 0xDFFF00)
+		return;
+	s = blitter_read_word(saddr);
+	if (srcshade_on)
+		s = shadow_hires_shade16(s, iinc_masked);
+	out->value16 = shadow_hires_lfu16(s, d16, lfu_func);
+	out->frac16  = 0;
 }
 /* ADD16SAT / ADDARRAY are defined inline below so the compiler can
  * specialise per call-site (most callers pass compile-time constants
@@ -2146,6 +2357,12 @@ void BlitterMidsummer2(void)
           * fractional source X drifts across 0 mid-row. */
          int16_t a1_x_at_sread = a1_x;
          int16_t a1_y_at_sread = a1_y;
+         /* Fractional-position twins, cached for the same reason: the
+          * hi-res Stage 2 sub-sample walk (see shadow_hires_sub_mid)
+          * needs the full 16.16 source position THAT WAS USED for the
+          * sread that loaded srcd. */
+         uint16_t a1_fx_at_sread = a1_frac_x;
+         uint16_t a1_fy_at_sread = a1_frac_y;
 
          indone = false;
 
@@ -2468,7 +2685,14 @@ void BlitterMidsummer2(void)
          if (srcen && !srcenx && !srcenz && !dsten && !dstenz && !dstwrz
                && !bcompen && !dcompen && !gourd && !gourz && !srcshade
                && !adddsel && !patdsel && zmode == 0
-               && a1addx != 3 && a2addx != 3)
+               && a1addx != 3 && a2addx != 3
+               /* Hi-res Stage 2: a DSTA2 copy with a fractional outer
+                * source step qualifies for supersampling, which only the
+                * state-machine dwrite performs.  The collapsed path does
+                * identical stock work, so routing through the state
+                * machine only changes shadow content.  Option-gated:
+                * with hi-res off this term is always false. */
+               && !(shadowHiresActive && shadowHiresN == 2 && dsta2 && upda1f))
          {
             /* Pre-decode values that are invariant across the inner loop.
              * For a simple copy with no fractional increment:
@@ -2994,6 +3218,8 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
                 * time -- see a1_x_at_sread declaration. */
                a1_x_at_sread = a1_x;
                a1_y_at_sread = a1_y;
+               a1_fx_at_sread = a1_frac_x;
+               a1_fy_at_sread = a1_frac_y;
                //uint32_t srcAddr, pixAddr;
                //ADDRGEN(srcAddr, pixAddr, gena2i, zaddr,
                //	a1_x, a1_y, a1_base, a1_pitch, a1_pixsize, a1_width, a1_zoffset,
@@ -3036,6 +3262,8 @@ A2ptrldi	:= NAN2 (a2ptrldi, a2update\, a2pldt);*/
                 * time -- see a1_x_at_sread declaration. */
                a1_x_at_sread = a1_x;
                a1_y_at_sread = a1_y;
+               a1_fx_at_sread = a1_frac_x;
+               a1_fy_at_sread = a1_frac_y;
                srcd2 = srcd1;
                srcd1 = ((uint64_t)blitter_read_long(address) << 32) | (uint64_t)blitter_read_long(address + 4);
                //Kludge to take pixel size into account...
@@ -3403,7 +3631,86 @@ A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
                         if (shadowFBActive && gourd)
                            ShadowFBStoreCry(address, (uint16_t)wdata, sfb_f);
                         if (shadowHiresActive)
-                           ShadowHiresStoreCry(address, (uint16_t)wdata, sfb_f);
+                        {
+                           /* Stage 2 (see shadow_hires_sub_mid): pixel-
+                            * mode 16bpp write whose A1 source walk
+                            * consumes a fraction and whose data path is
+                            * source-dependent (LFU, optionally shaded).
+                            * Everything else keeps Stage 1 replication.
+                            * The pixel passed all comparators at 1x
+                            * (pixel-mode inhibits set winhibit and skip
+                            * the write entirely), so the block decision
+                            * is uniform by construction. */
+                           int sh2 = 0;
+                           shadowfb_sub sblk[4];
+                           if (shadowHiresN == 2 && !winhibit
+                                 && dsta2 && srcen && !bcompen
+                                 && a1_pixsize == 4 && srcshift == 0
+                                 && !patdsel && !gourd && !adddsel)
+                           {
+                              int32_t hx = 0, hy = 0, vx = 0, vy = 0;
+                              int q_in = (a1addx == 3
+                                    && ((a1_incf_x | a1_incf_y) != 0));
+                              int q_out = (a1addx == 2 && !a1addy && upda1f
+                                    && ((a1_stepf_x | a1_stepf_y) != 0));
+                              if (q_in)
+                              {
+                                 hx = (((int32_t)a1_inc_x << 16)
+                                       | a1_incf_x) >> 1;
+                                 hy = (((int32_t)a1_inc_y << 16)
+                                       | a1_incf_y) >> 1;
+                              }
+                              if (q_out)
+                              {
+                                 vx = (((int32_t)a1_step_x << 16)
+                                       | a1_stepf_x) >> 1;
+                                 vy = (((int32_t)a1_step_y << 16)
+                                       | a1_stepf_y) >> 1;
+                              }
+                              if (q_in || q_out)
+                              {
+                                 int32_t px = ((int32_t)a1_x_at_sread << 16)
+                                            | a1_fx_at_sread;
+                                 int32_t py = ((int32_t)a1_y_at_sread << 16)
+                                            | a1_fy_at_sread;
+                                 uint32_t iim = iinc & 0x00FFFFFF;
+                                 uint16_t d16 = (uint16_t)dstd;
+                                 sblk[0].value16 = (uint16_t)wdata;
+                                 sblk[0].frac16  = sfb_f;
+                                 if (q_in)
+                                    shadow_hires_sub_mid(&sblk[1],
+                                          px + hx, py + hy,
+                                          a1_base, a1_pitch, a1_pixsize,
+                                          a1_width, srcshade, iim,
+                                          lfufunc, d16, &sblk[0]);
+                                 else
+                                    sblk[1] = sblk[0];
+                                 if (q_out)
+                                    shadow_hires_sub_mid(&sblk[2],
+                                          px + vx, py + vy,
+                                          a1_base, a1_pitch, a1_pixsize,
+                                          a1_width, srcshade, iim,
+                                          lfufunc, d16, &sblk[0]);
+                                 else
+                                    sblk[2] = sblk[0];
+                                 if (q_in && q_out)
+                                    shadow_hires_sub_mid(&sblk[3],
+                                          px + hx + vx, py + hy + vy,
+                                          a1_base, a1_pitch, a1_pixsize,
+                                          a1_width, srcshade, iim,
+                                          lfufunc, d16, &sblk[0]);
+                                 else
+                                    sblk[3] = (q_in ? sblk[1] : sblk[2]);
+                                 sh2 = 1;
+                              }
+                           }
+                           if (sh2)
+                              ShadowHiresStoreCryBlock(address,
+                                    (uint16_t)wdata, sblk);
+                           else
+                              ShadowHiresStoreCry(address,
+                                    (uint16_t)wdata, sfb_f);
+                        }
                      }
                   }
                }

--- a/src/tom/shadowfb.c
+++ b/src/tom/shadowfb.c
@@ -226,6 +226,31 @@ void ShadowHiresStoreCry(uint32_t addr, uint16_t value16, uint16_t frac16)
                             | (hiresEpoch << HIRES_TAG_EPOCH_SHIFT);
 }
 
+void ShadowHiresStoreCryBlock(uint32_t addr, uint16_t stock16,
+                              const shadowfb_sub *blk)
+{
+   uint32_t idx, page, word, nn, k;
+   shadowfb_sub *sub;
+
+   if (!shadowHiresActive)
+      return;
+   addr &= 0xFFFFFF;
+   if (addr >= 0x800000)
+      return;
+   idx  = (addr & 0x1FFFFE) >> 1;
+   page = idx >> 12;
+   word = idx & 0xFFF;
+   if (!shadow_hires_page(page))
+      return;
+
+   nn  = (uint32_t)shadowHiresN * (uint32_t)shadowHiresN;
+   sub = hiresPageSub[page] + word * nn;
+   for (k = 0; k < nn; k++)
+      sub[k] = blk[k];
+   hiresPageTag[page][word] = (uint32_t)stock16 | SHADOWFB_TAG_VALID
+                            | (hiresEpoch << HIRES_TAG_EPOCH_SHIFT);
+}
+
 /* Value+epoch-checked block lookup.  Returns the N*N block or NULL. */
 static const shadowfb_sub *shadow_hires_block(uint32_t addr, uint16_t current16)
 {

--- a/src/tom/shadowfb.c
+++ b/src/tom/shadowfb.c
@@ -132,9 +132,21 @@ void ShadowFBShutdown(void)
 /* Tag layout (design section 3.4):
  *   bits  0-15  value16 (the stock word the block was derived from)
  *   bit  16     VALID (so zero-init never false-matches RAM zeros)
- *   bits 17-24  frame epoch (entry trusted iff epoch == now or now-1)
+ *   bits 17-24  frame epoch (entry trusted iff written within the last
+ *               HIRES_EPOCH_WINDOW presented frames)
  */
 #define HIRES_TAG_EPOCH_SHIFT 17
+/* Trusted-window size in presented frames (design section 3.4 / R3).
+ * The design's initial now/now-1 guess assumed the 3D view is redrawn
+ * every frame; Doom -- the Stage 2 anchor title -- runs its engine at
+ * ~10-15Hz double-buffered, so the displayed buffer's blocks are
+ * routinely 3-8 presented frames old and a 2-frame window rejected
+ * every one of them (measured: 0.00% supersampled output).  16 frames
+ * (~267ms NTSC) covers slow engines while still bounding the R3
+ * stale-structure class: a false positive needs RAM to coincidentally
+ * equal a dead tag AND the word untouched for 16 frames, and it still
+ * self-heals at the next real write. */
+#define HIRES_EPOCH_WINDOW 16
 
 int shadowHiresActive = 0;
 int shadowHiresN = 1;
@@ -268,7 +280,7 @@ static const shadowfb_sub *shadow_hires_block(uint32_t addr, uint16_t current16)
    if ((tag & 0x1FFFF) != ((uint32_t)current16 | SHADOWFB_TAG_VALID))
       return NULL;
    ep = (tag >> HIRES_TAG_EPOCH_SHIFT) & 0xFF;
-   if (ep != hiresEpoch && ep != ((hiresEpoch - 1) & 0xFF))
+   if (((hiresEpoch - ep) & 0xFF) >= HIRES_EPOCH_WINDOW)
       return NULL;
    return hiresPageSub[page]
         + word * (uint32_t)shadowHiresN * (uint32_t)shadowHiresN;

--- a/src/tom/shadowfb.h
+++ b/src/tom/shadowfb.h
@@ -86,9 +86,11 @@ void ShadowFBLineFromRAM(int idx, uint32_t srcAddr, uint16_t value16);
  *
  * Coherence is the same value-check-at-read scheme as the 1x shadow,
  * PLUS a frame-epoch field in the tag (design section 3.4): an entry
- * is only trusted when its epoch is the current or previous frame,
- * which bounds the stale-structure artifact class that the 1x
- * bounded-error argument does not cover at Nx (design section 5.4).
+ * is only trusted when it was written within the last few presented
+ * frames (HIRES_EPOCH_WINDOW in shadowfb.c -- sized for slow
+ * double-buffered engines like Doom's ~15Hz renderer), which bounds
+ * the stale-structure artifact class that the 1x bounded-error
+ * argument does not cover at Nx (design section 5.4).
  *
  * Stage 1 semantics: every writer stores the stock pixel replicated
  * N*N times (box replication), so output is bit-exactly the Nx box

--- a/src/tom/shadowfb.h
+++ b/src/tom/shadowfb.h
@@ -150,6 +150,15 @@ void ShadowHiresShutdown(void);
  * Addresses outside the bottom-8MB RAM mirror window are ignored. */
 void ShadowHiresStoreCry(uint32_t addr, uint16_t value16, uint16_t frac16);
 
+/* Stage 2: record a 16bpp CRY destination write whose N*N block carries
+ * real per-subpixel content (fractional-walk source supersampling).
+ * `stock16` is the stock 16-bit value the blit wrote (the tag key --
+ * readers value-check against it); `blk` holds N*N entries in
+ * sub-row-major order (sy*N + sx).  Same address rules as
+ * ShadowHiresStoreCry. */
+void ShadowHiresStoreCryBlock(uint32_t addr, uint16_t stock16,
+                              const shadowfb_sub *blk);
+
 /* OP 16bpp resolve site: copy the RAM shadow block for srcAddr into
  * the Nx line buffer at stock pixel `idx` (tag+epoch checked against
  * value16, the word the OP just read); on miss, replicate

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -852,25 +852,15 @@ void tom_render_16bpp_cry_scanline(uint32_t * backbuffer)
  * shadow line buffer that ShadowHiresLineFromRAM populated during the
  * OP's single per-scanline pass.
  *
- * Stage 1 output contract: every emitted pixel is bit-exactly the NxN
- * box replication of what the stock renderer would emit for the same
- * line-buffer contents.  Two cases:
- *
- *  - true-color OFF: on a shadow line tag match the entry's value16 is
- *    structurally equal to the stock line-buffer value (Stage 1 writers
- *    only ever store the stock value), so LUT[entry.value16] ==
- *    LUT[color]; on a miss we use LUT[color] directly.
- *
- *  - true-color ON: we always emit the 1x true-color result (`base`,
- *    identical logic to the stock renderer's substitution block) and
- *    ignore hi-res entries.  The 1x shadow state evolves identically in
- *    a 1x run and an Nx run, so this is exact by construction; using
- *    ShadowFBCryRGB on hi-res entries instead could diverge from the 1x
- *    run in stale-tag coincidence corners because the two stores have
- *    different write sites and the hi-res tag carries an epoch.  Stage 2
- *    switches the hit path to ShadowFBCryRGB(entry) once entries carry
- *    real sub-pixel content and the box-replication property no longer
- *    holds by design. */
+ * Stage 2 output contract: blocks written by non-qualifying blit shapes
+ * still carry box replication (Stage 1 semantics), so their output is
+ * bit-exactly the NxN box replication of the stock pixel.  Blocks
+ * written by qualifying fractional-source-walk blits carry real
+ * per-subpixel content, and the box-replication property no longer
+ * holds there BY DESIGN -- that is the feature.  On a tag miss (stale
+ * entry, unshadowed page, foreign line-buffer writer) every subpixel
+ * falls back to `base`, the exact 1x result including the 1x
+ * true-color substitution. */
 static void tom_render_16bpp_cry_scanline_hires(uint32_t * backbuffer)
 {
    unsigned i;
@@ -926,7 +916,7 @@ static void tom_render_16bpp_cry_scanline_hires(uint32_t * backbuffer)
       for (sub = 0; sub < n; sub++)
       {
          ent = NULL;
-         if (!shadowFBActive && sfbIdx >= 0 && sfbIdx < SHADOWFB_LINE_PIXELS
+         if (sfbIdx >= 0 && sfbIdx < SHADOWFB_LINE_PIXELS
                && shadowHiresLineTag[sfbIdx] ==
                   ((uint32_t)color | SHADOWFB_TAG_VALID))
             ent = shadowHiresLineSub
@@ -934,7 +924,19 @@ static void tom_render_16bpp_cry_scanline_hires(uint32_t * backbuffer)
                   * (uint32_t)n;
          for (sx = 0; sx < n; sx++)
          {
-            uint32_t out = ent ? CRY16ToRGB32[ent[sx].value16] : base;
+            /* Stage 2: entries carry real per-subpixel content, so a
+             * hit renders each entry -- with true-color on, through
+             * ShadowFBCryRGB so the entry's own frac16 composes
+             * (design section 3.2); with it off, through the stock
+             * LUT.  A miss falls back to the exact 1x result. */
+            uint32_t out;
+            if (ent)
+               out = shadowFBActive
+                   ? (0xFF000000
+                      | ShadowFBCryRGB(ent[sx].value16, ent[sx].frac16))
+                   : CRY16ToRGB32[ent[sx].value16];
+            else
+               out = base;
             for (s = 0; s < pwidth_scale; s++)
                *rows[sub]++ = out;
          }

--- a/test/tools/hires_shot.c
+++ b/test/tools/hires_shot.c
@@ -1,0 +1,201 @@
+/*
+ * hires_shot.c -- hi-res Stage 2 evidence tool.
+ *
+ * Runs a title headlessly (scripted input via the shared harness's
+ * --press), dumps requested frames as PPM screenshots, and quantifies
+ * the sub-pixel variance of each dumped frame: the percentage of 2x2
+ * blocks whose four subpixels are NOT all equal.  At 1x (or on a
+ * Stage 1 / non-beneficiary title at 2x) that percentage is 0.000; on a
+ * Stage 2 beneficiary at 2x it is nonzero exactly where qualifying
+ * fractional-source-walk blits landed -- the box-replication property
+ * failing there is the feature (see docs/hires-upscaling-design.md,
+ * section 8 Stage 2).
+ *
+ * Usage:
+ *   ./test/tools/hires_shot [core] <rom> [--frames N] [--option K=V]
+ *       [--press F:BTN[:HOLD]]... [--shot F]... [--shot-every N]
+ *       [--out-prefix PATH]
+ *
+ * Emits "SHOT frame=... w=... h=... blocks=... nonuniform=... pct=..."
+ * per dumped frame and a trailing "VARIANCE total_blocks=... pct=..."
+ * summary over all dumped frames.  PPMs are written when --out-prefix
+ * is given (PATH_f%05u.ppm).
+ *
+ * Build:
+ *   cc -O2 -Wall -std=c99 -I. -I./test/harness -I./libretro-common/include \
+ *      -o test/tools/hires_shot test/tools/hires_shot.c \
+ *      test/harness/harness.c -ldl -lm
+ *
+ * Honors VJ_EXPECT_BUILD (build-identity guard, see scripts/build-id.sh).
+ */
+
+#include "harness.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define HS_MAX_SHOTS 512
+
+typedef struct {
+    unsigned  shots[HS_MAX_SHOTS];
+    unsigned  nshots;
+    unsigned  every;
+    const char *prefix;
+    unsigned  frame;
+
+    uint32_t *fb;
+    unsigned  fb_w, fb_h;
+
+    unsigned long long tot_blocks;
+    unsigned long long tot_nonuniform;
+    unsigned  dumped;
+} hs_state;
+
+static int hs_wanted(hs_state *st, unsigned frame)
+{
+    unsigned i;
+    if (st->every && frame && (frame % st->every) == 0)
+        return 1;
+    for (i = 0; i < st->nshots; i++)
+        if (st->shots[i] == frame)
+            return 1;
+    return 0;
+}
+
+static void hs_video(void *ud, const void *data, unsigned width,
+                     unsigned height, size_t pitch)
+{
+    hs_state *st = (hs_state *)ud;
+    const uint8_t *base = (const uint8_t *)data;
+    unsigned y, x;
+
+    if (!data)
+        return;
+    if (!st->fb || st->fb_w != width || st->fb_h != height) {
+        free(st->fb);
+        st->fb = (uint32_t *)malloc((size_t)width * height * 4);
+        st->fb_w = width;
+        st->fb_h = height;
+    }
+    if (!st->fb)
+        return;
+    for (y = 0; y < height; y++) {
+        const uint32_t *row = (const uint32_t *)(base + y * pitch);
+        for (x = 0; x < width; x++)
+            st->fb[(size_t)y * width + x] = row[x] & 0x00FFFFFFu;
+    }
+}
+
+static void hs_dump(hs_state *st, unsigned frame)
+{
+    unsigned w = st->fb_w, h = st->fb_h;
+    unsigned long long blocks = 0, nonuni = 0;
+    unsigned y, x;
+
+    if (!st->fb)
+        return;
+
+    /* 2x2 block uniformity (only meaningful when dims are even). */
+    if (w >= 2 && h >= 2) {
+        for (y = 0; y + 1 < h; y += 2) {
+            const uint32_t *r0 = st->fb + (size_t)y * w;
+            const uint32_t *r1 = r0 + w;
+            for (x = 0; x + 1 < w; x += 2) {
+                uint32_t p = r0[x];
+                blocks++;
+                if (r0[x + 1] != p || r1[x] != p || r1[x + 1] != p)
+                    nonuni++;
+            }
+        }
+    }
+    st->tot_blocks     += blocks;
+    st->tot_nonuniform += nonuni;
+    st->dumped++;
+
+    printf("SHOT frame=%u w=%u h=%u blocks=%llu nonuniform=%llu pct=%.4f\n",
+           frame, w, h, blocks, nonuni,
+           blocks ? 100.0 * (double)nonuni / (double)blocks : 0.0);
+
+    if (st->prefix) {
+        char path[1024];
+        FILE *f;
+        snprintf(path, sizeof(path), "%s_f%05u.ppm", st->prefix, frame);
+        f = fopen(path, "wb");
+        if (f) {
+            fprintf(f, "P6\n%u %u\n255\n", w, h);
+            for (y = 0; y < h; y++) {
+                for (x = 0; x < w; x++) {
+                    uint32_t p = st->fb[(size_t)y * w + x];
+                    uint8_t rgb[3];
+                    rgb[0] = (uint8_t)(p >> 16);
+                    rgb[1] = (uint8_t)(p >> 8);
+                    rgb[2] = (uint8_t)p;
+                    fwrite(rgb, 1, 3, f);
+                }
+            }
+            fclose(f);
+        } else {
+            fprintf(stderr, "hires_shot: cannot write '%s'\n", path);
+        }
+    }
+}
+
+static bool hs_frame(void *ud, unsigned frame)
+{
+    hs_state *st = (hs_state *)ud;
+    st->frame = frame;
+    if (hs_wanted(st, frame))
+        hs_dump(st, frame);
+    return true;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    hs_state st;
+    int i;
+
+    memset(&st, 0, sizeof(st));
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--shot") == 0 && i + 1 < argc) {
+            if (st.nshots < HS_MAX_SHOTS)
+                st.shots[st.nshots++] = (unsigned)strtoul(argv[i + 1], NULL, 0);
+            argv[i] = argv[i + 1] = (char *)"--quiet";
+        } else if (strcmp(argv[i], "--shot-every") == 0 && i + 1 < argc) {
+            st.every = (unsigned)strtoul(argv[i + 1], NULL, 0);
+            argv[i] = argv[i + 1] = (char *)"--quiet";
+        } else if (strcmp(argv[i], "--out-prefix") == 0 && i + 1 < argc) {
+            st.prefix = argv[i + 1];
+            argv[i] = argv[i + 1] = (char *)"--quiet";
+        }
+    }
+
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+    if (!cfg.rom_path) {
+        fprintf(stderr, "hires_shot: no ROM given\n");
+        return 1;
+    }
+
+    cfg.video_callback      = hs_video;
+    cfg.video_callback_data = &st;
+    cfg.frame_callback      = hs_frame;
+    cfg.frame_callback_data = &st;
+
+    if (!harness_load_rom(&cfg))
+        return 1;
+
+    harness_run(&cfg);
+
+    printf("VARIANCE shots=%u total_blocks=%llu nonuniform=%llu pct=%.4f\n",
+           st.dumped, st.tot_blocks, st.tot_nonuniform,
+           st.tot_blocks
+               ? 100.0 * (double)st.tot_nonuniform / (double)st.tot_blocks
+               : 0.0);
+
+    free(st.fb);
+    harness_shutdown(&cfg);
+    return 0;
+}


### PR DESCRIPTION
Stage 2 of the internal-resolution track: blits whose source walk carries fractional increments onto 16bpp CRY destinations now sample the source at 2× density into the shadow surface — real sub-pixel detail, not interpolation. The stock write path is untouched: the supersampled walk is a parallel read-only pass, and every decision (transparency, key, Z, clip, LFU) is made once at 1x from stock and applied to the whole block.

## Implementation
Both engines: fast `blitter_generic` (XADDINC+FINC inner and XADD0+FSTEP column-scaler shapes; SRCSHADE/ADDDSEL/LFU data paths mirrored per-subpixel) and accurate `BlitterMidsummer2` (same shapes in pixel-mode dwrites, sub-samples via ADDRGEN itself, SRCSHADE via an exact lane-0 ADDARRAY replica so the stock pipeline's carry state is never touched). Renderer consumes per-subpixel entries under true-color. One design deviation that mattered: the epoch trust window widened 2→16 frames — Doom's ~15 Hz double-buffered engine leaves displayed blocks 3–8 presented frames old, so the design's window produced 0.00% supersampled output; 16 saturates the benefit while keeping the R3 staleness bound.

## Which titles actually benefit on screen

Measured on this branch @ `836baf6`, clean tree, build-identity guard on, **both blitter engines**, each scene screenshot-verified in real gameplay (not inferred from a frame count). The metric is the fraction of 2×2 output blocks carrying genuine sub-pixel detail — a **coverage** number, not "N% better image". Full method, per-title input scripts and instrumentation in [`docs/hires-stage0-census.md` §9](docs/hires-stage0-census.md).

**Verified beneficiaries — these are the only titles this PR claims:**

| Title | Scene | On-screen benefit |
|---|---|---|
| **Alien vs Predator (1994)** | Alien, textured corridor | **30.6 %** |
| **Skyhammer** | in-mission cockpit, city flight | **10.0 – 22.7 %** |
| **Doom** | E1M1 | **8.68 %** |
| **Missile Command 3D** | Original 3D | **5.03 – 5.88 %** |

Identical to four decimal places on the Fast and Accurate engines.

**Census candidates that measured zero — stated plainly, not hidden.** The Stage 0 census listed 8 commercial "qualifying" titles, but it counted qualifying blit *shapes*, not supersampled pixels reaching the display. Three of those measured **0.0000 %** in verified gameplay, and the mechanisms are understood and different:

| Title | Result | Why |
|---|---|---|
| **Hover Strike** (cart) | 0.0000 % | Stage 2 fires correctly — 10.38 M of 10.41 M candidate stores accepted, 87 % of the resulting blocks carry real sub-samples — but **89 % of them land at `$100000`, a region the display never reads**. The game renders its 3D view off-screen and plain-copies it to the displayed framebuffer; the copy is an integer 1:1 walk, so it replicates and the detail is discarded. |
| **I-War** | 0.0000 % | The detail is never produced: **81 % of its qualifying walks magnify** (< 1 source texel per destination pixel), so the `pos + inc/2` sub-sample lands inside the same texel and returns the identical value. The 20 % that does carry detail reaches the screen intact. Information-theoretic, not a bug. |
| **Towers II** | 0.0000 % | Same class as I-War — its scaling is a constant 1.0625× vertical magnification (§4 of the census), i.e. smoothing, not minification. |
| **Iron Soldier 2 (CD)** | **unverified** | Gameplay could not be reached headlessly: the disc boots and reaches its `START GAME` menu, but no button the shared harness can script ever selects an entry. Its benefit is **unknown**, not zero. Needs a gameplay savestate. |
| **CRZ Demo** (homebrew) | **not measured** | Not run. §2 records 1.90 M of its 1.96 M blits as gouraud and both engines exclude `GOURD`, so near-zero is the prediction — but that is a prediction, not a measurement. |

The earlier "AvP: 0.0000 %" figure **could not be reproduced and its cause was not established** — treat it as retracted rather than explained. Its variance is near-constant across the sampled window and the run logs `video_stall`, so it is fair to ask whether a frozen buffer was measured: it was not, and the design proves it — the hi-res tag carries a 16-presented-frame epoch window, so a framebuffer that stopped being rewritten decays to `0.0000`. A sustained 30.6 % over 800 frames is only possible under continuous re-rendering.

**The rule this establishes:** *Stage 2 recovers information only where the source walk minifies.* A fractional walk is necessary but not sufficient. That is why the census's shape count over-predicted, and it is written into the doc so the optimistic list is not re-derived later.

Also recorded as a useful negative: the accurate engine's phrase-mode `dwrite` deviation is **not** the blocker for any measured title (Doom's accurate run: 5,071,224 pixel-mode 16bpp destination writes, **zero** phrase-mode). Don't spend effort there on the strength of this census.

**Follow-on candidate (not in this PR):** *shadow-aware copy propagation* — propagating a source region's N×N sub-blocks through a copy whose source is itself shadow-tracked, instead of writing replicated blocks at the destination. That would recover Hover Strike (and by engine identity Hover Strike: Unconquered Lands). Evidence is the address-bucket table in §9.5.

## Gates (all measured, none weakened)
- OFF bit-identical to develop@83aed48 (frame_hash_ab, 600f × 5 titles); savestate digests identical 1x vs 2x × 5 titles.
- Non-beneficiaries (Cybermorph, Checkered Flag): still pass exact box-replication — Stage 2 changes nothing for them (0.0000 % sub-pixel variance).
- `make TEST_EXPORTS=1 test` exit 0, zero skips (twice); Doom pace metrics 0 diffs 1x vs 2x; perf at 2x: Doom +1.5 %, MC3D +7.4 % over Stage 1's 2x.
- `test/tools/hires_shot.c`: scripted screenshots + per-frame sub-pixel-variance metric (the box property failing on beneficiaries is the measured feature).

Note for anyone re-measuring: the shared harness leaves `vjs.useFastBlitter` at its init value unless `--option virtualjaguar_usefastblitter=disabled` is passed, so an unqualified harness run measures the **Fast** blitter while the shipped core default is **Accurate**.

Device look at AvP/Skyhammer/Doom at 2x recommended before merge, per house rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
