### PR TITLE
fix(blitter): rate-limit the blit-memo arena-full notice (#411)

### DIFF
--- a/src/tom/blit_memo.c
+++ b/src/tom/blit_memo.c
@@ -163,6 +163,12 @@ static int blitMemoCDNoticeLogged = 0;
 static bm_shadow_rec *bmShArena = NULL;
 static uint32_t bmShUsed = 0;
 static int bmShFull = 0;            /* reclaim at the next frame boundary */
+/* Arena-exhaustion flushes since the memo was armed.  A busy title can
+ * exhaust the arena on most frames, so the notice is rate-limited (see
+ * BlitMemoFrame) -- an unconditional line here reached the log at frame
+ * rate.  Reset only on arm/teardown, never in BlitMemoFlush, so the
+ * "first" notice stays first for the whole session. */
+static uint32_t bmShFullFlushes = 0;
 static bm_shadow_rec bmScratchSh[BM_SH_SCRATCH];  /* verify-mode capture */
 static uint32_t bmScratchShN = 0;
 
@@ -461,6 +467,7 @@ static int bm_alloc_shadow_arena(void)
    }
    bmShUsed = 0;
    bmShFull = 0;
+   bmShFullFlushes = 0;
    return 1;
 }
 
@@ -817,7 +824,20 @@ void BlitMemoFrame(void)
        * Reclaim wholesale now that no skip run is outstanding. */
       if (bmShFull)
       {
-         LOG_INF("[BLITMEMO] shadow arena full; flushing memo\n");
+         /* Rate-limited: a title whose blit stream outruns the arena
+          * hits this on most frames, and an unconditional notice put a
+          * line in the host log at frame rate (reported on AvP with the
+          * memo enabled by hand).  Announce the first one, then only
+          * every 256th, carrying the running total so the frequency is
+          * still visible. */
+         bmShFullFlushes++;
+         if (bmShFullFlushes == 1)
+            LOG_INF("[BLITMEMO] shadow arena full (%u records); flushing "
+                    "memo. Further occurrences are logged every 256th.\n",
+                    (unsigned)BM_SH_ARENA_RECS);
+         else if ((bmShFullFlushes & 0xFF) == 0)
+            LOG_INF("[BLITMEMO] shadow arena full; flushing memo "
+                    "(%u flushes so far)\n", (unsigned)bmShFullFlushes);
          BlitMemoFlush();
       }
    }
@@ -880,6 +900,7 @@ void BlitMemoShutdown(void)
    bmShArena = NULL;
    bmShUsed = 0;
    bmShFull = 0;
+   bmShFullFlushes = 0;
    bmScratchShN = 0;
    blitMemoMode = BLIT_MEMO_OFF;
    blitMemoRecording = 0;

--- a/src/tom/blit_memo.c
+++ b/src/tom/blit_memo.c
@@ -882,6 +882,14 @@ void BlitMemoSetMode(int mode)
       return;
    }
 
+   /* Re-arming counts as a fresh session for the arena-full notice.  The
+    * shadow arena is NOT freed when the mode goes OFF (only the pool is),
+    * so bm_alloc_shadow_arena() -- which is guarded on !bmShArena -- does
+    * not run again on the way back in.  Without this, a user who toggles
+    * the option off and on would never see the explanatory first-occurrence
+    * line again, only the terse every-256th one. */
+   bmShFullFlushes = 0;
+
    /* The pool is allocated lazily at the first blit launch, not here, so
     * content that never reaches BlitMemoLaunch() -- CD titles, anything
     * running with a shadow surface, anything that never blits -- pays


### PR DESCRIPTION
`BlitMemoFrame()` logged `[BLITMEMO] shadow arena full; flushing memo` at INFO on **every** arena-exhaustion flush. A title whose blit stream outruns the 400,000-record arena hits that on most frames, so the line reached the host log at frame rate.

Reported on **Alien vs Predator** with `virtualjaguar_blit_memo` enabled by hand. Note AvP is deliberately *not* tagged for the memo in `titledb.c` (the entry has an explicit comment saying it waits for the full corpus sweep plus a device check), so this only affects users who turn the option on themselves.

## Measured

AvP, 1800 frames scripted into gameplay, memo enabled:

| | before | after |
|---|---|---|
| arena-full flushes | 8 | 8 |
| log lines | **8** | **1** |

Sustained play is worse than the fixture — the flush rate rises with scene complexity, which is exactly when the log is least useful and most voluminous.

## Change

Announce the first occurrence (now naming the arena size, so a reader can tell *undersized arena* from *one pathological frame*), then only every 256th, carrying the running total so the frequency stays visible:

```
[BLITMEMO] shadow arena full (400000 records); flushing memo. Further occurrences are logged every 256th.
```

The counter resets when the memo is armed and at teardown, **never in `BlitMemoFlush`** — otherwise the "first" notice would fire on every flush and reintroduce the spam it replaces.

## Verification

- **Inert**: `frame_hash_ab` over 1800 frames with the memo enabled is **byte-identical** between `develop` and this commit. Logging only.
- AvP repro emits **1 line where it emitted 8**.
- `make TEST_EXPORTS=1 test` — **exit 0**.
- `bash scripts/c89-lint.sh src/tom/blit_memo.c` — passes.

## Deliberately not addressed

Whether the arena should be **larger**, or the eviction policy smarter, for AvP-class workloads. Flushing the whole memo several times a run means it rebuilds from scratch and may never pay for its write-hook cost on such titles. That is a real perf question for #411's follow-up, but it needs measurement rather than a bigger constant, and it does not belong in a log-hygiene fix.