### PR TITLE
fix(build): add test_audio_boundary and test_audio_rate to make-test prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -878,7 +878,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
-		test/test_audio_pipeline test/test_audio_clipping test/test_audio_presence test/test_pit_clock_rate \
+		test/test_audio_pipeline test/test_audio_clipping test/test_audio_presence test/test_audio_boundary test/test_audio_rate test/test_pit_clock_rate \
 		test/test_blitter_mmio test/test_blitter_cmd test/test_eeprom_lifecycle test/test_eeprom_read_race test/test_tom_visible_window \
 		test/test_framebuffer_integrity test/test_state_compat \
 		test/test_frontend_pacing test/test_jgd \


### PR DESCRIPTION
## Problem

`make TEST_EXPORTS=1 test` fails with **exit 127** on a fresh worktree (when the private ROM corpus is present): the `test:` recipe invokes `./test/test_audio_boundary` and `./test/test_audio_rate` (both gated on the Atari Karts ROM), but neither binary is in the `test:` prerequisite list — they appear only in `clean` and their per-binary build rules, so nothing ever builds them before the recipe runs.

## Fix

One line: add both binaries to the prerequisite list (the same continuation line that already carries `test_audio_clipping` / `test_audio_presence`).

## Audit

Compared every binary invoked in the `test:` recipe against the prerequisite list:

- `test_audio_boundary`, `test_audio_rate` — **missing** (fixed here)
- `netlink_pair_test.sh` / `netlink_latency_test.sh` binaries (`netlink_pair`, `netlink_latency`, `netlink_delay_proxy`) — already prerequisites
- `gen_eeprom_test_rom` — compiled inline by the recipe itself
- everything else invoked is already in the list

## Verification

Full `make -j TEST_EXPORTS=1 test` from a **fresh worktree** off develop with the private ROM corpus linked: exit 0, both Atari Karts checks (`boundary`, `rate`) executed against the real ROM (not skipped), and the skip ledger reports `Skipped checks: none — every optional check ran`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)