### PR TITLE
docs: correct v3.2.0 notes — 2x supersampling shipped in the tag

### DIFF
--- a/docs/RELEASE_NOTES_v3.2.0.md
+++ b/docs/RELEASE_NOTES_v3.2.0.md
@@ -19,9 +19,7 @@ mid-game sound freeze, and damaged CDI V2 rips now booting.
   supersampled with real sub-pixel content (fractional-walk source sampling,
   the "Stage 2" of the design), so 3D titles gain genuine detail; anything
   that doesn't qualify falls back to exact 2×2 box replication. The emulated
-  machine cannot observe the option: a corpus-wide census (#351), a per-frame
-  hash gate, and savestate digests prove the 1x path bit-identical. Combines
-  with True Color. *(Correction 2026-08-09: this file originally described
+  hash gate, and savestate digests prove the 1x path is bit-identical. Combines
   the release as box-replication-only with supersampling "in progress"; the
   `104ee5d` when #359 was squash-merged on top of the Stage 2 branch. The
 - **OP shadow-resolve hit/miss counters** (#362) make the supersampled

--- a/docs/RELEASE_NOTES_v3.2.0.md
+++ b/docs/RELEASE_NOTES_v3.2.0.md
@@ -13,16 +13,22 @@ mid-game sound freeze, and damaged CDI V2 rips now booting.
   banding in 3D titles. The game-visible 16-bit framebuffer is unchanged —
   savestates, achievements, and emulation behaviour are bit-identical.
   CRY 16bpp video modes only. Default off.
-- **2x internal resolution** (#351, #353). New core option
+- **2x internal resolution** (#351, #353, #359). New core option
   `virtualjaguar_internal_resolution` (`1x`/`2x`, restart required) renders
-  internally at a multiple of native resolution. Stage 1 ships exact 2×2 box
-  replication — proven inert by construction: a corpus-wide census (#351)
-  plus a per-frame hash gate and savestate digests show the emulated machine
-  cannot observe the option. Combines with True Color. Groundwork for real
-  sub-pixel gouraud/blit precision (Stage 2, in progress).
-- **OP shadow-resolve hit/miss counters** (#362) make hi-res Stage 2's
-  silent-fallback failure mode diagnosable at a glance (verbose crash-detect
-  heartbeat), with misses split by cause.
+  internally at a multiple of native resolution — and qualifying blits are
+  supersampled with real sub-pixel content (fractional-walk source sampling,
+  the "Stage 2" of the design), so 3D titles gain genuine detail; anything
+  that doesn't qualify falls back to exact 2×2 box replication. The emulated
+  machine cannot observe the option: a corpus-wide census (#351), a per-frame
+  hash gate, and savestate digests prove the 1x path bit-identical. Combines
+  with True Color. *(Correction 2026-08-09: this file originally described
+  the release as box-replication-only with supersampling "in progress"; the
+  supersampling path in fact shipped in this tag — it landed on develop in
+  104ee5d when #359 was squash-merged on top of the Stage 2 branch. The
+  GitHub release body carries the same correction.)*
+- **OP shadow-resolve hit/miss counters** (#362) make the supersampled
+  path's silent-fallback failure mode diagnosable at a glance (verbose
+  crash-detect heartbeat), with misses split by cause.
 
 ## Bug fixes
 

--- a/docs/RELEASE_NOTES_v3.2.0.md
+++ b/docs/RELEASE_NOTES_v3.2.0.md
@@ -23,9 +23,7 @@ mid-game sound freeze, and damaged CDI V2 rips now booting.
   hash gate, and savestate digests prove the 1x path bit-identical. Combines
   with True Color. *(Correction 2026-08-09: this file originally described
   the release as box-replication-only with supersampling "in progress"; the
-  supersampling path in fact shipped in this tag — it landed on develop in
-  104ee5d when #359 was squash-merged on top of the Stage 2 branch. The
-  GitHub release body carries the same correction.)*
+  `104ee5d` when #359 was squash-merged on top of the Stage 2 branch. The
 - **OP shadow-resolve hit/miss counters** (#362) make the supersampled
   path's silent-fallback failure mode diagnosable at a glance (verbose
   crash-detect heartbeat), with misses split by cause.


### PR DESCRIPTION
While dispositioning the roadmap I found the v3.2.0 notes understate what shipped: squash-merging #359 (which was stacked on `feature/338-hires-stage2`) landed the **full Stage 2 supersampling implementation** on develop in 104ee5d — before the release cut. That's why #357 was closed as superseded. So v3.2.0's `2x` option supersamples qualifying blits (real sub-pixel content) and falls back to box replication for the rest; the notes claimed box-replication-only with Stage 2 "in progress".

Corrected in both places, each with an explicit correction note rather than a silent rewrite:
- the [GitHub release body](https://github.com/libretro/virtualjaguar-libretro/releases/tag/v3.2.0) (already edited — the screenshot section now presents the AvP captures as this release's output, which they are: measured on the exact shipped code)
- `docs/RELEASE_NOTES_v3.2.0.md` (this PR)

Roadmap fallout handled separately: #367 is being repurposed from "ship Stage 2" (already shipped) to Stage 3 (OP scaled-object supersampling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)