### PR TITLE
docs: restore four lines dropped when #375 merged

### DIFF
--- a/docs/RELEASE_NOTES_v3.2.0.md
+++ b/docs/RELEASE_NOTES_v3.2.0.md
@@ -19,9 +19,13 @@ mid-game sound freeze, and damaged CDI V2 rips now booting.
   supersampled with real sub-pixel content (fractional-walk source sampling,
   the "Stage 2" of the design), so 3D titles gain genuine detail; anything
   that doesn't qualify falls back to exact 2×2 box replication. The emulated
+  machine cannot observe the option: a corpus-wide census (#351), a per-frame
   hash gate, and savestate digests prove the 1x path is bit-identical. Combines
+  with True Color. *(Correction 2026-08-09: this file originally described
   the release as box-replication-only with supersampling "in progress"; the
+  supersampling path in fact shipped in this tag — it landed on develop in
   `104ee5d` when #359 was squash-merged on top of the Stage 2 branch. The
+  GitHub release body carries the same correction.)*
 - **OP shadow-resolve hit/miss counters** (#362) make the supersampled
   path's silent-fallback failure mode diagnosable at a glance (verbose
   crash-detect heartbeat), with misses split by cause.


### PR DESCRIPTION
The 2x bullet in `docs/RELEASE_NOTES_v3.2.0.md` lost four lines during the #375 merge — the text now breaks mid-sentence ("The emulated / hash gate, and savestate digests…") and the correction note lost its opening. This restores the paragraph exactly as authored in #375. Four inserted lines, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)