### PR TITLE
fix(blitter): hi-res Stage 2 sub-samples must not read past the source's last pixel/line (#396)

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -964,9 +964,21 @@ void blitter_generic(uint32_t cmd)
                            && (SRCSHADE || (!GOURD && !PATDSEL)))
                      {
                         int32_t hx = 0, hy = 0, vx = 0, vy = 0;
-                        int q_in = (xadd_a1_control == XADDINC
+                        /* The half-step sub-sample lies between this
+                         * pixel's stock sample and the NEXT one, so it is
+                         * inside the source region iff that next sample
+                         * exists.  On the last inner pixel / outer line
+                         * the walk ends here and the forward half-step
+                         * can read past the source's edge (issue #396:
+                         * Doom span blits end flush with the 64x64 flat,
+                         * and the overrun reads the next texture in the
+                         * lump -- isolated wrong-chroma speckles), so
+                         * those subpixels keep stock replication. */
+                        int q_in = (inner_loop != 0
+                              && xadd_a1_control == XADDINC
                               && (((a1_xadd | a1_yadd) & 0xFFFF) != 0));
-                        int q_out = (xadd_a1_control == XADD0
+                        int q_out = (outer_loop != 0
+                              && xadd_a1_control == XADD0
                               && a1_yadd == 0 && UPDA1F
                               && (((a1_step_x | a1_step_y) & 0xFFFF) != 0));
                         if (q_in)
@@ -3667,9 +3679,21 @@ A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
                                  && !patdsel && !gourd && !adddsel)
                            {
                               int32_t hx = 0, hy = 0, vx = 0, vy = 0;
-                              int q_in = (a1addx == 3
+                              /* The half-step sub-sample lies between
+                               * this pixel's stock sample and the NEXT
+                               * one, so it is inside the source region
+                               * iff that next sample exists.  On the
+                               * last inner pixel (inner0, set by the
+                               * icount decrement above) / last outer
+                               * line (ocount == 1 here; it decrements
+                               * only after the inner loop finishes) the
+                               * forward half-step can read past the
+                               * source's edge (issue #396 speckles), so
+                               * those subpixels keep stock replication. */
+                              int q_in = (!inner0 && a1addx == 3
                                     && ((a1_incf_x | a1_incf_y) != 0));
-                              int q_out = (a1addx == 2 && !a1addy && upda1f
+                              int q_out = (ocount != 1
+                                    && a1addx == 2 && !a1addy && upda1f
                                     && ((a1_stepf_x | a1_stepf_y) != 0));
                               if (q_in)
                               {


### PR DESCRIPTION
## Summary
Fixes #396 — isolated bright pixel dots along texture edges in Doom (and other blitter-rendered titles) at `virtualjaguar_internal_resolution=2x`.

## Root cause
Stage 2 supersampling samples each extra subpixel at the stock source position **plus half the walk increment** — i.e. toward the *next* stock sample. Mid-span that midpoint is inside the source region by per-axis convexity (it lies between two in-bounds stock samples), but on the **last inner-loop pixel** (fractional XADDINC walk) and the **last outer line** (XADD0 + fractional FSTEP column scaler) the next sample does not exist, and the forward half-step reads past the source's edge.

Doom's floor/ceiling span blits end flush with the 64×64 flat texture, so the overrun read the first row of the *next* flat in the lump and stored a saturated wrong-chroma texel — traced instance: dst `$1D1FB2`-adjacent word, stock `$CA1B` (dark brown), walk at y=62.614 with yadd=+3.442 → half-step sub-sample at y=64.34 on a 64-high flat → `$1DC0` (bright cyan). Doom's PWIDTH=8 presentation doubles each sub-column, which is why the dots render as 2×2 blocks.

## Fix
Gate the qualifying-shape tests on the next sample existing:
- fast engine: `inner_loop != 0` (q_in) / `outer_loop != 0` (q_out) — both post-decremented, 0 == last iteration
- accurate engine: `!inner0` (set by the icount decrement before the store) / `ocount != 1` (ocount decrements only after the inner loop finishes)

The affected edge subpixels fall back to Stage 1 box replication of the stock pixel. No stock-pipeline behavior changes; the guards live entirely inside the `shadowHiresN == 2` shadow-store block.

## Verification
- Headless A/B on Doom (NTSC) attract demo, matched true-color 1x reference (`virtualjaguar_pertitle_defaults=disabled`): frame 1200 (in-game Area 3, the scene from the issue screenshot) isolated-speckle count **12 → 0** (3×3-neighborhood brightness detector, threshold 60); frames 900/1500/1800/2400 unchanged.
- Supersampled block coverage 12.05% → 11.83% — the feature is intact, only span-edge subpixels lost their (invalid) samples.
- `make TEST_EXPORTS=1 test` passes end-to-end (the one failure seen locally was the pre-existing missing `test/test_audio_boundary` prerequisite in the `test:` target, unrelated — flagged separately).
- `scripts/c89-lint.sh src/tom/blitter.c` clean.

Worth an on-device (iOS RetroArch) re-check of Doom Area 3 to confirm against the original report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)