### PR TITLE
fix(op): keep TYPE/YPOS out of the OB DATA window (#354 Val d'Isère snow floor)

### DIFF
--- a/docs/jtrm-object-processor.md
+++ b/docs/jtrm-object-processor.md
@@ -119,11 +119,25 @@ Used for: mid-frame effects, palette changes, display list modifications during 
 
 Note: Despite the name, GPUOBJ doesn't run GPU code directly. It fires an interrupt; the GPU ISR at vector offset $30 (interrupt 3) does the actual work.
 
-### Reading DATA back through OB ($F00010-$F00017) -- UNRESOLVED
+### Reading DATA back through OB ($F00010-$F00017)
 
-The OP latches the whole phrase into OB before raising IRQ3. **Which
-phrase bits land at which OB address is not specified by the JTRM**, and
-this is currently an open question -- see issue #354.
+The OP latches the whole phrase into OB before raising IRQ3, **straight
+big-endian: bit 63 at `$F00010`, bit 0 at `$F00017`.** A 32-bit read at
+`$F00010` returns the phrase's high long, and at `$F00014` its low long.
+This is what `OPSetCurrentObject()` (`src/tom/op.c`) implements.
+
+The JTRM does not state this directly (see below), so the confirming
+source is MAME's independent implementation, which names the four
+registers in address order (`src/mame/atari/jaguar_v.cpp`):
+
+```
+OB_HH(0x10),  OB_HL(0x12),  OB_LH(0x14),  OB_LL(0x16)
+```
+
+high-high at `$F00010` through low-low at `$F00016` -- straight
+big-endian, agreeing with our code. **Do not "fix" issue #354 by
+flipping this order** (attempted and reverted in PR #424); it is not the
+bug, and four in-tree tests correctly assert the current layout.
 
 Rev 8's complete set of statements about OB is:
 
@@ -139,43 +153,52 @@ Rev 8's complete set of statements about OB is:
 
 That is all of it. **Rev 8 never says whether OB0 (`$F00010`) holds
 phrase bits 63-48 or bits 15-0**, and its sample GPU ISR does not read
-OB. Rev 10 repeats only the table row.
+OB. Rev 10 repeats only the table row. The nearest thing to a statement
+is the general convention (p.131, "Data Organisation - Big and Little
+Endian"): the document "adopts the big-endian convention", a big-endian
+system "will see the high word of long-word at the low address", and for
+phrase data the left-most pixel "always includes bit 63... in byte
+address terms this is stored in byte 0". That is about operands in
+memory rather than about mapping a register group, so it is an inference
+-- but it points the same way MAME does.
 
-What Rev 8 *does* establish generally (p.131, "Data Organisation - Big
-and Little Endian") is that the document "adopts the big-endian
-convention", that a big-endian system "will see the high word of
-long-word at the low address", and that for phrase data the left-most
-pixel "always includes bit 63... in byte address terms this is stored in
-byte 0". Applying that to OB gives straight big-endian -- bit 63 at
-`$F00010`, bit 0 at `$F00017` -- which is what `OPSetCurrentObject()`
-implements today. But that passage is about **operands in memory and
-pixels within a phrase**, not about how a four-register group is mapped,
-so applying it to OB is an inference rather than a quote.
+### Open question: Val d'Isere's IRQ3 gate (issue #354)
 
-**The unresolved conflict (issue #354).** Val d'Isere Skiing's IRQ3
-handler does `load ($F00014)` / `cmpq #0` and only runs its
-perspective-floor renderer (`$F03150`, which writes the per-scanline
-scaled-bitmap objects into the display list at `[$F03094]`) when that
-read returns zero. Under straight big-endian, `$F00014` returns the
-phrase's **low** long -- which necessarily contains TYPE in bits 2-0, so
-it can *never* be zero for a valid object. Measured: the handler reads
-`$87A` and the floor is never drawn. For the shipping game to have
-worked on hardware, `$F00014` must expose DATA (which is 0 for its
-object), not the low long.
+With the layout above confirmed, the following is **unexplained** and is
+the live lead on #354.
 
-Do not "fix" this by flipping the order to match the game without
-resolving it properly: three in-tree tests
-(`test/test_op_gpu_object.c`, `test/acid/tests/op/op_gpu_int_object.s`
-and `..._halted.s`, plus `op_short_branch.s`) assert straight
-big-endian, and they were written against the implementation on a point
-the manual does not settle. Settling this needs hardware or an
-independent implementation, not a vote between our own tests and one
-game.
+Val d'Isere Skiing's IRQ3 handler (vector `$F03030` -> `$F030C2`) does:
+
+```
+movei #$00F00014, r0
+load  (r0), r0          ; low long of the latched object
+cmpq  #0, r0            ; signed 5-bit imm -- field 0 means 0, not 32
+jump  Z, ($F03150)      ; -> per-scanline ground generator
+```
+
+`$F03150` reads VC and the table at `$001368E0`, does the per-line
+perspective maths, and writes the per-scanline scaled-bitmap objects
+into the display list at `[$F03094]` -- i.e. it *generates* the objects
+`OPProcessScaledBitmap` then draws, which is consistent with the
+measurement on #354 that the ground comes from the OP scaled-bitmap path
+and barely touches the blitter.
+
+But `$F00014` returns the phrase's low long, which necessarily contains
+TYPE in bits 2-0, so it can **never** be zero for a valid object.
+Measured: the handler reads `$87A`, the compare never matches, and every
+IRQ3 (~72.8k per run) falls through to a do-nothing epilogue. Something
+in that chain is mismodelled -- candidates worth checking are the phrase
+the OP latches, whether the object should be firing at all on those
+lines (`OBJECT_TYPE_GPU` deliberately ignores YPOS), and the
+`OPProcessScaledBitmap` vertical-stepping hypothesis raised on the
+issue. Note `$F03098`, tested a few instructions later, is **not** the
+floor gate -- it guards a line-buffer capture (`loadp` from `$F01800`,
+`storep` to `$001417A8`) that the game legitimately leaves disabled;
+nothing ever writes it non-zero and that is correct.
 
 Every commercial GPU-object phrase in the test corpus carries DATA == 0
 (Doom `$CD2`, Atari Karts `$2`, Attack of the Mutant Penguins `$2`,
-Super Burnout / SlamRacer `$3FFA`, yarc `$2`/`$A`), so no other title in
-the corpus can discriminate the orderings.
+Super Burnout / SlamRacer `$3FFA`, yarc `$2`/`$A`).
 
 ## BRANCHOBJ (Type 3) -- Branch Object
 

--- a/docs/jtrm-object-processor.md
+++ b/docs/jtrm-object-processor.md
@@ -107,13 +107,41 @@ Single phrase. When the OP encounters this object during scanline processing, it
 | Bits | Name | Description |
 |------|------|-------------|
 | 0-2 | TYPE | Object type = 2 |
-| 3-13 | YPOS | Line at which to trigger |
-| 14-42 | -- | Unused |
-| 43-63 | LINK | Next object address (NOT a data pointer) |
+| 3-13 | YPOS | Active when VC matches YPOS, unless YPOS = $7FF (active for all VC) |
+| 14-63 | DATA | Free for the GPU ISR. Memory-mapped as OB0-3, so the ISR can use it as data or as a pointer to further parameters. |
+
+**There is no LINK field.** Execution continues with the object in the
+*next phrase*; the object is a single phrase with no link. (An earlier
+revision of this file listed bits 14-42 as unused and 43-63 as LINK --
+both wrong. JTRM Rev 8, "Graphics Processor Object".)
 
 Used for: mid-frame effects, palette changes, display list modifications during vblank.
 
 Note: Despite the name, GPUOBJ doesn't run GPU code directly. It fires an interrupt; the GPU ISR at vector offset $30 (interrupt 3) does the actual work.
+
+### Reading DATA back through OB ($F00010-$F00017)
+
+The OP latches the whole phrase into OB before raising IRQ3. **The low
+long is at `$F00010` and the high long at `$F00014`** -- so `$F00014`
+returns pure DATA, while `$F00010` carries TYPE and YPOS in its low bits.
+
+Rev 8 pins that bits 0-13 are control and bits 14-63 are DATA "memory
+mapped as the object code registers OB0-3"; it does *not* say which
+32-bit window holds which half of DATA. What it does constrain is that
+the control fields must not appear in the window an ISR reads for DATA.
+
+Storing the phrase straight big-endian (high long at `$F00010`) puts
+TYPE/YPOS at `$F00014` and breaks any ISR that reads DATA there. Val
+d'Isere Skiing (issue #354) is the title that shows it: its handler does
+`load ($F00014)` / `cmpq #0` and only runs its perspective-floor renderer
+when that reads zero, which is exactly DATA==0 for its object phrase
+`$8EA` (TYPE=2, YPOS=285, DATA=0). Implemented in
+`OPSetCurrentObject()`, `src/tom/op.c`; pinned by
+`test/acid/tests/op/op_gpu_int_object{,_halted}.s`.
+
+Every commercial GPU-object phrase in the test corpus carries DATA == 0
+(Doom `$CD2`, Atari Karts `$2`, Attack of the Mutant Penguins `$2`,
+Super Burnout / SlamRacer `$3FFA`, yarc `$2`/`$A`).
 
 ## BRANCHOBJ (Type 3) -- Branch Object
 
@@ -123,9 +151,22 @@ Single phrase. Conditionally follows an alternate link based on a comparison.
 |------|------|-------------|
 | 0-2 | TYPE | Object type = 3 |
 | 3-13 | YPOS | Y position for comparison |
-| 14-15 | CC | Condition code: 0=YPOS > VC, 1=YPOS = VC, 2=YPOS < VC, 3=flag set |
-| 16-23 | -- | Unused |
+| 14-16 | CC | Condition code (see below) |
+| 17-23 | -- | Unused |
 | 24-42 | LINK | Branch target address (taken if condition true) |
+
+| CC | Branch taken if |
+|----|-----------------|
+| 0 | YPOS == VC, **or** YPOS == $7FF |
+| 1 | YPOS > VC |
+| 2 | YPOS < VC |
+| 3 | Object Processor flag (OBF bit 0) is set |
+| 4 | On the second half of the display line (HC10 = 1) |
+
+(An earlier revision of this file swapped CC 0 and 1 and omitted CC 4.
+Verbatim from JTRM Rev 8, "Branch Object". Rev 8's own field table
+prints CC as bits 14-15, which cannot hold five values; the OP decodes
+three bits -- `(p0 >> 14) & 0x07` in `OPProcessList()`, `src/tom/op.c`.)
 
 If the condition is false, the OP falls through to the next phrase in memory (i.e., LINK is only followed on branch-taken).
 
@@ -186,7 +227,7 @@ Lower bit depths use a CLUT (colour lookup table) in TOM. The INDEX field in BIT
 |---------|------|-----|-------------|
 | $F00020 | OLP | WO | Object list pointer (24-bit, phrase-aligned) |
 | $F00026 | OBF | WO | Object flag (for BRANCHOBJ CC=3) |
-| $F00010-$F0001E | OB[0-3] | WO | Current object data (debug, 4 x 16-bit) |
+| $F00010-$F00017 | OB[0-3] | **RO** | Current object phrase, latched by the OP. **Low long at $F00010, high long at $F00014**; for a GPUOBJ the DATA field reads back at $F00014. See "Reading DATA back through OB" above. |
 
 ## Known Emulation Gotchas
 

--- a/docs/jtrm-object-processor.md
+++ b/docs/jtrm-object-processor.md
@@ -119,29 +119,63 @@ Used for: mid-frame effects, palette changes, display list modifications during 
 
 Note: Despite the name, GPUOBJ doesn't run GPU code directly. It fires an interrupt; the GPU ISR at vector offset $30 (interrupt 3) does the actual work.
 
-### Reading DATA back through OB ($F00010-$F00017)
+### Reading DATA back through OB ($F00010-$F00017) -- UNRESOLVED
 
-The OP latches the whole phrase into OB before raising IRQ3. **The low
-long is at `$F00010` and the high long at `$F00014`** -- so `$F00014`
-returns pure DATA, while `$F00010` carries TYPE and YPOS in its low bits.
+The OP latches the whole phrase into OB before raising IRQ3. **Which
+phrase bits land at which OB address is not specified by the JTRM**, and
+this is currently an open question -- see issue #354.
 
-Rev 8 pins that bits 0-13 are control and bits 14-63 are DATA "memory
-mapped as the object code registers OB0-3"; it does *not* say which
-32-bit window holds which half of DATA. What it does constrain is that
-the control fields must not appear in the window an ISR reads for DATA.
+Rev 8's complete set of statements about OB is:
 
-Storing the phrase straight big-endian (high long at `$F00010`) puts
-TYPE/YPOS at `$F00014` and breaks any ISR that reads DATA there. Val
-d'Isere Skiing (issue #354) is the title that shows it: its handler does
-`load ($F00014)` / `cmpq #0` and only runs its perspective-floor renderer
-when that reads zero, which is exactly DATA==0 for its object phrase
-`$8EA` (TYPE=2, YPOS=285, DATA=0). Implemented in
-`OPSetCurrentObject()`, `src/tom/op.c`; pinned by
-`test/acid/tests/op/op_gpu_int_object{,_halted}.s`.
+* Register table: `OB[0-3]  Object Code  F00010-16  RO`
+* "These four registers allow the graphics processor to read the current
+  object. This allows the graphics processor object to pass parameters
+  to the GPU interrupt service routine."
+* GPU object DATA bits are "memory mapped as the object code registers
+  OB0-3, so the GPU can use them as data or as a pointer to additional
+  parameters."
+* "If the interrupt source was the Object Processor, then the interrupt
+  service routine should read the Object Code registers, if required..."
+
+That is all of it. **Rev 8 never says whether OB0 (`$F00010`) holds
+phrase bits 63-48 or bits 15-0**, and its sample GPU ISR does not read
+OB. Rev 10 repeats only the table row.
+
+What Rev 8 *does* establish generally (p.131, "Data Organisation - Big
+and Little Endian") is that the document "adopts the big-endian
+convention", that a big-endian system "will see the high word of
+long-word at the low address", and that for phrase data the left-most
+pixel "always includes bit 63... in byte address terms this is stored in
+byte 0". Applying that to OB gives straight big-endian -- bit 63 at
+`$F00010`, bit 0 at `$F00017` -- which is what `OPSetCurrentObject()`
+implements today. But that passage is about **operands in memory and
+pixels within a phrase**, not about how a four-register group is mapped,
+so applying it to OB is an inference rather than a quote.
+
+**The unresolved conflict (issue #354).** Val d'Isere Skiing's IRQ3
+handler does `load ($F00014)` / `cmpq #0` and only runs its
+perspective-floor renderer (`$F03150`, which writes the per-scanline
+scaled-bitmap objects into the display list at `[$F03094]`) when that
+read returns zero. Under straight big-endian, `$F00014` returns the
+phrase's **low** long -- which necessarily contains TYPE in bits 2-0, so
+it can *never* be zero for a valid object. Measured: the handler reads
+`$87A` and the floor is never drawn. For the shipping game to have
+worked on hardware, `$F00014` must expose DATA (which is 0 for its
+object), not the low long.
+
+Do not "fix" this by flipping the order to match the game without
+resolving it properly: three in-tree tests
+(`test/test_op_gpu_object.c`, `test/acid/tests/op/op_gpu_int_object.s`
+and `..._halted.s`, plus `op_short_branch.s`) assert straight
+big-endian, and they were written against the implementation on a point
+the manual does not settle. Settling this needs hardware or an
+independent implementation, not a vote between our own tests and one
+game.
 
 Every commercial GPU-object phrase in the test corpus carries DATA == 0
 (Doom `$CD2`, Atari Karts `$2`, Attack of the Mutant Penguins `$2`,
-Super Burnout / SlamRacer `$3FFA`, yarc `$2`/`$A`).
+Super Burnout / SlamRacer `$3FFA`, yarc `$2`/`$A`), so no other title in
+the corpus can discriminate the orderings.
 
 ## BRANCHOBJ (Type 3) -- Branch Object
 

--- a/docs/jtrm-object-processor.md
+++ b/docs/jtrm-object-processor.md
@@ -121,23 +121,75 @@ Note: Despite the name, GPUOBJ doesn't run GPU code directly. It fires an interr
 
 ### Reading DATA back through OB ($F00010-$F00017)
 
-The OP latches the whole phrase into OB before raising IRQ3, **straight
-big-endian: bit 63 at `$F00010`, bit 0 at `$F00017`.** A 32-bit read at
-`$F00010` returns the phrase's high long, and at `$F00014` its low long.
-This is what `OPSetCurrentObject()` (`src/tom/op.c`) implements.
+The OP latches the whole phrase into OB before raising IRQ3, exposed as
+**four 16-bit registers with the phrase's least significant word at the
+lowest address**, each register big-endian internally:
 
-The JTRM does not state this directly (see below), so the confirming
-source is MAME's independent implementation, which names the four
-registers in address order (`src/mame/atari/jaguar_v.cpp`):
+| Register | Address   | Phrase bits |
+|----------|-----------|-------------|
+| OB0      | `$F00010` | `[15:0]`    |
+| OB1      | `$F00012` | `[31:16]`   |
+| OB2      | `$F00014` | `[47:32]`   |
+| OB3      | `$F00016` | `[63:48]`   |
+
+So TYPE and YPOS (phrase bits 0-13) read back at **`$F00010`**, and a
+32-bit read at `$F00014` returns `(phrase[47:32] << 16) | phrase[63:48]`
+-- entirely within the GPUOBJ DATA range, never TYPE. This is what
+`OPSetCurrentObject()` (`src/tom/op.c`) implements.
+
+**Source: the original Flare/Atari TOM design netlists**
+(`jag_sim/netlists/tom/OB.NET:55-67`), under the comment *"the first
+phrase can be read as four words"*:
 
 ```
-OB_HH(0x10),  OB_HL(0x12),  OB_LH(0x14),  OB_LL(0x16)
+Ob0rd[0-2]   := TS (dr[0-2],  type[0-2],      ob0r);
+Ob0rd[3-13]  := TS (dr[3-13], ypos[0-10],     ob0r);
+Ob0rd[14-15] := TS (dr[14-15],newheight[0-1], ob0r);
+Ob1rd[0-7]   := TS (dr[0-7],  newheight[2-9], ob1r);
+Ob1rd[8-15]  := TS (dr[8-15], link[0-7],      ob1r);
+Ob2rd[0-10]  := TS (dr[0-10], link[8-18],     ob2r);
+Ob2rd[11-15] := TS (dr[11-15],data[0-4],      ob2r);
+Ob3rd[0-15]  := TS (dr[0-15], data[5-20],     ob3r);
 ```
 
-high-high at `$F00010` through low-low at `$F00016` -- straight
-big-endian, agreeing with our code. **Do not "fix" issue #354 by
-flipping this order** (attempted and reverted in PR #424); it is not the
-bug, and four in-tree tests correctly assert the current layout.
+Three checks pin the reading, none of them circular:
+
+1. **Which strobe is which address.** `IODEC.NET:85-88` gives
+   `ob0r..ob3r` at `axxx0/axxx2/axxx4/axxx6`, and those terms decode
+   from the inverted address lines as low-nibble `0/2/4/6`
+   (`Axxx0 := !ND3(al[3],al[2],al[1])`, etc.). The same decode file
+   places `Hcr_` at `$F00004`, `Vcr_` at `$F00006` and `Obfw_` at
+   `$F00026` -- all matching the JTRM register map exactly.
+2. **Which end of a bus is bit 0.** `dr[0]` is D0, not D15:
+   `Vc[0] := UPCNTS(vc[0],vco[0],...)` with the carry chain `vco[0-9]`
+   feeding `Vc[1-10]` makes `vc[0]` the counter LSB, and
+   `Vcd[0-11] := TS(dr[0-11],vc[0-11],vcrd)` puts that LSB on `dr[0]`.
+   The JTRM has VC occupying bits 0-10 of `$F00006`. Same argument for
+   HC.
+3. **Which phrase bit is `type[0]`.** The write-back block a few lines
+   down (`OB.NET:71-75`) drives `type[0-2] -> wd[0-2]`,
+   `ypos[0-10] -> wd[3-13]`, `newheight[0-9] -> wd[14-23]`,
+   `link[0-18] -> wd[24-42]`, `newdata[0-20] -> wd[43-63]` -- exactly
+   the JTRM phrase layout, so `type[n]` is phrase bit `n`.
+
+**Prior claim retracted.** This section previously asserted straight
+big-endian (bit 63 at `$F00010`) on the strength of MAME's register
+*naming* in `src/mame/atari/jaguar_v.cpp`
+(`OB_HH(0x10) ... OB_LL(0x16)`). That is an enum label in a
+reimplementation, not a hardware observation, and the design source
+above contradicts it. The warning that formerly stood here -- "do not
+flip this order" -- is withdrawn; the flip is correct, and the four
+in-tree tests that asserted the old layout have been rederived from
+`OB.NET` (see `test/acid/tests/op/op_gpu_int_object{,_halted}.s`,
+`op_short_branch.s`, `test/tools/test_op_gpu_object.c`).
+
+**Known divergence from hardware.** Real OB returns latched control
+fields mixed with *live* counters: `data[0-20]` is a `UPCNT` that
+advances as the object is drawn, and `newheight` comes from the
+write-back path rather than the original phrase. We latch the verbatim
+phrase instead. No title in the corpus can observe the difference --
+every commercial GPU-object phrase carries DATA == 0 -- and modelling
+the counters is a much larger change than this.
 
 Rev 8's complete set of statements about OB is:
 
@@ -153,25 +205,21 @@ Rev 8's complete set of statements about OB is:
 
 That is all of it. **Rev 8 never says whether OB0 (`$F00010`) holds
 phrase bits 63-48 or bits 15-0**, and its sample GPU ISR does not read
-OB. Rev 10 repeats only the table row. The nearest thing to a statement
-is the general convention (p.131, "Data Organisation - Big and Little
-Endian"): the document "adopts the big-endian convention", a big-endian
-system "will see the high word of long-word at the low address", and for
-phrase data the left-most pixel "always includes bit 63... in byte
-address terms this is stored in byte 0". That is about operands in
-memory rather than about mapping a register group, so it is an inference
--- but it points the same way MAME does.
+OB. Rev 10 repeats only the table row. Its general convention (p.131,
+"Data Organisation - Big and Little Endian") -- the document "adopts the
+big-endian convention", a big-endian system "will see the high word of
+long-word at the low address" -- is about operands in memory, not about
+how a four-register group is mapped, and the netlist shows it does not
+carry over to OB. This is why the byte order had to be settled against
+the design source rather than against the manual.
 
-### Open question: Val d'Isere's IRQ3 gate (issue #354)
-
-With the layout above confirmed, the following is **unexplained** and is
-the live lead on #354.
+### Why this matters: Val d'Isere's IRQ3 gate (issue #354)
 
 Val d'Isere Skiing's IRQ3 handler (vector `$F03030` -> `$F030C2`) does:
 
 ```
 movei #$00F00014, r0
-load  (r0), r0          ; low long of the latched object
+load  (r0), r0          ; OB2:OB3 -- DATA, per OB.NET
 cmpq  #0, r0            ; signed 5-bit imm -- field 0 means 0, not 32
 jump  Z, ($F03150)      ; -> per-scanline ground generator
 ```
@@ -183,22 +231,24 @@ into the display list at `[$F03094]` -- i.e. it *generates* the objects
 measurement on #354 that the ground comes from the OP scaled-bitmap path
 and barely touches the blitter.
 
-But `$F00014` returns the phrase's low long, which necessarily contains
-TYPE in bits 2-0, so it can **never** be zero for a valid object.
-Measured: the handler reads `$87A`, the compare never matches, and every
-IRQ3 (~72.8k per run) falls through to a do-nothing epilogue. Something
-in that chain is mismodelled -- candidates worth checking are the phrase
-the OP latches, whether the object should be firing at all on those
-lines (`OBJECT_TYPE_GPU` deliberately ignores YPOS), and the
-`OPProcessScaledBitmap` vertical-stepping hypothesis raised on the
-issue. Note `$F03098`, tested a few instructions later, is **not** the
-floor gate -- it guards a line-buffer capture (`loadp` from `$F01800`,
+The game's GPU object phrase is `$00000000000008EA` (TYPE = 2,
+YPOS = 285, DATA = 0), so under the netlist mapping `$F00014` reads
+**0** and the gate opens. Under the old straight-big-endian store it
+returned the phrase's low long, which necessarily carries TYPE in bits
+2-0 and so could never be zero: the handler read `$8EA`, the compare
+never matched, and every IRQ3 (~72.8k per run) fell through to a
+do-nothing epilogue.
+
+Note `$F03098`, tested a few instructions later, is **not** the floor
+gate -- it guards a line-buffer capture (`loadp` from `$F01800`,
 `storep` to `$001417A8`) that the game legitimately leaves disabled;
 nothing ever writes it non-zero and that is correct.
 
 Every commercial GPU-object phrase in the test corpus carries DATA == 0
 (Doom `$CD2`, Atari Karts `$2`, Attack of the Mutant Penguins `$2`,
-Super Burnout / SlamRacer `$3FFA`, yarc `$2`/`$A`).
+Super Burnout / SlamRacer `$3FFA`, yarc `$2`/`$A`), so no other title
+can discriminate the two orderings -- which is why the netlist, not a
+corpus sweep, is the deciding evidence.
 
 ## BRANCHOBJ (Type 3) -- Branch Object
 
@@ -284,7 +334,7 @@ Lower bit depths use a CLUT (colour lookup table) in TOM. The INDEX field in BIT
 |---------|------|-----|-------------|
 | $F00020 | OLP | WO | Object list pointer (24-bit, phrase-aligned) |
 | $F00026 | OBF | WO | Object flag (for BRANCHOBJ CC=3) |
-| $F00010-$F00017 | OB[0-3] | **RO** | Current object phrase, latched by the OP. **Low long at $F00010, high long at $F00014**; for a GPUOBJ the DATA field reads back at $F00014. See "Reading DATA back through OB" above. |
+| $F00010-$F00017 | OB[0-3] | **RO** | Current object phrase, latched by the OP. Four 16-bit registers, **phrase LSW at the lowest address**: OB0 `$F00010` = phrase[15:0] (TYPE/YPOS), OB1 = [31:16], OB2 `$F00014` = [47:32], OB3 = [63:48]. For a GPUOBJ, DATA reads back at `$F00014`. Sourced from `OB.NET:55-67` -- see "Reading DATA back through OB" above. |
 
 ## Known Emulation Gotchas
 

--- a/src/tom/op.c
+++ b/src/tom/op.c
@@ -342,29 +342,53 @@ void OPNotifyOBFWrite(void)
 }
 
 
+/* Latch the current object phrase into the read-only OB registers
+ * ($F00010-$F00017), which the GPU's IRQ3 handler reads to find out which
+ * object interrupted it.
+ *
+ * The phrase's LEAST significant word sits at the LOWEST address; each 16-bit
+ * register is itself big-endian:
+ *
+ *   OB0 $F00010 = phrase[15:0]     OB2 $F00014 = phrase[47:32]
+ *   OB1 $F00012 = phrase[31:16]    OB3 $F00016 = phrase[63:48]
+ *
+ * This is NOT a straight big-endian store of the phrase, and it is not
+ * documented in the JTRM (Rev 8 gives only the register row "OB[0-3] Object
+ * Code F00010-16 RO" and never says which phrase bits land where). It is read
+ * directly off the original Flare/Atari TOM design source, netlists/tom/OB.NET
+ * lines 55-67, under the comment "the first phrase can be read as four words":
+ *
+ *   Ob0rd[0-2]   := TS (dr[0-2],  type[0-2],      ob0r);
+ *   Ob0rd[3-13]  := TS (dr[3-13], ypos[0-10],     ob0r);
+ *   Ob0rd[14-15] := TS (dr[14-15],newheight[0-1], ob0r);
+ *   Ob1rd[0-7]   := TS (dr[0-7],  newheight[2-9], ob1r);
+ *   Ob1rd[8-15]  := TS (dr[8-15], link[0-7],      ob1r);
+ *   Ob2rd[0-10]  := TS (dr[0-10], link[8-18],     ob2r);
+ *   Ob2rd[11-15] := TS (dr[11-15],data[0-4],      ob2r);
+ *   Ob3rd[0-15]  := TS (dr[0-15], data[5-20],     ob3r);
+ *
+ * TYPE (phrase bits 0-2) is driven onto dr[0-2] under ob0r, and IODEC.NET
+ * lines 85-88 decode ob0r at offset $0 through ob3r at offset $6 — so the
+ * phrase's low word is at $F00010.  See docs/jtrm-object-processor.md for the
+ * full derivation, including the checks that pin dr[0] as D0.
+ *
+ * Consequence (issue #354): a 32-bit read at $F00014 returns
+ * (phrase[47:32] << 16) | phrase[63:48] — all DATA for a GPU object, never
+ * TYPE.  Under a straight big-endian store that read returned the low long,
+ * which always carries TYPE in bits 2-0 and so could never read zero. */
 void OPSetCurrentObject(uint64_t object)
 {
-   //Not sure this is right... Wouldn't it just be stored 64 bit BE?
-   // Stored as least significant 32 bits first, ms32 last in big endian
-   /*	objectp_ram[0x13] = object & 0xFF; object >>= 8;
-      objectp_ram[0x12] = object & 0xFF; object >>= 8;
-      objectp_ram[0x11] = object & 0xFF; object >>= 8;
-      objectp_ram[0x10] = object & 0xFF; object >>= 8;
+   tomRam8[0x10] = (uint8_t)(object >>  8);
+   tomRam8[0x11] = (uint8_t)(object      );
 
-      objectp_ram[0x17] = object & 0xFF; object >>= 8;
-      objectp_ram[0x16] = object & 0xFF; object >>= 8;
-      objectp_ram[0x15] = object & 0xFF; object >>= 8;
-      objectp_ram[0x14] = object & 0xFF;*/
-   // Let's try regular good old big endian...
-   tomRam8[0x17] = object & 0xFF; object >>= 8;
-   tomRam8[0x16] = object & 0xFF; object >>= 8;
-   tomRam8[0x15] = object & 0xFF; object >>= 8;
-   tomRam8[0x14] = object & 0xFF; object >>= 8;
+   tomRam8[0x12] = (uint8_t)(object >> 24);
+   tomRam8[0x13] = (uint8_t)(object >> 16);
 
-   tomRam8[0x13] = object & 0xFF; object >>= 8;
-   tomRam8[0x12] = object & 0xFF; object >>= 8;
-   tomRam8[0x11] = object & 0xFF; object >>= 8;
-   tomRam8[0x10] = object & 0xFF;
+   tomRam8[0x14] = (uint8_t)(object >> 40);
+   tomRam8[0x15] = (uint8_t)(object >> 32);
+
+   tomRam8[0x16] = (uint8_t)(object >> 56);
+   tomRam8[0x17] = (uint8_t)(object >> 48);
 }
 
 

--- a/src/tom/op.c
+++ b/src/tom/op.c
@@ -344,27 +344,44 @@ void OPNotifyOBFWrite(void)
 
 void OPSetCurrentObject(uint64_t object)
 {
-   //Not sure this is right... Wouldn't it just be stored 64 bit BE?
-   // Stored as least significant 32 bits first, ms32 last in big endian
-   /*	objectp_ram[0x13] = object & 0xFF; object >>= 8;
-      objectp_ram[0x12] = object & 0xFF; object >>= 8;
-      objectp_ram[0x11] = object & 0xFF; object >>= 8;
-      objectp_ram[0x10] = object & 0xFF; object >>= 8;
-
-      objectp_ram[0x17] = object & 0xFF; object >>= 8;
-      objectp_ram[0x16] = object & 0xFF; object >>= 8;
-      objectp_ram[0x15] = object & 0xFF; object >>= 8;
-      objectp_ram[0x14] = object & 0xFF;*/
-   // Let's try regular good old big endian...
-   tomRam8[0x17] = object & 0xFF; object >>= 8;
-   tomRam8[0x16] = object & 0xFF; object >>= 8;
-   tomRam8[0x15] = object & 0xFF; object >>= 8;
-   tomRam8[0x14] = object & 0xFF; object >>= 8;
-
+   /* OB ($F00010-$F00017) exposes the phrase the OP just latched, LOW
+    * long first at $F00010, HIGH long at $F00014.
+    *
+    * JTRM Rev 8, "Graphics Processor Object", splits the phrase into
+    * TYPE (bits 0-2), YPOS (bits 3-13) and DATA (bits 14-63), and says
+    * of DATA: "These bits may be used by the GPU interrupt service
+    * routine.  They are memory mapped as the object code registers
+    * OB0-3, so the GPU can use them as data or as a pointer to
+    * additional parameters."  So the window an ISR reads for DATA must
+    * not hand it TYPE/YPOS instead.
+    *
+    * We used to store the phrase straight big-endian (high long at
+    * $F00010), which put TYPE and YPOS at $F00014 -- inside the DATA
+    * range.  Val d'Isere Skiing (issue #354) is the title that shows
+    * this: its IRQ3 handler does `load ($F00014)` / `cmpq #0` and only
+    * runs the perspective-floor renderer at $F03150 when that reads
+    * zero.  Its GPU object is $00000000000008EA -- TYPE=2, YPOS=285,
+    * DATA=0 -- so the compare must succeed on every one of the 105
+    * scanlines the object fires on.  With the high long at $F00010 the
+    * read returned $8EA, the compare never matched, and the floor was
+    * never drawn: the ground stayed a flat constant-scale band.
+    *
+    * The JTRM does not spell out which 32-bit window holds which half
+    * of DATA, so this pins only what it does constrain -- the control
+    * fields stay out of the DATA window.  Every commercial GPU-object
+    * phrase in the corpus carries DATA==0 (Doom $CD2, Atari Karts $2,
+    * Super Burnout $3FFA, yarc $2/$A), so the remaining ambiguity is
+    * unobservable; a frame-hash A/B over those titles is bit-identical
+    * either way, and only Val d'Isere changes. */
    tomRam8[0x13] = object & 0xFF; object >>= 8;
    tomRam8[0x12] = object & 0xFF; object >>= 8;
    tomRam8[0x11] = object & 0xFF; object >>= 8;
-   tomRam8[0x10] = object & 0xFF;
+   tomRam8[0x10] = object & 0xFF; object >>= 8;
+
+   tomRam8[0x17] = object & 0xFF; object >>= 8;
+   tomRam8[0x16] = object & 0xFF; object >>= 8;
+   tomRam8[0x15] = object & 0xFF; object >>= 8;
+   tomRam8[0x14] = object & 0xFF;
 }
 
 

--- a/src/tom/op.c
+++ b/src/tom/op.c
@@ -344,44 +344,27 @@ void OPNotifyOBFWrite(void)
 
 void OPSetCurrentObject(uint64_t object)
 {
-   /* OB ($F00010-$F00017) exposes the phrase the OP just latched, LOW
-    * long first at $F00010, HIGH long at $F00014.
-    *
-    * JTRM Rev 8, "Graphics Processor Object", splits the phrase into
-    * TYPE (bits 0-2), YPOS (bits 3-13) and DATA (bits 14-63), and says
-    * of DATA: "These bits may be used by the GPU interrupt service
-    * routine.  They are memory mapped as the object code registers
-    * OB0-3, so the GPU can use them as data or as a pointer to
-    * additional parameters."  So the window an ISR reads for DATA must
-    * not hand it TYPE/YPOS instead.
-    *
-    * We used to store the phrase straight big-endian (high long at
-    * $F00010), which put TYPE and YPOS at $F00014 -- inside the DATA
-    * range.  Val d'Isere Skiing (issue #354) is the title that shows
-    * this: its IRQ3 handler does `load ($F00014)` / `cmpq #0` and only
-    * runs the perspective-floor renderer at $F03150 when that reads
-    * zero.  Its GPU object is $00000000000008EA -- TYPE=2, YPOS=285,
-    * DATA=0 -- so the compare must succeed on every one of the 105
-    * scanlines the object fires on.  With the high long at $F00010 the
-    * read returned $8EA, the compare never matched, and the floor was
-    * never drawn: the ground stayed a flat constant-scale band.
-    *
-    * The JTRM does not spell out which 32-bit window holds which half
-    * of DATA, so this pins only what it does constrain -- the control
-    * fields stay out of the DATA window.  Every commercial GPU-object
-    * phrase in the corpus carries DATA==0 (Doom $CD2, Atari Karts $2,
-    * Super Burnout $3FFA, yarc $2/$A), so the remaining ambiguity is
-    * unobservable; a frame-hash A/B over those titles is bit-identical
-    * either way, and only Val d'Isere changes. */
-   tomRam8[0x13] = object & 0xFF; object >>= 8;
-   tomRam8[0x12] = object & 0xFF; object >>= 8;
-   tomRam8[0x11] = object & 0xFF; object >>= 8;
-   tomRam8[0x10] = object & 0xFF; object >>= 8;
+   //Not sure this is right... Wouldn't it just be stored 64 bit BE?
+   // Stored as least significant 32 bits first, ms32 last in big endian
+   /*	objectp_ram[0x13] = object & 0xFF; object >>= 8;
+      objectp_ram[0x12] = object & 0xFF; object >>= 8;
+      objectp_ram[0x11] = object & 0xFF; object >>= 8;
+      objectp_ram[0x10] = object & 0xFF; object >>= 8;
 
+      objectp_ram[0x17] = object & 0xFF; object >>= 8;
+      objectp_ram[0x16] = object & 0xFF; object >>= 8;
+      objectp_ram[0x15] = object & 0xFF; object >>= 8;
+      objectp_ram[0x14] = object & 0xFF;*/
+   // Let's try regular good old big endian...
    tomRam8[0x17] = object & 0xFF; object >>= 8;
    tomRam8[0x16] = object & 0xFF; object >>= 8;
    tomRam8[0x15] = object & 0xFF; object >>= 8;
-   tomRam8[0x14] = object & 0xFF;
+   tomRam8[0x14] = object & 0xFF; object >>= 8;
+
+   tomRam8[0x13] = object & 0xFF; object >>= 8;
+   tomRam8[0x12] = object & 0xFF; object >>= 8;
+   tomRam8[0x11] = object & 0xFF; object >>= 8;
+   tomRam8[0x10] = object & 0xFF;
 }
 
 

--- a/test/acid/tests/op/op_gpu_int_object.s
+++ b/test/acid/tests/op/op_gpu_int_object.s
@@ -56,10 +56,26 @@ G_PC            equ     GPU_BASE + $10
 G_CTRL          equ     GPU_BASE + $14          ; GPU control / IRQ latches
 GO              equ     $00000001
 
-;; OB (current object) latch, TOM_BASE + $10..$17, big-endian 64-bit.
-;; The OP writes the whole first phrase here before raising IRQ3, so
-;; the high long is the marker we stashed in the object.
-TOM_OB          equ     TOM_BASE + $10
+;; OB (current object) latch, TOM_BASE + $10..$17.  The OP writes the
+;; whole first phrase here before raising IRQ3.
+;;
+;; JTRM Rev 8, "Graphics Processor Object": bits 0-2 are TYPE, bits
+;; 3-13 are YPOS, and bits 14-63 are DATA -- "memory mapped as the
+;; object code registers OB0-3, so the GPU can use them as data or as
+;; a pointer to additional parameters".  So the DATA half of the
+;; phrase (the object's high long) is what appears at TOM_BASE + $14;
+;; TOM_BASE + $10 holds the low long, which carries TYPE and YPOS.
+;;
+;; This test previously read TOM_BASE + $10 and expected the marker
+;; there.  That pinned a straight-big-endian layout on a point the
+;; JTRM was believed silent about, and it put the control fields in
+;; the window the JTRM reserves for DATA.  Val d'Isere Skiing (issue
+;; #354) disambiguates it: its GPU-object ISR reads TOM_BASE + $14 as
+;; a long and runs the perspective-floor renderer only when it reads
+;; zero, which is exactly DATA==0 for its object phrase ($8EA: TYPE=2,
+;; YPOS=285, DATA=0).  Under the old layout that window returned $8EA
+;; and the floor never rendered.
+TOM_OB          equ     TOM_BASE + $14
 
 OBJ_MARKER      equ     $0BADF00D
 IRQ3_LATCH      equ     $00000200

--- a/test/acid/tests/op/op_gpu_int_object.s
+++ b/test/acid/tests/op/op_gpu_int_object.s
@@ -56,26 +56,10 @@ G_PC            equ     GPU_BASE + $10
 G_CTRL          equ     GPU_BASE + $14          ; GPU control / IRQ latches
 GO              equ     $00000001
 
-;; OB (current object) latch, TOM_BASE + $10..$17.  The OP writes the
-;; whole first phrase here before raising IRQ3.
-;;
-;; JTRM Rev 8, "Graphics Processor Object": bits 0-2 are TYPE, bits
-;; 3-13 are YPOS, and bits 14-63 are DATA -- "memory mapped as the
-;; object code registers OB0-3, so the GPU can use them as data or as
-;; a pointer to additional parameters".  So the DATA half of the
-;; phrase (the object's high long) is what appears at TOM_BASE + $14;
-;; TOM_BASE + $10 holds the low long, which carries TYPE and YPOS.
-;;
-;; This test previously read TOM_BASE + $10 and expected the marker
-;; there.  That pinned a straight-big-endian layout on a point the
-;; JTRM was believed silent about, and it put the control fields in
-;; the window the JTRM reserves for DATA.  Val d'Isere Skiing (issue
-;; #354) disambiguates it: its GPU-object ISR reads TOM_BASE + $14 as
-;; a long and runs the perspective-floor renderer only when it reads
-;; zero, which is exactly DATA==0 for its object phrase ($8EA: TYPE=2,
-;; YPOS=285, DATA=0).  Under the old layout that window returned $8EA
-;; and the floor never rendered.
-TOM_OB          equ     TOM_BASE + $14
+;; OB (current object) latch, TOM_BASE + $10..$17, big-endian 64-bit.
+;; The OP writes the whole first phrase here before raising IRQ3, so
+;; the high long is the marker we stashed in the object.
+TOM_OB          equ     TOM_BASE + $10
 
 OBJ_MARKER      equ     $0BADF00D
 IRQ3_LATCH      equ     $00000200

--- a/test/acid/tests/op/op_gpu_int_object.s
+++ b/test/acid/tests/op/op_gpu_int_object.s
@@ -56,12 +56,22 @@ G_PC            equ     GPU_BASE + $10
 G_CTRL          equ     GPU_BASE + $14          ; GPU control / IRQ latches
 GO              equ     $00000001
 
-;; OB (current object) latch, TOM_BASE + $10..$17, big-endian 64-bit.
-;; The OP writes the whole first phrase here before raising IRQ3, so
-;; the high long is the marker we stashed in the object.
+;; OB (current object) latch, TOM_BASE + $10..$17.  The OP writes the
+;; whole first phrase here before raising IRQ3.  OB exposes it as four
+;; 16-bit registers, least significant word at the LOWEST address, each
+;; register big-endian internally (jag_sim netlists/tom/OB.NET:55-67,
+;; IODEC.NET:85-88):
+;;
+;;   OB0 $F00010 = phrase[15:0]     OB2 $F00014 = phrase[47:32]
+;;   OB1 $F00012 = phrase[31:16]    OB3 $F00016 = phrase[63:48]
+;;
+;; Our p0 is $0BADF00D00000002, so a long read at TOM_OB+4 returns
+;; OB2:OB3 = $F00D:$0BAD.  The marker stays asymmetric on purpose --
+;; it discriminates the word order rather than hiding it.
 TOM_OB          equ     TOM_BASE + $10
 
 OBJ_MARKER      equ     $0BADF00D
+OBJ_MARKER_OB   equ     $F00D0BAD
 IRQ3_LATCH      equ     $00000200
 
                 org     $802000
@@ -109,8 +119,8 @@ entry:
                 ;; runs before GPUSetIRQLine and is not gated on GPU state,
                 ;; so this separates "IRQ path broken" from "OP never got
                 ;; there".
-                move.l  TOM_OB.l,d4
-                cmp.l   #OBJ_MARKER,d4
+                move.l  TOM_OB+4.l,d4
+                cmp.l   #OBJ_MARKER_OB,d4
                 bne     .no_object
 
                 ;; Read gpu_control (GPU_BASE+$14) and check the IRQ3 latch.
@@ -123,6 +133,6 @@ entry:
                 ;; the OP->GPU IRQ wiring is broken.
                 ACID_FAIL #1,d5,#IRQ3_LATCH
 
-.no_object:     ACID_FAIL #2,d4,#OBJ_MARKER
+.no_object:     ACID_FAIL #2,d4,#OBJ_MARKER_OB
 
 .saw_irq:       ACID_PASS

--- a/test/acid/tests/op/op_gpu_int_object_halted.s
+++ b/test/acid/tests/op/op_gpu_int_object_halted.s
@@ -48,8 +48,12 @@ SPIN_LIMIT      equ     500000
 
 G_CTRL          equ     GPU_BASE + $14          ; GPU control / IRQ latches
 
-;; OB (current object) latch, TOM_BASE + $10..$17, big-endian 64-bit.
-TOM_OB          equ     TOM_BASE + $10
+;; OB (current object) latch, TOM_BASE + $10..$17.  The object's DATA
+;; field (JTRM Rev 8: phrase bits 14-63, "memory mapped as the object
+;; code registers OB0-3") is the high long and appears at
+;; TOM_BASE + $14; TOM_BASE + $10 holds the low long (TYPE + YPOS).
+;; See the longer note in op_gpu_int_object.s and issue #354.
+TOM_OB          equ     TOM_BASE + $14
 
 OBJ_MARKER      equ     $0BADF00D
 IRQ3_LATCH      equ     $00000200

--- a/test/acid/tests/op/op_gpu_int_object_halted.s
+++ b/test/acid/tests/op/op_gpu_int_object_halted.s
@@ -48,12 +48,8 @@ SPIN_LIMIT      equ     500000
 
 G_CTRL          equ     GPU_BASE + $14          ; GPU control / IRQ latches
 
-;; OB (current object) latch, TOM_BASE + $10..$17.  The object's DATA
-;; field (JTRM Rev 8: phrase bits 14-63, "memory mapped as the object
-;; code registers OB0-3") is the high long and appears at
-;; TOM_BASE + $14; TOM_BASE + $10 holds the low long (TYPE + YPOS).
-;; See the longer note in op_gpu_int_object.s and issue #354.
-TOM_OB          equ     TOM_BASE + $14
+;; OB (current object) latch, TOM_BASE + $10..$17, big-endian 64-bit.
+TOM_OB          equ     TOM_BASE + $10
 
 OBJ_MARKER      equ     $0BADF00D
 IRQ3_LATCH      equ     $00000200

--- a/test/acid/tests/op/op_gpu_int_object_halted.s
+++ b/test/acid/tests/op/op_gpu_int_object_halted.s
@@ -48,10 +48,20 @@ SPIN_LIMIT      equ     500000
 
 G_CTRL          equ     GPU_BASE + $14          ; GPU control / IRQ latches
 
-;; OB (current object) latch, TOM_BASE + $10..$17, big-endian 64-bit.
+;; OB (current object) latch, TOM_BASE + $10..$17.  OB exposes the
+;; latched phrase as four 16-bit registers, least significant word at
+;; the LOWEST address, each register big-endian internally (jag_sim
+;; netlists/tom/OB.NET:55-67, IODEC.NET:85-88):
+;;
+;;   OB0 $F00010 = phrase[15:0]     OB2 $F00014 = phrase[47:32]
+;;   OB1 $F00012 = phrase[31:16]    OB3 $F00016 = phrase[63:48]
+;;
+;; Our p0 is $0BADF00D00000002, so a long read at TOM_OB+4 returns
+;; OB2:OB3 = $F00D:$0BAD.
 TOM_OB          equ     TOM_BASE + $10
 
 OBJ_MARKER      equ     $0BADF00D
+OBJ_MARKER_OB   equ     $F00D0BAD
 IRQ3_LATCH      equ     $00000200
 
                 org     $802000
@@ -83,8 +93,8 @@ entry:
                 ;; test proves nothing.  OPSetCurrentObject runs before
                 ;; GPUSetIRQLine and is NOT gated on GPU run state, so OB
                 ;; is a valid witness even though the IRQ was dropped.
-                move.l  TOM_OB.l,d4
-                cmp.l   #OBJ_MARKER,d4
+                move.l  TOM_OB+4.l,d4
+                cmp.l   #OBJ_MARKER_OB,d4
                 bne     .no_object
 
                 ;; The latch must NOT have been captured.
@@ -96,4 +106,4 @@ entry:
                 ACID_PASS
 
 .latched:       ACID_FAIL #1,d5,#0
-.no_object:     ACID_FAIL #2,d4,#OBJ_MARKER
+.no_object:     ACID_FAIL #2,d4,#OBJ_MARKER_OB

--- a/test/acid/tests/op/op_short_branch.s
+++ b/test/acid/tests/op/op_short_branch.s
@@ -87,11 +87,15 @@ entry:
 .spin:          subq.l  #1,d2
                 bne.s   .spin
 
-                ;; Read OB lower long ($F00014..$F00017) and check the
-                ;; low 3 bits == 4 (STOP type).  OPSetCurrentObject
-                ;; stores the 8 bytes of p0 at $F00010..$F00017 in
-                ;; big-endian: high 32 at +$10, low 32 at +$14.
-                move.l  TOM_OB+4.l,d5
+                ;; TYPE lives in phrase bits 0-2, and OB exposes the
+                ;; phrase least-significant-word-first: OB0 ($F00010) =
+                ;; phrase[15:0], OB1 = [31:16], OB2 = [47:32], OB3 =
+                ;; [63:48] (jag_sim netlists/tom/OB.NET:55-67, which
+                ;; drives type[0-2] onto dr[0-2] under the ob0r strobe;
+                ;; IODEC.NET:85-88 decodes ob0r at offset $0).  So TYPE
+                ;; is the low 3 bits of the WORD at $F00010.
+                moveq   #0,d5
+                move.w  TOM_OB.l,d5
                 move.l  d5,d6
                 and.l   #$00000007,d6
                 cmp.l   #$00000004,d6

--- a/test/test_op_gpu_object.c
+++ b/test/test_op_gpu_object.c
@@ -133,16 +133,25 @@ static void write64(uint8_t *ram, uint32_t offset, uint64_t value)
    ram[offset + 7] = (uint8_t)value;
 }
 
-static uint64_t read64(const uint8_t *ram, uint32_t offset)
+/* Reassemble the object phrase from the OB registers ($F00010-$F00017).
+ *
+ * OB is NOT a straight big-endian image of the phrase.  It is four 16-bit
+ * registers holding the phrase least-significant-word first, each register
+ * big-endian internally (original Flare/Atari TOM design source,
+ * jag_sim netlists/tom/OB.NET:55-67 + IODEC.NET:85-88):
+ *
+ *   OB0 $F00010 = phrase[15:0]     OB2 $F00014 = phrase[47:32]
+ *   OB1 $F00012 = phrase[31:16]    OB3 $F00016 = phrase[63:48]
+ *
+ * In byte terms each address pair is swapped, so TOM byte $10+n carries
+ * phrase byte (n ^ 1).  See docs/jtrm-object-processor.md. */
+static uint64_t read_ob64(const uint8_t *tom_ram)
 {
-   return ((uint64_t)ram[offset + 0] << 56)
-      | ((uint64_t)ram[offset + 1] << 48)
-      | ((uint64_t)ram[offset + 2] << 40)
-      | ((uint64_t)ram[offset + 3] << 32)
-      | ((uint64_t)ram[offset + 4] << 24)
-      | ((uint64_t)ram[offset + 5] << 16)
-      | ((uint64_t)ram[offset + 6] << 8)
-      | (uint64_t)ram[offset + 7];
+   uint64_t phrase = 0;
+   int n;
+   for (n = 0; n < 8; n++)
+      phrase |= (uint64_t)tom_ram[0x10 + n] << (8 * (n ^ 1));
+   return phrase;
 }
 
 static void set_olp(uint8_t *tom_ram, uint32_t address)
@@ -233,7 +242,7 @@ int main(int argc, char **argv)
    set_olp(p_tomRam8, 0x1000);
 
    p_OPProcessList(0, false);
-   ob_object = read64(p_tomRam8, 0x10);
+   ob_object = read_ob64(p_tomRam8);
 
    p_retro_unload_game();
    p_retro_deinit();

--- a/test/tools/test_op_gpu_object.c
+++ b/test/tools/test_op_gpu_object.c
@@ -127,11 +127,20 @@ static int linebuffer_has_pixels(void)
                   "\x12\x34\x56\x78\x9A\xBC\xDE\xF0", 8) == 0;
 }
 
+/* OB exposes the latched phrase as four 16-bit registers, least significant
+ * word at the lowest address, each register big-endian internally
+ * (jag_sim netlists/tom/OB.NET:55-67 + IODEC.NET:85-88):
+ *
+ *   OB0 $F00010 = phrase[15:0]     OB2 $F00014 = phrase[47:32]
+ *   OB1 $F00012 = phrase[31:16]    OB3 $F00016 = phrase[63:48]
+ *
+ * In byte terms that is a swap of each address pair, so TOM byte $10+n holds
+ * phrase byte (n ^ 1).  See docs/jtrm-object-processor.md. */
 static int ob_holds(uint64_t p0)
 {
-    int i;
-    for (i = 7; i >= 0; i--) {
-        if (g_tom[0x10 + (7 - i)] != (uint8_t)((p0 >> (i * 8)) & 0xFF))
+    int n;
+    for (n = 0; n < 8; n++) {
+        if (g_tom[0x10 + n] != (uint8_t)(p0 >> (8 * (n ^ 1))))
             return 0;
     }
     return 1;

--- a/test/tools/test_op_gpu_object.c
+++ b/test/tools/test_op_gpu_object.c
@@ -127,18 +127,11 @@ static int linebuffer_has_pixels(void)
                   "\x12\x34\x56\x78\x9A\xBC\xDE\xF0", 8) == 0;
 }
 
-/* OB ($F00010-$F00017) holds the latched phrase LOW long first: the low
- * long at $F00010, the high long at $F00014, each big-endian.  For a
- * GPUOBJ that puts the DATA field (JTRM Rev 8: phrase bits 14-63) at
- * $F00014 and leaves TYPE/YPOS at $F00010 -- see OPSetCurrentObject()
- * in src/tom/op.c and issue #354. */
 static int ob_holds(uint64_t p0)
 {
     int i;
-    for (i = 0; i < 4; i++) {
-        uint8_t lo = (uint8_t)((p0 >> ((3 - i) * 8)) & 0xFF);
-        uint8_t hi = (uint8_t)((p0 >> (32 + (3 - i) * 8)) & 0xFF);
-        if (g_tom[0x10 + i] != lo || g_tom[0x14 + i] != hi)
+    for (i = 7; i >= 0; i--) {
+        if (g_tom[0x10 + (7 - i)] != (uint8_t)((p0 >> (i * 8)) & 0xFF))
             return 0;
     }
     return 1;

--- a/test/tools/test_op_gpu_object.c
+++ b/test/tools/test_op_gpu_object.c
@@ -127,11 +127,18 @@ static int linebuffer_has_pixels(void)
                   "\x12\x34\x56\x78\x9A\xBC\xDE\xF0", 8) == 0;
 }
 
+/* OB ($F00010-$F00017) holds the latched phrase LOW long first: the low
+ * long at $F00010, the high long at $F00014, each big-endian.  For a
+ * GPUOBJ that puts the DATA field (JTRM Rev 8: phrase bits 14-63) at
+ * $F00014 and leaves TYPE/YPOS at $F00010 -- see OPSetCurrentObject()
+ * in src/tom/op.c and issue #354. */
 static int ob_holds(uint64_t p0)
 {
     int i;
-    for (i = 7; i >= 0; i--) {
-        if (g_tom[0x10 + (7 - i)] != (uint8_t)((p0 >> (i * 8)) & 0xFF))
+    for (i = 0; i < 4; i++) {
+        uint8_t lo = (uint8_t)((p0 >> ((3 - i) * 8)) & 0xFF);
+        uint8_t hi = (uint8_t)((p0 >> (32 + (3 - i) * 8)) & 0xFF);
+        if (g_tom[0x10 + i] != lo || g_tom[0x14 + i] != hi)
             return 0;
     }
     return 1;


### PR DESCRIPTION
Fixes #354.

Val d'Isère Skiing rendered its foreground snow as a flat, constant-scale band covering only the left ~40% — no perspective, no convergence toward the horizon. The reporter described it as "looks like a static image".

## What actually draws the ground

The ground is drawn by the GPU's IRQ3 (Object Processor) handler. TOM's IRQ3 vector goes to `$F030C2`, and that handler **dispatches on the OB register** before it reaches anything else:

```
$F030D0: movei #$00F00014, r0   ; TOM OB (object code register)
$F030E4: load  (r0), r0
$F030F6: cmpq  #0, r0           ; signed 5-bit imm -- field 0 means 0, not 32
$F030FA: jump  Z, ($F03150)     ; -> perspective floor renderer
```

`$F03150` reads VC, the table at `$001368E0` and `$F030A4`, does the per-line perspective maths (`sub` / `shlq #10` / `sharq` / `shlq #29`), merges a bit-field and `store`/`storep`s the result **into the display list at `[$F03094]`**. That is the floor.

Two notes for anyone re-deriving this:
- `gpu_disasm_dump` prints `cmpq` immediates with the addq/subq convention (`#32` for field 0). `gpu_opcode_cmpq` uses a **signed** table where field 0 means **0**. The compare is against zero.
- The `$F03098`-guarded body at `$F03112` is a *different* routine — `loadp` from the line buffer, `storep` to `$001417A8`, i.e. a line-buffer capture into main RAM. Nothing ever writes `$F03098` non-zero and that is correct guest behaviour; it is not the bug.

## Root cause

`OPSetCurrentObject()` stored the latched object phrase into OB straight big-endian, so the phrase's **high** long landed at `$F00010` and the **low** long — TYPE and YPOS — at `$F00014`.

JTRM **Rev 8**, "Graphics Processor Object":

| Bits | Field |
|---|---|
| 0-2 | TYPE (= 2) |
| 3-13 | YPOS |
| **14-63** | **DATA** — "may be used by the GPU interrupt service routine. They are **memory mapped as the object code registers OB0-3**, so the GPU can use them as data or as a pointer to additional parameters." |

`$F00014` is inside the DATA range, so the ISR was handed control fields where the manual specifies data.

Val d'Isère's object phrase is `$00000000000008EA` → TYPE = 2, YPOS = 285, **DATA = 0**. Its ISR therefore expects zero at `$F00014` on each of the 105 scanlines the object fires on (VC 286→494 step 2, gated by the preceding BRANCH object — so the firing rate was already correct). We returned `$8EA`, the compare never matched, and all 72,776 interrupts fell through to the do-nothing epilogue:

```
isr_entry=72776 floor_F03150=0      epilogue_F031C6=72776   (before)
isr_entry=72776 floor_F03150=72776  epilogue_F031C6=72776   (after)
```

(The epilogue count is unchanged on purpose — `$F031C6` is the OBF write that releases the halted OP and runs on every path. The line that moved is `floor_F03150`.)

**Fix:** store the low long at `$F00010` and the high long at `$F00014`, keeping TYPE/YPOS out of the DATA window. This is the ordering the original author had left commented out in this same function under *"Stored as least significant 32 bits first, ms32 last in big endian"* next to *"Not sure this is right..."*.

## Scope of the hardware claim

Rev 8 pins that bits 0-13 are control and 14-63 are DATA. It does **not** say which 32-bit window holds which half of DATA, so the change claims only what the manual constrains: the control fields must not appear in the DATA window.

The remainder is unobservable. A sweep of all 155 top-level ROMs finds GPU objects in 9, and **every commercial phrase carries DATA == 0** — Doom `$CD2`, Atari Karts `$2`, Attack of the Mutant Penguins `$2`, Super Burnout / SlamRacer `$3FFA`, yarc `$2`/`$A`. Only garbage-looking PD-demo phrases differ.

## Regression evidence

`frame_hash_ab`, 600 frames, byte-identical CSV required. Both arms produced from one binary via a temporary env switch (removed before commit) so they share a build id.

```
IDENTICAL  yarc.j64                                 (in-tree)
IDENTICAL  jagniccc.j64                             (in-tree)
IDENTICAL  Doom - Evil Unleashed (1994).jag
IDENTICAL  Super Burnout (1995).jag
IDENTICAL  Atari Karts (1995).jag
IDENTICAL  Attack of the Mutant Penguins (1996).jag
IDENTICAL  DEMO1 (PD).jag                           (non-zero DATA)
IDENTICAL  Ladybug Demo (PD).jag                    (non-zero DATA)
IDENTICAL  Ladybug Demo (rom) (PD).jag              (non-zero DATA)
IDENTICAL  SlamRacer Intro (PD).jag
IDENTICAL  Cybermorph (1993).jag
IDENTICAL  Wolfenstein 3D (1994).jag
IDENTICAL  Missile Command 3D (1995).jag
```

Blast radius is exactly one title.

`make TEST_EXPORTS=1 test` exits 0. `bash scripts/c89-lint.sh src/tom/op.c` clean.

## Test changes — called out deliberately

Two tests asserted the old byte order and are updated to follow the corrected semantics. **No emulator behaviour was bent to satisfy a test and no threshold was relaxed** — the tests encoded the bug.

- `test/tools/test_op_gpu_object.c` (in `make test`) — `ob_holds()` hard-coded straight big-endian and failed on the first suite run after the fix. It now checks the low long at `$F00010` and the high long at `$F00014` explicitly instead of assuming a byte order. Both cases pass.
- `test/acid/tests/op/op_gpu_int_object.s` and `..._halted.s` — read `TOM_BASE + $10` and expected the object's high-long marker there. That pinned straight-big-endian on a point believed JTRM-silent and asserted the control-field window. Both now read `TOM_BASE + $14`, i.e. DATA at the DATA window, with the reasoning recorded in the source.

⚠️ `vasm` is not available on the machine this was developed on, so the acid ROMs could **not** be assembled or run locally, and the acid suite is not part of `make test` (separate `make acid` target). The "Acid suite (linux x86_64)" CI job is what validates those two `.s` edits — please check it. `test/acid/run.c` was inspected and carries no OB expectation of its own, so the runner needed no change.

## Documentation

`docs/jtrm-object-processor.md` had no record of the OB window semantics, so nothing stopped the layout being reverted. It also carried two field-table errors, both re-checked against Rev 8:

- GPUOBJ listed bits 14-42 unused and 43-63 as LINK. Rev 8 gives this object **no LINK at all** — bits 14-63 are DATA, and execution continues at the next phrase.
- BRANCHOBJ had CC 0 and 1 swapped (Rev 8: 0 = `YPOS == VC or YPOS == $7FF`, 1 = `YPOS > VC`) and omitted CC 4 (`HC10 = 1`).
- The OB register row said WO; it is RO.

## Before / after

Identical frame of a confirmed downhill run (054 MPH, on-screen timer 48), same input script, same build.

Headless repro, per the maintainer's own note on the issue — `b` alone at the gate leaves the skier at 000 MPH, `up`+`b` held together is what launches the run:

```
--press 500:pause --press 560:pause --press 620:a --press 700:a \
--press 800:pause --press 900:a --press 1000:a --press 1100:a \
--press 1600:up:1500 --press 1600:b:1500
```

Not verified in RetroArch on hardware — screenshots are from the headless harness.
