### PR TITLE
fix(blitter): render Cybermorph projectiles under the accurate blitter

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -1319,8 +1319,26 @@ void blitter_blit(uint32_t cmd)
       unsigned v;
       zadd = REG(ZINC);
 
+      /* The four 16.16 Z corner values reach the blitter through the
+       * B_Z0-B_Z3 aliases ($F0228C-$F02298).  BlitterWriteByte splits
+       * every one of those writes into the SRCZINT (integer half) and
+       * SRCZFRAC (fractional half) mirrors and stores NOTHING at the
+       * PHRASEZ0..3 offsets themselves, so `REG(PHRASEZ0 + v*4)` read
+       * permanently-stale blitter_ram and handed the Z comparator
+       * near-zero source Z for every blit -- which, with Z_OP_SUP
+       * ("inhibit when source Z > destination Z"), never inhibits and
+       * also stamps ~0 into the Z buffer, disabling Z-buffering
+       * outright.  Rebuild each corner from the mirror, exactly as the
+       * Gouraud intensity init below rebuilds gd_c[]/gd_i[] from the
+       * PATTERNDATA/SRCDATA mirrors of the B_I0-B_I3 aliases. */
       for(v = 0; v < 4; v++)
-         z_i[v] = REG(PHRASEZ0 + v*4);
+      {
+         uint32_t b = 6 - (v * 2);
+         z_i[v] = ((uint32_t)blitter_ram[SRCZINT  + b]     << 24)
+                | ((uint32_t)blitter_ram[SRCZINT  + b + 1] << 16)
+                | ((uint32_t)blitter_ram[SRCZFRAC + b]     <<  8)
+                |  (uint32_t)blitter_ram[SRCZFRAC + b + 1];
+      }
    }
 
    // Gouraud shading
@@ -1632,23 +1650,29 @@ void COMP_CTRL(uint8_t *dbinh, bool *nowrite,
 
    /* nowrite and winhibit (pixel-mode write inhibit)
     *
-    * Z-comparator lane in pixel-mode 16bpp: the fast blitter reads
-    * source/dest Z via `REG(SRCZINT|DSTZ) & 0xFFFF`, which is bytes 2-3
-    * of the 8-byte register (low 16 of the high 32 half).  In the
-    * GET64-shift lane convention here, that is lane 2 -- so
-    * `zcomp & 0x04` matches fast.  Previously accurate used `zcomp & 0x01`
-    * (lane 0 = bytes 6-7), which produced visibly wrong z-inhibit
-    * decisions in BSG sprite blits (cmd=09900F71 / 09800F41 families:
-    * pixel-mode 16bpp DCOMPEN sprites with constant source Z).
+    * Z-comparator lane in pixel-mode 16bpp.  In PIXEL (non-phrase)
+    * mode both engines take the source/destination Z from the register
+    * file rather than from a phrase position, so there is exactly one
+    * correct lane and it is fixed.  The fast blitter reads it through
+    * READ_RDATA_16's pixel-mode arm, `REG(r + 4) & 0xFFFF`: `REG(r+4)`
+    * is the longword at bytes 4-7 and the `& 0xFFFF` keeps its LOW
+    * half, i.e. bytes **6-7** of the 8-byte register.  Those are the
+    * bytes BlitterWriteByte fills from the B_Z0 alias, and in the
+    * GET64 big-endian view they are bits 15..0 -- lane 0.  So the
+    * matching accurate-path test is `zcomp & 0x01`.
     *
-    * This is a match-fast pragmatic fix; the JTRM-pure behaviour would
-    * select the lane based on the destination pixel's position within a
-    * phrase, which neither path currently does.  See #189 for the full
-    * divergence writeup. */
+    * This previously read `zcomp & 0x04` (lane 2 = bytes 2-3 = B_Z2),
+    * justified by a misreading of `REG(r+4) & 0xFFFF` as "bytes 2-3".
+    * That compared an unrelated Z corner and inhibited whole sprites:
+    * Cybermorph's projectile (cmd=09900F39, A1_FLAGS=00032420 --
+    * pixel-mode 16bpp DSTENZ/Z_OP_SUP/DCOMPEN, the same family as the
+    * BSG cmd=09900F71 / 09800F41 sprites) was rejected in its entirety
+    * under the accurate blitter while the fast blitter drew it.  See
+    * #189 for the full divergence writeup. */
    winhibit = (bcompen && !bcompbit && !phrase_mode)
       || (dcompen && (dcomp & 0x01) && !phrase_mode && (pixsize == 3))
       || (dcompen && ((dcomp & 0x03) == 0x03) && !phrase_mode && (pixsize == 4))
-      || ((zcomp & 0x04) && !phrase_mode && (pixsize == 4));
+      || ((zcomp & 0x01) && !phrase_mode && (pixsize == 4));
    *nowrite = winhibit && !bkgwren;
 
    /* 16-bit pixel mode flag */


### PR DESCRIPTION
Cybermorph shows the fired projectile with the fast blitter but not with the
accurate one, which is the shipped default — so users are missing projectiles.

Two independent Z-buffer defects, both found chasing that symptom. **They are
separable**: hunk (a) alone fully fixes the projectile (verified — see below).

## Reproduction

From the maintainer's `Cybermorph (1993).state1`. **Fire is `B`, not `A`** — `A`
is thrust and moves the whole scene, masking the projectile. Diffing
press-vs-no-press within one build:

| frame | fast | accurate (before) |
|---|---|---|
| 28 | 286 px, bbox x=[153,171] y=[128,145] | **0 px** |
| 32 | 69 px, bbox x=[159,167] y=[118,126] | **0 px** |

The projectile blit is `cmd=09900F39`, `A1_FLAGS=00032420` — `SRCEN | DSTEN |
DSTENZ | DSTWRZ | UPDA1F | UPDA1 | UPDA2 | DSTA2 | Z_OP_SUP | LFU_AN | LFU_A |
DCOMPEN`, 16 bpp, `xaddctl=3` (**XADDINC — pixel mode**). Note **GOURZ is
clear**: source Z is a constant from the register file. Forcing `zmode = 0` made
the projectile appear at the identical bbox, proving the blit is issued
correctly and the Z comparator was rejecting all of it.

## (a) Wrong Z-comparator lane in pixel-mode 16 bpp — the projectile bug

`COMP_CTRL` gated `winhibit` on `zcomp & 0x04`. The mechanism that makes this
wrong is in `dzread`:

```c
if (dzread)
{
   dstz = ((uint64_t)blitter_read_long(address) << 32) | blitter_read_long(address + 4);
   if (!phrase_mode && pixsize == 4)
      dstz >>= 48;            /* valid Z now in lane 0; lanes 1-3 are ZERO */
}
```

In pixel mode the destination Z is shifted into **lane 0, and lanes 1-3 become
zero**. Source Z is *not* correspondingly shifted here, because `szreadi = (sread
&& srcenz)` and this blit has `SRCENZ` clear — so `srcz` keeps all four lanes
from `GET64(blitter_ram, SRCZINT)`. With `Z_OP_SUP` (GT), lanes 1-3 then compare
a nonzero source Z against 0, which is true on essentially every pixel, so
`zcomp` bits 1/2/3 are spuriously set. Testing `zcomp & 0x04` read one of those
garbage lanes and inhibited unconditionally — the whole sprite vanished.

**Lane 0 is not merely the matching lane; in pixel mode it is the only lane with
a valid destination Z.** `0x04` → `0x01`.

The old comment justified `0x04` by claiming the fast blitter reads Z from
"bytes 2-3 of the 8-byte register". That also misreads `READ_RDATA_16`'s
pixel-mode arm, `REG(r+4) & 0xFFFF`: `REG(r+4)` is the longword at bytes 4-7 and
the mask keeps its **low** half — bytes **6-7**, where `BlitterWriteByte` lands
the `B_Z0` alias, which is lane 0 in the `GET64` big-endian view. Both readings
agree on lane 0.

This is the `#189` area and the old value was labelled a "match-fast pragmatic
fix". Under the mechanism above lane 0 cannot be the wrong choice in pixel mode,
so the BSG observation behind `0x04` was either misattributed or has since been
superseded by another fix.

## (b) Gouraud Z corners read from permanently-dead registers

`blitter_blit` used `z_i[v] = REG(PHRASEZ0 + v*4)`. But `BlitterWriteByte`
intercepts the whole `[0x7C, 0x9B]` range (the `B_I0-B_I3` and `B_Z0-B_Z3`
aliases) and redirects each byte into the `PATTERNDATA`/`SRCDATA` and
`SRCZINT`/`SRCZFRAC` mirrors — or discards it, as `case PHRASEINT0 + 0: break;`
does. Either way **nothing is ever stored at `PHRASEZ0..3`**;
`blitter_ram[0x8C..0x9B]` is dead memory.

Measured: fast saw source Z `0x0000-0x0003` where the game had written `0x7C41`.
With `Z_OP_SUP` a near-zero source Z never inhibits and also stamps ~0 into the
Z buffer — **the fast blitter had no working Z-buffer at all**. Rebuilt from the
mirror, mirroring how the Gouraud intensity init already rebuilds
`gd_c[]`/`gd_i[]`. Fast's Z now matches accurate lane-for-lane to ±1 LSB.

Hardware grounding: `docs/jtrm-register-map.md` 228-229 (`B_SRCZ1` = integer,
`B_SRCZ2` = fraction, with the note that JTRM ≤ v2.2 reversed them, so
`docs/jtrm-blitter.md`'s wording is the stale one), and `blitter_mmio.c`'s alias
table for the per-byte mapping. `ZINC` (0x74) is outside the alias range —
checked, unaffected.

## Results

| check | result |
|---|---|
| Cybermorph projectile, accurate, f28 | 0 px → **286 px**, bbox identical to fast |
| Cybermorph projectile, accurate, f32 | 0 px → **69 px**, bbox identical to fast |
| hunk (a) **alone** (b reverted) | **286 px / 69 px — same result**, so the two are independent |
| `test_blitter_compare` Cybermorph (state1, f20-26) | 7428 → **5892** divergent |
| `test_blitter_compare` Battle Sphere / yarc / jagniccc (f200-320) | **0** divergent each |
| framebuffer hashes pre-fix vs post-fix | 24/24 identical (yarc, jagniccc, Battle Sphere, Cybermorph × both modes × f120/220/300) |
| `scripts/c89-lint.sh src/tom/blitter.c` | clean |
| `make TEST_EXPORTS=1 test` | **exit 0**, zero failures |

Cybermorph gameplay delta vs pre-fix, frame 28: **accurate** changes exactly the
286 px of the projectile bbox and nothing else; **fast** changes 1669 px of the
3D viewport, which is (b) restoring Z-buffering that was previously absent —
intended, and the frame is coherent and now matches accurate.

The remaining 5892 Cybermorph divergences are all `cmd=00113078` and are a
**pre-existing** ±1 LSB difference in how the engines carry the Z fraction. Not
touched here.

## Coverage caveat — please read before trusting the corpus row

I instrumented `COMP_CTRL` to count blits arriving with
`!phrase_mode && pixsize == 4 && zmode != 0`, i.e. the condition hunk (a)
changes:

```
yarc.j64        : 0   (path never executed)
jagniccc.j64    : 0   (path never executed)
Battle Sphere   : 0   (path never executed, 320 frames from boot)
Cybermorph      : >0  (path exercised)
```

So the "0 divergent blits / identical hashes" results for those three ROMs show
that hunk (a) **did not execute** there — they are evidence of non-interference,
**not** evidence that the lane change is correct across the corpus. Only
Cybermorph exercises it in what I could test.

That matters because the BSG `state1` behind the 3190-blit / 0-diff baseline in
`docs/cart-issue-triage.md` is no longer present in the private states tree, and
Battle Sphere from boot never reaches this path. **Anyone holding a BSG sprite
save state should re-check `cmd=09900F71` / `09800F41` before merge** — those
are the blits the old `0x04` value was introduced for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)