### PR TITLE
ci(release): ship cue2cdi binaries for Linux, macOS, Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,7 +338,8 @@ jobs:
           mkdir -p dist
           case "${{ matrix.config.platform }}" in
             linux-x86_64)
-              gcc -O2 -Wall -std=c99 -o dist/cue2cdi-linux-x86_64 test/tools/cue2cdi.c
+              make cue2cdi CC="${{ matrix.config.cc }}"
+              cp test/tools/cue2cdi dist/cue2cdi-linux-x86_64
               strip dist/cue2cdi-linux-x86_64
               ;;
             macos-arm64)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,6 +321,37 @@ jobs:
           tar -C dist -czf "dist/virtualjaguar_libretro-${{ matrix.config.platform }}-debug.tar.gz" "${DBG}"
           rm "dist/${DBG}"
 
+      # ----------------------------------------------------------------
+      # cue2cdi -- standalone CUE/BIN -> DiscJuggler CDI converter
+      # (test/tools/cue2cdi.c, `make cue2cdi`).  Shipped for the three
+      # common desktop platforms only; dropping the binary into dist/
+      # rides the existing artifact -> stage -> release/nightly flow, so
+      # it appears in both tagged releases and the rolling nightly and
+      # lands in SHA256SUMS automatically.  macOS ships one universal
+      # (arm64 + x86_64) binary built from the arm64 job; Windows from
+      # the MINGW64 job.
+      # ----------------------------------------------------------------
+      - name: Build cue2cdi (shipped desktop platforms)
+        if: ${{ matrix.config.platform == 'linux-x86_64' || matrix.config.platform == 'macos-arm64' || matrix.config.platform == 'windows-x86_64' }}
+        run: |
+          set -e
+          mkdir -p dist
+          case "${{ matrix.config.platform }}" in
+            linux-x86_64)
+              gcc -O2 -Wall -std=c99 -o dist/cue2cdi-linux-x86_64 test/tools/cue2cdi.c
+              strip dist/cue2cdi-linux-x86_64
+              ;;
+            macos-arm64)
+              clang -O2 -Wall -std=c99 -arch arm64 -arch x86_64 \
+                -o dist/cue2cdi-macos-universal test/tools/cue2cdi.c
+              strip -S -x dist/cue2cdi-macos-universal
+              ;;
+            windows-x86_64)
+              gcc -O2 -Wall -std=c99 -o dist/cue2cdi-windows-x86_64.exe test/tools/cue2cdi.c
+              strip dist/cue2cdi-windows-x86_64.exe
+              ;;
+          esac
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Ships `cue2cdi` (the standalone CUE/BIN → DiscJuggler CDI converter, `make cue2cdi`) as release artifacts:

- `cue2cdi-linux-x86_64` — from the linux-x86_64 job
- `cue2cdi-macos-universal` — one fat arm64 + x86_64 binary from the macos-arm64 job (verified locally: builds `-Wall`-clean, `lipo` confirms both slices, runs)
- `cue2cdi-windows-x86_64.exe` — from the MINGW64 job (source audited: all binary I/O is `rb`/`wb`, only `dirent.h`/`sys/stat.h` beyond stdlib — MinGW-w64 provides both)

The binaries drop into `dist/` so they ride the existing artifact → stage → publish flow into **both** tagged releases and the rolling nightly, and land in `SHA256SUMS.txt` automatically — no changes to the stage/release jobs needed.

Note: `release.yml` runs on develop pushes and tags, not on PRs — the Linux/Windows halves get their CI proof on the first nightly rerun after merge. Watch that run's three desktop jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)