### PR TITLE
fix(test): dup2 stderr onto the mkstemp fd in test_pertitle_db — no reopen-by-path TOCTOU

### DIFF
--- a/test/tools/test_pertitle_db.c
+++ b/test/tools/test_pertitle_db.c
@@ -59,28 +59,30 @@ static int  saved_stderr_fd = -1;
 
 static void log_capture_begin(void)
 {
-    FILE *capture;
+    /* Redirect stderr onto the mkstemp() fd directly -- no close() +
+     * reopen-by-path, so there is no TOCTOU window on log_path.  The
+     * path is kept only to read the log back and unlink it. */
     int fd = mkstemp(log_path);
 
     log_path_valid = 0;
     if (fd < 0)
         return;
-    close(fd);
 
     fflush(stderr);
     saved_stderr_fd = dup(fileno(stderr));
     if (saved_stderr_fd < 0) {
+        close(fd);
         unlink(log_path);
         return;
     }
-    capture = freopen(log_path, "w+", stderr);
-    if (!capture) {
-        dup2(saved_stderr_fd, fileno(stderr));
+    if (dup2(fd, fileno(stderr)) < 0) {
+        close(fd);
         close(saved_stderr_fd);
         saved_stderr_fd = -1;
         unlink(log_path);
         return;
     }
+    close(fd);
     log_path_valid = 1;
 }
 


### PR DESCRIPTION
## What

`test/tools/test_pertitle_db.c`'s `log_capture_begin()` created a temp file with `mkstemp()`, **closed the fd**, then reopened the same path with `freopen()`. Between the close and the reopen the path can be replaced — the exact TOCTOU pattern Copilot flagged on #379 and that was already fixed in `test/tools/test_wedge_spin.c` (4c1e882). This ports that fix.

stderr is now redirected onto the `mkstemp()` fd directly with `dup2()`; `log_path` is kept only to read the log back and `unlink()` it.

## Error paths

Mirrors `test_wedge_spin.c` exactly:

| failure | handling |
|---|---|
| `mkstemp()` < 0 | return (nothing to clean up) |
| `dup(fileno(stderr))` < 0 | `close(fd)` + `unlink(log_path)` |
| `dup2(fd, fileno(stderr))` < 0 | `close(fd)` + `close(saved_stderr_fd)` + reset + `unlink(log_path)` |

No stderr restore in the `dup2`-failure branch — `dup2` failing means stderr was never replaced, so there is nothing to restore (the old `freopen` path needed the restore because `freopen` can fail *after* detaching the stream).

`log_capture_end()` is unchanged; it already restored via `dup2(saved_stderr_fd, ...)`.

## Verification

`make -j TEST_EXPORTS=1 test` on macOS/arm64 — **exit 0, zero FAIL lines, `Skipped checks: none -- every optional check ran`** (private ROM tree linked in, so nothing name-skipped).

All five `--case` invocations from the Makefile pass with the AvP ROM present (CRC verified `0xDC187F82`, so the DB lookup actually ran rather than being CRC-skipped):

```
case 1  PASS case1_hires_db_applied / case1_titledb_log_present
case 2  PASS case2_gate_disabled_is_stock_hires / _truecolor
case 3  PASS case3_manual_choice_with_db_off
case 4  PASS case4_hires_still_applied / case4_default_valued_option_substituted
case 5  PASS case5_nondb_rom_stock / case5_no_titledb_log
```

**Case 1 is the discriminating one**: it asserts the `[titledb]` line *is* found in the captured log, so it fails if the capture is broken. Case 5 asserts the line is *absent* and would pass even with capture entirely dead.

`bash scripts/c89-lint.sh test/tools/test_pertitle_db.c` — passed.

## Scope

`grep -rn freopen test/ src/` finds no other instance — this was the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)