### PR TITLE
fix(test): one hardened preflight/classifier for both boot-matrix sweeps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -932,6 +932,10 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# into test/tools/ on first run (see the script header); needs only
 	@# the in-tree test/roms/yarc.j64, never test/roms/private.
 	bash test/tools/vjtrace_selftest.sh ./$(TARGET)
+	@# Boot-matrix shared logic (matrix_common.sh): core-fault verdicts must
+	@# never be blamed on a title, and the row cache must ignore docs-only
+	@# changes. Synthetic logs only -- no ROMs, no core, runs in <1s.
+	bash test/tools/matrix_common_test.sh
 	./test/test_blitter_mmio
 	./test/test_blitter_cmd ./$(TARGET)
 	./test/test_pit_clock_rate

--- a/test/tools/cart_boot_matrix.sh
+++ b/test/tools/cart_boot_matrix.sh
@@ -43,22 +43,32 @@ TIMEOUT_SECS="${CART_MATRIX_TIMEOUT:-90}"
 JOBS="${CART_MATRIX_JOBS:-4}"
 MAX_RUNS="${CART_MATRIX_MAX_RUNS:-0}"
 
-CORE="${CART_MATRIX_CORE:-./virtualjaguar_libretro.dylib}"
-[ -f "$CORE" ] || CORE=./virtualjaguar_libretro.so
-# Refuse to start without a core.  The fallback above silently selected a
-# nonexistent .so when the dylib was missing (an ABI-mode switch deletes it,
-# and a stray iOS-built .o makes the relink fail), and every worker then
-# dlopen-failed -- which the classifier read as "the ROM would not load" and
-# wrote 123 false LOAD_FAIL rows.  Fail here instead.
-if [ ! -f "$CORE" ]; then
-    echo "error: no core at ./virtualjaguar_libretro.{dylib,so}" >&2
-    echo "build one with:  make TEST_EXPORTS=1" >&2
-    exit 1
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/matrix_common.sh"
+
+# Core discovery, the test-export check and the build-identity guard are shared
+# with the CD sweep (matrix_common.sh).  Refusing to start without a core is the
+# point: the old fallback silently selected a nonexistent .so when the dylib was
+# missing (an ABI-mode switch deletes it, and a stray iOS-built .o makes the
+# relink fail), every worker then dlopen-failed, and the classifier read that as
+# "the ROM would not load" -- 123 false LOAD_FAIL rows.
+if [ -n "${CART_MATRIX_CORE:-}" ]; then
+    CORE="$CART_MATRIX_CORE"
+    if [ ! -f "$CORE" ]; then
+        echo "error: CART_MATRIX_CORE=$CORE does not exist" >&2
+        exit 1
+    fi
+else
+    matrix_find_core || exit 1
+    CORE="./$MATRIX_CORE"
 fi
 PROBE=./test/tools/cart_boot_probe
 
-BUILD_ID="$(bash scripts/build-id.sh)"
+BUILD_ID="$(matrix_build_id)"
 export VJ_EXPECT_BUILD="$BUILD_ID"
+
+# Row-cache identity (#440): scoped to inputs that can change a verdict, so a
+# docs-only commit no longer invalidates all 154 rows.  See matrix_common.sh.
+CACHE_ID="$(matrix_cache_id)"
 
 ROWDIR="$LOGDIR/rows"
 mkdir -p "$LOGDIR" "$ROWDIR"
@@ -72,32 +82,7 @@ if [ ! -d "$ROMS_ROOT" ]; then
     exit 1
 fi
 
-TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
-
-run_bounded() {
-    # usage: run_bounded <seconds> <logfile> <cmd...>
-    secs="$1"; logfile="$2"; shift 2
-    if [ -n "$TIMEOUT_BIN" ]; then
-        "$TIMEOUT_BIN" "$secs" "$@" >"$logfile" 2>&1
-        return $?
-    fi
-    "$@" >"$logfile" 2>&1 &
-    pid=$!
-    waited=0
-    while kill -0 "$pid" 2>/dev/null; do
-        sleep 1
-        waited=$((waited + 1))
-        if [ "$waited" -ge "$secs" ]; then
-            kill -TERM "$pid" 2>/dev/null
-            sleep 2
-            kill -KILL "$pid" 2>/dev/null
-            wait "$pid" 2>/dev/null
-            return 124
-        fi
-    done
-    wait "$pid"
-    return $?
-}
+run_bounded() { matrix_run_bounded "$@"; }
 
 field() {
     # usage: field <name> <probe-line>   (numeric / $hex fields)
@@ -126,10 +111,11 @@ classify_mode() {
     fi
     # A dlopen failure is a HARNESS fault, not a title result.  Writing it as
     # LOAD_FAIL is what let a missing core masquerade as 123 unloadable ROMs,
-    # and because rows are cached per build id, the bad rows were then reused
-    # by the next invocation.  Never let that reach the matrix.
-    if grep -q 'dlopen(' "$logfile" 2>/dev/null; then
-        echo "? (core_error)|core failed to load — row invalid, not a title result"
+    # and because rows are cached, the bad rows were then reused by the next
+    # invocation.  Shared with the CD sweep so one fix covers both.
+    core_err="$(matrix_core_error "$logfile")"
+    if [ -n "$core_err" ]; then
+        echo "? (core_error)|$core_err"
         return
     fi
     if [ -z "$line" ] || printf '%s' "$line" | grep -q 'load_fail=1'; then
@@ -182,7 +168,7 @@ process_one() {
     slug="$(printf '%s' "$base" | tr -c 'A-Za-z0-9._-' '_')"
     rowfile="$ROWDIR/$slug.row"
 
-    if [ -f "$rowfile" ] && grep -q "build:$BUILD_ID" "$rowfile"; then
+    if [ -f "$rowfile" ] && grep -q "build:$CACHE_ID" "$rowfile"; then
         return 0
     fi
 
@@ -205,11 +191,12 @@ process_one() {
         "$title" \
         "${hle%%|*}" "${hle#*|}" \
         "${bios%%|*}" "${bios#*|}" \
-        "$BUILD_ID" > "$rowfile"
+        "$CACHE_ID" > "$rowfile"
     echo "done: $title  [hle: ${hle%%|*}]  [bios: ${bios%%|*}]"
 }
 export -f process_one run_bounded classify_mode field
-export ROWDIR LOGDIR FRAMES TIMEOUT_SECS TIMEOUT_BIN PROBE CORE BUILD_ID VJ_EXPECT_BUILD
+export -f matrix_core_error matrix_run_bounded
+export ROWDIR LOGDIR FRAMES TIMEOUT_SECS MATRIX_TIMEOUT_BIN PROBE CORE BUILD_ID CACHE_ID VJ_EXPECT_BUILD
 
 # ---------------------------------------------------------------------------
 # ROM list -> fresh work list (respecting MAX_RUNS) -> parallel workers
@@ -229,7 +216,7 @@ count=0
 while IFS= read -r rom; do
     base="$(basename "$rom")"
     slug="$(printf '%s' "$base" | tr -c 'A-Za-z0-9._-' '_')"
-    if [ -f "$ROWDIR/$slug.row" ] && grep -q "build:$BUILD_ID" "$ROWDIR/$slug.row"; then
+    if [ -f "$ROWDIR/$slug.row" ] && grep -q "build:$CACHE_ID" "$ROWDIR/$slug.row"; then
         continue
     fi
     printf '%s\n' "$rom" >> "$FRESH"
@@ -237,7 +224,7 @@ while IFS= read -r rom; do
     if [ "$MAX_RUNS" -gt 0 ] && [ "$count" -ge "$MAX_RUNS" ]; then break; fi
 done < "$LIST"
 
-echo "corpus: $TOTAL ROMs; fresh this invocation: $count; build: $BUILD_ID; jobs: $JOBS"
+echo "corpus: $TOTAL ROMs; fresh this invocation: $count; build: $BUILD_ID; cache: $CACHE_ID; jobs: $JOBS"
 
 # Preflight: the build-identity guard must pass BEFORE any worker writes a
 # row.  A stale or mismatched core once turned an entire sweep into 153
@@ -258,9 +245,11 @@ if [ "$count" -gt 0 ]; then
     # "if a CARTPROBE line exists", so a first ROM that legitimately fails to
     # load (e.g. an alpha dump) skipped the whole preflight and let a broken
     # core through -- exactly how the 123-LOAD_FAIL sweep got started.
-    if grep -q 'dlopen(' "$preflight_log"; then
-        echo "error: core failed to dlopen: $CORE" >&2
-        grep -m1 'dlopen(' "$preflight_log" >&2
+    preflight_err="$(matrix_core_error "$preflight_log")"
+    if [ -n "$preflight_err" ]; then
+        echo "error: $preflight_err" >&2
+        echo "  core: $CORE" >&2
+        grep -m1 'dlopen(' "$preflight_log" >&2 2>/dev/null
         echo "rebuild with:  make clean && make TEST_EXPORTS=1" >&2
         exit 1
     fi
@@ -272,8 +261,9 @@ if [ "$count" -gt 0 ]; then
         while read -r cand; do
             run_bounded "$TIMEOUT_SECS" "$preflight_log" \
                 "$PROBE" "$CORE" "$cand" --frames 1
-            if grep -q 'dlopen(' "$preflight_log"; then
-                echo "error: core failed to dlopen: $CORE" >&2
+            preflight_err="$(matrix_core_error "$preflight_log")"
+            if [ -n "$preflight_err" ]; then
+                echo "error: $preflight_err (core: $CORE)" >&2
                 exit 1
             fi
             if grep -q '^CARTPROBE ' "$preflight_log"; then probe_ok=1; break; fi

--- a/test/tools/cd_boot_matrix.sh
+++ b/test/tools/cd_boot_matrix.sh
@@ -54,9 +54,9 @@
 #                         unlimited). Combined with the resume guard this lets
 #                         a long sweep be chunked across short invocations:
 #                         each chunk skips the rows earlier chunks recorded,
-#                         because the build stamp does not move when the only
-#                         thing that changed is this script's own output
-#                         (scripts/build-id.sh BUILD_ID_IGNORE).
+#                         because rows are keyed on the content-scoped cache id
+#                         (matrix_common.sh), which this script's own output
+#                         cannot move.
 set -u
 
 # ---------------------------------------------------------------------------
@@ -84,76 +84,43 @@ if [ ! -d "$ROMS_ROOT" ]; then
     exit 1
 fi
 
-DYLIB=""
-for candidate in virtualjaguar_libretro.dylib virtualjaguar_libretro.so; do
-    if [ -f "$candidate" ]; then DYLIB="$candidate"; break; fi
-done
-if [ -z "$DYLIB" ]; then
-    echo "No built core found -- building with TEST_EXPORTS=1..." >&2
-    make TEST_EXPORTS=1 -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" || {
-        echo "FATAL: build failed" >&2; exit 1; }
-    for candidate in virtualjaguar_libretro.dylib virtualjaguar_libretro.so; do
-        if [ -f "$candidate" ]; then DYLIB="$candidate"; break; fi
-    done
-fi
+. "$SCRIPT_DIR/matrix_common.sh"
+
+# Core discovery is shared with the cart sweep (matrix_common.sh): it is fatal
+# if no core exists after a rebuild attempt.  This script used to loop over the
+# candidates, build, and then NOT re-check -- leaving $DYLIB empty and running
+# every harness against "".
+matrix_find_core || exit 1
+DYLIB="$MATRIX_CORE"
 
 # The harnesses dlsym() CDROMDiagGetCounters; a plain `make` (no
 # TEST_EXPORTS=1) relinks against the slim production export list and
 # silently drops it, and every dlsym-based assertion then reports SKIP.
-if command -v nm >/dev/null 2>&1; then
-    if ! nm -gU "$DYLIB" 2>/dev/null | grep -q CDROMDiagGetCounters; then
-        echo "$DYLIB is missing test-export symbols -- rebuilding with TEST_EXPORTS=1..." >&2
-        rm -f "$DYLIB"
-        make TEST_EXPORTS=1 -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" || {
-            echo "FATAL: build failed" >&2; exit 1; }
-    fi
-fi
+matrix_require_test_exports "$DYLIB" CDROMDiagGetCounters
 
 # Build-identity guard: every harness invocation below verifies that the
 # core's embedded git rev matches the working tree (scripts/build-id.sh),
-# so matrix rows can never be produced by a stale/wrong-branch binary.
+# so matrix rows can never be produced by a stale/wrong-branch binary.  This
+# stays deliberately broad -- a rebuild is cheap, publishing a matrix from the
+# wrong core is not.
 #
-# The id is computed ONCE per invocation and stamped into every row this
-# invocation writes (see run_title).  Resuming across invocations only
-# works because scripts/build-id.sh excludes the results file from its
-# dirty check -- otherwise writing the first row would flip the id and the
-# next invocation would re-run everything it had just recorded.  The
-# default $OUT is on that ignore list; a custom tracked $OUT is not, so
-# warn rather than let the sweep silently fail to converge.  (This applies
-# to any re-invocation, chunked or not: an interrupted unlimited sweep
-# resumes through the same guard.)
-#
-# The ignore list is written repo-root-relative, so an absolute $OUT has to
-# be normalised before the comparison.  `git ls-files` resolves an absolute
-# path inside the repo on its own, but the string compare below does not:
-# without this, CD_MATRIX_OUT=/abs/path/to/docs/cd-boot-matrix.md -- a file
-# that IS ignored -- fails the compare and draws a warning stating the exact
-# opposite of the truth.
-OUT_REL=$OUT
-OUT_DIR=$(dirname "$OUT")
-if OUT_PREFIX=$(cd "$OUT_DIR" 2>/dev/null && git rev-parse --show-prefix 2>/dev/null); then
-    OUT_REL="${OUT_PREFIX}$(basename "$OUT")"
-fi
-if git ls-files --error-unmatch "$OUT" >/dev/null 2>&1 \
-   && ! scripts/build-id.sh --ignores 2>/dev/null | grep -qxF "$OUT_REL"; then
-    echo "WARNING: CD_MATRIX_OUT=$OUT is tracked by git but is not in" >&2
-    echo "  scripts/build-id.sh's ignore list. Writing rows will flip the build" >&2
-    echo "  id to '-dirty', so the next chunked invocation will treat every row" >&2
-    echo "  this one records as stale and re-run it. Add the path to" >&2
-    echo "  BUILD_ID_IGNORE, or point CD_MATRIX_OUT at an untracked file." >&2
-fi
-
-VJ_EXPECT_BUILD=$(scripts/build-id.sh 2>/dev/null || true)
+# Row caching used to key on this same id, which is why writing rows had to be
+# hidden from it via scripts/build-id.sh's BUILD_ID_IGNORE list (otherwise the
+# first row flipped the id to '-dirty' and the next chunk re-ran everything it
+# had just recorded).  That workaround is no longer load-bearing: rows are keyed
+# on $CACHE_ID below, which is scoped to inputs that can change a verdict, and
+# $OUT is not one of them.  A tracked custom $OUT is therefore fine.
+VJ_EXPECT_BUILD="$(matrix_build_id)"
 export VJ_EXPECT_BUILD
 if [ -n "$VJ_EXPECT_BUILD" ]; then
     echo "expected core build id: $VJ_EXPECT_BUILD" >&2
-    if ! strings "$DYLIB" 2>/dev/null | grep -Eq "$VJ_EXPECT_BUILD( |\$)"; then
-        echo "$DYLIB does not embed build id $VJ_EXPECT_BUILD -- rebuilding..." >&2
-        rm -f "$DYLIB"
-        make TEST_EXPORTS=1 -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" || {
-            echo "FATAL: build failed" >&2; exit 1; }
-    fi
+    matrix_verify_core_build "$DYLIB" "$VJ_EXPECT_BUILD"
 fi
+
+# Row-cache identity is deliberately NOT the git rev (issue #440): a docs-only
+# commit must not invalidate every recorded row.  See matrix_common.sh.
+CACHE_ID="$(matrix_cache_id)"
+echo "row-cache id: $CACHE_ID" >&2
 
 # TEST_EXPORTS=1 is required: the per-binary rules only exist in that
 # Makefile branch.  A bare `make test/<bin>` falls through to GNU make's
@@ -168,38 +135,8 @@ for bin in test/test_cd_hle_boot test/test_cd_bios_boot; do
     fi
 done
 
-# Portable bounded-execution helper: prefer GNU coreutils `timeout`/`gtimeout`,
-# fall back to a plain-bash watchdog. Returns 124 on timeout (matches GNU
-# `timeout`'s convention) so callers have one thing to check either way.
-TIMEOUT_BIN=""
-if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN="timeout"
-elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN="gtimeout"
-fi
-
-run_bounded() {
-    # usage: run_bounded <seconds> <logfile> -- <cmd...>
-    secs="$1"; logfile="$2"; shift 2
-    if [ -n "$TIMEOUT_BIN" ]; then
-        "$TIMEOUT_BIN" "$secs" "$@" >"$logfile" 2>&1
-        return $?
-    fi
-    "$@" >"$logfile" 2>&1 &
-    pid=$!
-    waited=0
-    while kill -0 "$pid" 2>/dev/null; do
-        sleep 1
-        waited=$((waited + 1))
-        if [ "$waited" -ge "$secs" ]; then
-            kill -TERM "$pid" 2>/dev/null
-            sleep 2
-            kill -KILL "$pid" 2>/dev/null
-            wait "$pid" 2>/dev/null
-            return 124
-        fi
-    done
-    wait "$pid"
-    return $?
-}
+# Bounded execution lives in matrix_common.sh (identical in both sweeps).
+run_bounded() { matrix_run_bounded "$@"; }
 
 # ---------------------------------------------------------------------------
 # Per-title x mode runner
@@ -298,6 +235,12 @@ run_one() {
 
 classify_stage() {
     mode="$1"; log="$2"; rc="$3"
+    # Core-level faults FIRST: a core that would not load, or that is the wrong
+    # build, says nothing about the title.  Blaming the title here is what let a
+    # missing core publish 123 false LOAD_FAIL rows in the cart matrix (7e6975f);
+    # this script had no such guard at all until #430.
+    core_err="$(matrix_core_error "$log")"
+    if [ -n "$core_err" ]; then echo "? (core_error)"; return; fi
     if [ "$rc" -eq 124 ]; then echo "HARNESS_HANG"; return; fi
     if grep -aq '\[CRASH\]' "$log" 2>/dev/null; then echo "LOAD_FAIL (harness crash)"; return; fi
     if grep -aq 'load failed' "$log" 2>/dev/null; then echo "LOAD_FAIL"; return; fi
@@ -551,13 +494,13 @@ run_title() {
     row_lineno="$(find_row_lineno "$title" "$mode")"
     if [ -n "$row_lineno" ]; then
         row_line="$(sed -n "${row_lineno}p" "$OUT")"
-        if [ -z "$VJ_EXPECT_BUILD" ]; then
-            # No build identity available (no git?): can't tell fresh from
+        if [ -z "$CACHE_ID" ]; then
+            # No cache identity available (no git?): can't tell fresh from
             # stale -- keep legacy skip behavior, but say so.
-            echo "  [$mode] $title -- already recorded, skipping (build id unavailable; provenance unverified)" >&2
+            echo "  [$mode] $title -- already recorded, skipping (cache id unavailable; provenance unverified)" >&2
             return 0
         fi
-        if printf '%s' "$row_line" | grep -qF "<!-- build:$VJ_EXPECT_BUILD -->"; then
+        if printf '%s' "$row_line" | grep -qF "<!-- build:$CACHE_ID -->"; then
             echo "  [$mode] $title -- already recorded by this build, skipping" >&2
             return 0
         fi
@@ -572,7 +515,7 @@ run_title() {
     fi
     RUNS_DONE=$((RUNS_DONE + 1))
     if [ -n "$row_lineno" ]; then
-        echo "  [$mode] $title -- stale row (recorded by '$row_old_build', current '$VJ_EXPECT_BUILD'); re-running" >&2
+        echo "  [$mode] $title -- stale row (recorded by '$row_old_build', current '$CACHE_ID'); re-running" >&2
     else
         echo "  [$mode] $title ..." >&2
     fi
@@ -580,6 +523,15 @@ run_title() {
     log="$RUN_LOG"; rc="$RUN_RC"
 
     stage="$(classify_stage "$mode" "$log" "$rc")"
+    if [ "$stage" = "? (core_error)" ]; then
+        # A core that will not load fails identically for every title.  Abort
+        # before writing anything rather than publishing a matrix of invalid
+        # rows that the row cache will then serve to the next invocation.
+        echo "FATAL: $(matrix_core_error "$log")" >&2
+        echo "  core: $DYLIB   log: $log" >&2
+        echo "  rebuild with:  make clean && make TEST_EXPORTS=1" >&2
+        exit 1
+    fi
     watchdog="$(watchdog_of "$log")"
     [ -z "$watchdog" ] && watchdog="(none)"
     evidence="$(pc_summary_of "$log")"
@@ -609,7 +561,7 @@ run_title() {
     # inside the last cell as an HTML comment so rendered markdown is
     # unchanged.
     stamp=""
-    [ -n "$VJ_EXPECT_BUILD" ] && stamp=" <!-- build:$VJ_EXPECT_BUILD -->"
+    [ -n "$CACHE_ID" ] && stamp=" <!-- build:$CACHE_ID -->"
     row="$(printf '| %s | %s | %s | %s | %s | %s%s |' \
         "$title" "$mode" "$score" "$stage" \
         "$(printf '%s' "$watchdog" | sed 's/|/\\|/g')" \

--- a/test/tools/matrix_common.sh
+++ b/test/tools/matrix_common.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# test/tools/matrix_common.sh -- shared preflight, core-error classification and
+# row-cache identity for the boot-matrix sweeps (cart_boot_matrix.sh and
+# cd_boot_matrix.sh).
+#
+# WHY THIS FILE EXISTS
+#   Both sweeps independently reimplemented core discovery, the build-identity
+#   preflight and result classification.  That duplication is why the same
+#   three faults existed in two places: `7e6975f` fixed them in the cart script
+#   only, and the CD script still blamed titles for a core that would not load.
+#   One implementation means a fix lands in both sweeps at once.
+#
+# WHAT STAYS PER-SCRIPT
+#   Stage-classification ladders.  Cart and CD boot stages genuinely differ and
+#   must not be merged behind a mode switch.  Only the CORE-LEVEL verdicts --
+#   "the core did not load", "the core is not the build we asked for" -- are
+#   shared, because those are never a statement about the title.
+#
+# Source it from a sweep script:
+#   . "$(dirname "${BASH_SOURCE[0]}")/matrix_common.sh"
+
+# ---------------------------------------------------------------------------
+# Core discovery + preflight
+# ---------------------------------------------------------------------------
+
+MATRIX_CORE=""
+
+matrix_find_core() {
+    # usage: matrix_find_core || exit 1     then use "$MATRIX_CORE"
+    #
+    # Sets the global MATRIX_CORE rather than echoing, DELIBERATELY: called as
+    # core="$(matrix_find_core)" the function runs in a subshell, where `exit 1`
+    # kills only that subshell and hands the caller an EMPTY STRING -- which is
+    # the very fault this function exists to prevent.  The regression test
+    # (matrix_common_test.sh) pins this.
+    #
+    # The old cart version fell through to a nonexistent .so when the dylib was
+    # missing (an ABI-mode switch deletes it, and a stray iOS-built .o makes the
+    # relink fail); every worker then dlopen-failed and the classifier wrote 123
+    # false LOAD_FAIL rows.  The old CD version looped over the same candidates
+    # but never re-checked after its rebuild, so it could continue with an EMPTY
+    # core path.  Both are fatal here.
+    local candidate found=""
+    MATRIX_CORE=""
+    for candidate in virtualjaguar_libretro.dylib virtualjaguar_libretro.so; do
+        if [ -f "$candidate" ]; then found="$candidate"; break; fi
+    done
+    if [ -z "$found" ]; then
+        echo "no built core found -- building with TEST_EXPORTS=1..." >&2
+        make TEST_EXPORTS=1 -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" >&2 \
+            || { echo "FATAL: build failed" >&2; exit 1; }
+        for candidate in virtualjaguar_libretro.dylib virtualjaguar_libretro.so; do
+            if [ -f "$candidate" ]; then found="$candidate"; break; fi
+        done
+    fi
+    if [ -z "$found" ]; then
+        echo "FATAL: no core at ./virtualjaguar_libretro.{dylib,so} after a build" >&2
+        echo "  build one by hand with:  make TEST_EXPORTS=1" >&2
+        return 1
+    fi
+    MATRIX_CORE="$found"
+}
+
+matrix_require_test_exports() {
+    # usage: matrix_require_test_exports <core> <symbol>
+    # A plain `make` relinks against the slim production export list and drops
+    # the dlsym-able internals; every dlsym-based assertion then reports SKIP,
+    # which reads as a pass.  Rebuild rather than sweep a half-blind core.
+    local core="$1" symbol="$2"
+    command -v nm >/dev/null 2>&1 || return 0
+    if ! nm -gU "$core" 2>/dev/null | grep -q "$symbol"; then
+        echo "$core is missing test exports ($symbol) -- rebuilding..." >&2
+        command rm -f "$core"
+        make TEST_EXPORTS=1 -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" >&2 \
+            || { echo "FATAL: build failed" >&2; exit 1; }
+    fi
+}
+
+matrix_build_id() {
+    # The conservative, git-rev-based identity used for VJ_EXPECT_BUILD.  This
+    # guards against testing a STALE BINARY and is deliberately broad: it is
+    # cheap to rebuild, expensive to publish a matrix from the wrong core.
+    bash scripts/build-id.sh 2>/dev/null || true
+}
+
+matrix_verify_core_build() {
+    # usage: matrix_verify_core_build <core> <build-id>
+    # Rebuild if the binary does not embed the expected id.
+    local core="$1" want="$2"
+    [ -n "$want" ] || return 0
+    if ! strings "$core" 2>/dev/null | grep -Eq "$want( |\$)"; then
+        echo "$core does not embed build id $want -- rebuilding..." >&2
+        command rm -f "$core"
+        make TEST_EXPORTS=1 -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" >&2 \
+            || { echo "FATAL: build failed" >&2; exit 1; }
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Row-cache identity  (issue #440)
+# ---------------------------------------------------------------------------
+
+# Paths whose content can actually change a matrix row: the emulated machine,
+# the harnesses that drive it, and the sweep scripts that classify the result.
+# Everything else -- docs, the site, .gitignore, release notes, and the matrix
+# output itself -- cannot, and must not invalidate the cache.
+MATRIX_INPUT_PATHS="src libretro.c libretro_core_options.h libretro-common \
+Makefile Makefile.common test/harness test/cd_assertions.h \
+test/tools/cart_boot_probe.c test/tools/cart_boot_matrix.sh \
+test/tools/cd_boot_matrix.sh test/tools/matrix_common.sh \
+test/test_cd_hle_boot.c test/test_cd_bios_boot.c"
+
+matrix_cache_id() {
+    # A narrow identity for the ROW CACHE, distinct from matrix_build_id.
+    #
+    # Rows used to be keyed on the git rev, so ANY commit invalidated every
+    # cached row.  A sweep once re-measured all 154 cart titles (~45 min) after
+    # two commits that touched only .gitignore and the matrix's own output --
+    # zero core code -- and produced byte-identical results.  Key on content
+    # that can change a verdict instead.
+    #
+    # Committed tree state for those paths, plus any uncommitted diff to them,
+    # so a dirty working tree is still distinguished.  Falls back to the broad
+    # build id outside a git checkout.
+    local trees diff
+    if ! git rev-parse --git-dir >/dev/null 2>&1; then
+        matrix_build_id
+        return
+    fi
+    trees="$(for p in $MATRIX_INPUT_PATHS; do
+                 git rev-parse "HEAD:$p" 2>/dev/null || printf 'absent:%s\n' "$p"
+             done)"
+    diff="$(git diff HEAD -- $MATRIX_INPUT_PATHS 2>/dev/null)"
+    printf '%s\n%s\n' "$trees" "$diff" \
+        | { shasum 2>/dev/null || sha1sum; } \
+        | cut -c1-12
+}
+
+# ---------------------------------------------------------------------------
+# Core-level classification  (the never-blame-the-title rule)
+# ---------------------------------------------------------------------------
+
+matrix_core_error() {
+    # usage: reason="$(matrix_core_error <logfile>)"
+    #        [ -n "$reason" ] && { record "? (core_error)|$reason"; return; }
+    #
+    # MUST be consulted before any title verdict.  A core that fails to dlopen,
+    # or that is not the build we asked for, says nothing about the ROM -- and
+    # because rows are cached, one such row is reused by every later invocation.
+    # harness.c prints "harness: dlopen(<path>): <dlerror>" on a failed load;
+    # the build guard prints "FATAL build mismatch".
+    local log="$1"
+    [ -f "$log" ] || { printf 'log %s missing\n' "$log"; return; }
+    if grep -aq 'dlopen(' "$log" 2>/dev/null; then
+        printf 'core failed to load -- row invalid, not a title result\n'
+        return
+    fi
+    if grep -aq 'FATAL build mismatch' "$log" 2>/dev/null; then
+        printf 'core does not match VJ_EXPECT_BUILD -- row invalid\n'
+        return
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Bounded execution
+# ---------------------------------------------------------------------------
+
+MATRIX_TIMEOUT_BIN="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)"
+
+matrix_run_bounded() {
+    # usage: matrix_run_bounded <seconds> <logfile> <cmd...>
+    # Returns 124 on timeout, matching GNU timeout, whichever path is taken.
+    local secs="$1" logfile="$2"
+    shift 2
+    if [ -n "$MATRIX_TIMEOUT_BIN" ]; then
+        "$MATRIX_TIMEOUT_BIN" "$secs" "$@" >"$logfile" 2>&1
+        return $?
+    fi
+    "$@" >"$logfile" 2>&1 &
+    local pid=$! waited=0
+    while kill -0 "$pid" 2>/dev/null; do
+        sleep 1
+        waited=$((waited + 1))
+        if [ "$waited" -ge "$secs" ]; then
+            kill -TERM "$pid" 2>/dev/null
+            sleep 2
+            kill -KILL "$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
+            return 124
+        fi
+    done
+    wait "$pid"
+    return $?
+}

--- a/test/tools/matrix_common_test.sh
+++ b/test/tools/matrix_common_test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# test/tools/matrix_common_test.sh -- regression gate for matrix_common.sh.
+#
+# The matrix sweeps take 45+ minutes and need the private ROM corpus, so they
+# cannot be a per-change gate.  These checks exercise the shared logic directly
+# with synthetic logs and run in under a second.
+#
+# Covers the three faults that produced 123 false LOAD_FAIL rows (7e6975f, #430)
+# and the row-cache churn that re-measured a whole corpus for nothing (#440).
+#
+# Usage: bash test/tools/matrix_common_test.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+. "$SCRIPT_DIR/matrix_common.sh"
+
+PASS=0
+FAIL=0
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/matrix_common_test.XXXXXX")"
+cleanup() { command rm -rf "$TMP"; }
+trap cleanup EXIT
+
+ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+
+# ---------------------------------------------------------------------------
+echo "matrix_core_error -- a core fault must never be blamed on the title"
+# ---------------------------------------------------------------------------
+
+printf 'harness: dlopen(./virtualjaguar_libretro.so): image not found\n' > "$TMP/dlopen.log"
+r="$(matrix_core_error "$TMP/dlopen.log")"
+[ -n "$r" ] && ok "dlopen failure is reported as a core error" \
+             || bad "dlopen failure is reported as a core error" "got empty verdict"
+
+printf '[HARNESS] FATAL build mismatch: core is abc1234, expected def5678\n' > "$TMP/mismatch.log"
+r="$(matrix_core_error "$TMP/mismatch.log")"
+[ -n "$r" ] && ok "build mismatch is reported as a core error" \
+             || bad "build mismatch is reported as a core error" "got empty verdict"
+
+# The critical negative: a title that genuinely fails to load must NOT be
+# reclassified as a core error, or every real LOAD_FAIL disappears from the
+# matrix and the sweep looks cleaner than it is.
+printf '[FAIL] Some Title -- load failed\nCARTPROBE load_fail=1 frames=0\n' > "$TMP/loadfail.log"
+r="$(matrix_core_error "$TMP/loadfail.log")"
+[ -z "$r" ] && ok "a genuine ROM load failure is NOT a core error" \
+             || bad "a genuine ROM load failure is NOT a core error" "got: $r"
+
+printf 'CARTPROBE frames=600 pc_valid=1 pc=$001234 lit_frames=600\n' > "$TMP/good.log"
+r="$(matrix_core_error "$TMP/good.log")"
+[ -z "$r" ] && ok "a healthy run is not a core error" \
+             || bad "a healthy run is not a core error" "got: $r"
+
+r="$(matrix_core_error "$TMP/does-not-exist.log")"
+[ -n "$r" ] && ok "a missing log is a core error, not a silent pass" \
+             || bad "a missing log is a core error, not a silent pass" "got empty verdict"
+
+# ---------------------------------------------------------------------------
+echo "matrix_cache_id -- scoped to inputs that can change a verdict (#440)"
+# ---------------------------------------------------------------------------
+
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    base="$(matrix_cache_id)"
+    [ -n "$base" ] && ok "cache id is non-empty" || bad "cache id is non-empty"
+
+    [ "$(matrix_cache_id)" = "$base" ] && ok "cache id is stable across calls" \
+        || bad "cache id is stable across calls"
+
+    # A docs-only edit -- the exact case that cost a 45-minute re-sweep.
+    DOC=docs/cart-boot-matrix.md
+    if [ -f "$DOC" ]; then
+        cp "$DOC" "$TMP/doc.bak"
+        printf '\n<!-- test scratch -->\n' >> "$DOC"
+        after="$(matrix_cache_id)"
+        command cp -f "$TMP/doc.bak" "$DOC"
+        [ "$after" = "$base" ] && ok "a docs edit does NOT invalidate the row cache" \
+            || bad "a docs edit does NOT invalidate the row cache" "id moved $base -> $after"
+    fi
+
+    # A core-source edit MUST invalidate it, or a real regression is served
+    # stale rows and looks clean.
+    SRC=src/tom/blitter_mmio.c
+    if [ -f "$SRC" ]; then
+        cp "$SRC" "$TMP/src.bak"
+        printf '\n/* test scratch */\n' >> "$SRC"
+        after="$(matrix_cache_id)"
+        command cp -f "$TMP/src.bak" "$SRC"
+        [ "$after" != "$base" ] && ok "a core-source edit DOES invalidate the row cache" \
+            || bad "a core-source edit DOES invalidate the row cache" "id unchanged at $base"
+    fi
+else
+    echo "  skip (not a git checkout)"
+fi
+
+# ---------------------------------------------------------------------------
+echo "matrix_run_bounded -- timeout convention"
+# ---------------------------------------------------------------------------
+
+matrix_run_bounded 5 "$TMP/rb.log" true
+[ $? -eq 0 ] && ok "propagates success" || bad "propagates success"
+
+matrix_run_bounded 5 "$TMP/rb.log" sh -c 'exit 3'
+[ $? -eq 3 ] && ok "propagates a non-zero exit code" || bad "propagates a non-zero exit code"
+
+matrix_run_bounded 1 "$TMP/rb.log" sh -c 'sleep 5'
+[ $? -eq 124 ] && ok "returns 124 on timeout" || bad "returns 124 on timeout"
+
+# ---------------------------------------------------------------------------
+echo "matrix_find_core -- refuses to continue without a core"
+# ---------------------------------------------------------------------------
+
+# Run in an empty directory with a `make` that produces nothing: the function
+# must exit non-zero rather than return an empty path (the CD script's old
+# behaviour, which then ran every harness against "").
+mkdir -p "$TMP/empty/bin"
+printf '#!/bin/sh\nexit 0\n' > "$TMP/empty/bin/make"
+chmod +x "$TMP/empty/bin/make"
+out="$( cd "$TMP/empty" && PATH="$TMP/empty/bin:$PATH" bash -c \
+        ". '$SCRIPT_DIR/matrix_common.sh'; matrix_find_core || exit 1; echo \"CORE=[\$MATRIX_CORE]\"" 2>/dev/null )"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    bad "the documented caller pattern aborts when no core exists" "exited 0, output: $out"
+elif printf '%s' "$out" | grep -q 'CORE='; then
+    bad "the documented caller pattern aborts when no core exists" "kept going: $out"
+else
+    ok "the documented caller pattern aborts when no core exists"
+fi
+
+# And the trap that made this necessary: in a command substitution, a failing
+# matrix_find_core must not silently yield "".
+out="$( cd "$TMP/empty" && PATH="$TMP/empty/bin:$PATH" bash -c \
+        ". '$SCRIPT_DIR/matrix_common.sh'; core=\"\$(matrix_find_core)\" || exit 1; echo \"CORE=[\$core]\"" 2>/dev/null )"
+[ -z "$out" ] && ok "command-substitution callers still get a non-zero status" \
+              || bad "command-substitution callers still get a non-zero status" "got: $out"
+
+# ---------------------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #430, closes #432, closes #440.

One PR because the three issues are the same code: #432 extracts the shared library, and #430's core-error verdict plus #440's cache key are exactly the logic that belongs *inside* it. Fixing them in place first would mean writing each fix twice and then deleting one copy.

## What was wrong

`cart_boot_matrix.sh` and `cd_boot_matrix.sh` each had their own copy of core discovery, the build-identity preflight and result classification — which is why `7e6975f` hardened the cart script and left the CD script carrying the same class of fault.

**#430** — verified by reading `cd_boot_matrix.sh`, not inferred from the cart script:

| fault | status in the CD script |
|---|---|
| core failure blamed on the title | **present** — `classify_stage()` had no `dlopen(` check at all |
| core discovery can yield an empty path | **present** — looped, built, never re-checked; harnesses then ran against `""` |
| preflight gated behind "a probe line exists" | **absent** — its identity guard already ran unconditionally |

**#440** — rows were keyed on the git rev, so *any* commit invalidated *every* cached row. A sweep re-measured all 154 cart titles (~45 minutes) after two commits touching only `.gitignore` and the matrix's own output — zero core code — and produced byte-identical results.

## What changed

`test/tools/matrix_common.sh` now owns core discovery, the test-export check, the build-identity guard, bounded execution, the core-error verdict, and the row-cache identity. Stage-classification ladders stay per-script: cart and CD boot stages genuinely differ and shouldn't hide behind a mode switch.

Two identities, two jobs:

- **`VJ_EXPECT_BUILD`** stays the git rev. Its job is catching a stale binary, where over-invalidating is the safe direction — and it earned that during this work (see below).
- **`matrix_cache_id()`** is new and narrow: committed tree state plus uncommitted diff for the paths that can change a verdict (core sources, harnesses, probes, the sweep scripts). Docs, the site and the matrix output are not among them. This also retires the `BUILD_ID_IGNORE` workaround, which existed only because writing a row used to move the key.

`matrix_find_core()` sets a global rather than echoing, deliberately: called as `core="$(matrix_find_core)"` it runs in a subshell where `exit 1` hands the caller an empty string — the exact fault it exists to prevent. The test caught that in the first draft of this change.

## Verification

The sweeps take 45+ minutes and need the private corpus, so they can't gate a change. `test/tools/matrix_common_test.sh` exercises the shared logic with synthetic logs in under a second — 14 checks, now part of `make test`. It pins the negative case too: a genuine ROM load failure must **not** be reclassified as a core error, or every real `LOAD_FAIL` quietly vanishes and the matrix looks cleaner than it is.

End-to-end on the real cart sweep:

1. A stale core (`v3.3.0 7e6975f` vs a dirty tree) made the sweep **abort and write nothing** — the guard working, unprompted.
2. After a rebuild, four titles classified correctly, rows stamped with the cache id.
3. `Alien vs Predator (Alpha)`, a genuine bad dump, still reports `LOAD_FAIL` — not swallowed as `core_error`.
4. Dirtying `docs/cart-boot-matrix.md` left the cache id at `50ef01cba40a`, and the next invocation **skipped the cached titles** instead of re-running them. Under the old keying that edit alone would have re-swept the corpus.

## Follow-up

#431 (regenerate the stale CD matrix) is unblocked by this, but still needs confirmation that the full CD disc set is present before it's worth running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
