### PR TITLE
docs(op): correct REMAINDER bit range, pin HSCALE/VSCALE direction (#354 investigation)

### DIFF
--- a/.claude/skills/vj-debug/SKILL.md
+++ b/.claude/skills/vj-debug/SKILL.md
@@ -194,6 +194,27 @@ the current directory when omitted.
 
 ### Pixels wrong
 
+- **What is the OP actually drawing?** `test/tools/op_list_dump` — decodes the
+  live Object Processor display list into JTRM fields (TYPE, YPOS, HEIGHT,
+  XPOS, IWIDTH, DWIDTH, DEPTH, PITCH, HSCALE, VSCALE, REMAINDER, DATA + raw
+  phrases + BRANCH link/cc).
+  ```
+  cc -O2 -Wall -std=c99 -I. -I./test/harness -I./libretro-common/include -o test/tools/op_list_dump \
+     test/tools/op_list_dump.c test/harness/harness.c -ldl -lm
+  # find the list base first: OP_OBJECT events carry the object phrase address
+  /tmp/vjt_smoke ./virtualjaguar_libretro.dylib rom.jag --frames 900 --trace-out /tmp/t.vjtr
+  ./test/tools/trace_dump /tmp/t.vjtr --type OP_OBJECT --frame 880:881
+  OPLIST_BASE=13BA00 OPLIST_COUNT=26 ./test/tools/op_list_dump ./virtualjaguar_libretro.dylib rom.jag --frames 900 --quiet
+  ```
+  Reach for this **first** on any "wrong size / wrong position / missing plane"
+  bug, before reading `src/tom/op.c`. It separates "the OP is misbehaving" from
+  "the OP is faithfully drawing bad data the game wrote" — which are opposite
+  fixes. On issue #354 it showed the suspect object's own HSCALE=$10 fully
+  explains the render, exonerating the OP.
+  **Do not read HSCALE/VSCALE backwards**: JTRM Rev 8 defines them as
+  *destination per source*, so below $20 SHRINKS. Two separate sessions have now
+  lost time to the inverted reading; `docs/jtrm-object-processor.md` carries the
+  verbatim wording.
 - `test/tools/frame_hash_ab` — per-frame framebuffer-hash CSV; compares WHEN
   a distinct image state first appears across two arms (see "Two
   configs/builds behave differently" above for the build/run lines).

--- a/docs/jtrm-object-processor.md
+++ b/docs/jtrm-object-processor.md
@@ -70,16 +70,35 @@ Same as BITOBJ but adds a third phrase for scaling parameters:
 ### Third Phrase (scaling, bits 63-0):
 | Bits | Name | Description |
 |------|------|-------------|
-| 0-7 | HSCALE | Horizontal scale factor (3.5 fixed point: integer[7:5], fraction[4:0]) |
-| 8-15 | VSCALE | Vertical scale factor (3.5 fixed point) |
-| 16-31 | REMAINDER | Vertical remainder (fractional accumulator for Y scaling) |
+| 0-7 | HSCALE | Horizontal scale (3.5 fixed point). **Pixels written into the line buffer per _source_ pixel.** |
+| 8-15 | VSCALE | Vertical scale (3.5 fixed point). **Display lines drawn per _source_ line.** Equals HSCALE for an object to keep its aspect ratio. |
+| 16-23 | REMAINDER | Vertical remainder (3.5 fixed point, **8 bits**) |
+| 24-63 | -- | Unused, write zeroes |
 
 Scale factor encoding (3.5 fixed point):
 - $20 (0b001_00000) = 1.0x (no scaling)
 - $40 (0b010_00000) = 2.0x (double size)
 - $10 (0b000_10000) = 0.5x (half size)
 
-For vertical scaling, the OP uses REMAINDER to accumulate fractional lines. When REMAINDER overflows, the same DATA line is repeated (for scaling > 1x) or a line is skipped (for scaling < 1x).
+**Direction matters and is easy to get backwards.** HSCALE/VSCALE are *destination
+per source*, so a value below $20 SHRINKS the object and a value above $20 magnifies
+it. An object with IWIDTH=40 phrases at 8bpp (320 source pixels) and HSCALE=$10
+renders 320 x 0.5 = **160** pixels wide, not 640. `OPProcessScaledBitmap()` in
+`src/tom/op.c` implements this as `scaledWidthInPixels = (iwidth *
+phraseWidthToPixels[depth] * hscale) >> 5`, which is correct.
+
+REMAINDER algorithm (JTRM, verbatim intent): after each display line is drawn REMAINDER
+is decremented by one (i.e. $20). If it becomes negative, VSCALE is added until it is
+positive again, and HEIGHT is decremented every time VSCALE is added. The new REMAINDER
+is written back to the object. So the source line advances `ceil($20 / VSCALE)` times
+per display line -- VSCALE < 1.0 shrinks. The horizontal loop in `op.c` is the exact
+analogue of this, which is the cross-check that pins the HSCALE direction.
+
+> Sourced verbatim from the Jaguar Technical Reference Manual Revision 8,
+> "Scaled Bit Mapped Object" (Software Reference, p.20). An earlier version of this
+> file listed REMAINDER as bits 16-31; that was wrong -- it is 8 bits at 16-23, and
+> `op.c`'s `(p2 >> 16) & 0xFF` was right all along. Verified 2026-08-12 while
+> investigating issue #354; the incorrect entry actively misled that investigation.
 
 ## GPUOBJ (Type 2) -- GPU Interrupt Object
 

--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -39,6 +39,7 @@ skip_file() {
         test/tools/hires_state_digest.c) return 0 ;;
         test/tools/hires_shot.c) return 0 ;;
         test/tools/blit_memo_verify.c) return 0 ;;
+        test/tools/op_list_dump.c) return 0 ;;
     esac
     return 1
 }

--- a/test/tools/op_list_dump.c
+++ b/test/tools/op_list_dump.c
@@ -1,0 +1,132 @@
+/*
+ * op_list_dump.c -- decode the Object Processor display list.
+ *
+ * Answers "what is the OP actually drawing, and with what fields?".  Runs a
+ * title headlessly (scripted input via the shared harness's --press), then
+ * walks the object list in main RAM and prints every object decoded into its
+ * JTRM fields: TYPE, YPOS, HEIGHT, XPOS, IWIDTH, DWIDTH, DEPTH, PITCH,
+ * HSCALE, VSCALE, REMAINDER, DATA, plus the raw phrases and a BRANCH
+ * object's LINK/CC.
+ *
+ * This exists because reasoning about a rendering bug from src/tom/op.c alone
+ * is unreliable -- the object fields the game actually wrote are the ground
+ * truth for whether the OP is misbehaving or faithfully drawing bad data.  It
+ * was written for issue #354 (Val d'Isere foreground snow) and established
+ * that the snow plane is a type-1 SCALED BITMAP whose own HSCALE=$10 yields a
+ * 160px-wide object -- i.e. the OP was correct and the defect is upstream.
+ *
+ * FINDING THE LIST BASE: run any trace_probe_attach()-based tool with
+ * --trace-out and read the OP_OBJECT events (test/tools/trace_dump --type
+ * OP_OBJECT); their `addr` field is the object phrase address.  Pass the
+ * lowest one as OPLIST_BASE.
+ *
+ * Field layout is JTRM Rev 8 "Bit Mapped Object" / "Scaled Bit Mapped Object";
+ * see docs/jtrm-object-processor.md.  Note HSCALE/VSCALE are DESTINATION per
+ * SOURCE (below $20 shrinks) -- do not read them backwards.
+ *
+ * Env knobs:
+ *   OPLIST_BASE=13BA00   hex address of the first object   (default 13BA00)
+ *   OPLIST_COUNT=26      number of 0x20-byte slots to walk (default 26)
+ *   OPLIST_STRIDE=20     hex slot stride                   (default 20)
+ *
+ * Usage:
+ *   ./test/tools/op_list_dump [core] <rom> [--frames N] [--press F:BTN[:HOLD]]...
+ *
+ * Build:
+ *   cc -O2 -Wall -std=c99 -I. -I./test/harness -I./libretro-common/include \
+ *      -o test/tools/op_list_dump test/tools/op_list_dump.c \
+ *      test/harness/harness.c -ldl -lm
+ */
+
+#include "harness.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static uint32_t (*rdlong)(uint32_t, uint32_t);
+
+static uint64_t phrase(uint32_t a)
+{
+    return ((uint64_t)rdlong(a, 0) << 32) | rdlong(a + 4, 0);
+}
+
+static const char *type_name(unsigned t)
+{
+    switch (t) {
+        case 0:  return "BITMAP";
+        case 1:  return "SCALED";
+        case 2:  return "GPUOBJ";
+        case 3:  return "BRANCH";
+        case 4:  return "STOP  ";
+        default: return "?     ";
+    }
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    uint32_t base   = 0x13BA00;
+    uint32_t stride = 0x20;
+    int count = 26;
+    uint32_t addr;
+    int i;
+    uint64_t p0, p1, p2;
+    unsigned type;
+    const char *env;
+
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+    if (!harness_load_rom(&cfg))
+        return 1;
+    harness_run(&cfg);
+
+    rdlong = (uint32_t (*)(uint32_t, uint32_t))harness_dlsym(&cfg, "JaguarReadLong");
+    if (!rdlong) {
+        fprintf(stderr, "op_list_dump: core does not export JaguarReadLong "
+                        "(build with TEST_EXPORTS=1)\n");
+        return 1;
+    }
+
+    env = getenv("OPLIST_BASE");
+    if (env) base = (uint32_t)strtoul(env, NULL, 16);
+    env = getenv("OPLIST_COUNT");
+    if (env) count = atoi(env);
+    env = getenv("OPLIST_STRIDE");
+    if (env) stride = (uint32_t)strtoul(env, NULL, 16);
+
+    printf("addr   type    ypos hgt  xpos iwid dwid dep pit hscl vscl remn data\n");
+    for (i = 0; i < count; i++) {
+        addr = base + (uint32_t)i * stride;
+        p0 = phrase(addr);
+        p1 = phrase(addr + 8);
+        p2 = phrase(addr + 16);
+        type = (unsigned)(p0 & 0x07);
+
+        printf("%06X %s %4u %4u %5d %4u %4u  %u   %u  $%02X  $%02X $%04X %06X\n",
+               addr, type_name(type),
+               (unsigned)((p0 >> 3) & 0x7FF),
+               (unsigned)((p0 >> 14) & 0x3FF),
+               (int)(((int16_t)((p1 << 4) & 0xFFFF)) >> 4),
+               (unsigned)((p1 >> 28) & 0x3FF),
+               (unsigned)((p1 >> 18) & 0x3FF),
+               (unsigned)((p1 >> 12) & 0x07),
+               (unsigned)((p1 >> 15) & 0x07),
+               (unsigned)(p2 & 0xFF),
+               (unsigned)((p2 >> 8) & 0xFF),
+               (unsigned)((p2 >> 16) & 0xFF),
+               (unsigned)((p0 >> 40) & 0xFFFFF8));
+
+        printf("       raw p0=%08X%08X p1=%08X%08X p2=%08X%08X",
+               (unsigned)(p0 >> 32), (unsigned)p0,
+               (unsigned)(p1 >> 32), (unsigned)p1,
+               (unsigned)(p2 >> 32), (unsigned)p2);
+        if (type == 3)
+            printf(" | BRANCH link=%06X cc=%u",
+                   (unsigned)((p0 & 0x000007FFFF000000ULL) >> 21),
+                   (unsigned)((p0 >> 14) & 0x07));
+        printf("\n");
+    }
+
+    harness_shutdown(&cfg);
+    return 0;
+}


### PR DESCRIPTION
Investigating #354 (Val d'Isère foreground snow scaling) turned up a documentation bug that has now misled two separate readers. This PR fixes the doc and lands the tool built for the investigation. **No `src/` change — emulation behaviour is untouched.**

## The doc bug

`docs/jtrm-object-processor.md` listed the scaled-object `REMAINDER` field as bits **16-31**. The Jaguar Technical Reference Manual Revision 8 ("Scaled Bit Mapped Object", Software Reference p.20) says bits **23-16, eight bits** — so `op.c`'s `(p2 >> 16) & 0xFF` was right all along and the doc was wrong.

The doc also never stated the one property of HSCALE/VSCALE that is easy to get backwards. Verbatim from the manual:

> **0-7 HSCALE** — This eight bit field contains a three bit integer part and a five bit fractional part. **The number determines how many pixels are written into the line buffer for each source pixel.**

They are *destination per source*, so a value below `$20` **shrinks**. Added with a worked example (IWIDTH=40 phrases @ 8bpp with HSCALE=`$10` renders **160**px, not 640px) and the REMAINDER algorithm that pins the vertical direction — and, by exact analogy, the horizontal one.

### Why this isn't cosmetic

Both errors caused real lost time on #354:

- the bad REMAINDER range sent me looking for a nonexistent 16-bit field;
- the missing direction note independently led a reviewer to propose an inverted-HSCALE "fix".

Both readings are falsified by the manual. Neither would have been proposed had the doc been right. The doc's own header says it is "cross-referenced with this codebase", which is exactly the circularity that let this survive.

## New tool: `test/tools/op_list_dump`

The OP display-list decoder built for the investigation. Dumps every object's `TYPE/YPOS/HEIGHT/XPOS/IWIDTH/DWIDTH/DEPTH/PITCH/HSCALE/VSCALE/REMAINDER/DATA`, the raw phrases, and a BRANCH object's `LINK/CC`.

```
13BA00 SCALED  287  260     0   40   40  3   1  $10  $20 $0000 0470A0
       raw p0=0470A277444108F9 p1=0000000280A0B000 p2=0000000000002010
13BA20 BRANCH  285    1 -1814    0    0  0   0  $FB  $3F $0000 000000
       raw p0=00000277480048EB ... | BRANCH link=13BA40 cc=1
```

It separates **"the OP is misbehaving"** from **"the OP is faithfully drawing bad data the game wrote"** — opposite fixes. On #354 it established the latter in one run. Indexed in `.claude/skills/vj-debug/SKILL.md` under "Pixels wrong" as the *first* thing to reach for on a wrong-size/missing-plane bug, carrying the HSCALE-direction warning.

Skip-listed in `scripts/c89-lint.sh` alongside every other harness-based tool (`frame_hash_ab`, `hires_shot`, `hires_box_check`, `blit_memo_verify`, …) — they build against `test/harness/`, which is outside `$INCLUDES`.

## On #354 itself

**Not fixed; deliberately not guessed at.** The foreground snow plane is a type-1 SCALED BITMAP whose own `HSCALE=$10` fully accounts for the 160px-wide render on a 260px display. The 68K writes that constant every frame from `pc=$802F2A`.

Ruled out with evidence:

- **field-order swap** — JTRM Rev 8 table, HSCALE is bits 0-7;
- **scale-direction inversion** — JTRM wording, plus the `$0A/$0A` sprites, which are non-unity and so discriminate direction at 10x (a tree renders 5px, not 51px);
- **HSCALE corruption/drift** — vjtrace `--watch`: constant `$2010`, re-asserted every frame;
- **branch fall-through to a hidden second object chain** — `OP_BRANCH` fires on every evaluation (448/frame, always to `$13BA40`), and `$13BA28` holds no object (its "p0" is bit-identical to `$13BA20`'s p1).

The OP is correct; the divergence is upstream and most likely needs a hardware/BigPEmu capture to confirm the target appearance. Full write-up in the investigation report.

## Verification

- `bash scripts/c89-lint.sh` — clean (incl. sse2/neon passes)
- `make TEST_EXPORTS=1` — builds clean
- `git diff --name-only -- src/` — empty; no behaviour change is possible
- Smoke-ran `frame_hash_ab` on `yarc.j64`, `jagniccc.j64`, and Val d'Isère — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
