### PR TITLE
docs(401): census Doom's real render cost — the GPU model is already at its netlist ceiling

### DIFF
--- a/docs/doom-render-cost-census.md
+++ b/docs/doom-render-cost-census.md
@@ -158,14 +158,21 @@ pixels/field, 31-33k phrases/field → 74k sysclks = 16.7% of a field**
 missing time.
 
 > **Configuration seam — read before reusing this number.** Every other
-> figure in this document was measured in the **default fast-blitter**
-> configuration; this row alone had to be taken with
+> figure in this document was measured with the blitter left at the
+> **headless test harness's** default, which is **fast**
+> (`test/harness/harness.c:385-387` hardcodes
+> `virtualjaguar_usefastblitter` to `"enabled"` for any run that doesn't pass
+> `--option` to override it). That is *not* the shipped core's default: the
+> core option itself (`libretro_core_options.h:130-141`) defaults
+> `virtualjaguar_usefastblitter` to `"disabled"`, i.e. **Accurate** — a
+> RetroArch user who has never touched the Blitter option is running
+> accurate, not fast. This row alone had to be taken with
 > `virtualjaguar_usefastblitter=disabled`, because that is the only mode with
 > the perf counters (§4.1 correction below). `blitter_generic` and
 > `blitter_blit` are not identical renderers — divergence between them is the
 > whole premise of `test/tools/test_blitter_compare`. The blit *count* was
 > corroborated across the seam: the vjtrace `--field-csv` `blit_cmd` column in
-> a default fast-blitter run reads **389 blits/field**, against **~400** from
+> a harness-default (fast) run reads **389 blits/field**, against **~400** from
 > the accurate-blitter probe. Pixel and phrase counts were **not** corroborated
 > and are accurate-blitter figures. The conclusion is insensitive to this (0.34
 > vs 0.4 field does not change "no single component is 10x cheap"), but do not
@@ -175,8 +182,11 @@ missing time.
 > traffic (renders via GPU/OP)". That reading came from a `blitter_calls`
 > perf counter that reads zero under the **fast** blitter:
 > `PERF_INC(blitter_calls)` exists only in `blitter_generic`/the accurate
-> path, not in `blitter_blit` (`src/tom/blitter.c:1158`), and fast is the
-> default. Run blitter censuses with
+> path, not in `blitter_blit` (`src/tom/blitter.c:1158`). Zero blits was a
+> tooling artifact of the **headless harness's** fast-blitter default
+> (`test/harness/harness.c:385-387`), not of the **shipped core's**
+> default, which is accurate (`libretro_core_options.h:130-141`,
+> `"disabled"`). Run blitter censuses with
 > `--option virtualjaguar_usefastblitter=disabled`.
 
 ### 4.2 68K

--- a/docs/doom-render-cost-census.md
+++ b/docs/doom-render-cost-census.md
@@ -1,0 +1,255 @@
+# Doom render-cost census (#401)
+
+Where Jaguar Doom's per-frame time actually goes in this core, measured
+component by component. Written to close out a #401 attempt that set out to
+"make the GPU cost model accurate enough that render time lands in the right
+band" and found that **the GPU cost model is already at its ground-truth
+ceiling, and the render is not where the missing time is.**
+
+No emulator behaviour was changed to produce this document. Everything below
+is measurement against `develop` @ `adb5ed4` plus throwaway instrumentation
+that was reverted.
+
+Companion documents:
+
+* [`doom-pace-calibration.md`](doom-pace-calibration.md) — the game side
+  (`MiniLoop`, `vblsinframe`, the two `I_Update` copies and their gates).
+* [`gpu-timing-spec.md`](gpu-timing-spec.md) — the Flare-netlist timing rules
+  the GPU model implements; §14 holds the Verilator-pinned constants used as
+  the ceiling below.
+
+---
+
+## 0. Method and units
+
+Title: `Doom - Evil Unleashed (1994).jag`, attract demo, NTSC, headless
+harness, windows over frames 900-1500 (the demo's steady state; the first
+~600 fields are title/idle and are excluded).
+
+One NTSC field = **442,717 GPU cycles**. Doom's 3D view presents once per
+**2 fields** — the GPU-side `I_Update` in `r_phase9.gas` gates on
+`ticcount - lastticcount >= 2`. So a *rendered frame* ("flip") is 885,434 GPU
+cycles of wall budget, and every "fields" figure below is
+`cycles / 442,717`.
+
+Two instruments:
+
+* **GPU PC census** — the `BENCH_PROFILE` halfline-rate PC sampler
+  (`gpuPCSample`, 524 samples/field, 628,800 samples/run) read by
+  `test/tools/m68k_pc_histogram` with `PC_GPU=1`. Sampling is uniform in
+  time, so bucket share *is* time share.
+* **Work-cycle counter** — a temporary counter in `GPUExec` accumulating
+  `opcode_cycles + gpu_bus_stall + gpu_pipe_core_stall` split by whether the
+  PC was inside one of Doom's three spin loops (below). This is the
+  "GPU busy-time per rendered frame" instrument #401 asks for; the raw
+  opcode count is useless because the GPU is **budget-saturated in every
+  configuration** (442,717 ops/field with all timing off — it never idles, it
+  spins).
+
+---
+
+## 1. The GPU spends ~75% of every field in three spin loops
+
+Disassembled from GPU local RAM at runtime (`test/tools/gpu_disasm_dump`).
+
+| Region | Share | What it is |
+|---|---:|---|
+| `$F0308A-$F0309E` | 26.6% | **Idle mailbox poll.** `store #1,($F0304C)` / `load ($F03048),r1` / `or r1,r1` / `jr Z` — GPU advertising "idle" and waiting for the 68K to post a job. Both addresses are GPU **local** RAM. |
+| `$F03672-$F0369A` | 34.5% | **Display-list adopt handshake.** `[$40634] = [$47DBC]`, then spin until `[$40634] == [$21FD0]` — waiting for the 68K video ISR to adopt the new list. Main-RAM external loads. |
+| `$F0362C-$F03658` | 13.8% | **The `r_phase9` 2-field gate.** `delta = [ticcount] - [lastticcount]`, `moveq #2`, `cmp`, loop while `delta < 2`. This is Doom's own floor. |
+| `$F03000` | 4.2% | GPU interrupt vector. |
+| `$F030C4-$F030D4` | 1.6% | Block-copy loop — real work. |
+| everything else | **19.3%** | The actual renderer. |
+
+> **Correction to #401's problem statement.** The issue names
+> `$F0308A-$F0309E` as "the texel inner loop". It is not: it is the
+> local-RAM idle-mailbox poll above. Optimising or re-pricing that address
+> range changes nothing but spin iteration count.
+
+Because two of the three loops are the GPU *waiting on the 68K*, and the
+third is the game's own field gate, **making instructions more expensive
+mostly buys fewer spin iterations, not a later flip** — until render work
+alone crosses 2 fields. This is why present rate and tic rate are insensitive
+instruments below that threshold, and why halving the RISC clock moved the
+tic rate by 3%.
+
+---
+
+## 2. Render cost per rendered frame, by configuration
+
+`work` = cycles executed with the PC outside the three spin windows.
+
+| Configuration | work cyc/flip | work fields/flip | work ops/flip | GPU ext acc/flip | fields/flip |
+|---|---:|---:|---:|---:|---:|
+| all timing OFF (default) | 200k-274k | **0.45-0.62** | 200k-274k | 0 | 2.00 |
+| `gpu_pipeline_timing` | 407k-500k | **0.92-1.13** | 167k-206k | 10.3k-11.7k | 2.00-2.22 |
+| `blitter_timing` + `dram_timing` | 553k-644k | **1.25-1.45** | 223k-283k | 0 | 2.00-2.04 |
+| all three | 780k-974k | **1.76-2.20** | 228k-299k | 14k-20k | 2.19-2.52 |
+
+The renderer is ~**250k GPU instructions per rendered frame** and that count
+is configuration-independent (as it must be — it is set by the scene).
+
+---
+
+## 3. The GPU model is already at the netlist ceiling
+
+Apply `gpu-timing-spec.md` §14's Verilator-pinned rules to the measured
+instruction mix (250k instructions, ~10-20k external accesses, ~13k local-RAM
+ops per flip):
+
+| Term | Rule | Cost/flip |
+|---|---|---:|
+| Register-writing instructions | §14: write-back port conflict retires a disjoint-register stream at **2.00 ticks/instr** | ~500k = 1.13 field |
+| External accesses | §14: `L = 7 + D`; model charges issue 2 + grant 2 + DRAM 5 + return 3 = **12**, exactly the page-miss value | 124-240k if fully exposed, mostly concealed — ~16 instructions separate consecutive accesses, and 16 instructions at 2 ticks already exceeds 12 |
+| Local-RAM loads | §5: 3-tick latency, non-blocking, engine accepts one op per 2 ticks | largely concealed |
+| **Ceiling** | | **~1.1-1.3 fields** |
+
+Measured with `gpu_pipeline_timing` on: **0.92-1.13 fields**. The model is
+within ~15% of the ceiling its own ground truth permits.
+
+External pricing was verified directly rather than assumed: mean
+`bus_arbiter_charge_access` cost over 24,132 GPU external accesses per field
+is **5.05 sysclks** (the DRAM page-miss average), the `cost == 0 →
+GPU_PIPE_IO_CLKS` fallback fires **4 times per field out of 24,132**, and
+only **226 of 24,132** accesses are cart ROM — Doom's GPU render is
+essentially all main DRAM, so ROM wait states are not a hidden lever either.
+
+**For the render alone to pace the loop at 4 fields/flip it would have to
+reach 1.77M ticks over 250k instructions — about 7 ticks per instruction,
+3.5x beyond what the netlist permits.**
+
+### The counterfactual confirms the lever is real but out of reach
+
+Multiplying *only* non-spin instruction cost (spins excluded, so the floor
+cannot absorb it):
+
+| Render cost multiplier | work fields/flip | fields/flip |
+|---:|---:|---:|
+| x1 | 0.45-0.62 | 2.00 |
+| x2 | 0.86-1.24 | 1.99-2.14 |
+| x4 | 2.05-2.80 | **2.70-3.33** |
+
+So render cost *does* drive present rate once it crosses the 2-field floor,
+exactly as #401 predicted — but the multiplier needed (~x6-x8 over stock,
+~x3 over the netlist-accurate model) has no hardware justification.
+
+---
+
+## 4. The other components, priced
+
+| Component | Cost per rendered frame | Source |
+|---|---:|---|
+| GPU render, netlist-accurate | 0.9-1.3 field | §2/§3 above — measured |
+| Blitter | **0.34 field** | `blitter_budget_probe` — measured, but see the configuration seam in §4.1 |
+| 68K | ~1 field of non-spin work | **ESTIMATE** — sample-share only, §4.2 |
+| Object Processor | field-locked by construction | — |
+| **Serialized upper bound** | **~2.3-2.5 fields** (68K term estimated) | |
+
+Only two of the three non-zero rows are measured cycle counts. The 68K row is
+a share-of-samples estimate, so the total is a shape, not a figure — it
+supports "no single component is an order of magnitude cheap" and does **not**
+support any precise claim about the size of the residual.
+
+### 4.1 Blitter — Doom is *not* blitter-free
+
+`blitter_budget_probe` on the accurate blitter: **~400 blits/field, 42-45k
+pixels/field, 31-33k phrases/field → 74k sysclks = 16.7% of a field**
+(peak 74.8%). Per rendered frame that is ~0.34 field. Real, but not the
+missing time.
+
+> **Configuration seam — read before reusing this number.** Every other
+> figure in this document was measured in the **default fast-blitter**
+> configuration; this row alone had to be taken with
+> `virtualjaguar_usefastblitter=disabled`, because that is the only mode with
+> the perf counters (§4.1 correction below). `blitter_generic` and
+> `blitter_blit` are not identical renderers — divergence between them is the
+> whole premise of `test/tools/test_blitter_compare`. The blit *count* was
+> corroborated across the seam: the vjtrace `--field-csv` `blit_cmd` column in
+> a default fast-blitter run reads **389 blits/field**, against **~400** from
+> the accurate-blitter probe. Pixel and phrase counts were **not** corroborated
+> and are accurate-blitter figures. The conclusion is insensitive to this (0.34
+> vs 0.4 field does not change "no single component is 10x cheap"), but do not
+> quote 42-45k px/field as a fast-blitter number.
+
+> **Correction to #401.** The issue states "Doom performs zero blitter
+> traffic (renders via GPU/OP)". That reading came from a `blitter_calls`
+> perf counter that reads zero under the **fast** blitter:
+> `PERF_INC(blitter_calls)` exists only in `blitter_generic`/the accurate
+> path, not in `blitter_blit` (`src/tom/blitter.c:1158`), and fast is the
+> default. Run blitter censuses with
+> `--option virtualjaguar_usefastblitter=disabled`.
+
+### 4.2 68K
+
+68K PC census over the same window: `$004662-$00466E` **31.3%**,
+`$009C80-$009C88` **14.1%**, `$005282-$00528E` **6.9%** — three tight loops
+holding **52%** of all samples, the signature of a processor spending half
+its time waiting (`MiniLoop`'s `while (!I_RefreshCompleted())` and the DSP
+handshake). The remaining ~48% is charged at UAE published timings with
+essentially no DRAM wait states. This number is an estimate: unlike the GPU
+it was not separated with a cycle-accurate work/spin counter.
+
+---
+
+## 5. Conclusion and the remaining gap
+
+Aggregated, this core delivers a Doom rendered frame in **2.00 fields** with
+all timing options off and **~2.2-2.5 fields** with all three on, against a
+reference expectation of **3-4 fields** on hardware.
+
+That reframes #401 substantially:
+
+* The headline "our GPU executes Doom's render ~10x cheaper than hardware"
+  is **not supported**. Priced at its netlist ceiling the render is ~1.1
+  fields of a 3-4 field frame; stock it is ~0.5. The GPU error is roughly
+  **2x**, and `gpu_pipeline_timing` already recovers most of it.
+* No single component is an order of magnitude cheap. The residual (~1-1.5
+  fields, sized off a budget whose 68K term is estimated — see §4) is spread
+  across everything and does not have an identified owner.
+* The best-supported candidate for the residual is **DRAM bandwidth
+  contention** — the OP, blitter, refresh, GPU and 68K share one memory
+  controller, and this core charges every master its *idle-bus* cost with no
+  queueing (`bus_arbiter.contention_scale` defaults to 1). `gpu-timing-spec.md`
+  §4 already flags "bus grant latency under load (blitter/OP running)" as the
+  one remaining sim-pinned item. Calibrating it needs a Verilator run or a
+  hardware capture; guessing a scale factor would be unfalsifiable.
+
+### Is the existing option combination safe to default on?
+
+Measured, since it is the obvious follow-on question: with
+`gpu_pipeline_timing` + `blitter_timing` + `dram_timing` all enabled, Doom's
+attract demo runs clean at `risc_clock_scale` 0.5x / 1x / 1.5x / 2x (every
+value the option offers) — no wedge, no deadlock, so #406's knife-edge does
+not reproduce on this combination at these scales.
+
+But the gain does not survive overclocking, which is the point against
+shipping it as an accuracy default:
+
+| `risc_clock_scale` | fields/flip, all three on |
+|---|---:|
+| 0.5x | 2.05-2.54 |
+| 1x | 2.19-2.52 |
+| 1.5x | 2.01-2.17 |
+| 2x | 2.00-2.08 |
+
+At 2x the extra cost is exactly cancelled and the demo is back on the
+2-field floor. A default-on accuracy model that any user can switch off by
+raising an unrelated performance option is not an accuracy model. That, plus
+the fact that the combination only recovers ~0.3 of the missing ~1-1.5
+fields, is why this attempt did not flip the defaults.
+
+### What NOT to try next
+
+* Re-pricing GPU instructions. The ceiling is measured and documented above.
+* Re-pricing cart ROM. 226 of 24,132 GPU external accesses per field.
+* Optimising or re-pricing `$F0308A-$F0309E`. It is a spin loop.
+
+### Load-bearing unverified input
+
+Every "we are Nx fast" statement rests on **hardware taking 3-4 fields per
+Doom frame**, which is a reference expectation, not something measured here.
+The supporting game-side evidence is that Doom's demo hard-codes
+`vblsinframe = 4` (`d_main.c:284`) and gameplay clamps it to 8 — the authors
+budgeted for 4-8. A BigPEmu or hardware capture of `lasttics` in the attract
+demo would either confirm the residual or shrink it, and is the single
+highest-value next measurement.

--- a/test/tools/blitter_budget_probe.c
+++ b/test/tools/blitter_budget_probe.c
@@ -42,6 +42,15 @@
  *
  * Requires a BENCH_PROFILE=1 core (perf counters) with test exports:
  *   make clean && make BENCH_PROFILE=1 TEST_EXPORTS=1
+ * (`make` does not track CFLAGS changes, so `make clean` is load-bearing --
+ * a plain rebuild leaves the old objects and the counters stay absent.)
+ *
+ * ALSO REQUIRES THE ACCURATE BLITTER.  PERF_INC(blitter_calls) exists only
+ * in blitter_generic(); blitter_blit() -- the default "fast" blitter -- has
+ * no counters, so a default run reports 0 blits and the verdict reads
+ * "blitter is not a factor".  Always pass:
+ *   --option virtualjaguar_usefastblitter=disabled
+ * The tool now exits 2 rather than printing that false negative.
  * Build:
  *   cc -O2 -Wall -std=c99 -I. -I./libretro-common/include \
  *      -o test/tools/blitter_budget_probe test/tools/blitter_budget_probe.c \
@@ -164,6 +173,22 @@ int main(int argc, char **argv)
 
     printf("\nPEAK: frame %u at %.1f%% of one field; %u/%u frames exceed 100%%\n",
            st.peak_frame, st.peak_field_pct, st.over100, cfg.frames);
+    /* Zero blits is almost never the truth -- it is the fast blitter.
+     * PERF_INC(blitter_calls) lives only in the accurate blitter path
+     * (blitter_generic), not in blitter_blit(), and fast is the default,
+     * so a fast-blitter run silently reports 0 and the verdict below
+     * reads as "blitter is not a factor".  That false negative is how
+     * "Doom performs zero blitter traffic" got into #401; Doom in fact
+     * issues ~400 blits/field (docs/doom-render-cost-census.md §4.1). */
+    if (st.peak_field_pct <= 0.0)
+    {
+        printf("=> NO blitter traffic counted.  The perf counters only exist in the\n"
+               "   ACCURATE blitter; re-run with\n"
+               "     --option virtualjaguar_usefastblitter=disabled\n"
+               "   before concluding this title does not use the blitter.\n");
+        harness_shutdown(&cfg);
+        return 2;
+    }
     printf("%s\n", st.peak_field_pct > 100.0
         ? "=> blitter work alone cannot fit in one field: hardware needs >=2 VBLs\n"
           "   for those frames while we deliver them in one, so render-bound game\n"

--- a/test/tools/blitter_budget_probe.c
+++ b/test/tools/blitter_budget_probe.c
@@ -47,10 +47,15 @@
  *
  * ALSO REQUIRES THE ACCURATE BLITTER.  PERF_INC(blitter_calls) exists only
  * in blitter_generic(); blitter_blit() -- the default "fast" blitter -- has
- * no counters, so a default run reports 0 blits and the verdict reads
- * "blitter is not a factor".  Always pass:
+ * no counters, so a run that leaves the blitter on fast reports 0 blits
+ * with no way to tell "title issues none" from "counters can't see them".
+ * Always pass:
  *   --option virtualjaguar_usefastblitter=disabled
- * The tool now exits 2 rather than printing that false negative.
+ * The tool tracks whether that option was passed explicitly: a zero-blits
+ * result under the accurate blitter is reported as a legitimate 0-traffic
+ * measurement (exit 0); a zero-blits result without it is reported as
+ * genuinely ambiguous and exits 2, since the counters may simply be blind
+ * to real traffic in that configuration.
  * Build:
  *   cc -O2 -Wall -std=c99 -I. -I./libretro-common/include \
  *      -o test/tools/blitter_budget_probe test/tools/blitter_budget_probe.c \
@@ -82,6 +87,10 @@ typedef struct {
     unsigned long long w_reads, w_writes, w_calls, w_inner;
     double   peak_field_pct;
     unsigned peak_frame, over100;
+    /* set when --option virtualjaguar_usefastblitter=disabled was passed
+     * explicitly, i.e. the accurate blitter (and its perf counters) was
+     * live for the whole run -- see the zero-blits branch in main(). */
+    unsigned accurate_requested;
 } budget_state;
 
 static budget_state st;
@@ -141,6 +150,16 @@ int main(int argc, char **argv)
     }
 
     if (!harness_init_from_args(&cfg, argc, argv)) return 1;
+    {
+        /* Was the accurate blitter explicitly requested?  If so, the perf
+         * counters (accurate-path only) were live for the whole run, so a
+         * zero-blits result below is a real measurement, not a config gap. */
+        unsigned oi;
+        for (oi = 0; oi < cfg.num_options; oi++)
+            if (!strcmp(cfg.options[oi].key, "virtualjaguar_usefastblitter") &&
+                !strcmp(cfg.options[oi].value, "disabled"))
+                st.accurate_requested = 1;
+    }
     if (!harness_load_rom(&cfg)) { harness_shutdown(&cfg); return 1; }
 
     find = (find_fn)harness_dlsym(&cfg, "perf_counters_find");
@@ -173,19 +192,37 @@ int main(int argc, char **argv)
 
     printf("\nPEAK: frame %u at %.1f%% of one field; %u/%u frames exceed 100%%\n",
            st.peak_frame, st.peak_field_pct, st.over100, cfg.frames);
-    /* Zero blits is almost never the truth -- it is the fast blitter.
-     * PERF_INC(blitter_calls) lives only in the accurate blitter path
-     * (blitter_generic), not in blitter_blit(), and fast is the default,
-     * so a fast-blitter run silently reports 0 and the verdict below
-     * reads as "blitter is not a factor".  That false negative is how
-     * "Doom performs zero blitter traffic" got into #401; Doom in fact
-     * issues ~400 blits/field (docs/doom-render-cost-census.md §4.1). */
+    /* Zero blits is ambiguous under the fast blitter, not automatically
+     * false: PERF_INC(blitter_calls) lives only in the accurate blitter
+     * path (blitter_generic), not in blitter_blit(), so a fast-blitter run
+     * silently reports 0 whether or not the title actually issues blits --
+     * that gap is how "Doom performs zero blitter traffic" got into #401;
+     * Doom in fact issues ~400 blits/field under the accurate blitter
+     * (docs/doom-render-cost-census.md §4.1). But if the ACCURATE blitter
+     * was explicitly selected (st.accurate_requested), the counters were
+     * live for the whole run, so a zero here is a real measurement -- not
+     * every title uses the blitter, and asserting the fast-blitter
+     * explanation for that case would itself be a confident wrong
+     * conclusion from ambiguous-looking data. */
     if (st.peak_field_pct <= 0.0)
     {
-        printf("=> NO blitter traffic counted.  The perf counters only exist in the\n"
-               "   ACCURATE blitter; re-run with\n"
+        if (st.accurate_requested)
+        {
+            printf("=> ZERO blitter traffic, with the ACCURATE blitter explicitly selected\n"
+                   "   (--option virtualjaguar_usefastblitter=disabled), so the perf counters\n"
+                   "   were live for the whole run.  This is a legitimate result: this title\n"
+                   "   issues no blitter traffic in this window -- it is not a fast-blitter\n"
+                   "   counter gap.\n");
+            harness_shutdown(&cfg);
+            return 0;
+        }
+        printf("=> NO blitter traffic counted, but the counters only exist in the ACCURATE\n"
+               "   blitter path and this run did not explicitly select it, so this result is\n"
+               "   AMBIGUOUS: it may mean the title truly issues no blits, or it may mean the\n"
+               "   fast blitter is simply hiding real traffic from these counters. Re-run\n"
+               "   with:\n"
                "     --option virtualjaguar_usefastblitter=disabled\n"
-               "   before concluding this title does not use the blitter.\n");
+               "   to resolve which one it is before concluding either way.\n");
         harness_shutdown(&cfg);
         return 2;
     }

--- a/test/tools/m68k_pc_histogram.c
+++ b/test/tools/m68k_pc_histogram.c
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include "../harness/harness.h"
 
 #define NBUCKET 4096u
@@ -85,13 +86,43 @@ int main(int argc, char **argv)
     qsort(order, NBUCKET, sizeof(order[0]), cmp);
     printf("total samples=%u\n", total);
     {
-        /* Guard the parse: PC_TOP=0 or a non-numeric value would print no
-         * rows at all, which reads exactly like "no samples were taken" --
-         * a confusing zero this tool can already produce for a real reason
-         * (a core built without BENCH_PROFILE).  One such failure mode is
-         * enough. */
+        /* Guard the parse: atoi() on PC_TOP=0, a negative value, or a
+         * non-numeric value silently becomes 0 (prints no rows -- reads
+         * exactly like "no samples were taken", a confusing zero this tool
+         * can already produce for a real reason: a core built without
+         * BENCH_PROFILE) or, cast to unsigned, an enormous topn (dumps every
+         * bucket). strtoul() with endptr/errno validation rejects both
+         * non-numeric input and out-of-range values instead of coercing them,
+         * and the result is clamped to [1, NBUCKET] so a huge PC_TOP can't
+         * walk past the bucket table either. */
         const char *e = getenv("PC_TOP");
-        if (e && atoi(e) > 0) topn = (unsigned)atoi(e);
+        if (e && *e != '\0')
+        {
+            char *end = NULL;
+            unsigned long v;
+            /* strtoul() accepts a leading '-' and silently wraps it into a
+             * huge unsigned value (the C standard's documented behaviour,
+             * not a bug) -- reject that explicitly rather than letting the
+             * clamp below turn "-1" into "NBUCKET" without a word. */
+            if (e[0] == '-')
+                fprintf(stderr,
+                        "PC_TOP=%s ignored (must be an integer in [1, %u]); using default %u\n",
+                        e, NBUCKET, topn);
+            else
+            {
+                errno = 0;
+                v = strtoul(e, &end, 10);
+                if (end == e || *end != '\0' || errno == ERANGE || v == 0)
+                    fprintf(stderr,
+                            "PC_TOP=%s ignored (must be an integer in [1, %u]); using default %u\n",
+                            e, NBUCKET, topn);
+                else
+                {
+                    if (v > NBUCKET) v = NBUCKET;
+                    topn = (unsigned)v;
+                }
+            }
+        }
     }
     for (i = 0; i < NBUCKET && shown < topn; i++)
         if (hcount[order[i]])

--- a/test/tools/m68k_pc_histogram.c
+++ b/test/tools/m68k_pc_histogram.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 {
     harness_config cfg = HARNESS_CONFIG_DEFAULT;
     uint32_t order[NBUCKET];
-    unsigned i, shown = 0;
+    unsigned i, shown = 0, topn = 24;
     cfg.frames = 900;
     if (!harness_init_from_args(&cfg, argc, argv))
         return 1;
@@ -84,7 +84,16 @@ int main(int argc, char **argv)
     for (i = 0; i < NBUCKET; i++) order[i] = i;
     qsort(order, NBUCKET, sizeof(order[0]), cmp);
     printf("total samples=%u\n", total);
-    for (i = 0; i < NBUCKET && shown < 24; i++)
+    {
+        /* Guard the parse: PC_TOP=0 or a non-numeric value would print no
+         * rows at all, which reads exactly like "no samples were taken" --
+         * a confusing zero this tool can already produce for a real reason
+         * (a core built without BENCH_PROFILE).  One such failure mode is
+         * enough. */
+        const char *e = getenv("PC_TOP");
+        if (e && atoi(e) > 0) topn = (unsigned)atoi(e);
+    }
+    for (i = 0; i < NBUCKET && shown < topn; i++)
         if (hcount[order[i]])
         {
             printf("  $%06X  %7u  %5.1f%%\n", hpc[order[i]],


### PR DESCRIPTION
Measurement record for a #401 attempt that set out to "make the GPU cost model accurate enough that render time lands in the right band" and found **the premise does not hold**. **No emulator behaviour is changed — there are zero `src/` changes in this PR.**

Full census: [`docs/doom-render-cost-census.md`](docs/doom-render-cost-census.md).

## Headline

**"Our GPU executes Doom's render ~10x cheaper than hardware" is not supported. It is ~2x, and `virtualjaguar_gpu_pipeline_timing` already recovers most of it.**

Doom's renderer is ~250k GPU instructions per rendered frame. Priced at the `gpu-timing-spec.md` §14 Verilator ceiling (write-back port conflict 2.00 ticks/instr; external load `L = 7+D` = 12 sysclks), that is ~1.1 fields of a 3-4 field frame — and the existing model already measures 0.92-1.13 fields, within ~15% of its own ground truth.

GPU busy-time per rendered frame (cycles with the PC outside Doom's spin loops; 1 field = 442,717 cycles, 1 flip = 2 fields):

| Configuration | work fields/flip | fields/flip |
|---|---:|---:|
| all timing OFF (default) | 0.45-0.62 | 2.00 |
| `gpu_pipeline_timing` | 0.92-1.13 | 2.00-2.22 |
| `blitter_timing` + `dram_timing` | 1.25-1.45 | 2.00-2.04 |
| all three | 1.76-2.20 | 2.19-2.52 |
| netlist ceiling (computed) | ~1.1-1.3 | — |
| needed for 4 fields/flip | ~4.0 | 4.00 |

A counterfactual that multiplies *only* non-spin instruction cost (so the 2-field floor cannot absorb it) confirms the lever is real but out of reach: x2 → 2.0-2.1 fields/flip, x4 → 2.70-3.33. Reaching 4 needs ~x3 beyond what the netlist permits.

## Two corrections that would otherwise be re-derived

1. **`$F0308A-$F0309E` is not "the texel inner loop"** (as #401 states). Disassembled at runtime it is `store #1,($F0304C)` / `load ($F03048),r1` / `or r1,r1` / `jr Z` — a GPU-local-RAM idle mailbox poll. The GPU spends ~75% of every field in three spin loops, two of them waiting on the 68K.
2. **Doom is not blitter-free.** It issues ~400 blits/field, 42-45k px/field (0.34 field per rendered frame; that cost figure is measured under the ACCURATE blitter, the only mode with the perf counters — the blit *count* is corroborated across that seam at 389/field by the vjtrace `blit_cmd` column in a default fast-blitter run, see the census §4.1). The "zero blitter traffic" in #401 was a **tooling false negative**: `PERF_INC(blitter_calls)` exists only in the accurate blitter while *fast* is the default, so `blitter_budget_probe` silently reported 0 blits and printed "blitter work fits within one field".

Also ruled out: external memory is not underpriced (mean `bus_arbiter` cost 5.05 sysclks over 24,132 accesses/field, total latency 12 = §14's page-miss value; the 4-clk fallback fires 4×/field; only 226/24,132 accesses are cart ROM).

## Changes

- `docs/doom-render-cost-census.md` — the full census, component budget, netlist-ceiling derivation, counterfactual, and a "what not to try next" list.
- `test/tools/blitter_budget_probe.c` — **fix the false negative**: exit 2 and name `--option virtualjaguar_usefastblitter=disabled` instead of printing "blitter is not a factor" on a zero-blit run. Header documents that `make clean` is load-bearing (make does not track CFLAGS changes).
- `test/tools/m68k_pc_histogram.c` — `PC_TOP` env knob so the tail below the spin loops is readable; default stays 24 rows.

## Verification

- Zero `src/` changes ⇒ output byte-identical to develop with options off, by construction.
- `make TEST_EXPORTS=1 test` — **exit 0**.
- #406 scale sweep, all three timing options on: Doom clean at `risc_clock_scale` 0.5x / 1x / 1.5x / 2x (every value the option offers) — no wedge. But the gain does not survive overclocking (2x → back to 2.00 fields/flip), which is one reason this did not flip the defaults.

## Recommendation

Re-scope #401 to "find the owner of the residual ~1-1.5 fields"; lead candidate is DRAM bandwidth contention (every master is charged its idle-bus cost with no queueing; `gpu-timing-spec.md` §4 already flags this as the remaining sim-pinned item). **Highest-value next measurement: a BigPEmu or hardware capture of `lasttics` in the Doom attract demo** — every "we are Nx fast" claim in the issue, including this one, rests on an unverified 3-4 field reference expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
