### PR TITLE
test(input): prove one press reads as one press — isolate the tap-repeat bug

### DIFF
--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -133,6 +133,7 @@
 [PASS tests/timing/halfline_period_us.jag
 [PASS tests/timing/hc_advance.jag
 [PASS tests/timing/hc_within_scanline_range.jag
+[PASS tests/timing/input_edge_per_field.jag
 [PASS tests/timing/jerry_pit_setup.jag
 [PASS tests/timing/pit_countdown_rate.jag
 [PASS tests/timing/vblank_60hz_exact.jag

--- a/test/acid/tests/timing/input_edge_per_field.s
+++ b/test/acid/tests/timing/input_edge_per_field.s
@@ -1,0 +1,177 @@
+;
+; tests/timing/input_edge_per_field.s - one physical press must read as
+; one press edge, and as exactly as many held fields as it was held.
+;
+; WHY THIS ROM EXISTS
+; -------------------
+; Reported symptom: a short D-pad tap registers as more than one press
+; -- Doom's menu cursor jumps two or three entries, Hover Strike's ship
+; accelerates faster than the tap should allow -- unless the tap is
+; extremely quick.
+;
+; Exactly two mechanisms produce that, and they need different fixes, so
+; the first job is to tell them apart:
+;
+;   (a) INPUT over-sampling.  The pad is latched more than once per
+;       field, or one continuous press reads as several press edges.
+;       That is a core input bug and breaks every title that
+;       edge-detects.
+;
+;   (b) LOOP rate.  Input is clean, but the title's tick loop iterates
+;       more often per second than on hardware, so its own auto-repeat
+;       threshold is crossed sooner in wall-clock terms.  Jaguar Doom's
+;       menu is this shape: M_Ticker (m_main.c) repeats on
+;       `movecount == 6`, and M_Drawer -- unlike the gameplay path --
+;       never calls I_Update(), so the menu loop carries NO 3-tick gate
+;       and runs at whatever rate the renderer allows.
+;
+; This ROM isolates (a).  The pad is sampled in the VI handler, exactly
+; once per field -- the same place and cadence Jaguar Doom samples it
+; (init.s `Frame:`, which reads $81FE then bumps _ticcount) -- and the
+; handler maintains:
+;
+;   EDGES  press transitions (not-held -> held)
+;   HELD   fields the button was observed held
+;
+; The host drives it: hold one button for a known number of fields, then
+; read the published counters.  For a single continuous N-field press a
+; correct machine must report EDGES == 1 and HELD == N.  EDGES > 1 means
+; the core manufactures press events (mechanism a).  EDGES == 1 while
+; games still misbehave means input is clean and the fault is (b), a
+; timing-accuracy problem that cannot be fixed in the input path.
+;
+; Detail codes:
+;   1 = EDGES exceeds HELD -- impossible on hardware; more press
+;       transitions than fields held.  observed = EDGES, expected = HELD.
+;   2 = HELD nonzero but EDGES zero -- edge detection never fired.
+;
+                include "include/jaguar_header.s"
+                include "include/acid_test.s"
+                include "include/jaguar_regs.s"
+
+;; Published results (below ACID_BASE, clear of the vector table).
+RES_EDGES       equ     $00000800
+RES_HELD        equ     $00000804
+RES_FIELDS      equ     $00000808
+RES_READY       equ     $0000080C               ; $5A5A5A5A when finished
+;; ISR working state.
+CUR_FIELDS      equ     $00000810
+CUR_EDGES       equ     $00000814
+CUR_HELD        equ     $00000818
+PREV_HELD       equ     $0000081C
+
+;; irq_ack_handler() returns vector 64 ($100) for ALL hardware IRQs.
+HW_IRQ_VECTOR   equ     $00000100
+
+JOYSTICK        equ     $F14000
+
+;; ~5 s at NTSC: long enough for the host to press well inside it.
+WINDOW_FIELDS   equ     300
+
+                org     $802000
+entry:
+                ACID_INIT
+
+                moveq   #0,d0
+                move.l  d0,RES_EDGES.l
+                move.l  d0,RES_HELD.l
+                move.l  d0,RES_FIELDS.l
+                move.l  d0,RES_READY.l
+                move.l  d0,CUR_FIELDS.l
+                move.l  d0,CUR_EDGES.l
+                move.l  d0,CUR_HELD.l
+                move.l  d0,PREV_HELD.l
+
+                ;; Install the VI handler at vector 64.
+                lea     irq_handler(pc),a0
+                move.l  a0,HW_IRQ_VECTOR.l
+
+                ;; Clear pending TOM IRQs (high byte = clear bits).
+                move.w  #$1F00,TOM_INT1
+
+                ;; Fire VI once per field, near the top of the frame.
+                move.w  #2,TOM_VI
+
+                ;; Enable IRQ_VIDEO (low byte = enable mask).
+                move.w  #IRQ_VIDEO_MASK,TOM_INT1
+
+                ;; Allow IPL=2 in 68K SR (supervisor, mask=0).
+                move.w  #$2000,sr
+
+                ;; Spin until the ISR has counted the whole window.
+.wait:          move.l  CUR_FIELDS.l,d0
+                cmp.l   #WINDOW_FIELDS,d0
+                blt.s   .wait
+
+                ;; Mask interrupts so the reads are stable.
+                move.w  #$2700,sr
+
+                move.l  CUR_EDGES.l,d4
+                move.l  CUR_HELD.l,d5
+                move.l  CUR_FIELDS.l,d3
+
+                move.l  d4,RES_EDGES.l
+                move.l  d5,RES_HELD.l
+                move.l  d3,RES_FIELDS.l
+                move.l  #$5A5A5A5A,RES_READY.l
+
+                ;; Self-checks that need no host knowledge.
+                tst.l   d5
+                beq.s   .pass                   ; never pressed: nothing to judge
+                tst.l   d4
+                beq     .no_edge
+                cmp.l   d5,d4
+                bgt     .too_many_edges
+.pass:
+                ACID_PASS
+
+.too_many_edges:
+                ACID_FAIL #1,d4,d5
+
+.no_edge:
+                ACID_FAIL #2,d4,d5
+
+;; ---------------------------------------------------------------
+;; VI handler: sample the pad once per field, exactly where Jaguar
+;; Doom samples it.
+;; ---------------------------------------------------------------
+irq_handler:
+                movem.l d0-d2,-(sp)
+
+                addq.l  #1,CUR_FIELDS.l
+
+                ;; Byte-for-byte the read Jaguar Doom's Frame: handler
+                ;; performs (init.s): select column $81FE, long-read the
+                ;; port, mask the unused bits, rotate the nibble into
+                ;; place.  After the ror the layout is
+                ;;   d0 = xxAPxxxx RLDUxxxx xxxxxxxx xxxxxxxx
+                ;; so the D-pad sits in bits 23-20.
+                move.w  #$81FE,JOYSTICK
+                move.l  JOYSTICK,d0
+                or.l    #$F0FFFFFC,d0
+                ror.l   #4,d0
+
+                ;; Inputs are active LOW; invert so held reads as 1.
+                not.l   d0
+                and.l   #$00F00000,d0           ; RLDU field
+
+                tst.l   d0
+                beq.s   .released
+
+                addq.l  #1,CUR_HELD.l
+                move.l  PREV_HELD.l,d1
+                tst.l   d1
+                bne.s   .done
+                addq.l  #1,CUR_EDGES.l          ; rising edge
+                moveq   #1,d2
+                move.l  d2,PREV_HELD.l
+                bra.s   .done
+.released:
+                moveq   #0,d2
+                move.l  d2,PREV_HELD.l
+.done:
+                ;; Re-clear video pending bit so the next field can fire.
+                move.w  #$0100,TOM_INT1         ; clear IRQ_VIDEO pending
+                move.w  #IRQ_VIDEO_MASK,TOM_INT1 ; re-enable
+                movem.l (sp)+,d0-d2
+                rte

--- a/test/tools/input_edge_test.c
+++ b/test/tools/input_edge_test.c
@@ -1,0 +1,178 @@
+/* test/tools/input_edge_test.c -- does one physical press read as one
+ * press?
+ *
+ * Drives test/acid/tests/timing/input_edge_per_field.jag, which samples
+ * the pad exactly once per video field (the fastest cadence any correct
+ * title can observe, since the pad is read from the VI handler) and
+ * publishes, in main RAM:
+ *
+ *   $800 EDGES   press transitions (not-held -> held)
+ *   $804 HELD    fields the button was seen held
+ *   $808 FIELDS  fields elapsed
+ *   $80C READY   $5A5A5A5A once the window closes
+ *
+ * The reported symptom is that a short D-pad tap registers as more than
+ * one press -- Doom's menu jumps two or three entries, Hover Strike's
+ * ship accelerates too fast -- unless the tap is very quick.  Two
+ * different mechanisms produce that and they need different fixes:
+ *
+ *   (a) input over-sampling: the core manufactures press events, so a
+ *       single continuous press reads as several edges.  Every title
+ *       that edge-detects would break.
+ *   (b) loop rate: input is clean, but the game's tick loop runs more
+ *       often per second than on hardware, so the title's own
+ *       auto-repeat threshold is crossed sooner in wall-clock terms.
+ *       Doom's menu is this shape -- M_Ticker repeats on movecount==6,
+ *       and M_Drawer never calls I_Update(), so the menu loop carries
+ *       no 3-tick gate at all.
+ *
+ * This tool decides between them.  For each press length N it holds one
+ * D-pad button for exactly N frames and checks EDGES == 1 and HELD == N.
+ * Any N reporting EDGES > 1 is mechanism (a) and names the core as the
+ * culprit.  All lengths reporting EDGES == 1 means input is clean and
+ * the fault is (b) -- a timing-accuracy problem that cannot be fixed in
+ * the input path.
+ *
+ * Build:
+ *   cc -O2 -Wall -std=c99 -I. -I./libretro-common/include \
+ *      -o test/tools/input_edge_test test/tools/input_edge_test.c \
+ *      test/harness/harness.c -ldl -lm
+ * Run:
+ *   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) ./test/tools/input_edge_test \
+ *      ./virtualjaguar_libretro.dylib \
+ *      test/acid/tests/timing/input_edge_per_field.jag [--hold N]...
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <libretro.h>
+
+#include "../harness/harness.h"
+
+#define RES_EDGES   0x800
+#define RES_HELD    0x804
+#define RES_FIELDS  0x808
+#define RES_READY   0x80C
+#define READY_MAGIC 0x5A5A5A5AU
+
+/* Press starts here, well after the ROM has entered its sample loop. */
+#define PRESS_START 120
+
+static uint8_t *ram;
+
+static uint32_t rd32(uint32_t addr)
+{
+    const uint8_t *p = ram + addr;
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8)  | (uint32_t)p[3];
+}
+
+int main(int argc, char **argv)
+{
+    static const unsigned default_holds[] = { 1, 2, 3, 4, 6, 8, 12, 20 };
+    unsigned holds[32];
+    unsigned nholds = 0;
+    int failures = 0;      /* real input faults: a press read as many edges */
+    int inconclusive = 0;  /* ROM never published -- proves nothing */
+    unsigned h, i;
+
+    for (i = 1; i + 1 < (unsigned)argc; i++)
+        if (!strcmp(argv[i], "--hold") && nholds < 32)
+            holds[nholds++] = (unsigned)atoi(argv[i + 1]);
+    if (!nholds) {
+        for (i = 0; i < sizeof(default_holds) / sizeof(default_holds[0]); i++)
+            holds[nholds++] = default_holds[i];
+    }
+
+    printf("hold(frames)  edges  held  verdict\n");
+    printf("------------  -----  ----  -------\n");
+
+    for (h = 0; h < nholds; h++) {
+        harness_config cfg = HARNESS_CONFIG_DEFAULT;
+        uint32_t edges, held, ready;
+        unsigned n = holds[h];
+        const char *verdict;
+
+        /* Must outlast the ROM's own WINDOW_FIELDS (600) or it never
+         * publishes and the run proves nothing. */
+        cfg.frames = PRESS_START + n + 620;
+        cfg.quiet = 1;
+        if (!harness_init_from_args(&cfg, argc, argv)) return 1;
+        /* Synthetic ROMs need the HLE BIOS: the real BIOS authenticates
+         * the cart and a hand-built test ROM cannot satisfy that, so it
+         * would never reach our code.  Same reason test/acid/run.c
+         * forces this. */
+        harness_set_option(&cfg, "virtualjaguar_bios", "disabled");
+        if (!harness_load_rom(&cfg)) { harness_shutdown(&cfg); return 1; }
+
+        /* jaguarMainRAM is `uint8_t *jaguarMainRAM` -- a POINTER variable
+         * into jagMemSpace, not the array itself.  dlsym returns the
+         * address of the pointer, so it must be dereferenced; reading it
+         * directly yields the pointer's own bytes, not emulated RAM. */
+        {
+            uint8_t **ramp = (uint8_t **)harness_dlsym(&cfg, "jaguarMainRAM");
+            ram = ramp ? *ramp : NULL;
+        }
+        if (!ram) {
+            fprintf(stderr, "no jaguarMainRAM export (need TEST_EXPORTS=1)\n");
+            harness_shutdown(&cfg);
+            return 1;
+        }
+
+        /* One continuous press of exactly n frames. */
+        harness_press(&cfg, 0, RETRO_DEVICE_ID_JOYPAD_UP, PRESS_START, n);
+        harness_run(&cfg);
+
+        ready = rd32(RES_READY);
+        edges = rd32(RES_EDGES);
+        held  = rd32(RES_HELD);
+
+        if (ready != READY_MAGIC) {
+            /* Counters are uninitialised RAM here -- report nothing. */
+            verdict = "INCONCLUSIVE: ROM did not publish";
+            inconclusive++;
+            edges = held = 0;
+        } else if (held == 0) {
+            /* Not an input-multiplication result: the ROM ran but never
+             * observed the button at all.  Says nothing about edges. */
+            verdict = "INCONCLUSIVE: ROM never saw the button";
+            inconclusive++;
+        } else if (edges == 0) {
+            verdict = "FAIL: press never seen";
+            failures++;
+        } else if (edges > 1) {
+            verdict = "FAIL: one press read as many";
+            failures++;
+        } else {
+            verdict = "ok (1 press = 1 edge)";
+        }
+
+        printf("%12u  %5u  %4u  %s\n", n, edges, held, verdict);
+        harness_shutdown(&cfg);
+    }
+
+    printf("\n");
+    if (inconclusive) {
+        printf("VERDICT: none -- %d of %u runs never published their counters,\n"
+               "  so this tells us nothing about input either way.  Raise the\n"
+               "  frame count or lower WINDOW_FIELDS in the ROM and re-run.\n",
+               inconclusive, nholds);
+        return 2;
+    }
+    if (failures) {
+        printf("VERDICT: core manufactures press events -- an input bug.\n"
+               "  A single continuous press produced more than one edge.\n"
+               "  Titles that edge-detect (Doom menu, Hover Strike) will\n"
+               "  see phantom repeats regardless of their own repeat logic.\n");
+        return 1;
+    }
+    printf("VERDICT: input is clean -- every press read as exactly one edge.\n"
+           "  So multi-step menu movement is NOT the input path; it is the\n"
+           "  game's own auto-repeat being reached sooner in wall-clock time\n"
+           "  because the title's tick loop runs faster than on hardware\n"
+           "  (Doom's menu has no I_Update() gate at all).  Fixing it means\n"
+           "  render-completion timing, not input handling.\n");
+    return 0;
+}

--- a/test/tools/input_edge_test.c
+++ b/test/tools/input_edge_test.c
@@ -95,9 +95,10 @@ int main(int argc, char **argv)
         unsigned n = holds[h];
         const char *verdict;
 
-        /* Must outlast the ROM's own WINDOW_FIELDS (600) or it never
-         * publishes and the run proves nothing. */
-        cfg.frames = PRESS_START + n + 620;
+        /* Must outlast the ROM's own WINDOW_FIELDS (300, see
+         * input_edge_per_field.s) or it never publishes and the run
+         * proves nothing. */
+        cfg.frames = PRESS_START + n + 320;
         cfg.quiet = 1;
         if (!harness_init_from_args(&cfg, argc, argv)) return 1;
         /* Synthetic ROMs need the HLE BIOS: the real BIOS authenticates
@@ -134,19 +135,25 @@ int main(int argc, char **argv)
             verdict = "INCONCLUSIVE: ROM did not publish";
             inconclusive++;
             edges = held = 0;
-        } else if (held == 0) {
-            /* Not an input-multiplication result: the ROM ran but never
-             * observed the button at all.  Says nothing about edges. */
-            verdict = "INCONCLUSIVE: ROM never saw the button";
+        } else if (held == 0 || edges == 0) {
+            /* The ROM ran but never observed the press.  That is a rig
+             * or press-timing problem, not evidence about
+             * over-sampling -- it must never feed the "manufactures
+             * press events" verdict. */
+            verdict = "INCONCLUSIVE: ROM never saw the press";
             inconclusive++;
-        } else if (edges == 0) {
-            verdict = "FAIL: press never seen";
-            failures++;
         } else if (edges > 1) {
             verdict = "FAIL: one press read as many";
             failures++;
+        } else if (held != n) {
+            /* One edge but the wrong duration: the core dropped or
+             * stretched input frames.  A real input-path defect (a
+             * held button must be visible for exactly the fields it
+             * was held), distinct from edge multiplication. */
+            verdict = "FAIL: held-duration mismatch";
+            failures++;
         } else {
-            verdict = "ok (1 press = 1 edge)";
+            verdict = "ok (1 press = 1 edge, held == N)";
         }
 
         printf("%12u  %5u  %4u  %s\n", n, edges, held, verdict);
@@ -162,10 +169,11 @@ int main(int argc, char **argv)
         return 2;
     }
     if (failures) {
-        printf("VERDICT: core manufactures press events -- an input bug.\n"
-               "  A single continuous press produced more than one edge.\n"
-               "  Titles that edge-detect (Doom menu, Hover Strike) will\n"
-               "  see phantom repeats regardless of their own repeat logic.\n");
+        printf("VERDICT: input-path defect -- a press was multiplied or its\n"
+               "  held duration was distorted (see FAIL rows above).  Titles\n"
+               "  that edge-detect or time held input (Doom menu, Hover\n"
+               "  Strike) will misbehave regardless of their own repeat\n"
+               "  logic.\n");
         return 1;
     }
     printf("VERDICT: input is clean -- every press read as exactly one edge.\n"


### PR DESCRIPTION
Isolates the reported bug: **a short D-pad tap registers as more than one press** — Doom's menu jumps two or three entries, Hover Strike's ship accelerates faster than the tap allows — unless the tap is extremely quick.

## Why a test first

Two mechanisms produce that symptom and they need **opposite** fixes:

- **(a) input over-sampling** — the core manufactures press events, so one continuous press reads as several edges. Fix would be in the input path.
- **(b) loop rate** — input is clean, but the title's tick loop iterates more often per second than on hardware, so the game's own auto-repeat threshold is crossed sooner in wall-clock terms. Fix is render-completion timing; touching input would be wrong.

Guessing between them is how this class stays open. This decides it.

## How

`test/acid/tests/timing/input_edge_per_field.s` samples the pad **in the VI handler** using byte-for-byte the read Jaguar Doom performs ([`init.s`](https://github.com/JNechaevsky/jaguar-doom/blob/master/init.s) `Frame:` — column `$81FE`, long read, `$F0FFFFFC` mask, `ror #4`), counts press edges and held fields, and publishes both to RAM. `test/tools/input_edge_test` holds one button for a known number of frames and asserts `edges == 1` and `held == N`.

## Result on develop — input is clean

| hold (frames) | edges | held |
|---|---|---|
| 1 | 1 | 1 |
| 2 | 1 | 2 |
| 3 | 1 | 3 |
| 4 | 1 | 4 |
| 6 | 1 | 6 |
| 8 | 1 | 8 |
| 12 | 1 | 12 |
| 20 | 1 | 20 |

**(a) is ruled out** — the input path does not multiply presses at any tap length.

That leaves (b), and Doom's menu is exactly that shape: `M_Ticker` ([`m_main.c`](https://github.com/JNechaevsky/jaguar-doom/blob/master/m_main.c)) repeats on `movecount == 6`, while `M_Drawer` — unlike the gameplay path — **never calls `I_Update()`**, so the menu loop has no 3-tick gate and free-runs at whatever rate the renderer allows. Together with #403's gate ROM (gameplay gate correct at exactly 20/s), the fault is localised to render-completion pacing on ungated loops.

## Rig traps this surfaced

Both produced plausible-looking wrong answers before being guarded:

- `jaguarMainRAM` is a **pointer variable**, not the array — `dlsym` returns the pointer's address and it must be dereferenced; reading it directly yields the pointer's own bytes.
- Synthetic ROMs need `virtualjaguar_bios=disabled` — the real BIOS authenticates the cart, so a hand-built ROM never reaches its code.

The tool reports **INCONCLUSIVE** (exit 2) rather than a verdict whenever the ROM fails to publish or never observes the button, so a broken rig cannot masquerade as a finding.

Related: #399, #401, #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)