### PR TITLE
perf(trace): arm the vjtrace recorder on demand so it costs nothing when idle

### DIFF
--- a/src/core/vjtrace.c
+++ b/src/core/vjtrace.c
@@ -48,6 +48,17 @@ static uint64_t ring_cap = 0;     /* power of two not required; use modulo */
 static uint64_t ring_head = 0;    /* total events ever emitted */
 static uint64_t seq_ctr = 0;
 static uint32_t cur_frame = 0;
+/* Default OFF: every hot-path recording site (vjtrace_emit() and the
+ * GPU/DSP per-instruction PC-history hooks below) checks this first and
+ * returns immediately when clear, so a VJ_TRACE build that never traces
+ * pays one predictable, well-predicted branch per site instead of doing
+ * real ring/history work -- see the PERFORMANCE NOTE in vjtrace.h. */
+/* Non-static: the VJT_PCHIST_* macros in vjtrace.h test this at the
+ * call site inside GPUExec()/DSPExec(), so it must be linkable. */
+int vjtrace_armed = 0;
+
+void vjtrace_arm(void)    { vjtrace_armed = 1; }
+void vjtrace_disarm(void) { vjtrace_armed = 0; }
 
 void vjtrace_init(void)
 {
@@ -148,7 +159,11 @@ static uint32_t vjt_pc_of(uint32_t who)
 void vjtrace_emit(uint8_t type, uint8_t who, uint32_t addr, uint32_t value)
 {
    vjtrace_ev *e;
-   if (!ring)
+   /* Gated centrally here rather than at each of the ~15 VJT_EMIT call
+    * sites (tom.c, op.c, blitter.c, gpu.c, m68kinterface.c): one check
+    * covers all of them, including IRQ/OP/blitter events that fire every
+    * frame regardless of whether anyone is recording. */
+   if (!vjtrace_armed || !ring)
       return;
    e = &ring[ring_head % ring_cap];
    e->seq = seq_ctr++;
@@ -247,6 +262,12 @@ static uint32_t dsp_pchist_fill = 0;
 
 void vjtrace_pchist_gpu(uint32_t pc)
 {
+   /* Called from GPUExec() on EVERY GPU instruction, armed or not -- the
+    * armed check must be the very first thing this function does (see
+    * the PERFORMANCE NOTE in vjtrace.h: this was the ~6-8% wall-clock
+    * regression before the armed gate existed). */
+   if (!vjtrace_armed)
+      return;
    gpu_pchist[gpu_pchist_head] = pc;
    gpu_pchist_head = (gpu_pchist_head + 1) & (VJT_PCHIST_CAP - 1);
    if (gpu_pchist_fill < VJT_PCHIST_CAP)
@@ -255,6 +276,10 @@ void vjtrace_pchist_gpu(uint32_t pc)
 
 void vjtrace_pchist_dsp(uint32_t pc)
 {
+   /* Called from DSPExec() on EVERY DSP instruction -- see the note on
+    * vjtrace_pchist_gpu() above. */
+   if (!vjtrace_armed)
+      return;
    dsp_pchist[dsp_pchist_head] = pc;
    dsp_pchist_head = (dsp_pchist_head + 1) & (VJT_PCHIST_CAP - 1);
    if (dsp_pchist_fill < VJT_PCHIST_CAP)
@@ -557,6 +582,7 @@ void vjtrace_shutdown(void)
    ring_head = 0;
    seq_ctr = 0;
    cur_frame = 0;
+   vjtrace_armed = 0;   /* back to the documented default-OFF state */
    vjtrace_nwatch = 0;
    memset(watches, 0, sizeof(watches));
    memset(&vjtrace_counters, 0, sizeof(vjtrace_counters));

--- a/src/core/vjtrace.h
+++ b/src/core/vjtrace.h
@@ -11,32 +11,65 @@
  * never built with VJ_TRACE) can still include this header for the
  * types used by the binary dump format.
  *
- * PERFORMANCE NOTE (VJ_TRACE is coupled 1:1 to TEST_EXPORTS=1, so this
- * taxes every test-mode build, not just callers that use vjtrace
- * directly): the GPU/DSP per-instruction PC-history hooks in GPUExec()/
- * DSPExec() (see vjtrace_pchist_gpu()/vjtrace_pchist_dsp() below)
+ * PERFORMANCE NOTE (VJ_TRACE is coupled 1:1 to TEST_EXPORTS=1, so any
+ * always-on cost here taxes every test-mode build, not just callers
+ * that use vjtrace directly -- roughly 40 harnesses link a VJ_TRACE
+ * core and never trace at all): the GPU/DSP per-instruction PC-history
+ * hooks in GPUExec()/DSPExec() (see vjtrace_pchist_gpu()/
+ * vjtrace_pchist_dsp() below), unconditionally writing every recorded
+ * event through vjtrace_emit() (tom.c/op.c/blitter.c/gpu.c/
+ * m68kinterface.c fire ~15 VJT_EMIT sites, some -- OP_OBJECT/
+ * OP_LIST_START -- multiple thousand times a frame), originally
  * measured a ~6-8% wall-clock throughput regression on `make
  * BENCH_PROFILE=1 benchmark` versus a build with no vjtrace hooks at
  * all (task-3-report.md has the full before/after numbers). A plain
  * function call and an inlined macro that writes the ring arrays
  * directly were both measured -- 11 paired, interleaved samples put
  * them within 0.02% of each other, i.e. statistically indistinguishable
- * on this hardware -- so the cost is the per-instruction ring write
- * itself, not call overhead, and the simpler function-call form was
- * kept. Any wall-clock-derived assertion is measurably tighter in a
- * VJ_TRACE build than in production: `test/test_frontend_pacing.c`'s
- * default invocation (no `--max-fastest-frame-fraction` override, see
- * Makefile:1163) asserts the fastest observed frame beats 0.5x the
- * frame period (8.333 ms at 60 fps) -- a real, load-sensitive margin
- * (the Makefile's own comment at line 1173-1178 notes it "would flake
- * on loaded CI runners: observed locally 11.3 ms vs the 8.3 ms limit
- * under parallel builds", which is why the *other* two invocations
- * defuse it with `--max-fastest-frame-fraction 100`). Measured passing
- * with room at commit 2b5d132 (fastest frame 4.326 ms, 52% of the
- * 8.333 ms limit) -- not a confirmed regression -- but the margin is
- * real and shared with every other per-instruction VJ_TRACE hook added
- * in the future; re-check this assertion specifically (not just `make
- * test`'s overall exit code) after adding another one. */
+ * on this hardware -- so the cost was the per-instruction ring write
+ * itself, not call overhead.
+ *
+ * That regression was real and visible outside synthetic benchmarks:
+ * `test/test_frontend_pacing.c`'s strict 1x row (no
+ * `--max-fastest-frame-fraction` override, Makefile:1163) asserts the
+ * fastest observed frame beats 0.5x the frame period (8.333 ms at
+ * 60 fps) -- already load-sensitive on its own (the Makefile's own
+ * comment near line 1173 notes it "would flake on loaded CI runners:
+ * observed locally 11.3 ms vs the 8.3 ms limit under parallel builds",
+ * which is why the *other* two invocations defuse it with
+ * `--max-fastest-frame-fraction 100`) -- and flaked for real on a
+ * loaded 32-bit CI runner once the vjtrace hot-path hooks were always
+ * compiled in (9.4-14.0 ms observed, vs 4.3 ms on the same job before
+ * vjtrace existed).
+ *
+ * FIX: every hot-path recording site now checks a module-private
+ * "armed" flag (vjtrace_armed, default OFF) FIRST and returns
+ * immediately when clear -- vjtrace_emit() centrally (covering all
+ * ~15 VJT_EMIT call sites in one place) and vjtrace_pchist_gpu()/
+ * vjtrace_pchist_dsp() individually (they're called directly from
+ * GPUExec()/DSPExec(), not through vjtrace_emit()). A disarmed VJ_TRACE
+ * build now pays one predictable, well-branch-predicted comparison per
+ * site instead of doing real ring/history work, which should put its
+ * throughput within noise of a plain (non-VJ_TRACE) build -- see the
+ * paired-sampling numbers in the commit that introduced vjtrace_arm()/
+ * vjtrace_disarm() for the actual before/after measurement.
+ *
+ * vjtrace_arm() is called from trace_probe_attach()
+ * (test/harness/trace_probe.c) the moment a tool actually requests
+ * tracing (--watch/--trace-out/--field-csv/--snap/--mark), so every
+ * existing tracing consumer is unaffected -- backtraces and the ring
+ * are complete from the attach point forward, same as before. Callers
+ * that want tracing without going through trace_probe's CLI can call
+ * vjtrace_arm()/vjtrace_disarm() directly. If a tool asks trace_probe
+ * for tracing but the resolved core doesn't export vjtrace_arm (an
+ * older core, built before this fix), that is a hard, loud failure
+ * (exit 2) via the same missing-symbol check every other required
+ * vjtrace export already goes through -- never a silently-empty ring.
+ *
+ * Any wall-clock-derived assertion in a DISARMED VJ_TRACE build should
+ * now behave the same as a plain build; re-verify that specifically
+ * (not just `make test`'s overall exit code) if a new always-on
+ * (unarmed-reachable) vjtrace hook is ever added. */
 #ifndef __VJTRACE_H__
 #define __VJTRACE_H__
 
@@ -100,6 +133,20 @@ void vjtrace_init(void);
  * static already has via retro_unload_game()/retro_deinit().  Idempotent:
  * safe to call when the ring was never allocated or already freed. */
 void vjtrace_shutdown(void);
+/* Arms/disarms recording. Default OFF (see the PERFORMANCE NOTE above):
+ * every hot-path recording site (vjtrace_emit(), vjtrace_pchist_gpu(),
+ * vjtrace_pchist_dsp()) checks this first and is a cheap no-op while
+ * disarmed. trace_probe_attach() (test/harness/trace_probe.c) calls
+ * vjtrace_arm() the moment a tool actually requests tracing, so this
+ * is transparent to every existing tracing consumer; call directly for
+ * programmatic control without the CLI flags. vjtrace_shutdown() resets
+ * back to disarmed. Backtraces/ring contents are only guaranteed
+ * complete from the moment vjtrace_arm() was called, not from core
+ * boot -- matches the existing "events before the first retro_run carry
+ * frame 0" caveat below: nothing is recorded before someone asks for
+ * it. */
+void vjtrace_arm(void);
+void vjtrace_disarm(void);
 /* Sets the frame number stamped onto every subsequently emitted event.
  * Called from the TOP of retro_run (libretro.c) with a 1-based counter,
  * so events emitted while frame N is being run -- by the machine and by
@@ -269,16 +316,32 @@ void vjtrace_backtrace(int who, uint32_t *out, int maxn, int *count);
 
 extern vjtrace_counters_t vjtrace_counters;
 extern uint32_t vjtrace_nwatch;
+extern int vjtrace_armed;
 
 #define VJT_EMIT(t, w, a, v)   vjtrace_emit((uint8_t)(t), (uint8_t)(w), (a), (v))
 #define VJT_WATCH_WR(a, v, w)  do { if (vjtrace_nwatch) vjtrace_watch_check((a), (v), (w), 1); } while (0)
 #define VJT_WATCH_RD(a, v, w)  do { if (vjtrace_nwatch) vjtrace_watch_check((a), (v), (w), 0); } while (0)
+
+/* Per-instruction PC-history hooks.  These sit in GPUExec()/DSPExec(),
+ * the two hottest loops in the emulator (a busy title runs ~450k GPU
+ * instructions per frame), so the armed test happens HERE at the call
+ * site -- same shape as VJT_WATCH_* above -- and not only inside the
+ * callee.  Gating in the callee alone still costs a cross-TU call per
+ * instruction in a disarmed build, which is exactly the wall-clock tax
+ * the armed gate exists to remove (it pushed the 32-bit CI runner's
+ * test_frontend_pacing over its 8.333 ms fastest-frame limit).  The
+ * callee keeps its own check as well, so a direct caller cannot bypass
+ * the gate. */
+#define VJT_PCHIST_GPU(pc)     do { if (vjtrace_armed) vjtrace_pchist_gpu(pc); } while (0)
+#define VJT_PCHIST_DSP(pc)     do { if (vjtrace_armed) vjtrace_pchist_dsp(pc); } while (0)
 
 #else /* !VJ_TRACE */
 
 #define VJT_EMIT(t, w, a, v)   do { } while (0)
 #define VJT_WATCH_WR(a, v, w)  do { } while (0)
 #define VJT_WATCH_RD(a, v, w)  do { } while (0)
+#define VJT_PCHIST_GPU(pc)     do { } while (0)
+#define VJT_PCHIST_DSP(pc)     do { } while (0)
 
 #endif /* VJ_TRACE */
 

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -1029,7 +1029,7 @@ void DSPExec(int32_t cycles)
       uint16_t opcode;
       uint32_t index;
 #ifdef VJ_TRACE
-      vjtrace_pchist_dsp(dsp_pc);
+      VJT_PCHIST_DSP(dsp_pc);
 #endif
 
 		/* If IMASK was cleared, see if any other interrupts are pending --

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -1441,7 +1441,7 @@ void GPUExec(int32_t cycles)
       uint32_t index;
       gpuExecSliceRemaining = cycles;
 #ifdef VJ_TRACE
-      vjtrace_pchist_gpu(gpu_pc);
+      VJT_PCHIST_GPU(gpu_pc);
 #endif
       if (gpu_pc >= GPU_WORK_RAM_BASE && gpu_pc < GPU_WORK_RAM_BASE + 0x1000)
       {

--- a/test/harness/trace_probe.c
+++ b/test/harness/trace_probe.c
@@ -32,6 +32,7 @@ struct trace_probe {
     int  attached;
 
     /* Resolved core exports */
+    void     (*p_arm)(void);
     void     (*p_emit)(uint8_t, uint8_t, uint32_t, uint32_t);
     int      (*p_watch_add)(uint32_t, uint32_t, unsigned);
     int      (*p_dump)(const char *);
@@ -222,7 +223,13 @@ int trace_probe_attach(harness_config *cfg)
 
     /* All of these ship together under the vjtrace_* export wildcard, so
      * resolve the whole set and fail on any gap: a partial set means the
-     * core under test is not the one this probe was written against. */
+     * core under test is not the one this probe was written against.
+     * vjtrace_arm is part of this required set -- an older core that
+     * predates the armed gate would otherwise leave every hot-path
+     * recording site permanently disarmed, silently producing an empty
+     * ring instead of the trace this call is being asked for. */
+    tp->p_arm       = (void (*)(void))
+                      tp_need(cfg, "vjtrace_arm", &missing);
     tp->p_emit      = (void (*)(uint8_t, uint8_t, uint32_t, uint32_t))
                       tp_need(cfg, "vjtrace_emit", &missing);
     tp->p_watch_add = (int (*)(uint32_t, uint32_t, unsigned))
@@ -245,6 +252,14 @@ int trace_probe_attach(harness_config *cfg)
                 missing, cfg->core_path ? cfg->core_path : "(core)");
         exit(2);
     }
+
+    /* Arm before anything else can run: every hot-path recording site
+     * defaults to disarmed (see vjtrace.h's PERFORMANCE NOTE), and this
+     * call is the ONLY place that arms it for a CLI-driven tool -- so it
+     * must happen before the frame loop starts, and before the watch
+     * specs below install anything a disarmed vjtrace_emit() would
+     * otherwise drop. */
+    tp->p_arm();
 
     for (i = 0; i < cfg->num_watch_specs; i++)
         if (!tp_parse_watch(tp, cfg->watch_specs[i]))

--- a/test/harness/trace_probe.h
+++ b/test/harness/trace_probe.h
@@ -23,7 +23,13 @@
  * that case call trace_probe_frame() from your own hook instead.
  *
  * Attach is a no-op success when none of the flight-recorder flags were
- * given, so a tool may call it unconditionally.
+ * given, so a tool may call it unconditionally. When a flag WAS given,
+ * attach also arms vjtrace's recording (vjtrace_arm(), see the
+ * PERFORMANCE NOTE in src/core/vjtrace.h) -- every hot-path recording
+ * site defaults to disarmed so a VJ_TRACE build that never traces pays
+ * no per-instruction cost, and this call is what turns it on. Ring
+ * contents and GPU/DSP PC-history backtraces are only guaranteed
+ * complete from this attach point forward, not from core boot.
  *
  * ======================================================================
  * FLAGS (parsed by harness.c into cfg, acted on here)


### PR DESCRIPTION
Follow-up to #412. This commit was pushed to `feat/vjtrace` about a minute after that PR merged, so it missed the merge — `develop` currently has vjtrace **without** the armed gate, and every `TEST_EXPORTS` build is paying the per-instruction tax.

## Why this matters beyond speed

`VJ_TRACE` builds ran the PC-history hook on **every GPU and DSP instruction** whether or not anything was recording, so all ~40 harnesses carried the cost. For a facility whose whole purpose is diagnosing **timing** bugs, that is a correctness problem, not just a slow one: switching the recorder on perturbed the thing being measured.

The recorder now starts disarmed and is armed by `trace_probe_attach()`, so tracing tools behave exactly as before and non-tracing tools pay nothing. Asking for `--watch` / `--trace-out` / `--field-csv` / `--snap` against a core too old to arm fails **loudly** rather than silently producing an empty ring.

## The armed test is at the call site, deliberately

`GPUExec()` / `DSPExec()` are the hottest loops in the emulator — a busy title runs ~450k GPU instructions per frame. Gating inside the callee alone still costs a cross-TU call per instruction, so `VJT_PCHIST_GPU/DSP` test the flag at the call site, the same shape the existing `VJT_WATCH_*` macros already use. The callee keeps its own check so a direct caller cannot bypass the gate.

## Measured

Interleaved paired sampling on `test/roms/yarc.j64`, disarmed `VJ_TRACE` vs a plain build:

| pair | disarmed VJ_TRACE | plain |
|---|---|---|
| 1 | 259.53 | 260.28 |
| 2 | 260.71 | 259.81 |
| 3 | 259.56 | 262.10 |

Mean 259.9 vs 260.7 fps — **0.3%**, versus the ~6-8% previously documented. (A fourth pair was discarded as host noise: 251.5 vs 238.3, with the *plain* build slower.)

Verified on this branch, rebased onto current develop: `make TEST_EXPORTS=1` clean, `vjtrace_selftest.sh` all three checks PASS (so the armed path is unaffected), export lists in sync, C89 lint clean.

Note on CI: `build-Linux i686` fails `test_frontend_pacing`'s `fastest_frame_beats_realtime` on develop already (9.595 ms there against the 8.333 ms bar) — pre-existing, not from this change, and filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)