### PR TITLE
fix(cart): validate JST_ROM entry vector before trusting it as PC

### DIFF
--- a/src/core/file.c
+++ b/src/core/file.c
@@ -294,13 +294,20 @@ static bool JaguarLoadFileInternal(uint8_t *buffer, size_t bufsize)
        * cart base -- the other common convention, and where this demo's
        * real startup code (VMODE/VI register writes) actually lives.
        * Note: $DFFF00-$DFFFFF is the CDROM overlay, not cart ROM; the
-       * cart window ends at $DFFEFF. */
+       * cart window ends at $DFFEFF.
+       *
+       * An odd candidate is rejected for the same reason: the 68000 cannot
+       * fetch an instruction from an odd PC, and JaguarExecute() bails out
+       * immediately whenever (m68kPC & 1), so an in-range but misaligned
+       * vector (say $800001 out of a raw byte stream) would leave the CPU
+       * parked instead of running the game.  Those take the fallback too. */
       {
-        uint32_t candidate = GET32(jagMemSpace, 0x800404);
-        uint32_t masked = candidate & 0x00FFFFFF;
-        bool validVector = (masked < 0x200000)
-              || (masked >= 0x800000 && masked <= 0xDFFEFF)
-              || (masked >= 0xE00000 && masked <= 0xE1FFFF);
+         uint32_t candidate = GET32(jagMemSpace, 0x800404);
+         uint32_t masked = candidate & 0x00FFFFFF;
+         bool validVector = ((masked & 1) == 0)
+               && ((masked < 0x200000)
+                  || (masked >= 0x800000 && masked <= 0xDFFEFF)
+                  || (masked >= 0xE00000 && masked <= 0xE1FFFF));
 
          if (validVector)
             jaguarRunAddress = candidate;

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -269,8 +269,47 @@ static bool JaguarLoadFileInternal(uint8_t *buffer, size_t bufsize)
       jaguarCartInserted = true;
       memcpy(jagMemSpace + 0x800000, buffer, flatSize);
       JGDLoadROM(buffer, jaguarROMSize);
-      // Checking something...
-      jaguarRunAddress = GET32(jagMemSpace, 0x800404);
+
+      /* The common cart layout places a 68K vector table right after a
+       * $400-byte header: SSP at cart+$400, PC (the real entry point) at
+       * cart+$404.  Most JST_ROM images follow this, but some (raw demo
+       * builds, homebrew) do not and start executing at cart+0 instead --
+       * for those, cart+$404 lands mid-instruction-stream and decodes to
+       * whatever bytes happen to be there, not a vector.
+       *
+       * "Rayman Demo (1995) (UBI Soft).jag" is the measured case: bytes at
+       * cart+$400 are real 68K code (a MOVE.L immediate), and cart+$404
+       * happens to read as $3BE800F0, which masks to $E800F0 -- just past
+       * the mapped boot-ROM window ($E00000-$E1FFFF).  In HLE (no real
+       * BIOS to validate/redirect the cart), that garbage becomes the
+       * initial PC and the 68K never reaches the game's own code.  Real
+       * BIOS mode is unaffected: it runs its own boot code first and
+       * ignores jaguarRunAddress entirely (JaguarReset() only consults it
+       * for the non-BIOS path).
+       *
+       * A masked value outside every executable band (main RAM mirror,
+       * cart ROM, boot ROM) can never be a genuine vector, so treat it as
+       * evidence the header/vector-table convention isn't followed and
+       * fall back to the cart base -- the other common convention, and
+       * where this demo's real startup code (VMODE/VI register writes)
+       * actually lives. */
+      {
+         uint32_t candidate = GET32(jagMemSpace, 0x800404);
+         uint32_t masked = candidate & 0x00FFFFFF;
+         bool validVector = (masked < 0x200000)
+               || (masked >= 0x800000 && masked <= 0xDFFFFF)
+               || (masked >= 0xE00000 && masked <= 0xE1FFFF);
+
+         if (validVector)
+            jaguarRunAddress = candidate;
+         else
+         {
+            LOG_INF("[CART] cart+$404 ($%08X) is not a valid execute address; "
+                  "falling back to cart base $800000 as the entry point\n",
+                  candidate);
+            jaguarRunAddress = 0x800000;
+         }
+      }
       return true;
    }
    else if (fileType == JST_ALPINE)

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -287,18 +287,20 @@ static bool JaguarLoadFileInternal(uint8_t *buffer, size_t bufsize)
        * ignores jaguarRunAddress entirely (JaguarReset() only consults it
        * for the non-BIOS path).
        *
-       * A masked value outside every executable band (main RAM mirror,
-       * cart ROM, boot ROM) can never be a genuine vector, so treat it as
-       * evidence the header/vector-table convention isn't followed and
-       * fall back to the cart base -- the other common convention, and
-       * where this demo's real startup code (VMODE/VI register writes)
-       * actually lives. */
+       * A masked value outside every executable band (main RAM $000000-
+       * $1FFFFF, cart ROM $800000-$DFFEFF, boot ROM $E00000-$E1FFFF) can
+       * never be a genuine vector, so treat it as evidence the
+       * header/vector-table convention isn't followed and fall back to the
+       * cart base -- the other common convention, and where this demo's
+       * real startup code (VMODE/VI register writes) actually lives.
+       * Note: $DFFF00-$DFFFFF is the CDROM overlay, not cart ROM; the
+       * cart window ends at $DFFEFF. */
       {
-         uint32_t candidate = GET32(jagMemSpace, 0x800404);
-         uint32_t masked = candidate & 0x00FFFFFF;
-         bool validVector = (masked < 0x200000)
-               || (masked >= 0x800000 && masked <= 0xDFFFFF)
-               || (masked >= 0xE00000 && masked <= 0xE1FFFF);
+        uint32_t candidate = GET32(jagMemSpace, 0x800404);
+        uint32_t masked = candidate & 0x00FFFFFF;
+        bool validVector = (masked < 0x200000)
+              || (masked >= 0x800000 && masked <= 0xDFFEFF)
+              || (masked >= 0xE00000 && masked <= 0xE1FFFF);
 
          if (validVector)
             jaguarRunAddress = candidate;

--- a/test/test_hle_bios.c
+++ b/test/test_hle_bios.c
@@ -3095,6 +3095,82 @@ static void test_headerless_bin_rejected(void)
 }
 
 /* ================================================================
+ * Test 20: Cart Entry Vector Validation (cart+$404)
+ * A JST_ROM whose cart+$404 longword isn't a usable PC must fall back
+ * to the cart base $800000 instead of parking the 68K somewhere it can
+ * never execute.  Two rejection cases:
+ *   - out of range: $3BE800F0 masks to $E800F0, past the boot ROM
+ *     window (the measured Rayman Demo value)
+ *   - odd: $00802001 is inside the cart window but misaligned, and
+ *     JaguarExecute() returns immediately on (m68kPC & 1)
+ * A valid even in-range vector must still be taken verbatim.
+ * ================================================================ */
+static void load_entry_vector_rom(uint8_t *dummy_rom, const char *path,
+      uint32_t vector)
+{
+   struct retro_game_info game;
+
+   p_retro_unload_game();
+
+   dummy_rom[0x404] = (uint8_t)(vector >> 24);
+   dummy_rom[0x405] = (uint8_t)(vector >> 16);
+   dummy_rom[0x406] = (uint8_t)(vector >> 8);
+   dummy_rom[0x407] = (uint8_t)vector;
+
+   memset(&game, 0, sizeof(game));
+   game.path = path;
+   game.data = dummy_rom;
+   game.size = 131072;
+
+   if (!p_retro_load_game(&game))
+      FAIL("retro_load_game failed for entry vector $%08X", vector);
+}
+
+static void check_entry_vector(uint32_t vector, uint32_t expected)
+{
+   uint32_t *p_jaguarRunAddress;
+   uint32_t run_addr;
+
+   p_jaguarRunAddress = dlsym(core_handle, "jaguarRunAddress");
+   if (!p_jaguarRunAddress) {
+      FAIL("Missing jaguarRunAddress symbol");
+      return;
+   }
+
+   if (*p_jaguarRunAddress == expected)
+      PASS("cart+$404 = $%08X -> jaguarRunAddress $%08X",
+           vector, *p_jaguarRunAddress);
+   else
+      FAIL("cart+$404 = $%08X -> jaguarRunAddress $%08X (expected $%08X)",
+           vector, *p_jaguarRunAddress, expected);
+
+   run_addr = ram_get32(4);
+   if (run_addr == expected)
+      PASS("Reset PC vector RAM[4] = $%08X", run_addr);
+   else
+      FAIL("Reset PC vector RAM[4] = $%08X (expected $%08X)",
+           run_addr, expected);
+}
+
+static void test_entry_vector_validation(uint8_t *dummy_rom)
+{
+   printf("\n=== Test 20: Cart Entry Vector Validation ===\n");
+
+   /* Out of every executable band -> fall back to the cart base. */
+   load_entry_vector_rom(dummy_rom, "dummy_badvec.jag", 0x3BE800F0);
+   check_entry_vector(0x3BE800F0, 0x800000);
+
+   /* In the cart window but odd -> the 68K can't fetch there either. */
+   load_entry_vector_rom(dummy_rom, "dummy_oddvec.jag", 0x00802001);
+   check_entry_vector(0x00802001, 0x800000);
+
+   /* Restore the good vector: a valid even in-range one is still used
+    * verbatim, and the reloaded ROM is what main() unloads at exit. */
+   load_entry_vector_rom(dummy_rom, "dummy_goodvec.jag", 0x00802000);
+   check_entry_vector(0x00802000, 0x00802000);
+}
+
+/* ================================================================
  * Main
  * ================================================================ */
 int main(int argc, char *argv[])
@@ -3294,6 +3370,7 @@ int main(int argc, char *argv[])
 
    test_recognized_raw_homebrew_load();
    test_headerless_bin_rejected();
+   test_entry_vector_validation(dummy_rom);
 
    printf("\n=== Results: %d passed, %d failed ===\n", passes, fails);
 


### PR DESCRIPTION
First piece of the HLE-vs-BIOS boot-parity class found by the silent-audio sweep (4 titles work under Real BIOS but fail under HLE).

## The fix

`JaguarLoadFileInternal` unconditionally read the 68K entry vector from cart+$404. Rayman Demo doesn't follow the header+vector convention — cart+$400 onward is real 68K code, and cart+$404 decodes to $3BE800F0 → masked $E800F0, just past the boot-ROM window. In HLE that garbage became the initial PC. Now: a candidate vector outside every executable band (RAM mirror / cart / boot ROM) is rejected and the entry falls back to cart base $800000 (verified correct for this ROM — $802000 would land on unformatted $FFFF flash and fault instruction one). Real-BIOS mode never consults this path.

**Blast radius measured, not assumed:** corpus scan of 68 JST_ROM-sized images — only Rayman Demo (CRC-identical across all 3 copies, so not a bad dump) and one already-dead PD image fall outside the valid range; 10-title spot check all healthy; full suite exit 0 zero-skip including both mandatory audio tests; c89-lint clean.

**Honest status:** Rayman Demo now executes ~11 frames of its real code, then hits a second, unrelated deterministic fault (PC parks at $802BE6) — still broken for the user, but now debuggable past boot. The matrix row will shift `? (pc_escape)` → `GAME_CODE (black)` on next regen; that's reclassification, not a working game.

## The rest of the class (documented, deliberately not "fixed" here)

- **White Men Can't Jump** (silent in HLE): the DSP never starts in HLE — by design; `DSPReadLong/Word` auto-ack sound commands exactly when `!DSP_RUNNING && !useJaguarBIOS` so titles proceed silently instead of hanging. Naively setting DSPGO would break that gating; the real fix is a persistent HLE DSP audio engine, a previously-attempted-and-reverted design (`docs/emulation-bug-hunt-todos.md`).
- **Flip Out**: runs ~300 frames then exception-loops at $000404 — characterized, not isolated.
- **Ruiner Pinball**: DSP runs fine; the divergence is *video* (HLE 0% non-black vs BIOS 21.5% despite the game writing OLP $7B80). Also: `emulation-bug-hunt-todos.md`'s claim that Ruiner behaves identically in both modes is stale — freshly contradicted at b48f854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)