### PR TITLE
fix(cue2cdi): MinGW has no lstat/S_ISLNK — guard the symlink skip

### DIFF
--- a/test/tools/cue2cdi.c
+++ b/test/tools/cue2cdi.c
@@ -57,7 +57,8 @@
 #include <ctype.h>
 #include <stdint.h>
 
-/* Batch mode is host-side POSIX (opendir/readdir/lstat) */
+/* Batch mode walks directories with opendir/readdir (MinGW provides
+ * dirent.h; the symlink skip is POSIX-only, see collect_cues) */
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
@@ -1045,10 +1046,17 @@ static int collect_cues(const char *dirPath, PathList *out)
       if (de->d_name[0] == '.')
          continue;
       snprintf(full, sizeof(full), "%s/%s", dirPath, de->d_name);
+#ifdef _WIN32
+      /* MinGW has no lstat/S_ISLNK; stat() is fine — NTFS symlinks are
+       * rare and following one just converts the file it points at. */
+      if (stat(full, &st) != 0)
+         continue;
+#else
       if (lstat(full, &st) != 0)
          continue;
       if (S_ISLNK(st.st_mode))
          continue;
+#endif
       if (S_ISDIR(st.st_mode)) {
          if (collect_cues(full, out) != 0)
             ret = -1;


### PR DESCRIPTION
Unbreaks the nightly: [run 31340218464](https://github.com/libretro/virtualjaguar-libretro/actions/runs/31340218464) failed on `build-windows-x86_64` at the new cue2cdi step (#373) with `implicit declaration of 'lstat'` / `'S_ISLNK'` — MinGW provides neither. Batch mode's directory walk now uses plain `stat()` on Windows (following an NTFS symlink just converts the file it points at); POSIX keeps the symlink skip.

The other two shipped platforms passed on that run, so this is the last piece of #373's CI proof. Merging retriggers the nightly and completes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)