### PR TITLE
docs: hi-res Stage 2 on-screen verification (supersedes #357)

### DIFF
--- a/docs/hires-stage0-census.md
+++ b/docs/hires-stage0-census.md
@@ -268,6 +268,13 @@ Conclusions:
 **A1 — Titles qualifying for Stage 2 as designed (fractional source walk onto
 16bpp CRY, gameplay-verified, ≥ ~25 qualifying blits/frame):**
 
+> ⚠ **This table counts blit *shapes*, not supersampled pixels on screen.**
+> Of the nine rows below, four are verified on-screen beneficiaries, three
+> measured **zero**, one could not be verified, and one (CRZ Demo,
+> homebrew) was not measured. Do not quote this table as a beneficiary
+> list — see **§9, "Stage 2 on-screen verification"**, which measures what
+> actually reaches the display.
+
 | Title | qualifying blits/frame |
 |---|---|
 | Missile Command 3D | 1,865 |
@@ -357,3 +364,249 @@ The instrumentation pattern (for re-running or extending):
 
 Budget observed: ~5 ms/frame instrumented; the whole corpus (~115 titles ×
 2,400 frames) measures in under an hour on one host.
+
+---
+
+## 9. Stage 2 on-screen verification (added 2026-08-09)
+
+**Date:** 2026-08-09 · **Build:** `feature/338-hires-stage2` @ `836baf6`
+(Stage 2 + the ADDDSEL review fix), clean tree, `VJ_EXPECT_BUILD` guard
+enabled on every run. **Tool:** `test/tools/hires_shot`.
+
+### 9.1 Why this section exists
+
+§2/§3/§6 counted **qualifying blit shapes**: a fractional A1 source walk
+onto a 16bpp CRY destination. That is the *shape* Stage 2 can reach — it
+is not the same thing as *supersampled pixels arriving on the display*.
+Three further conditions have to hold, and each one is a real filter:
+
+- **(a) pixel-mode destination writes.** The accurate engine's phrase-mode
+  `dwrite` path keeps Stage 1 box replication (a documented Stage 2
+  deviation). *Measured: not a filter for any title here* — see §9.4.
+- **(b) a source-dependent data path.** `GOURD` and `PATDSEL` produce
+  output that does not depend on the source sample, so re-sampling the
+  source cannot change anything; both engines exclude them.
+- **(c) the supersampled content must survive to the displayed
+  framebuffer.** If a title renders into an off-screen buffer and then
+  plain-copies that buffer to the display, the copy is an integer 1:1
+  walk: it replicates, and the sub-pixel content is discarded.
+
+And one condition the census could not see at all:
+
+- **(d) the source walk must MINIFY.** Stage 2 derives its extra samples
+  by re-reading the source at `pos + inc/2`. When the walk consumes less
+  than one source texel per destination pixel (magnification), the
+  half-step lands inside the *same texel* and returns the identical
+  value. A fractional walk is necessary but not sufficient — only
+  minification carries information the 1x sample threw away.
+
+### 9.2 The metric
+
+`hires_shot` reports, for each dumped 2x frame, the **percentage of 2×2
+output blocks whose four subpixels are not all equal**. This is a
+*coverage* number — the fraction of the screen carrying real sub-pixel
+detail. It is **not** "N% better image". Stage 1 replication and every
+non-beneficiary give exactly `0.0000`; a nonzero value is exactly where
+Stage 2 fired and survived. (The number is only meaningful at 2x; run at
+1x it just measures ordinary neighbouring-pixel variance.)
+
+### 9.3 Measured results
+
+Every "scene" below was screenshot-verified (PPM → PNG → eyeballed) at the
+frames measured — **not** inferred from a frame count. The census's own
+IS1 mistake (a "gameplay" row measured on a menu) is the reason.
+
+| Title | Scene (screenshot-verified) | Frames | Accurate (shipped default) | Fast | Verdict |
+|---|---|---|---|---|---|
+| **Alien vs Predator (1994)** | Alien, textured corridor, SCORE HUD | 5200 / 6000 | **30.63 / 30.62 %** | 30.63 / 30.62 % | **verified** |
+| **Skyhammer** | in-mission cockpit, city flight, weapons armed | 2000 / 2600 / 2900 | **10.01 / 17.74 / 3.40 %** | 10.01 / 17.74 / 3.40 % | **verified** |
+| **Skyhammer** | attract flight (same renderer + HUD) | 1200 / 1800 / 2400 | 22.68 / 18.05 / 3.67 % | 22.68 / 18.05 / 3.67 % | **verified** |
+| **Doom** | E1M1 gameplay | 900 | **8.68 %** | 8.68 % | **verified** |
+| **Missile Command 3D** | Original 3D gameplay | 1600 / 2000 / 2400 | **5.03 / 5.88 / 5.16 %** | 5.03 / 5.88 / 5.16 % | **verified** |
+| **Hover Strike (cart)** | mission cockpit, terrain + ALERT HUD | 2400 / 3200 / 4000 | **0.00 / 0.00 / 0.00 %** | 0.55 / 0.00 / 0.32 % | **zero** (§9.5) |
+| **I-War** | gameplay, "DAMAGE CRITICAL" | 2800 / 3200 / 3600 | **0.00 / 0.00 / 0.00 %** | 0.39 / 0.26 / 0.41 % | **zero** (§9.6) |
+| **Towers II** | first-person dungeon | Acc: 12000 / 14800 · Fast: 12000 / 13500 / 14800 | **0.00 / 0.00 %** | 0.00 / 0.00 / 0.00 % | **zero** |
+| **Iron Soldier 2 (CD)** | gameplay not reachable headlessly | — | — | — | **unverified** (§9.7) |
+| **CRZ Demo (homebrew)** | — | — | — | — | **not measured** |
+| Checkered Flag / Cybermorph | gameplay (non-beneficiary controls) | — | 0.0000 % | 0.0000 % | zero, as designed |
+
+Notes on the table:
+
+- **Engine parity.** The harness leaves `vjs.useFastBlitter` at its init
+  value unless `--option virtualjaguar_usefastblitter=disabled` is passed,
+  so an unqualified harness run measures the **Fast** blitter while the
+  shipped core default is **Accurate**. Every row above was therefore run
+  on both. Doom, Skyhammer and AvP are bit-identical between engines. The
+  Fast column's small nonzero on Hover Strike and I-War comes from the
+  Fast engine's slightly wider Stage 2 predicate (`SRCSHADE || (!GOURD &&
+  !PATDSEL)`) versus the Accurate engine's (`!patdsel && !gourd &&
+  !adddsel`) — an engine-parity gap worth ~0.3–0.5 % of screen, noted in
+  §9.8.
+- **Skyhammer** is measured twice because its attract sequence drives the
+  full gameplay renderer and HUD; the in-mission row (reached with scripted
+  input, screenshot-verified in a mission cockpit) is the authoritative
+  one and both are strongly positive.
+- **CRZ Demo** (the homebrew row in §6's A1 table) was not measured here.
+  §2 records that 1.90 M of its 1.96 M blits are gouraud, and both engines
+  exclude `GOURD` — so reason (b) predicts near-zero — but that is a
+  prediction, not a measurement, and the row is left open rather than
+  asserted.
+
+### 9.4 Correction to a previously reported AvP result
+
+An earlier hand measurement circulated as "**AvP: 0.0000 % on both blitter
+engines**". **That is wrong.** On a clean `836baf6` tree with the
+build-identity guard enabled, AvP measures **30.63 %** — the *largest*
+on-screen benefit of any title measured, larger than Doom's. The scene
+(Alien, textured corridor, SCORE HUD, claw in frame) was screenshot-
+verified at both sampled frames on both engines. Instrumentation confirms
+why: 21.2 M of 22.2 M candidate shadow stores are accepted by the Stage 2
+predicate, 9.8 M of those blocks carry differing sub-samples, and 27.8 M
+block lookups at render time return non-uniform blocks. The earlier zero
+**could not be reproduced, and its cause was not established** — treat it
+as retracted rather than explained.
+
+**Pre-empting the obvious objection:** AvP's variance is near-constant
+across the sampled window (23,964 / 23,960 / 23,960 non-uniform blocks at
+frames 5200 / 5600 / 6000) and the run logs four `video_stall` lines, so
+it is fair to ask whether this is a frozen buffer rather than live
+rendering. It is not, and the shadow's own design proves it: the hi-res
+tag carries a frame epoch and an entry is trusted only if written within
+the last **16 presented frames** (`HIRES_EPOCH_WINDOW`, `shadowfb.c`). A
+framebuffer that stopped being rewritten would have every block fall out
+of the window and the measurement would decay to `0.0000`. A sustained
+30.6 % across 800 frames is only possible if the blitter is re-rendering
+those pixels continuously. The `video_stall` lines are the documented
+benign class — `crash_detect` hashes ~256 pixels per frame, and a
+visually near-static scene trips it.
+
+### 9.5 Hover Strike — detail is produced, then discarded downstream
+
+Hover Strike is **not** blocked by the Stage 2 predicate at all. Over 2,500
+frames of verified mission gameplay:
+
+| counter | value |
+|---|---|
+| candidate 16bpp shadow stores | 10,410,361 |
+| accepted by the Stage 2 predicate | 10,376,870 (99.7 %) |
+| accepted blocks carrying real sub-pixel detail | 9,056,918 (87 %) |
+| rejected: no fractional walk | 33,491 |
+| rejected: everything else (inhibit, no SRCEN, BCOMPEN, source depth, data path) | **0** |
+
+Yet the display shows ~0 %. The destination-address histogram explains it
+(64 KB buckets of main RAM; "render" = shadow-block lookups performed by
+the Nx renderer for displayed pixels):
+
+| bucket | Stage 2 stores | render lookups |
+|---|---|---|
+| `$000000`–`$040000` | 1,169,274 | 96.7 M |
+| `$050000`–`$0B0000` | 0 | 61.8 M |
+| **`$100000`** | **9,207,596 (89 %)** | **0** |
+
+89 % of the supersampled pixels land at `$100000`, a region the display
+**never reads**. Hover Strike renders its textured 3D view into an
+off-screen buffer and then copies that buffer to the displayed
+framebuffer; the copy is an integer 1:1 walk, so it replicates and the
+sub-pixel content is dropped. This is condition (c) above, and it is the
+one cheaply-fixable case found — see §9.8.
+
+### 9.6 I-War — the detail barely exists to begin with
+
+I-War is the opposite failure. Its Stage 2 stores and its display lookups
+share the same address buckets (`$0D0000`–`$160000`), so nothing is being
+discarded downstream. The content simply is not there:
+
+| counter | value |
+|---|---|
+| accepted by the Stage 2 predicate | 2,652,798 |
+| accepted blocks carrying real sub-pixel detail | 541,847 (20 %) |
+| qualifying walks with **< 1 source texel per destination pixel** | 2,151,841 (81 %) |
+| non-uniform blocks reaching the renderer | 604,757 |
+
+81 % of its fractional walks are **magnifying** — the `pos + inc/2`
+sub-sample lands inside the same source texel and returns the identical
+value, so the block is flat by construction. And the little detail that
+does exist *does* reach the screen (`604,757` non-uniform render hits ≈
+`541,847` detailed blocks). **This is information-theoretic, not a bug and
+not fixable within Stage 2**: there is no extra source information to
+recover. Towers II is the same class (its OP census in §4 already showed a
+constant `HSCALE $20` with only a 1.0625× vertical magnification —
+smoothing, not minification).
+
+**The rule to carry forward: Stage 2 recovers information only where the
+source walk minifies.** A fractional walk is necessary but not sufficient.
+Doom (44 % of its 4,936,831 qualifying walks at ≥ 1 texel/pixel) and AvP
+benefit; I-War and Towers II cannot.
+
+### 9.7 Iron Soldier 2 (CD) — not verified
+
+Gameplay could not be reached headlessly in this session. The disc boots,
+plays its intro, and shows its `START GAME / LOAD GAME / OPTIONS` menu
+around frames 4,900–7,700 (screenshot-verified), but no button the shared
+harness can script (`a b c pause option up down 0–6`, including 30-frame
+holds and a per-button sweep) ever selects a menu entry — presses only
+shorten the menu's timeout and advance the attract story/credits loop. Its
+attract 3D city fly-through (same renderer) measured `0.0000 %` at frames
+8800/10400/12000, but **that is an attract scene, not gameplay, and is not
+counted as a result either way.** IS2-CD's on-screen benefit is
+**unknown**, not zero. Re-running this needs a gameplay savestate.
+
+### 9.8 Follow-on candidates (evidence only — not implemented)
+
+1. **Shadow-aware copy propagation** (contained; would recover Hover
+   Strike, and by engine identity Hover Strike: Unconquered Lands). Today a
+   blit whose source region is itself shadow-tracked still writes Stage 1
+   replicated blocks at the destination. Propagating the source's N×N
+   sub-blocks through such a copy instead would carry the 9.2 M
+   supersampled pixels at `$100000` into the displayed buffer. Evidence:
+   the bucket table in §9.5. Cost is a source-side shadow lookup on
+   qualifying copies; the risk to guard is tag/epoch coherence on the
+   source side.
+2. **Engine predicate parity** (small). The Fast engine supersamples
+   `SRCSHADE`-with-`GOURD` and `ADDDSEL` blits that the Accurate engine
+   rejects. Worth ~0.3–0.5 % of screen on Hover Strike / I-War — i.e.
+   cosmetic — but the two engines should not disagree about what Stage 2
+   covers.
+3. **Not** phrase-mode support. The Stage 2 design flags the accurate
+   engine's phrase-mode `dwrite` deviation as a known gap; it was
+   instrumented here and is **not** the blocker for any measured title —
+   Doom's accurate-engine run recorded `5,071,224` pixel-mode 16bpp
+   destination writes and **zero** phrase-mode ones, and Hover Strike's
+   rejection buckets are empty. Do not spend effort there on the strength
+   of this census.
+
+### 9.9 Reproduction
+
+```bash
+cc -O2 -Wall -std=c99 -I. -I./test/harness -I./libretro-common/include \
+   -o test/tools/hires_shot test/tools/hires_shot.c \
+   test/harness/harness.c -ldl -lm
+
+VJ_EXPECT_BUILD=$(bash scripts/build-id.sh) ./test/tools/hires_shot \
+  ./virtualjaguar_libretro.dylib "<rom-or-cue>" \
+  --option virtualjaguar_internal_resolution=2x \
+  [--option virtualjaguar_usefastblitter=disabled] \
+  --frames N --press F:BTN ... --shot F --out-prefix /tmp/shot --quiet
+```
+
+Scripted input used per title (all screenshot-verified):
+
+| Title | `--press` sequence | shots |
+|---|---|---|
+| Doom | `300:a 500:a 700:a` | 900 |
+| Missile Command 3D | `300:a 600:a 900:a 1200:a` | 1600 2000 2400 |
+| Alien vs Predator | `3300:a 3600:a 3900:a 4200:a 4500:a 5000:a` | 5200 6000 |
+| Skyhammer (mission) | `400:a 700:a 1000:a 1300:a` | 2000 2600 2900 |
+| Skyhammer (attract) | *(none)* | 1200 1800 2400 |
+| Hover Strike | `200:a 400:a 700:a 1000:a 1300:a 1600:a 1900:a 2200:a` | 2400 3200 4000 |
+| I-War | `300:a 1000:b 1400:a 1800:a 2200:a 2600:a` | 2800 3200 3600 |
+| Towers II | `7300:a 7700:a 8100:a 8500:a 8900:a 9300:a 10100:b 10500:b 10900:b 11300:b` | 12000 13500 14800 |
+
+Convert and inspect with `sips -s format png <prefix>_fNNNNN.ppm --out x.png`.
+
+The §9.5/§9.6 counter tables came from a throwaway instrumentation patch
+(rejection buckets at both engines' Stage 2 sites in `src/tom/blitter.c`,
+plus hit/miss/non-uniform and address buckets in
+`ShadowHiresLineFromRAM` in `src/tom/shadowfb.c`, exported through
+`exports-test.list` and read via `harness_dlsym`). It was reverted before
+this commit; only this document is committed. Same pattern as §8.


### PR DESCRIPTION
Rescues the one piece of PR #357 that is not already on develop.

## Why #357 conflicts
PR #359 (AvP renderer analysis) was branched off `feature/338-hires-stage2`, so squash-merging it flattened the stack: **all of Stage 2's implementation reached develop under a docs-titled commit** (104ee5d — blitter.c +333, shadowfb, tom.c, hires_shot, fixtures). #357's branch is now strictly behind develop and conflicts with it; its remaining unique content is the census verification section, which is what this PR carries.

## What this adds
`docs/hires-stage0-census.md` §9 — measured on-screen coverage per title, every scene screenshot-verified (the census's own IS1 mistake was a 'gameplay' row measured on a menu):

| | |
|---|---|
| **verified** | AvP 30.6%, Skyhammer 3.4–17.7%, Doom 8.7%, Missile Command 3D 5.0–5.9% |
| **zero** | Hover Strike (produces the detail, then loses it — renders off-screen and the 1:1 copy replicates; fixable follow-on), I-War and Towers II (magnifying walks: nothing to recover) |
| **unverified** | Iron Soldier 2 (CD) — gameplay unreachable headlessly |

The A1 shape table now carries a warning not to quote it as a beneficiary list, and §9 states the rule the census structurally could not see: **Stage 2 recovers information only where the source walk minifies.** A fractional walk is necessary but not sufficient.

Also records two measured negatives that save future effort: phrase-mode support is *not* the blocker for any measured title, and the engines' Stage 2 predicates disagree by ~0.3–0.5% of screen (cosmetic, but they shouldn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)