### PR TITLE
feat(timing): charge the 68K real blitter bus time (experimental, default off)

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -623,6 +623,19 @@ static void check_variables(void)
    else
       CDTraceSetEnabled(0);
 
+   /* Blitter bus time: a blit kicked by the 68K charges the 68K the
+    * blit's whole bus duration through the pending-stall channel (the
+    * blitter is the top-priority bus master and the cacheless 68K is
+    * frozen while it runs).  Fixes render-bound loops pacing faster
+    * than hardware — Doom's menu auto-repeat landing inside a normal
+    * button tap (#399/#401).  See BlitDurationSysclks() in
+    * src/tom/blitter_mmio.c for the model and its deliberate floor. */
+   var.key = "virtualjaguar_blitter_timing";
+   var.value = NULL;
+   vjs.blitterTiming = false;
+   if (get_variable_pertitle(&var) && var.value)
+      vjs.blitterTiming = (strcmp(var.value, "enabled") == 0);
+
    /* DRAM timing: enabled/disabled only, covering BOTH halves of the
     * symmetric self-cost model (GPU stalls in gpu.c, 68K wait-states
     * in jaguar.c).  The calibration scale is deliberately NOT a core
@@ -636,13 +649,18 @@ static void check_variables(void)
       busArbiter.enabled = 0;
    /* No charging happens while disabled, so a carry left over from a
     * runtime toggle (or an older savestate) must not leak into the
-    * first charged access when the option is re-enabled. */
+    * first charged access when the option is re-enabled.  The
+    * pending-stall channel is shared with the blitter bus-time model,
+    * so it is only cleared when BOTH chargers are off — otherwise this
+    * (default) branch would wipe live blitter charges at every option
+    * read. */
    if (!busArbiter.enabled)
    {
       busArbiter.m68k_sysclk_carry = 0;
       busArbiter.refresh_clk_carry = 0;
       busArbiter.op_clk_accum = 0;
-      busArbiter.m68k_pending_stall = 0;
+      if (!vjs.blitterTiming)
+         busArbiter.m68k_pending_stall = 0;
    }
    {
       const char *scale_env = getenv("VJ_DRAM_SCALE");

--- a/libretro.c
+++ b/libretro.c
@@ -38,6 +38,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "settings.h"
 #include "shadowfb.h"
 #include "tom.h"
+#include "blitter.h"
 #include "gpu.h"
 #include "eeprom.h"
 #include "memtrack.h"
@@ -1165,6 +1166,10 @@ bool retro_serialize(void *data, size_t size)
    STATE_SAVE_VAR(buf, busArbiter.refresh_clk_carry);
    STATE_SAVE_VAR(buf, busArbiter.op_clk_accum);
    STATE_SAVE_VAR(buf, busArbiter.m68k_pending_stall);
+   {
+      uint32_t blitterBusy = BlitterTimingGetBusy();
+      STATE_SAVE_VAR(buf, blitterBusy);
+   }
 
    /* v8: Jaguar GameDrive chunk (bank pages + SPI engine; all-zero for
     * non-GD content). */
@@ -1249,6 +1254,15 @@ bool retro_unserialize(const void *data, size_t size)
       STATE_LOAD_VAR(buf, busArbiter.refresh_clk_carry);
       STATE_LOAD_VAR(buf, busArbiter.op_clk_accum);
       STATE_LOAD_VAR(buf, busArbiter.m68k_pending_stall);
+
+      if (version >= STATE_VERSION_BLITTER_TIMING)
+      {
+         uint32_t blitterBusy;
+         STATE_LOAD_VAR(buf, blitterBusy);
+         BlitterTimingSetBusy(blitterBusy);
+      }
+      else
+         BlitterTimingSetBusy(0);
    }
    else
    {
@@ -1256,6 +1270,7 @@ bool retro_unserialize(const void *data, size_t size)
       busArbiter.refresh_clk_carry = 0;
       busArbiter.op_clk_accum = 0;
       busArbiter.m68k_pending_stall = 0;
+      BlitterTimingSetBusy(0);
    }
 
    if (version >= STATE_VERSION_JAGGD)

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -232,7 +232,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_blitter_timing",
       "Blitter Bus Timing",
       NULL,
-      "EXPERIMENTAL, mid-calibration. Charge the 68000 the bus time each blit it starts would really take: the blitter is the highest-priority bus master, so on hardware the cacheless 68000 is frozen while a blit runs. Emulated blits complete in zero time, which lets games that pace themselves on blit completion (Doom's menus and demo, Hover Strike) run loops faster than a real Jaguar. Current model under-corrects and does not yet cover GPU-started blits; leave disabled unless testing.",
+      "EXPERIMENTAL, mid-calibration. Charge the 68000 the bus time each blit it starts would really take: the blitter is the highest-priority bus master, so on hardware the cacheless 68000 is frozen while a blit runs. Emulated blits complete in zero time, which lets games that pace themselves on blit completion (Doom's menus, Hover Strike) run loops faster than a real Jaguar. GPU-started blits are also tracked; the remaining uncorrected term is the DSP-handshake wait that overlaps the blit stall. Leave disabled unless testing.",
       NULL,
       "timing",
       {

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -229,6 +229,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "1x"
    },
    {
+      "virtualjaguar_blitter_timing",
+      "Blitter Bus Timing",
+      NULL,
+      "EXPERIMENTAL, mid-calibration. Charge the 68000 the bus time each blit it starts would really take: the blitter is the highest-priority bus master, so on hardware the cacheless 68000 is frozen while a blit runs. Emulated blits complete in zero time, which lets games that pace themselves on blit completion (Doom's menus and demo, Hover Strike) run loops faster than a real Jaguar. Current model under-corrects and does not yet cover GPU-started blits; leave disabled unless testing.",
+      NULL,
+      "timing",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "virtualjaguar_risc_clock_scale",
       "RISC (GPU/DSP) Clock Scale (Overclock)",
       NULL,

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -1386,8 +1386,11 @@ static void M68KExecuteWithStalls(uint32_t cycles)
        * freeze starves IRQ delivery: the VI handler that latches the
        * joypad stops running, a released button reads as held for the
        * whole debt, and one tap multiplies into many menu steps (the
-       * exact symptom this model exists to fix, amplified). */
-      uint32_t keep = cycles >> 3;
+       * exact symptom this model exists to fix, amplified).  Rounded
+       * UP so even a sub-8-cycle slice keeps at least one cycle --
+       * a floor of cycles>>3 would be 0 there and let a run of tiny
+       * event-bounded slices fully freeze the 68K after all. */
+      uint32_t keep = (cycles + 7) >> 3;
       stall = busArbiter.m68k_pending_stall >> 1;
       if (stall > cycles - keep)
          stall = cycles - keep;

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -1364,11 +1364,27 @@ uint8_t * GetRamPtr(void)
 static void M68KExecuteWithStalls(uint32_t cycles)
 {
    uint32_t stall;
-   if (busArbiter.enabled && busArbiter.m68k_pending_stall >= 2)
+   /* The drain is deliberately NOT gated on busArbiter.enabled: the
+    * pending-stall channel is shared by the dram_timing model (whose
+    * charge sites gate on the option) and blitter bus-time charges
+    * (gated on vjs.blitterTiming at the charge site in
+    * blitter_mmio.c).  With every charge site off the field stays
+    * zero and this branch never runs, so pure-default behavior is
+    * unchanged. */
+   if (busArbiter.m68k_pending_stall >= 2)
    {
+      /* Leave the 68K an eighth of every slice even under maximum
+       * debt.  The blitter is the top-priority master but not a
+       * perfect bus hog -- refresh slots and inter-op gaps still grant
+       * the 68K occasional cycles (JTRM bus priority) -- and a full
+       * freeze starves IRQ delivery: the VI handler that latches the
+       * joypad stops running, a released button reads as held for the
+       * whole debt, and one tap multiplies into many menu steps (the
+       * exact symptom this model exists to fix, amplified). */
+      uint32_t keep = cycles >> 3;
       stall = busArbiter.m68k_pending_stall >> 1;
-      if (stall > cycles)
-         stall = cycles;
+      if (stall > cycles - keep)
+         stall = cycles - keep;
       busArbiter.m68k_pending_stall -= stall << 1;
       cycles -= stall;
       /* A slice fully consumed by stall must not fall through to

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include "jaguar.h"
+#include "blitter.h"
 #include "log.h"  /* CDDA-DIAG */
 
 #include "cdrom.h"
@@ -1107,6 +1108,11 @@ void HalflineCallback(void)
          charge = halfclks;
       busArbiter.m68k_pending_stall += charge;
    }
+
+   /* Blitter bus-time window decays with real time: a blit finishes on
+    * its own whether or not anyone is watching (blitter_mmio.c). */
+   BlitterTimingTick(USEC_TO_RISC_CYCLES(
+                        vjs.hardwareTypeNTSC ? 31.777777777 : 32.0));
 
    //Change this to VBB???
    //Doesn't seem to matter (at least for Flip Out & I-War)

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -29,6 +29,7 @@ struct VJSettings
 	bool hardwareTypeNTSC;
 	bool useJaguarBIOS;
 	bool useFastBlitter;
+	bool blitterTiming;
 
 	int32_t joyport;
 	bool hardwareTypeAlpine;

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -37,7 +37,7 @@ extern "C" {
  *     jaggd.c).  One shared bump — all in-flight changes since the
  *     v3.1.0 release use v8. */
 #define STATE_MAGIC     0x564A5353  /* "VJSS" */
-#define STATE_VERSION   9
+#define STATE_VERSION   10
 /* Oldest layout retro_unserialize still accepts.  States between
  * STATE_MIN_VERSION and STATE_VERSION load by reading each chunk in the
  * layout the header version names (see DACStateLoad, CDROMStateLoad);
@@ -98,6 +98,12 @@ extern "C" {
  * the state -- the cursors alone reference content the load cannot
  * reconstruct. */
 #define STATE_VERSION_DAC_I2S_RING 9
+
+/* v10: blitter bus-time busy window (virtualjaguar_blitter_timing).
+ * One uint32 appended after the bus-arbiter fields.  Older states load
+ * with the window closed -- at most one pending blit's stall is lost,
+ * self-corrects within a field. */
+#define STATE_VERSION_BLITTER_TIMING 10
 
 /* Header flags */
 #define STATE_FLAG_MEMTRACK  0x01

--- a/src/tom/blitter.h
+++ b/src/tom/blitter.h
@@ -12,6 +12,10 @@ extern "C" {
 #endif
 
 void BlitterInit(void);
+/* Blitter bus-time model (virtualjaguar_blitter_timing) */
+void BlitterTimingTick(uint32_t sysclks);
+uint32_t BlitterTimingGetBusy(void);
+void BlitterTimingSetBusy(uint32_t clks);
 void BlitterReset(void);
 void BlitterDone(void);
 

--- a/src/tom/blitter_mmio.c
+++ b/src/tom/blitter_mmio.c
@@ -99,7 +99,12 @@ static uint32_t BlitDurationSysclks(void)
 
    /* Garbage counts (uninitialised B_COUNT) must not freeze a master
     * for seconds: cap at two fields' worth of bus time (a real
-    * fullscreen interleaved copy legitimately exceeds one field). */
+    * fullscreen interleaved copy legitimately exceeds one field).
+    * Deliberately LARGER than the one-field 68K debt cap in
+    * BlitterTimingChargeAccess(): this window models how long the
+    * hardware blit actually occupies the bus (and is what a GPU
+    * accessor pays in full), while the 68K debt cap separately bounds
+    * pad-latch staleness -- see the comment at that clamp. */
    if (clks > 885560u)
       clks = 885560u;
    return (uint32_t)clks;

--- a/src/tom/blitter_mmio.c
+++ b/src/tom/blitter_mmio.c
@@ -2,7 +2,9 @@
 #include "blitter_internal.h"
 
 #include <string.h>
+#include "bus_arbiter.h"
 #include "settings.h"
+#include "vjag_memory.h"
 
 #define A1_FLAGS        ((uint32_t)0x04)
 #define A1_PIXEL        ((uint32_t)0x0C)
@@ -22,6 +24,72 @@
 #define PHRASEZ1        ((uint32_t)0x90)
 #define PHRASEZ2        ((uint32_t)0x94)
 #define PHRASEZ3        ((uint32_t)0x98)
+
+/* How long this blit would keep the bus on real hardware, in system
+ * clocks (issue #399/#401: the emulated blitter completes every blit in
+ * zero emulated time, so titles that pace a render-bound loop on blit
+ * completion -- Jaguar Doom's menu, whose M_Drawer never calls
+ * I_Update() and so has no VBL gate at all -- iterate faster than
+ * hardware, and their auto-repeat thresholds land inside a normal
+ * button tap).
+ *
+ * The blitter is the top-priority bus master, so while a blit runs the
+ * 68K -- which has no cache and fetches every instruction from
+ * DRAM/ROM -- is effectively frozen.  Rather than model per-access bus
+ * arbitration, the 68K that kicks a blit is charged the blit's whole
+ * bus time through the existing pending-stall channel (drained
+ * gradually by M68KExecuteWithStalls, remainder carried across slices;
+ * the field is already serialized).  GPU-kicked blits are deliberately
+ * NOT charged: GPU code executes from local RAM and is not frozen the
+ * same way, and charging it correctly needs the GPU self-cost path.
+ *
+ * Cost model, from the JTRM DRAM timing used by bus_arbiter.h: one
+ * page-mode DRAM cycle is a fixed 2 system clocks.  Each inner-loop
+ * unit performs one memory op per enabled port: destination write
+ * always, plus source read (SRCEN), source Z read (SRCENZ),
+ * destination read (DSTEN), destination Z read (DSTENZ), Z write
+ * (DSTWRZ).  In phrase mode (A1 XADD = phrase) a unit moves 64 bits,
+ * so the pixel count collapses by 64/bpp.  Row-miss overhead and bus
+ * arbitration slack are real but second-order for linear sweeps and
+ * are deliberately left out: this is a documented FLOOR, so any error
+ * keeps us on the too-fast side rather than inventing slowness. */
+static uint32_t BlitDurationSysclks(void)
+{
+   uint32_t count, cmd, a1flags;
+   uint32_t ops;
+   uint64_t units, clks;
+
+   count   = GET32(blitter_ram, 0x3C);          /* B_COUNT */
+   cmd     = GET32(blitter_ram, COMMAND);
+   a1flags = GET32(blitter_ram, A1_FLAGS);
+
+   units = (uint64_t)(count & 0xFFFF) * (count >> 16);
+
+   ops = 1;                                     /* dst write */
+   if (cmd & 0x0001) ops++;                     /* SRCEN */
+   if (cmd & 0x0002) ops++;                     /* SRCENZ */
+   if (cmd & 0x0008) ops++;                     /* DSTEN */
+   if (cmd & 0x0010) ops++;                     /* DSTENZ */
+   if (cmd & 0x0020) ops++;                     /* DSTWRZ */
+
+   if (((a1flags >> 16) & 3) == 0)
+   {
+      /* Phrase mode: one memory op per 64-bit phrase. */
+      uint32_t bpp = 1u << ((a1flags >> 3) & 7);
+      if (bpp > 32)
+         bpp = 32;
+      units = (units * bpp + 63) / 64;
+   }
+
+   clks = units * ops * 2u;
+
+   /* Garbage counts (uninitialised B_COUNT) must not freeze the 68K
+    * for seconds: cap at one field's worth of bus time. */
+   if (clks > 442780u)
+      clks = 442780u;
+   return (uint32_t)clks;
+}
+
 
 void BlitterInit(void)
 {
@@ -158,12 +226,22 @@ void BlitterWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
 
    if ((offset & 0xFF) == 0x3A)
    {
+      /* Compute the bus time BEFORE dispatch: the engines update their
+       * shadow registers as they run. */
+      uint32_t busClks = 0;
+      if (vjs.blitterTiming && who == M68K)
+         busClks = BlitDurationSysclks();
+
       if (BlitterCompareIsEnabled())
          BlitterRunComparison();
       else if (vjs.useFastBlitter)
          blitter_blit(GET32(blitter_ram, COMMAND));
       else
          BlitterMidsummer2();
+
+      /* The blit's results are complete (memory is final, as before);
+       * only the TIME is owed.  See BlitDurationSysclks above. */
+      busArbiter.m68k_pending_stall += busClks;
    }
 }
 

--- a/src/tom/blitter_mmio.c
+++ b/src/tom/blitter_mmio.c
@@ -3,6 +3,7 @@
 
 #include <string.h>
 #include "bus_arbiter.h"
+#include "gpu.h"
 #include "settings.h"
 #include "vjag_memory.h"
 
@@ -33,30 +34,34 @@
  * hardware, and their auto-repeat thresholds land inside a normal
  * button tap).
  *
- * The blitter is the top-priority bus master, so while a blit runs the
- * 68K -- which has no cache and fetches every instruction from
- * DRAM/ROM -- is effectively frozen.  Rather than model per-access bus
- * arbitration, the 68K that kicks a blit is charged the blit's whole
- * bus time through the existing pending-stall channel (drained
- * gradually by M68KExecuteWithStalls, remainder carried across slices;
- * the field is already serialized).  GPU-kicked blits are deliberately
- * NOT charged: GPU code executes from local RAM and is not frozen the
- * same way, and charging it correctly needs the GPU self-cost path.
+ * The blitter is the top-priority bus master: while a blit runs,
+ * anything else that needs the bus waits.  Each dispatched blit opens
+ * a busy window of its priced duration; the window decays with real
+ * emulated time (BlitterTimingTick), and the NEXT blitter-register
+ * access from either master pays the remainder --
+ * BlitterTimingChargeAccess routes a 68K wait through the serialized
+ * pending-stall channel (drained by M68KExecuteWithStalls, which
+ * always leaves the 68K an eighth of each slice so IRQ delivery is
+ * never starved) and a GPU wait into the current GPU instruction's
+ * bus-stall accumulator.  Back-to-back blit chains -- Doom's menu
+ * erase/draw sequences, GPU wall-column loops -- therefore serialize
+ * at the real bus rate, while a master that fires one blit and never
+ * returns pays nothing further.
  *
- * Cost model, from the JTRM DRAM timing used by bus_arbiter.h: one
- * page-mode DRAM cycle is a fixed 2 system clocks.  Each inner-loop
- * unit performs one memory op per enabled port: destination write
- * always, plus source read (SRCEN), source Z read (SRCENZ),
- * destination read (DSTEN), destination Z read (DSTENZ), Z write
- * (DSTWRZ).  In phrase mode (A1 XADD = phrase) a unit moves 64 bits,
- * so the pixel count collapses by 64/bpp.  Row-miss overhead and bus
- * arbitration slack are real but second-order for linear sweeps and
- * are deliberately left out: this is a documented FLOOR, so any error
- * keeps us on the too-fast side rather than inventing slowness. */
+ * Cost model, from the JTRM DRAM timing used by bus_arbiter.h: each
+ * inner-loop unit performs one memory op per enabled port --
+ * destination write always, plus source read (SRCEN), source Z read
+ * (SRCENZ), destination read (DSTEN), destination Z read (DSTENZ),
+ * Z write (DSTWRZ).  In phrase mode (A1 XADD = phrase) a unit moves
+ * 64 bits, so the pixel count collapses by 64/bpp.  A write-only
+ * sweep stays in one DRAM row and pays the fixed 2-clock page-mode
+ * cycle per op; any second enabled port interleaves distant rows, so
+ * every op carries the row-change overhead too (+3 clocks at the
+ * default DRAMSPEED, MEMCON1 0x1861). */
 static uint32_t BlitDurationSysclks(void)
 {
    uint32_t count, cmd, a1flags;
-   uint32_t ops;
+   uint32_t ops, per_op;
    uint64_t units, clks;
 
    count   = GET32(blitter_ram, 0x3C);          /* B_COUNT */
@@ -81,13 +86,85 @@ static uint32_t BlitDurationSysclks(void)
       units = (units * bpp + 63) / 64;
    }
 
-   clks = units * ops * 2u;
+   /* Write-only sweeps stay in one DRAM row and run at the page-mode
+    * cycle (2 clocks).  As soon as a second port is enabled the access
+    * pattern interleaves two (or more) distant regions -- source row,
+    * destination row, back -- so in the worst case every access pays
+    * the row-change overhead on top: 2 + 3 clocks at the Jaguar's
+    * default DRAMSPEED (MEMCON1 0x1861; same table bus_arbiter.h
+    * uses). */
+   per_op = (ops > 1) ? 5u : 2u;
 
-   /* Garbage counts (uninitialised B_COUNT) must not freeze the 68K
-    * for seconds: cap at one field's worth of bus time. */
-   if (clks > 442780u)
-      clks = 442780u;
+   clks = units * ops * per_op;
+
+   /* Garbage counts (uninitialised B_COUNT) must not freeze a master
+    * for seconds: cap at two fields' worth of bus time (a real
+    * fullscreen interleaved copy legitimately exceeds one field). */
+   if (clks > 885560u)
+      clks = 885560u;
    return (uint32_t)clks;
+}
+
+/* Busy window: how much bus time the most recent blit still owns.
+ * Decays with emulated time (BlitterTimingTick from HalflineCallback);
+ * the NEXT blitter-register access from either master pays whatever
+ * remains and closes the window (BlitterTimingConsumeWait).  Serialized
+ * (savestates must replay identically with the model enabled). */
+static uint32_t blitterBusyClks = 0;
+
+void BlitterTimingTick(uint32_t sysclks)
+{
+   if (blitterBusyClks > sysclks)
+      blitterBusyClks -= sysclks;
+   else
+      blitterBusyClks = 0;
+}
+
+static uint32_t BlitterTimingConsumeWait(void)
+{
+   uint32_t r = blitterBusyClks;
+   blitterBusyClks = 0;
+   return r;
+}
+
+uint32_t BlitterTimingGetBusy(void)
+{
+   return blitterBusyClks;
+}
+
+void BlitterTimingSetBusy(uint32_t clks)
+{
+   blitterBusyClks = clks;
+}
+
+/* A master touched a blitter register while a blit is (still) running.
+ * On hardware the blitter is the highest-priority bus master, so the
+ * toucher waits out the remainder.  The 68K's wait goes through the
+ * pending-stall channel; a GPU wait is charged to the current GPU
+ * instruction's bus-stall accumulator (the load/store that touched us
+ * simply takes that long). */
+static void BlitterTimingChargeAccess(uint32_t who)
+{
+   uint32_t remaining;
+   if (!vjs.blitterTiming || blitterBusyClks == 0)
+      return;
+   remaining = BlitterTimingConsumeWait();
+   if (who == GPU)
+      GPUChargeBusStall(remaining);
+   else if (who != DSP)
+   {
+      /* Cap the total owed at one field.  On hardware nothing
+       * accumulates across fields -- a blit finishes inside its
+       * field and the bus frees -- so unbounded debt is an artifact
+       * of this scalar approximation, and letting it compound
+       * freezes the 68K for multiple fields, starves VI delivery,
+       * and leaves the pad latch stale (one tap read as many, the
+       * exact bug this model exists to fix).  The cap bounds latch
+       * staleness to what real hardware can exhibit. */
+      busArbiter.m68k_pending_stall += remaining;
+      if (busArbiter.m68k_pending_stall > 442780u)
+         busArbiter.m68k_pending_stall = 442780u;
+   }
 }
 
 
@@ -112,7 +189,7 @@ uint8_t BlitterReadByte(uint32_t offset, uint32_t who/*=UNKNOWN*/)
 {
    offset &= 0xFF;
 
-   (void)who;
+   BlitterTimingChargeAccess(who);
 
    /* Real hardware returns $00000805, as documented in the JTRM. */
    if (offset == (COMMAND + 0))
@@ -152,7 +229,7 @@ void BlitterWriteByte(uint32_t offset, uint8_t data, uint32_t who/*=UNKNOWN*/)
 {
    offset &= 0xFF;
 
-   (void)who;
+   BlitterTimingChargeAccess(who);
 
    /* INTENSITY writes also update their PATTERNDATA/SRCDATA mirrors. */
    if ((offset >= PHRASEINT0) && (offset <= (PHRASEZ3 + 3)))
@@ -229,7 +306,7 @@ void BlitterWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
       /* Compute the bus time BEFORE dispatch: the engines update their
        * shadow registers as they run. */
       uint32_t busClks = 0;
-      if (vjs.blitterTiming && who == M68K)
+      if (vjs.blitterTiming)
          busClks = BlitDurationSysclks();
 
       if (BlitterCompareIsEnabled())
@@ -240,8 +317,12 @@ void BlitterWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
          BlitterMidsummer2();
 
       /* The blit's results are complete (memory is final, as before);
-       * only the TIME is owed.  See BlitDurationSysclks above. */
-      busArbiter.m68k_pending_stall += busClks;
+       * only the TIME is owed.  The window is paid by the next
+       * blitter-register access from either master -- back-to-back
+       * blit chains (Doom's menu erase/draw sequences) serialize at
+       * the real bus rate, while a master that fires one blit and
+       * walks away pays nothing further. */
+      blitterBusyClks = busClks;
    }
 }
 

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -62,6 +62,11 @@ static uint32_t gpu_stall_scale_accum;
          gpu_bus_stall += bus_arbiter_charge_access(BM_GPU, (addr)); \
    } while (0)
 
+void GPUChargeBusStall(uint32_t sysclks)
+{
+   gpu_bus_stall += sysclks;
+}
+
 #define GPU_TRACE_DEBUG 0
 #if GPU_TRACE_DEBUG
 #define GPU_TRACE(...) LOG_DBG("[GPU-TRACE] " __VA_ARGS__)

--- a/src/tom/gpu.h
+++ b/src/tom/gpu.h
@@ -28,6 +28,9 @@ void GPUBeginSlice(uint32_t riscCycles);
 int32_t GPUSliceRemaining(void);
 void GPUSyncToM68K(void);
 void GPUUpdateRegisterBanks(void);
+/* Add wall-time system clocks to the current GPU instruction's bus
+ * stall (blitter bus-time model). */
+void GPUChargeBusStall(uint32_t sysclks);
 void GPUHandleIRQs(void);
 void GPUSetIRQLine(int irqline, int state);
 

--- a/test/test_blitter_mmio.c
+++ b/test/test_blitter_mmio.c
@@ -28,6 +28,13 @@ void BlitterRunComparison(void) {}
 void blitter_blit(uint32_t cmd) { (void)cmd; }
 void BlitterMidsummer2(void) {}
 
+/* Blitter bus-time model dependencies (vjs.blitterTiming stays 0 in the
+ * stub settings above, so the timing path short-circuits; these only
+ * need to link). */
+#include "bus_arbiter.h"
+struct BusArbiter busArbiter;
+void GPUChargeBusStall(uint32_t sysclks) { (void)sysclks; }
+
 static int failures = 0;
 
 #define CHECK(cond, fmt, ...) do { \


### PR DESCRIPTION
Draft: the mechanism behind the tap-repeat bug (#399), implemented and measured, parked default-off pending calibration.

## The unified story (built on #403 + #404's ROM results)

- Input is **clean**: 1 press = 1 edge at every hold length (ROM-proven).
- The gameplay path is **correctly gated** at 20 passes/s (ROM-proven).
- The defect is **ungated render-bound loops**: Doom's menu (`M_Drawer` never calls `I_Update()`) and its attract demo (one scripted input consumed per `MiniLoop` pass) pace at whatever rate the renderer completes — and our blitter completes every blit in **zero emulated time**, so those loops run hot and the menu's own `movecount==6` repeat lands inside a normal tap. Same shape expected for Hover Strike.

## Model

68K-kicked blits charge the 68K the blit's bus time (blitter = top-priority master; cacheless 68K is frozen during a blit). `BlitDurationSysclks()` prices `B_COUNT` units at one 2-sysclk page-mode DRAM cycle per enabled memory port, collapsing by 64/bpp in phrase mode, capped at one field. Charges land in the existing serialized pending-stall channel; the drain now leaves the 68K ⅛ of each slice so IRQ delivery never starves (a full freeze left the VI pad latch stale and turned one tap into *eight* steps — measured, instructive, fixed).

The busy window opens on **any** B_CMD dispatch, from either master; a GPU access that meets the window pays into the GPU's own bus-stall accumulator (`GPUChargeBusStall`), a 68K access pays through the pending-stall channel.

## Measurements (Doom menu, steps per tap)

| hold | develop | this PR (enabled) |
|---|---|---|
| 2 frames | 1 | **1** |
| 4 frames | 2 | 2 |
| 8 frames | 2 | 2 |
| 12 frames | 2 | 3 |
| sustained | step/5.6f | step/~8–10f |

Real per-blit charges observed: fullscreen SRCEN copy = 256,000 sysclks, fullscreen phrase-mode erase = 32,000 — the menu redraws both roughly once per pass, ~0.65 fields of bus time.

## Why the demo/gameplay (#401) is out of this model's reach — measured 2026-08-11

`test_doom_ticrate` on this branch (5e00b4f): demo runs **29.97 tics/s with the model off AND on** — the attract demo issues **zero** blitter commands (confirms the earlier `blitter_budget_probe` zero-traffic reading). Its render is pure GPU work, so no blitter busy-window can pace it. The 2× pace of #401 lives in the GPU's own execution/memory cost.

To size that gap I swept the GPU DRAM self-cost multiplier (`VJ_DRAM_SCALE`, env-only calibration knob on `virtualjaguar_dram_timing`):

| scale | effective clk/access | demo tics/s (median, 5400f) |
|---|---|---|
| 1 (stock) | 5 | 29.97 |
| 2 | 10 | 29.97 |
| 4 | 20 | 29.87 |
| 6 | 30 | 24.28 |
| 8 | 40 | **deadlock** (see below) |
| 12 | 60 | 16.48 |
| 16 | 80 | 14.39 |

Hardware target is ~15 tics/s (`vblsinframe=4`). Reaching it via per-access DRAM cost alone needs **~60–80 sysclks per access** — physically absurd for DRAM (real: ~5 with row miss) and the same magnitude the retired #169 experiment found ("penalty=60"). Conclusion: the missing time is not DRAM latency scale, it's the **unmodeled instruction-level cost** — load-result scoreboard blocking, pipeline hazards, OP bus occupancy during active display. That is exactly #313, and it should be calibrated against the open FPGA cores (MiSTer Jaguar / jag_sim), not tuned to one title.

The sweep also surfaced a latent race: at scale 8 (and only 8 among 1,2,4,6,12,16) the demo **deadlocks** right after starting — `video_stall` at frame 562, GPU spinning in local RAM at $F03416–1C, DSP running, gametic frozen. Lost-wakeup class (cf. the BrainDead 13 CPUINT fix). Env-only path today, but a correct #313 model will hit these interleavings for real; filed separately.

## Why default-off

Direction correct, magnitude under-corrects short taps; the demo is untouched (pure GPU render — measured above, structurally out of reach for a blitter model). Default-off is verified **byte-identical** to develop (step-frame comparison) and the full suite passes. Calibration list before default-on:

- [x] GPU-kicked blit charges (busy window opens on any dispatch; GPU pays via `GPUChargeBusStall`) — landed in 5e00b4f
- [x] Confirm the demo/gameplay path is out of scope for this model (measured: zero blits; gap sized at ~2 fields/frame of GPU self-cost → #313)
- [ ] Row-miss / arbitration overhead (current floor is deliberately optimistic)
- [ ] DSP-handshake (`dspfinished`) interaction — menu loop's final wait overlaps the blit stall, absorbing part of the charge
- [ ] Corpus A/B sweep + acid + device feel test

Related: #399, #401, #403, #404. Demo/gameplay pace continues in #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
