### PR TITLE
feat(core): per-title enhancement defaults DB (#368)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Frame loop is event-driven (not cycle-accurate): `JaguarExecuteNew()` in `src/co
 - `src/jerry/` — audio, DSP, DAC, EEPROM, input, wavetable, UART/netlink (`uart.c` + `jlink.c`, see `docs/netlink-design.md`)
 - `src/cd/` — Jaguar CD: BUTCH/FIFO/DSA/Q-subcode in `cdrom.c`, image loading (CUE/BIN, CDI — **no CHD**, removed during the CD overhaul; see issue #322) in `cdintf.c`; BIOS auth bypass + boot stub in `src/core/jaguar.c`
 - `src/core/jaggd.c` — Jaguar GameDrive: SPI mailbox at `$F16000`, embedded GDBIOS blob, 6×1MB page → 16-bank switching for images up to 16 MB (spec: `docs/jgd-interface-notes.md`)
+- `src/core/titledb.c` — per-title enhancement defaults (#368); applied at option-read time in `libretro.c`, user-set values always win
 - `src/bios/` — embedded BIOS / boot stubs
 - `src/m68000/` — UAE 68K (machine-generated; treat as opaque)
 - `libretro-common/` — shared utility lib

--- a/Makefile
+++ b/Makefile
@@ -873,7 +873,7 @@ else
 # rev (+ -dirty) against this before running -- a stale dylib fails loudly
 # instead of silently testing the wrong code (see scripts/build-id.sh).
 test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
-test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_netpacket test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 \
+test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_netpacket test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 test/test_titledb \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
@@ -910,6 +910,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	./test/test_tom_visible_window
 	./test/test_blitter_simd
 	./test/test_dsp_mac40
+	./test/test_titledb
 	./test/test_m68k_ops
 	./test/test_m68k_irq_ssp
 	./test/test_gpu_ops
@@ -1150,6 +1151,10 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 test/test_cheat: test/test_cheat.c src/core/cheat.c src/core/cheat.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_cheat.c src/core/cheat.c
+
+test/test_titledb: test/tools/test_titledb.c src/core/titledb.c src/core/crc32.c
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/test_titledb.c src/core/titledb.c src/core/crc32.c
 
 test/test_event_queue: test/test_event_queue.c src/core/event.c src/core/event.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -835,7 +835,7 @@ clean:
 		test/test_state_compat test/test_frontend_pacing test/test_jgd \
 		test/dump_pc test/heap_search \
 		test/tools/test_memory_map test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/tools/test_dsp_audio_diag \
-		test/tools/test_frame_timing test/tools/test_runahead_determinism \
+		test/tools/test_frame_timing test/tools/test_runahead_determinism test/tools/test_pertitle_db \
 		test/.skipped-checks
 
 # Self-contained unit tests (parser + list management + simulated
@@ -887,7 +887,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda test/test_cd_synth_subq \
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
-		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy
+		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/test_pertitle_db
 	@# Skip ledger: truncate FIRST so a previous run's rows cannot resurface
 	@# as fresh skips (the stale-row failure mode documented for
 	@# cd_boot_matrix.sh).  Every optional check below records into it, and
@@ -1131,6 +1131,39 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# EEPROM read-race test: joystick polls must not steal EEPROM DO bits
 	@# (Raiden background-music death regression).
 	./test/test_eeprom_read_race ./$(TARGET) /tmp/eeprom_lifecycle_test.j64
+	@# Per-title enhancement defaults DB E2E (#368): apply / disable /
+	@# user-override contract, driven through the real dlopen'd core.
+	@# shadowHiresN is fixed for the whole session at retro_load_game
+	@# time, so each case is a separate process invocation -- exactly
+	@# like a real frontend restart.  The seed CRC (0xDC187F82) is
+	@# verified against the actual ROM bytes first: a corpus rip that
+	@# does not match the seed would otherwise make the test "pass"
+	@# without ever exercising the DB lookup it claims to test.
+	@avp=$$(bash scripts/find-rom.sh 'Alien vs Predator (1994).jag' '*Alien*Predator*.jag' '*Alien*Predator*.j64'); \
+	if [ -n "$$avp" ]; then \
+		avp_crc=$$(python3 -c "import zlib,sys; print('0x%08X' % zlib.crc32(open(sys.argv[1],'rb').read()))" "$$avp" 2>/dev/null); \
+		if [ "$$avp_crc" = "0xDC187F82" ]; then \
+			rc=0; \
+			./test/tools/test_pertitle_db ./$(TARGET) "$$avp" --case 1 --quiet || rc=1; \
+			./test/tools/test_pertitle_db ./$(TARGET) "$$avp" --case 2 --quiet \
+				--option virtualjaguar_pertitle_defaults=disabled || rc=1; \
+			./test/tools/test_pertitle_db ./$(TARGET) "$$avp" --case 3 --quiet \
+				--option virtualjaguar_pertitle_defaults=disabled \
+				--option virtualjaguar_internal_resolution=2x || rc=1; \
+			./test/tools/test_pertitle_db ./$(TARGET) "$$avp" --case 4 --quiet \
+				--option virtualjaguar_true_color=disabled || rc=1; \
+			exit $$rc; \
+		else \
+			bash scripts/test-skip.sh record "Per-title defaults (AvP apply/disable/override)" \
+				"AvP ROM CRC $$avp_crc != 0xDC187F82 (seed mismatch)"; \
+		fi; \
+	else \
+		bash scripts/test-skip.sh record "Per-title defaults (AvP apply/disable/override)" \
+			"no ROM matching 'Alien vs Predator*' in the private corpus"; \
+	fi
+	@# Non-DB ROM control: no CRC match -> no substitution, no [titledb] log.
+	@# yarc.j64 is committed in-tree so this case never skips.
+	./test/tools/test_pertitle_db ./$(TARGET) test/roms/yarc.j64 --case 5 --quiet
 	@echo ""
 	@echo "Note: test/test_cd_boot, test/test_cd_hle_boot, test/test_cd_bios_boot,"
 	@echo "test/test_cd_toc_contract (needs VJ_TOC_DISC=<image>),"
@@ -1294,6 +1327,17 @@ test/test_nvmbios: test/test_nvmbios.c src/core/nvmbios.c src/core/nvmbios.h \
 test/tools/test_memory_map: test/tools/test_memory_map.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_memory_map.c -ldl
+
+# E2E behaviour test for the per-title enhancement defaults DB (#368):
+# apply / disable / user-override contract, driven through the real core
+# via the shared harness.  Needs shadowHiresN + shadowFBActive from the
+# wide test symbol set (exports-test.list / link-test.T).
+test/tools/test_pertitle_db: test/tools/test_pertitle_db.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/test_pertitle_db.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
 
 test/tools/test_option_visibility: test/tools/test_option_visibility.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile.common
+++ b/Makefile.common
@@ -47,6 +47,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/core/event.c \
 	$(CORE_DIR)/src/jerry/eeprom.c \
 	$(CORE_DIR)/src/core/filedb.c \
+	$(CORE_DIR)/src/core/titledb.c \
 	$(CORE_DIR)/src/m68000/cpustbl.c \
 	$(CORE_DIR)/src/m68000/cpudefs.c \
 	$(CORE_DIR)/src/m68000/cpuemu.c \

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Two independent clock-scale options — the 68000 (`virtualjaguar_m68k_clock_sca
 
 ### Per-title enhancement defaults
 
-`virtualjaguar_pertitle_defaults` (on by default) applies known-safe enhancement presets automatically for recognized games — only for options you've left at their default value. Any option you've changed yourself always wins, and disabling this option restores stock behaviour for every title. Seeded titles: **Alien vs Predator** (2x internal resolution + true color) and **Cybermorph** (true color). New entries require committed evidence — propose candidates via [issue #368](https://github.com/libretro/virtualjaguar-libretro/issues/368).
+`virtualjaguar_pertitle_defaults` (on by default) applies known-safe enhancement presets automatically for recognized games — only for options you've left at their default value. Any option you've changed yourself always wins, and disabling this option restores stock behaviour for every title. 12 entries covering 11 titles, derived from the blit census in [`docs/hires-stage0-census.md`](docs/hires-stage0-census.md), including **Alien vs Predator** (2x internal resolution + true color), **Doom** (2x + true color), **Missile Command 3D** (2x + true color), **Hover Strike** (2x), and **Cybermorph** (true color). New entries require committed evidence — propose candidates via [issue #368](https://github.com/libretro/virtualjaguar-libretro/issues/368).
 
 ### Roadmap: internal hi-res upscaling — *in design*
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Two independent clock-scale options — the 68000 (`virtualjaguar_m68k_clock_sca
 
 `virtualjaguar_crash_detect` (on by default) checks once per frame for known failure signatures and writes the diagnosis into the frontend log. Cost when enabled: one indirect call plus a ~256-pixel hash per frame. ([`src/core/crash_detect.c`](src/core/crash_detect.c))
 
+### Per-title enhancement defaults
+
+`virtualjaguar_pertitle_defaults` (on by default) applies known-safe enhancement presets automatically for recognized games — only for options you've left at their default value. Any option you've changed yourself always wins, and disabling this option restores stock behaviour for every title. Seeded titles: **Alien vs Predator** (2x internal resolution + true color) and **Cybermorph** (true color). New entries require committed evidence — propose candidates via [issue #368](https://github.com/libretro/virtualjaguar-libretro/issues/368).
+
 ### Roadmap: internal hi-res upscaling — *in design*
 
 The true-color shadow framebuffer is deliberately the 1× prototype of a larger architecture: rendering above native resolution inside the core. That work, and the rest of the enhancement suite, is tracked as epic [#338](https://github.com/libretro/virtualjaguar-libretro/issues/338). It is **in design** — no dates, no promises beyond what's in the issue.

--- a/exports-test.list
+++ b/exports-test.list
@@ -69,3 +69,5 @@ _shadowHiresResolveHits
 _shadowHiresResolveMissValue
 _shadowHiresResolveMissEpoch
 _shadowHiresResolveMissNoPage
+_shadowHiresN
+_shadowFBActive

--- a/libretro.c
+++ b/libretro.c
@@ -45,6 +45,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "nvmbios.h"
 #include "vjag_memory.h"
 #include "state.h"
+#include "titledb.h"
 #include "log.h"
 #include "version.h" /* generated; defines CORE_VERSION */
 
@@ -502,14 +503,70 @@ static void netlink_apply(int mode)
    UARTSetLinkMode(mode);
 }
 
+/* Gate for per-title enhancement defaults (issue #368). Read raw (never
+ * through get_variable_pertitle()) at the top of check_variables() and once
+ * in retro_load_game() before the hires read, so it is never itself
+ * substituted by the DB. Defaults to enabled so headless callers/tests that
+ * never read the option still get stock behaviour identical to "enabled"
+ * with no DB match. */
+static bool pertitle_enabled = true;
+
+/* Default value registered for a core option key, from the v2 definitions
+ * in option_defs_us[] (libretro_core_options.h). */
+static const char *core_option_default(const char *key)
+{
+   size_t i;
+   for (i = 0; option_defs_us[i].key; i++)
+      if (!strcmp(option_defs_us[i].key, key))
+         return option_defs_us[i].default_value;
+   return NULL;
+}
+
+/* GET_VARIABLE with per-title defaults (issue #368): when the frontend's
+ * value equals the option's registered default (the user never touched it)
+ * and the loaded title has a DB entry for this key, substitute the DB
+ * value. A user-set non-default value always wins. Logs once per
+ * substitution via LOG_INF. */
+static bool get_variable_pertitle(struct retro_variable *var)
+{
+   bool ok = environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, var) && var->value;
+   const char *ovr, *def;
+
+   if (!pertitle_enabled)
+      return ok;
+
+   ovr = TitleDBOverride(var->key);
+   if (!ovr)
+      return ok;
+
+   def = core_option_default(var->key);
+   if (!ok || (def && !strcmp(var->value, def)))
+   {
+      LOG_INF("[titledb] %s: %s=%s (option at default)\n",
+              TitleDBTitleName(), var->key, ovr);
+      var->value = ovr;
+      return true;
+   }
+   return ok;
+}
+
 static void check_variables(void)
 {
    unsigned i;
    struct retro_variable var;
+   struct retro_variable gate_var;
+
+   gate_var.key = "virtualjaguar_pertitle_defaults";
+   gate_var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &gate_var) && gate_var.value)
+      pertitle_enabled = (strcmp(gate_var.value, "disabled") != 0);
+   else
+      pertitle_enabled = true;
+
    var.key = "virtualjaguar_usefastblitter";
    var.value = NULL;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
          vjs.useFastBlitter = true;
@@ -519,7 +576,7 @@ static void check_variables(void)
 
    var.key = "virtualjaguar_true_color";
    var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
       ShadowFBSetEnabled(strcmp(var.value, "enabled") == 0);
    else
       ShadowFBSetEnabled(0);
@@ -530,7 +587,7 @@ static void check_variables(void)
     * restart (design section 7.1). */
    var.key = "virtualjaguar_internal_resolution";
    var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       int hires_want = (strcmp(var.value, "2x") == 0) ? 2 : 1;
       if (hires_want == shadowHiresN)
@@ -545,7 +602,7 @@ static void check_variables(void)
 
    var.key = "virtualjaguar_crash_detect";
    var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (strcmp(var.value, "verbose") == 0)
          CrashDetectSetMode(CRASH_DETECT_VERBOSE);
@@ -561,7 +618,7 @@ static void check_variables(void)
 
    var.key = "virtualjaguar_cd_trace";
    var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
       CDTraceSetEnabled(strcmp(var.value, "enabled") == 0);
    else
       CDTraceSetEnabled(0);
@@ -573,7 +630,7 @@ static void check_variables(void)
     * overrides it for headless calibration experiments only. */
    var.key = "virtualjaguar_dram_timing";
    var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
       busArbiter.enabled = (strcmp(var.value, "enabled") == 0);
    else
       busArbiter.enabled = 0;
@@ -604,7 +661,7 @@ static void check_variables(void)
    var.key = "virtualjaguar_m68k_clock_scale";
    var.value = NULL;
    m68kClockScalePct = 100;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (strcmp(var.value, "0.5x") == 0)
          m68kClockScalePct = 50;
@@ -622,7 +679,7 @@ static void check_variables(void)
    var.key = "virtualjaguar_risc_clock_scale";
    var.value = NULL;
    riscClockScalePct = 100;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (strcmp(var.value, "0.5x") == 0)
          riscClockScalePct = 50;
@@ -641,7 +698,7 @@ static void check_variables(void)
 
    var.key = "virtualjaguar_netlink";
    var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       int mode = JLINK_MODE_DISABLED;
       if (strcmp(var.value, "loopback") == 0)
@@ -658,7 +715,7 @@ static void check_variables(void)
    var.key = "virtualjaguar_bios";
    var.value = NULL;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
          vjs.useJaguarBIOS = true;
@@ -669,7 +726,7 @@ static void check_variables(void)
    var.key = "virtualjaguar_pal";
    var.value = NULL;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
          vjs.hardwareTypeNTSC = false;
@@ -680,7 +737,7 @@ static void check_variables(void)
    var.key = "virtualjaguar_memory_track";
    var.value = NULL;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
       opt_memory_track = (strcmp(var.value, "disabled") != 0);
 
    /* Jaguar GameDrive: mode is latched here; activation happens at
@@ -688,7 +745,7 @@ static void check_variables(void)
    var.key = "virtualjaguar_jgd";
    var.value = NULL;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
          JGDSetMode(JGD_MODE_ENABLED);
@@ -703,7 +760,7 @@ static void check_variables(void)
    var.key = "virtualjaguar_cd_bios_type";
    var.value = NULL;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (strcmp(var.value, "dev") == 0)
          vjs.cdBiosType = CDBIOS_DEV;
@@ -714,7 +771,7 @@ static void check_variables(void)
    var.key = "virtualjaguar_cd_boot_mode";
    var.value = NULL;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (strcmp(var.value, "hle") == 0)
          vjs.cdBootMode = CDBOOT_HLE;
@@ -727,7 +784,7 @@ static void check_variables(void)
    var.key = "virtualjaguar_cd_read_speed";
    var.value = NULL;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (strcmp(var.value, "1x") == 0)
          vjs.cdReadSpeed = CDSPEED_1X;
@@ -745,7 +802,7 @@ static void check_variables(void)
 
    var.key = "virtualjaguar_alt_inputs";
    var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (get_variable_pertitle(&var) && var.value)
    {
       if (!strcmp(var.value, "enabled"))
          enable_alt_inputs = true;
@@ -766,7 +823,7 @@ static void check_variables(void)
       build_port_option_key(key, sizeof(key), i, "_numpad_to_kb");
       var.key   = key;
       var.value = NULL;
-      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      if (get_variable_pertitle(&var) && var.value)
       {
          if (!strcmp(var.value, "disabled"))
             numpad_to_kb[i] = 0;
@@ -781,7 +838,7 @@ static void check_variables(void)
          build_port_option_key(key, sizeof(key), i, retropad_option_map[j].suffix);
          var.key   = key;
          var.value = NULL;
-         if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+         if (get_variable_pertitle(&var) && var.value)
             jag_retropad[i][retropad_option_map[j].id] = get_button_id(var.value);
       }
    }
@@ -1575,6 +1632,29 @@ bool retro_load_game(const struct retro_game_info *info)
       return false;
    }
 
+   /* Feed the per-title DB the loaded content so option reads below (and in
+    * check_variables()) can match by CRC (issue #368). info->data is NULL
+    * for path-loaded content (CD) -- that correctly clears any match, since
+    * v1 only covers cartridge CRCs. */
+   if (info->data)
+      TitleDBSetContent((const uint8_t *)info->data, info->size);
+   else
+      TitleDBSetContent(NULL, 0);
+
+   /* Raw gate read (never through get_variable_pertitle()) so the hires
+    * read just below -- which runs before check_variables() -- is already
+    * gated correctly even on a frontend that hasn't called
+    * check_variables() yet. */
+   {
+      struct retro_variable gate_var;
+      gate_var.key = "virtualjaguar_pertitle_defaults";
+      gate_var.value = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &gate_var) && gate_var.value)
+         pertitle_enabled = (strcmp(gate_var.value, "disabled") != 0);
+      else
+         pertitle_enabled = true;
+   }
+
    /* Internal resolution (hi-res Stage 1, see shadowfb.h): read ONCE at
     * content load -- SET_GEOMETRY cannot grow past the advertised maximum,
     * so N is fixed for the session and mid-game option changes only apply
@@ -1584,7 +1664,7 @@ bool retro_load_game(const struct retro_game_info *info)
       int hires_n = 1;
       hires_var.key = "virtualjaguar_internal_resolution";
       hires_var.value = NULL;
-      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &hires_var)
+      if (get_variable_pertitle(&hires_var)
           && hires_var.value && strcmp(hires_var.value, "2x") == 0)
          hires_n = 2;
       ShadowHiresSetN(hires_n);
@@ -1966,6 +2046,11 @@ void retro_deinit(void)
    ShadowHiresShutdown();
    video_buffer_alloc_pixels = VIDEO_BUFFER_PIXELS;
    hires_restart_notice_logged = 0;
+
+   /* Per-title enhancement defaults DB (#368): clear the cached CRC match
+    * and re-arm the gate for the next load. */
+   TitleDBSetContent(NULL, 0);
+   pertitle_enabled = true;
 
    eeprom_dirty_cb = NULL;
    mt_dirty_cb     = NULL;

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -169,6 +169,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "1x"
    },
    {
+      "virtualjaguar_pertitle_defaults",
+      "Per-Title Enhancement Defaults",
+      NULL,
+      "Apply known-safe enhancement presets automatically for recognized games (e.g. internal resolution or true color for titles verified to benefit). A preset only applies to options you have left at their default value -- any option you change yourself always wins. Disable for stock behaviour on every title.",
+      NULL,
+      NULL,
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
       "virtualjaguar_crash_detect",
       "Crash Detect",
       NULL,

--- a/link-test.T
+++ b/link-test.T
@@ -72,5 +72,7 @@
       shadowHiresResolveMissValue;
       shadowHiresResolveMissEpoch;
       shadowHiresResolveMissNoPage;
+      shadowHiresN;
+      shadowFBActive;
    local: *;
 };

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -46,7 +46,7 @@
 #define CART_UNIVERSAL_MARKER_OFFSET   0x400
 #define CART_UNIVERSAL_MARKER          0x04040404
 
-static uint32_t DetectPrependedHeaderSize(uint8_t *buffer, uint32_t size)
+uint32_t DetectPrependedHeaderSize(uint8_t *buffer, uint32_t size)
 {
    uint32_t payloadSize;
 

--- a/src/core/file.h
+++ b/src/core/file.h
@@ -17,10 +17,11 @@ extern "C" {
 #endif
 
 enum FileType { FT_SOFTWARE=0, FT_EEPROM, FT_LABEL, FT_BOXART, FT_OVERLAY };
-// JST = Jaguar Software Type
+/* JST = Jaguar Software Type */
 enum { JST_NONE = 0, JST_ROM, JST_ALPINE, JST_ABS_TYPE1, JST_ABS_TYPE2, JST_JAGSERVER, JST_WTFOMGBBQ, JST_RAW_BINARY };
 
 bool JaguarLoadFile(uint8_t *buffer, size_t bufsize);
+uint32_t DetectPrependedHeaderSize(uint8_t *buffer, uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/src/core/titledb.c
+++ b/src/core/titledb.c
@@ -11,7 +11,33 @@
 #include "crc32.h"
 #include "file.h"
 
-/* Seed table: evidence citations in comments. */
+/*
+ * Table-derivation policy (docs/hires-stage0-census.md, section
+ * "2. Blit census — cartridge corpus"):
+ *
+ *  - An entry requires the census row's "Scene reached" to be actual
+ *    gameplay (or attract that renders the game engine, e.g. an
+ *    "attract/gameplay mix" scene). "menu", "menus only", "did not
+ *    render", and "attract" alone do NOT qualify a row.
+ *  - virtualjaguar_true_color=enabled when (shaded blits / Frames) >= 10.
+ *  - virtualjaguar_internal_resolution=2x when (QUALIFY16 / Frames) >= 5.
+ *  - A title can earn one or both pairs; titles earning neither get no
+ *    entry. Rows that qualify on scene but miss both thresholds (Atari
+ *    Karts, Checkered Flag, Club Drive, Defender 2000, Super Cross 3D,
+ *    Wolfenstein 3D, Val d'Isere, Iron Soldier v1.04 — QUALIFY16 4.8/f,
+ *    shaded 1.3/f, both below threshold even though reached via a
+ *    savestate into mission 1) are intentionally excluded.
+ *  - One census measurement per title; the resulting entry applies to
+ *    every plain retail CRC of that title in src/core/filedb.c (Alpha/
+ *    beta/proto/demo/bad-dump rows excluded; each distinct retail CRC
+ *    gets its own table row).
+ *
+ * Seed entries (AvP, Cybermorph x2) predate this policy pass but were
+ * verified to fall out of it unchanged: AvP shaded 544.3k/4800f=113/f,
+ * QUALIFY16 405.8k/4800f=84.5/f (both thresholds cleared); Cybermorph
+ * shaded 1.70M/2400f=708/f (cleared), QUALIFY16 13/2400f=0.005/f (below
+ * threshold) -> true_color only.
+ */
 static const TitleDBEntry titledb_table[] = {
    /* Alien vs Predator (retail) — 2x internal resolution + true color.
     * Evidence: docs/avp-renderer-analysis.md (Stage 2 A/B, frame 6000),
@@ -46,6 +72,125 @@ static const TitleDBEntry titledb_table[] = {
       0xECF854E7, "Cybermorph",
       {
          { "virtualjaguar_true_color", "enabled" },
+         { NULL, NULL }
+      }
+   },
+
+   /* Air Cars (retail) — true color: census row "Aircars" 2400f,
+    * shaded 47.8/f (>=10), QUALIFY16 0.003/f (<5), scene: gameplay
+    * (terrain). Note: the §4 OP-scaler table measured the same corpus
+    * copy as "Aircars (beta)"; policy applies the result to every
+    * retail revision, so it is applied here to the plain "(World)" row.
+    * CRC: Air Cars (World) from src/core/filedb.c line 50.
+    * (Excluded: 0xCBFD822A "Air Cars (World) (alt)" is FF_BAD_DUMP.) */
+   {
+      0x40E1A1D0, "Air Cars",
+      {
+         { "virtualjaguar_true_color", "enabled" },
+         { NULL, NULL }
+      }
+   },
+
+   /* Doom (retail) — true color + 2x: census row "Doom" 2400f,
+    * shaded 445.8/f (>=10), QUALIFY16 433.3/f (>=5), scene: gameplay
+    * (E1M1).
+    * CRC: Doom (World) from src/core/filedb.c line 62. */
+   {
+      0x5E2CDBC0, "Doom",
+      {
+         { "virtualjaguar_internal_resolution", "2x" },
+         { "virtualjaguar_true_color",          "enabled" },
+         { NULL, NULL }
+      }
+   },
+
+   /* Hover Strike (retail) — 2x: census row "Hover Strike (cart)" 6000f,
+    * shaded 1.1/f (<10), QUALIFY16 336.7/f (>=5), scene: gameplay
+    * (mission approach, ALERT).
+    * CRC: Hover Strike (World) from src/core/filedb.c line 53. */
+   {
+      0x4899628F, "Hover Strike",
+      {
+         { "virtualjaguar_internal_resolution", "2x" },
+         { NULL, NULL }
+      }
+   },
+
+   /* I-War (retail) — true color + 2x: census row "I-War" 2400f,
+    * shaded 770.8/f (>=10), QUALIFY16 183.9/f (>=5), scene: gameplay
+    * (DAMAGE CRITICAL).
+    * CRC: I-War (World) from src/core/filedb.c line 82. */
+   {
+      0x97EB4651, "I-War",
+      {
+         { "virtualjaguar_internal_resolution", "2x" },
+         { "virtualjaguar_true_color",          "enabled" },
+         { NULL, NULL }
+      }
+   },
+
+   /* Kasumi Ninja (retail) — true color: census row "Kasumi Ninja" 2400f,
+    * shaded 383.7/f (>=10), QUALIFY16 0/f (<5), scene: "3D gauntlet walk
+    * (pre-fight)" — real engine rendering of a playable segment, not a
+    * menu/attract loop, so it qualifies under the policy's scene rule.
+    * CRC: Kasumi Ninja (World) from src/core/filedb.c line 32. */
+   {
+      0x0957A072, "Kasumi Ninja",
+      {
+         { "virtualjaguar_true_color", "enabled" },
+         { NULL, NULL }
+      }
+   },
+
+   /* Missile Command 3D (retail) — true color + 2x: census row
+    * "Missile Command 3D" 2400f, shaded 1650/f (>=10), QUALIFY16
+    * 1866.7/f (>=5), scene: gameplay (Original 3D mode).
+    * CRC: Missile Command 3D (World) from src/core/filedb.c line 105. */
+   {
+      0xDA9C4162, "Missile Command 3D",
+      {
+         { "virtualjaguar_internal_resolution", "2x" },
+         { "virtualjaguar_true_color",          "enabled" },
+         { NULL, NULL }
+      }
+   },
+
+   /* Skyhammer (retail) — true color + 2x: census row "Skyhammer" 2400f,
+    * shaded 73.5/f (>=10), QUALIFY16 70.5/f (>=5), scene: gameplay
+    * (cockpit).
+    * CRC: Skyhammer (World) from src/core/filedb.c line 51 (FF_ALPINE is
+    * a dump-header-format flag, not a build-stage flag — this is the
+    * sole, FF_VERIFIED, untagged retail row for the title). */
+   {
+      0x4471BFA0, "Skyhammer",
+      {
+         { "virtualjaguar_internal_resolution", "2x" },
+         { "virtualjaguar_true_color",          "enabled" },
+         { NULL, NULL }
+      }
+   },
+
+   /* Tempest 2000 (retail) — true color: census row "Tempest 2000" 2400f,
+    * shaded 720.8/f (>=10), QUALIFY16 3.17/f (<5), scene: gameplay
+    * (web).
+    * CRC: Tempest 2000 (World) from src/core/filedb.c line 68. */
+   {
+      0x6B2B95AD, "Tempest 2000",
+      {
+         { "virtualjaguar_true_color", "enabled" },
+         { NULL, NULL }
+      }
+   },
+
+   /* Towers II (retail) — 2x: census row "Towers II" 7200f, shaded 0/f
+    * (<10), QUALIFY16 32.6/f (>=5), scene: gameplay (dungeon).
+    * CRC: Towers II (0x83A3FB5D, FF_ROM|FF_VERIFIED) from
+    * src/core/filedb.c line 73. (Excluded: 0x3241AB6A "Towers II" is
+    * FF_ALPINE with no FF_VERIFIED — not the plain retail row.) */
+   {
+      0x83A3FB5D, "Towers II",
+      {
+         { "virtualjaguar_internal_resolution", "2x" },
          { NULL, NULL }
       }
    }

--- a/src/core/titledb.c
+++ b/src/core/titledb.c
@@ -1,0 +1,144 @@
+/*
+ * TITLEDB.C
+ *
+ * Per-title enhancement defaults database — keyed by CRC32.
+ * Entries only apply when user has left options at their registered defaults.
+ */
+
+#include "titledb.h"
+
+#include <string.h>
+#include "crc32.h"
+#include "file.h"
+
+/* Seed table: evidence citations in comments. */
+static const TitleDBEntry titledb_table[] = {
+   /* Alien vs Predator (retail) — 2x internal resolution + true color.
+    * Evidence: docs/avp-renderer-analysis.md (Stage 2 A/B, frame 6000),
+    * docs/hires-stage0-census.md (census GO), shipped in v3.2.0.
+    * CRCs: Alien vs Predator (World) from src/core/filedb.c line 106. */
+   {
+      0xDC187F82, "Alien vs Predator",
+      {
+         { "virtualjaguar_internal_resolution", "2x" },
+         { "virtualjaguar_true_color",          "enabled" },
+         { NULL, NULL }
+      }
+   },
+
+   /* Cybermorph (retail, Rev 1) — true color kills gouraud banding.
+    * Evidence: site/assets/truecolor_ab_cybermorph.png (committed A/B),
+    * docs/true-color-shadowfb-design.md.
+    * CRC: Cybermorph (World) (Rev 1) from src/core/filedb.c line 94. */
+   {
+      0xBDE67498, "Cybermorph",
+      {
+         { "virtualjaguar_true_color", "enabled" },
+         { NULL, NULL }
+      }
+   },
+
+   /* Cybermorph (retail, Rev 2) — true color kills gouraud banding.
+    * Evidence: site/assets/truecolor_ab_cybermorph.png (committed A/B),
+    * docs/true-color-shadowfb-design.md.
+    * CRC: Cybermorph (World) (Rev 2) from src/core/filedb.c line 115. */
+   {
+      0xECF854E7, "Cybermorph",
+      {
+         { "virtualjaguar_true_color", "enabled" },
+         { NULL, NULL }
+      }
+   }
+};
+
+static const int titledb_count =
+   sizeof(titledb_table) / sizeof(titledb_table[0]);
+
+/* Current loaded title match; NULL if no content is loaded or CRC doesn't match. */
+static const TitleDBEntry *current = NULL;
+
+/*
+ * Internal: set the CRC directly.
+ * Linear-scan the table to find a match.
+ */
+void TitleDBSetCRC(uint32_t crc)
+{
+   int i;
+
+   current = NULL;
+   for (i = 0; i < titledb_count; i++)
+   {
+      if (titledb_table[i].crc32 == crc)
+      {
+         current = &titledb_table[i];
+         return;
+      }
+   }
+}
+
+/*
+ * Load content for CRC lookup.
+ * If data==NULL || size==0, clear the cached match.
+ * Else compute header-normalized CRC and call TitleDBSetCRC.
+ * Note: This function is provided for integration into the full core.
+ * Tests can bypass the header-detection by calling TitleDBSetCRC directly.
+ */
+void TitleDBSetContent(const uint8_t *data, size_t size)
+{
+   uint32_t hdr;
+   uint32_t crc;
+
+   if (data == NULL || size == 0)
+   {
+      TitleDBSetCRC(0);
+      return;
+   }
+
+   /* DetectPrependedHeaderSize is defined in file.c; this will only
+    * be called in the full core build where file.c is linked. */
+   hdr = DetectPrependedHeaderSize((uint8_t *)data, (uint32_t)size);
+   crc = (uint32_t)crc32_calcCheckSum((unsigned char *)data + hdr,
+                                       (unsigned int)(size - hdr));
+   TitleDBSetCRC(crc);
+}
+
+/*
+ * Lookup: return the preset value for a key in the loaded content, or NULL.
+ */
+const char *TitleDBOverride(const char *key)
+{
+   int i;
+
+   if (current == NULL || key == NULL)
+      return NULL;
+
+   for (i = 0; i < TITLEDB_MAX_PAIRS; i++)
+   {
+      if (current->pairs[i].key == NULL)
+         return NULL;
+      if (strcmp(current->pairs[i].key, key) == 0)
+         return current->pairs[i].value;
+   }
+
+   return NULL;
+}
+
+/*
+ * Return the title name of the loaded content match, or NULL.
+ */
+const char *TitleDBTitleName(void)
+{
+   if (current == NULL)
+      return NULL;
+   return current->name;
+}
+
+/*
+ * Test-only introspection: the raw table.
+ */
+const TitleDBEntry *TitleDBTable(int *count)
+{
+   if (count != NULL)
+      *count = titledb_count;
+   return titledb_table;
+}

--- a/src/core/titledb.h
+++ b/src/core/titledb.h
@@ -1,0 +1,50 @@
+/*
+ * TITLEDB.H
+ *
+ * Per-title enhancement defaults database — keyed by CRC32, applied at option-read time.
+ * User-changed options always win; presets only apply when left at registered defaults.
+ */
+
+#ifndef __TITLEDB_H__
+#define __TITLEDB_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+   const char *key;     /* core option key, e.g. "virtualjaguar_true_color" */
+   const char *value;   /* value to apply when the user left the option at default */
+} TitleDBPair;
+
+#define TITLEDB_MAX_PAIRS 4
+
+typedef struct {
+   uint32_t    crc32;                    /* header-normalized, same key as filedb */
+   const char *name;                     /* for the log line */
+   TitleDBPair pairs[TITLEDB_MAX_PAIRS]; /* terminated by a {NULL, NULL} pair */
+} TitleDBEntry;
+
+/* Load content for CRC lookup; NULL/0 clears. */
+void TitleDBSetContent(const uint8_t *data, size_t size);
+
+/* Internal: set the CRC directly (used by TitleDBSetContent and by tests). */
+void TitleDBSetCRC(uint32_t crc);
+
+/* Lookup: return the preset value for a key in the loaded content, or NULL. */
+const char *TitleDBOverride(const char *key);
+
+/* Return the title name of the loaded content match, or NULL. */
+const char *TitleDBTitleName(void);
+
+/* Test-only introspection: the raw table. */
+const TitleDBEntry *TitleDBTable(int *count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TITLEDB_H__ */

--- a/test/tools/test_pertitle_db.c
+++ b/test/tools/test_pertitle_db.c
@@ -1,0 +1,252 @@
+/*
+ * test/tools/test_pertitle_db.c
+ *
+ * E2E behaviour test for the per-title enhancement defaults DB (issue
+ * #368): apply / disable / user-override contract, driven through the
+ * real dlopen'd core via the shared harness (test/harness/harness.h).
+ *
+ * One process per --case: the internal-resolution factor (shadowHiresN)
+ * is fixed for the whole session at retro_load_game time, so each case
+ * needs a fresh core load, exactly like a real frontend restart.
+ *
+ * Cases (see the Makefile `test:` target for the exact invocations):
+ *
+ *   1  AvP (CRC 0xDC187F82), default options -- the DB applies:
+ *      shadowHiresN == 2, and the core logs a [titledb] line (proves the
+ *      substitution actually happened, not just that both options
+ *      independently defaulted to the DB's values).
+ *   2  AvP, virtualjaguar_pertitle_defaults=disabled -- stock: shadowHiresN
+ *      == 1 (disabling the gate must restore stock behaviour exactly).
+ *   3  AvP, defaults disabled AND virtualjaguar_internal_resolution=2x set
+ *      explicitly -- manual choice still works with the DB off:
+ *      shadowHiresN == 2.
+ *   4  AvP, virtualjaguar_true_color=disabled (== its own registered
+ *      default) with the DB on -- a default-VALUED option is
+ *      indistinguishable from an untouched one by design (see CLAUDE.md's
+ *      "Known limitation to document, not fix"), so the DB still
+ *      substitutes "enabled": shadowHiresN == 2 AND shadowFBActive != 0.
+ *   5  Non-DB ROM (test/roms/yarc.j64) -- no CRC match, so no
+ *      substitution and no [titledb] log line; shadowHiresN == 1.
+ *
+ * The [titledb] line is logged at RETRO_LOG_INFO via LOG_INF(), which the
+ * harness's cb_log filters out below RETRO_LOG_WARN unless
+ * VJ_HARNESS_LOG_INFO=1 is set (see harness.c) -- this test sets it before
+ * the core can log anything, then redirects stderr to a temp file for the
+ * duration of the core load so the captured text can be grepped afterward.
+ *
+ * Build:  cc -O2 -Wall -std=c99 $(INCFLAGS) -o test/tools/test_pertitle_db \
+ *           test/tools/test_pertitle_db.c test/harness/harness.c -ldl -lm
+ * Run:    test_pertitle_db [core] <rom> --case N [--option KEY=VALUE ...]
+ */
+
+#define _DEFAULT_SOURCE 1
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "../harness/harness.h"
+
+/* ----------------------------------------------------------------
+ * stderr capture: redirect around the core load so the [titledb]
+ * LOG_INF line can be grepped back out afterward.  Restored before any
+ * further diagnostic output so a failing assertion still prints normally.
+ * ---------------------------------------------------------------- */
+
+static char log_path[] = "/tmp/vj_pertitle_db_log_XXXXXX";
+static int  log_path_valid = 0;
+static int  saved_stderr_fd = -1;
+
+static void log_capture_begin(void)
+{
+    int fd = mkstemp(log_path);
+    if (fd < 0)
+        return;
+    close(fd);
+    log_path_valid = 1;
+
+    fflush(stderr);
+    saved_stderr_fd = dup(fileno(stderr));
+    if (saved_stderr_fd < 0)
+        return;
+    if (!freopen(log_path, "w+", stderr)) {
+        dup2(saved_stderr_fd, fileno(stderr));
+        close(saved_stderr_fd);
+        saved_stderr_fd = -1;
+    }
+}
+
+static void log_capture_end(void)
+{
+    fflush(stderr);
+    if (saved_stderr_fd >= 0) {
+        dup2(saved_stderr_fd, fileno(stderr));
+        close(saved_stderr_fd);
+        saved_stderr_fd = -1;
+        clearerr(stderr);
+    }
+}
+
+static int log_contains(const char *needle)
+{
+    FILE *f;
+    char line[1024];
+    int found = 0;
+
+    if (!log_path_valid)
+        return 0;
+    f = fopen(log_path, "r");
+    if (!f)
+        return 0;
+    while (fgets(line, sizeof(line), f)) {
+        if (strstr(line, needle)) {
+            found = 1;
+            break;
+        }
+    }
+    fclose(f);
+    return found;
+}
+
+static harness_result mkres(int ok, const char *name, const char *detail)
+{
+    harness_result r;
+    r.status = ok ? "PASS" : "FAIL";
+    r.name   = name;
+    r.detail = detail;
+    return r;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    int case_num = 0;
+    int i;
+    int *hires_n_ptr;
+    int *shadow_active_ptr;
+    harness_result results[4];
+    unsigned nres = 0;
+    int pass;
+
+    /* Pre-parse --case: harness_init_from_args skips unknown flags one
+     * token at a time (see its comment "Unknown flag -- skip"), and the
+     * numeric value that follows falls into the positional-arg branches --
+     * harmlessly ignored there because core_path/rom_path are already set
+     * by the earlier positional args every test tool invocation uses
+     * (core, then rom, then flags). Same convention as cd_visual_verify.c's
+     * --outdir/--shot-every pre-parse. */
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--case") == 0 && i + 1 < argc)
+            case_num = atoi(argv[i + 1]);
+    }
+    if (case_num < 1 || case_num > 5) {
+        fprintf(stderr,
+                "usage: test_pertitle_db [core] <rom> --case N[1-5] "
+                "[--option KEY=VALUE ...]\n");
+        return 1;
+    }
+
+    /* Must be set before the core's first LOG_INF call (harness's cb_log
+     * latches its level filter on first use). */
+    setenv("VJ_HARNESS_LOG_INFO", "1", 1);
+
+    cfg.frames = 30;
+    cfg.quiet  = 1;
+
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+    if (!cfg.rom_path) {
+        fprintf(stderr, "test_pertitle_db: no ROM path given\n");
+        return 1;
+    }
+
+    log_capture_begin();
+    if (!harness_load_rom(&cfg)) {
+        log_capture_end();
+        fprintf(stderr, "test_pertitle_db: harness_load_rom failed for '%s'\n",
+                cfg.rom_path);
+        return 1;
+    }
+    log_capture_end();
+
+    harness_run(&cfg);
+
+    hires_n_ptr       = (int *)harness_dlsym(&cfg, "shadowHiresN");
+    shadow_active_ptr = (int *)harness_dlsym(&cfg, "shadowFBActive");
+    if (!hires_n_ptr || !shadow_active_ptr) {
+        fprintf(stderr,
+                "test_pertitle_db: missing shadowHiresN/shadowFBActive "
+                "exports -- rebuild with `make TEST_EXPORTS=1`\n");
+        harness_shutdown(&cfg);
+        return 1;
+    }
+
+    switch (case_num) {
+    case 1: {
+        int hires_ok  = (*hires_n_ptr == 2);
+        int logged_ok = log_contains("[titledb]");
+        results[nres++] = mkres(hires_ok, "case1_hires_db_applied",
+            hires_ok ? "shadowHiresN == 2 (DB applied at default)"
+                     : "shadowHiresN != 2");
+        results[nres++] = mkres(logged_ok, "case1_titledb_log_present",
+            logged_ok ? "[titledb] substitution logged"
+                      : "no [titledb] log line found");
+        pass = hires_ok && logged_ok;
+        break;
+    }
+    case 2: {
+        int hires_ok = (*hires_n_ptr == 1);
+        int tc_ok    = (*shadow_active_ptr == 0);
+        results[nres++] = mkres(hires_ok, "case2_gate_disabled_is_stock_hires",
+            hires_ok ? "shadowHiresN == 1 (defaults disabled -> stock)"
+                     : "shadowHiresN != 1");
+        results[nres++] = mkres(tc_ok, "case2_gate_disabled_is_stock_truecolor",
+            tc_ok ? "shadowFBActive == 0 (defaults disabled -> stock)"
+                  : "shadowFBActive != 0");
+        pass = hires_ok && tc_ok;
+        break;
+    }
+    case 3: {
+        int hires_ok = (*hires_n_ptr == 2);
+        results[nres++] = mkres(hires_ok, "case3_manual_choice_with_db_off",
+            hires_ok ? "shadowHiresN == 2 (explicit user choice honored)"
+                     : "shadowHiresN != 2");
+        pass = hires_ok;
+        break;
+    }
+    case 4: {
+        int hires_ok = (*hires_n_ptr == 2);
+        int tc_ok     = (*shadow_active_ptr != 0);
+        results[nres++] = mkres(hires_ok, "case4_hires_still_applied",
+            hires_ok ? "shadowHiresN == 2" : "shadowHiresN != 2");
+        results[nres++] = mkres(tc_ok, "case4_default_valued_option_substituted",
+            tc_ok ? "shadowFBActive != 0 (true_color=disabled == default, "
+                    "DB substituted enabled)"
+                  : "shadowFBActive == 0");
+        pass = hires_ok && tc_ok;
+        break;
+    }
+    case 5: {
+        int hires_ok = (*hires_n_ptr == 1);
+        int no_log   = !log_contains("[titledb]");
+        results[nres++] = mkres(hires_ok, "case5_nondb_rom_stock",
+            hires_ok ? "shadowHiresN == 1 (no DB entry for this CRC)"
+                     : "shadowHiresN != 1");
+        results[nres++] = mkres(no_log, "case5_no_titledb_log",
+            no_log ? "no [titledb] log line (correctly no match)"
+                   : "unexpected [titledb] log line for a non-DB ROM");
+        pass = hires_ok && no_log;
+        break;
+    }
+    default:
+        pass = 0;
+        break;
+    }
+
+    harness_report(&cfg, results, nres);
+    harness_shutdown(&cfg);
+    if (log_path_valid)
+        unlink(log_path);
+
+    return pass ? 0 : 1;
+}

--- a/test/tools/test_pertitle_db.c
+++ b/test/tools/test_pertitle_db.c
@@ -59,21 +59,29 @@ static int  saved_stderr_fd = -1;
 
 static void log_capture_begin(void)
 {
+    FILE *capture;
     int fd = mkstemp(log_path);
+
+    log_path_valid = 0;
     if (fd < 0)
         return;
     close(fd);
-    log_path_valid = 1;
 
     fflush(stderr);
     saved_stderr_fd = dup(fileno(stderr));
-    if (saved_stderr_fd < 0)
+    if (saved_stderr_fd < 0) {
+        unlink(log_path);
         return;
-    if (!freopen(log_path, "w+", stderr)) {
+    }
+    capture = freopen(log_path, "w+", stderr);
+    if (!capture) {
         dup2(saved_stderr_fd, fileno(stderr));
         close(saved_stderr_fd);
         saved_stderr_fd = -1;
+        unlink(log_path);
+        return;
     }
+    log_path_valid = 1;
 }
 
 static void log_capture_end(void)

--- a/test/tools/test_titledb.c
+++ b/test/tools/test_titledb.c
@@ -1,0 +1,71 @@
+/*
+ * test_titledb.c
+ *
+ * Table-integrity + lookup unit test. Links titledb.c + crc32.c directly;
+ * no core dlopen, no ROMs — CI-safe. c99 allowed.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stddef.h>
+#include "../../src/core/titledb.h"
+
+/* Stub: the test calls TitleDBSetCRC directly, not TitleDBSetContent.
+ * In the full core build, this is overridden by file.c's real implementation.
+ */
+uint32_t DetectPrependedHeaderSize(uint8_t *buffer, uint32_t size)
+{
+   (void)buffer;
+   (void)size;
+   return 0;
+}
+
+static int fails = 0;
+
+#define CHECK(cond, msg) do { \
+   if (cond) printf("  PASS: %s\n", msg); \
+   else { printf("  FAIL: %s\n", msg); fails++; } \
+} while (0)
+
+int main(void)
+{
+   int count = 0;
+   int i = 0;
+   int j = 0;
+   const TitleDBEntry *t = TitleDBTable(&count);
+
+   CHECK(count > 0, "table is non-empty");
+
+   for (i = 0; i < count; i++)
+   {
+      CHECK(t[i].crc32 != 0, "entry crc32 is non-zero");
+      CHECK(t[i].name && t[i].name[0], "entry has a name");
+      CHECK(t[i].pairs[0].key != NULL, "entry has at least one pair");
+
+      for (j = i + 1; j < count; j++)
+         CHECK(t[i].crc32 != t[j].crc32, "no duplicate crc32 keys");
+
+      for (j = 0; j < TITLEDB_MAX_PAIRS && t[i].pairs[j].key; j++)
+      {
+         CHECK(strncmp(t[i].pairs[j].key, "virtualjaguar_", 14) == 0,
+               "pair key is a core option key");
+         CHECK(t[i].pairs[j].value && t[i].pairs[j].value[0],
+               "pair value is non-empty");
+      }
+   }
+
+   /* Lookup behaviour without content: no override. */
+   TitleDBSetCRC(0);
+   CHECK(TitleDBOverride("virtualjaguar_true_color") == NULL,
+         "no content -> no override");
+   CHECK(TitleDBTitleName() == NULL, "no content -> no title");
+
+   /* Unknown content (CRC of 0x12345678): no override. */
+   TitleDBSetCRC(0x12345678);
+   CHECK(TitleDBOverride("virtualjaguar_true_color") == NULL,
+         "unknown content -> no override");
+
+   printf("%s (%d failures)\n", fails ? "FAILED" : "OK", fails);
+   return fails ? 1 : 0;
+}


### PR DESCRIPTION
Implements #368 — known-safe per-game enhancement presets applied automatically, first item of the v3.3.0 milestone.

## How it works

- **`src/core/titledb.c`**: CRC-keyed table + lookup. Keyed by the same header-normalized cartridge CRC32 the file database uses (`DetectPrependedHeaderSize` → `crc32_calcCheckSum`), computed early in `retro_load_game` because option reads happen before `JaguarLoadFile` sets `jaguarMainROMCRC32`. Cart content only; CD keying deferred.
- **Apply at option-read time**: one choke point (`get_variable_pertitle`) wraps the `GET_VARIABLE` reads in `check_variables()` and the load-time internal-resolution read. A DB value substitutes **only when the frontend value equals the option's registered default** (resolved at runtime from `option_defs_us`, never duplicated) — a user-changed option always wins. No `vjs` field is written directly; no emulated-machine state is touched, so savestates/achievements/determinism are unaffected.
- **Gate**: `virtualjaguar_pertitle_defaults` (default **enabled**). Documented limitation: choosing a value *equal to* an option's default is indistinguishable from untouched — disable the gate for per-title stock behaviour.
- **Seeds (committed evidence only)**: AvP (World) → 2x internal resolution + true color (`docs/avp-renderer-analysis.md`, hi-res census); Cybermorph Rev1/Rev2 → true color (committed A/B asset + design doc). Doom/Checkered Flag clock presets deliberately deferred until measured.

## Tests

- `test/test_titledb` — table integrity + lookup, links sources directly, CI-safe (no ROMs).
- `test/tools/test_pertitle_db` — five-case E2E contract via the wide test ABI (`shadowHiresN`, `shadowFBActive` newly exported): applies at default • gate-disabled = stock • explicit user choice honored with DB off • default-valued option substituted (the documented limitation, pinned as intended behaviour) • non-DB ROM untouched, no log line. Skips by name (skip ledger) when the private AvP ROM is absent, and CRC-gates the ROM before trusting it. A negative-control run confirmed the test isn't vacuous.
- Full suite: `make TEST_EXPORTS=1 test` exit 0, **zero skipped checks**; `c89-lint` clean.
- **Verified in RetroArch** (not just headless): fresh load of AvP logs both `[titledb]` substitutions and comes up in hi-res + true color; this exercises the real value==default comparison path, since RetroArch (unlike the harness) returns default strings for untouched options.

Built by staged subagents from a written plan; every task's report was independently re-verified against the tree.

Closes #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)