### PR TITLE
fix(m68k): GPU/DSP local RAM is a 16-bit port with a commit-on-partner latch (#355)

### DIFF
--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -559,6 +559,75 @@ static void M68KGPURAMSync(unsigned int address, unsigned int length)
       GPUSyncToM68K();
 }
 
+/* GPU and DSP local RAM are 32-bit memories, but an external bus master sees
+ * them as 16-bit ports that must be written as ordered longword pairs:
+ *
+ *   "Addresses in DSP space are only available as 16-bit memory into which
+ *    32-bit transfers must be performed in the order low address then high
+ *    address."            -- JTRM Technical Reference v8, p.101 (p.44 for TOM)
+ *
+ * So the hardware latches the word written to the low address and commits the
+ * full longword only when its partner at +2 arrives.  That latch is why the
+ * 68000 errata singles out the two instructions that emit the halves in the
+ * wrong order -- clr.l <ea> and move.l <ea>,-(An) "do not work correctly when
+ * writing to Jaguar GPU & DSP hardware registers and internal RAM"
+ * ("Hardware Bugs & Warnings", p.6).  Independent half-longword updates would
+ * be order-insensitive and that erratum could not exist.
+ *
+ * Committing a lone low-address word directly into RAM is therefore more
+ * permissive than the hardware, and it lets a concurrently running RISC read a
+ * longword that was never written as one.  Power Drive Rally does exactly
+ * that: its 68000 sound driver issues a bare `move.w #$14,$F1BE30` into a DSP
+ * voice descriptor.  On hardware that word just sits in the latch; here it
+ * used to land in DSP RAM, so the DSP's voice dispatcher read $00140000 as a
+ * state code, indexed its jump table at $F1BB14 with it, fetched 0 and jumped
+ * to PC 0.  The engine then ran garbage until it left mapped memory, at which
+ * point DSPExec's escape guard parked it for good -- LTXD stopped updating and
+ * the DAC froze on one sample, which is the "sound gets muted" in issue #355.
+ *
+ * A write that is part of a real 68000 long write (m68kInLongWrite) already
+ * arrives as a correctly ordered pair, so it bypasses the latch untouched. */
+#define M68K_RISC_LOCAL_RAM(a) \
+   (((a) >= GPU_WORK_RAM_BASE && (a) < GPU_WORK_RAM_BASE + 0x1000) \
+    || ((a) >= DSP_WORK_RAM_BASE && (a) < DSP_WORK_RAM_BASE + 0x2000))
+
+static uint32_t m68kRiscLatchAddr = 0xFFFFFFFF;   /* low address, or ~0 */
+static uint16_t m68kRiscLatchData = 0;
+
+static void M68KResetRiscWordLatch(void)
+{
+   m68kRiscLatchAddr = 0xFFFFFFFF;
+   m68kRiscLatchData = 0;
+}
+
+/* Returns true when the caller should stop -- the word was latched and must
+ * not reach RAM yet.  When the partner word arrives this commits the latched
+ * half first, preserving low-then-high order, and lets the caller write the
+ * second half normally. */
+static bool M68KRiscWordLatch(unsigned int address, unsigned int value)
+{
+   if (m68kInLongWrite || !M68K_RISC_LOCAL_RAM(address))
+      return false;
+
+   if (!(address & 2))
+   {
+      m68kRiscLatchAddr = address;
+      m68kRiscLatchData = (uint16_t)value;
+      return true;
+   }
+
+   if (m68kRiscLatchAddr == address - 2)
+   {
+      uint16_t hi = m68kRiscLatchData;
+      m68kRiscLatchAddr = 0xFFFFFFFF;
+      if (address >= 0xF10000)
+         JERRYWriteWord(address - 2, hi, M68K);
+      else
+         TOMWriteWord(address - 2, hi, M68K);
+   }
+   return false;
+}
+
 void m68k_write_memory_8(unsigned int address, unsigned int value)
 {
 #ifdef ALPINE_FUNCTIONS
@@ -611,6 +680,11 @@ void m68k_write_memory_16(unsigned int address, unsigned int value)
    // Musashi does this automagically for you, UAE core does not :-P
    address &= 0x00FFFFFF;
    M68K_BUS_CHARGE(address, 1);
+
+   /* GPU/DSP local RAM is a 16-bit port with a commit-on-partner latch --
+    * see M68KRiscWordLatch. */
+   if (M68KRiscWordLatch(address, value))
+      return;
 
    // Note that the Jaguar only has 2M of RAM, not 4!
    if ((address >= 0x000000) && (address <= 0x1FFFFE))
@@ -1047,6 +1121,8 @@ void JaguarReset(void)
    uint32_t clearEnd = JAGUAR_RAM_SIZE;
    uint32_t preserveStart = jaguarLoadedRAMStart;
    uint32_t preserveEnd = jaguarLoadedRAMEnd;
+
+   M68KResetRiscWordLatch();
 
    /* CD boot strategies (HLE/BIOS) hold per-run state (auth-bypass
     * installed flag, boot-stub-injected flag, HLE active flag, etc.)


### PR DESCRIPTION
Fixes #355 (Power Drive Rally sound stops midgame).

Stacked on #358 (the `audio_timeline` tool that made this diagnosable) — that PR is tooling-only, this one is the fix. Review #358 first or merge in either order; they don't touch the same files.

## The symptom is not silence

The DAC **freezes on a single constant sample** — RMS pinned to one decimal place across 200 seconds, 100% non-silent. That's why `test_audio_clipping` never caught it, and why "muted" is a slightly misleading description of what's happening.

## Root cause is in the 68000 write path, not the DSP

GPU and DSP local RAM are 32-bit memories, but an external bus master sees them as 16-bit ports that must be written as ordered longword pairs:

> *"Addresses in DSP space are only available as 16-bit memory into which 32-bit transfers must be performed in the order low address then high address."*
> — JTRM Technical Reference v8, p.101 (p.44 states the same for TOM)

The hardware latches the word written to the low address and commits the full longword only when its partner at +2 arrives. **That latch is why the errata exists**: `clr.l <ea>` and `move.l <ea>,-(An)` *"do not work correctly when writing to Jaguar GPU & DSP hardware registers and internal RAM"* ("Hardware Bugs & Warnings", p.6, covering `$F02000-$F07FFF` and `$F1A000-$F1F000`). Independent half-longword updates would be order-insensitive and that erratum could not exist.

We committed a lone low-address word straight into RAM — more permissive than hardware, and it lets a concurrently running RISC read a longword that was never written as one.

## What PDR actually does

Its 68000 sound driver issues a bare `move.w #$14,$F1BE30` into a DSP voice descriptor. Verified from a write trace: a standalone word write, `m68kInLongWrite == 0`, with **no partner write** to `$F1BE32`. On hardware that word just sits in the latch. Here it landed in DSP RAM, so the voice dispatcher read it as a state code:

```
$F1B0F0  load    (r15), r16        ; state code -- legal values are only -4, 0, +4
$F1B0F2  movefa  r2', r14          ; r14 = $F1BB14, jump-table base
$F1B0F4  load    (r14+r16), r25    ; $F1BB14 + $140000 = $0105BB14  ->  0
$F1B0F6  jump    (r25)             ; PC = 0
```

The engine then ran garbage until it left mapped memory, at which point `DSPExec`'s escape guard parked it for good — LTXD stopped updating and the DAC froze. Everything downstream (poisoned return addresses on the DSP stack, the eventual park at `$FFFFFFFF`) follows from that one bad longword.

## The fix

Model the latch. A standalone 68000 word write into GPU local RAM (`$F03000-$F03FFF`) or DSP local RAM (`$F1B000-$F1CFFF`) at a longword-aligned address is latched rather than committed; the partner write at +2 commits both halves in order. Writes already part of a 68000 long write arrive as a correctly ordered pair and bypass the latch untouched.

Byte writes are deliberately left alone — the JTRM does not address 8-bit access to internal RAM either way, so widening this to bytes would be speculation rather than accuracy.

This is the same failure class the existing `m68kInLongWrite` comment already documents for the GPU (*"the GPU must never observe a half-written longword"*, Pitfall's mailbox poll loop). That guard prevents the GPU from *running* mid-longword; it does nothing about a lone word write that genuinely modifies memory, which is this bug.

## Validation

- **Repro**: from a pre-failure save state, PDR fails at ~2 s with no input at all — the DSP leaves its engine and `r31` goes to garbage every frame. After the fix it stays in `$F1B0xx-$F1B3xx` with `r31=$00F1B010` and healthy RMS for the whole run.
- `make TEST_EXPORTS=1 test` — green, *"every optional check ran"*.
- **Both audio tests**, as required for DSP-path changes: Skyhammer 0% saturated / RMS 3083 (baseline 3080), Iron Soldier 2 clean, Iron Soldier 1 presence inside the develop envelope. No silencing regression.
- **Acid suite**: `check-baseline.py` reports `Regressions: 0`. (The 3 raw failures are the pre-existing `tests/bus/*` bus-contention entries already in `BASELINE.txt`.)
- **Corpus A/B**, baseline vs fixed, 900 frames each under real BIOS across 13 commercial titles — AvP, Doom, Wolf3D, Tempest 2000, Iron Soldier, Atari Karts, Checkered Flag, Cannon Fodder, Bubsy, Mutant Penguins, Brutal Sports Football, PDR, Val d'Isere: **identical** audio RMS and frame counts.

## Known limitation

The latch is not serialised into save states. It only holds data between the two halves of a manually split pair, and `retro_serialize` runs at a frame boundary, so a pending latch would have to survive an entire frame to matter — and losing it degrades to lone-write semantics, which is what the hardware does anyway. `JaguarReset` clears it.

## Not yet verified in RetroArch

Per CLAUDE.md, headless tests can't tell music from structured noise. This wants a listen on a real frontend before it's considered done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)