### PR TITLE
ci: add CodeRabbit config and a Kimi second-opinion PR reviewer

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,134 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/guides/configure-coderabbit
+#
+# Why this file is opinionated: most of what breaks in this repo is invisible to
+# a generic reviewer.  The buildbot compiles with MSVC, so C99 is a hard error
+# rather than a style preference; several source trees are machine-generated and
+# must never be "cleaned up"; and hardware behaviour is settled against the
+# Jaguar TRM and the jag_sim netlists, never against the comments in the code
+# (which have been wrong before — the PIT clock was documented at half its real
+# rate for years).
+
+language: en-US
+
+reviews:
+  profile: chill              # assertive drowns C89 nits in style noise
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    # develop is the integration branch; master takes release/hotfix PRs only.
+    base_branches:
+      - develop
+      - master
+
+  # Machine-generated, vendored, or binary-ish sources.  Reviewing these
+  # produces confident nonsense: cpuemu.c alone is ~1.8 MB of generated 68K
+  # dispatch, and the bios blobs are bin2c hex tables.
+  path_filters:
+    - "!src/m68000/cpuemu.c"
+    - "!src/m68000/cpustbl.c"
+    - "!src/m68000/cpudefs.c"
+    - "!src/m68000/readcpu.c"
+    - "!src/bios/jagbios.c"
+    - "!src/bios/jagcdbios.c"
+    - "!src/bios/jagdevcdbios.c"
+    - "!libretro-common/**"
+    - "!docs/cart-boot-matrix.md"
+    - "!docs/cd-boot-matrix.md"
+    - "!test/baselines/**"
+
+  path_instructions:
+    - path: "src/**/*.{c,h}"
+      instructions: >-
+        Enforce C89/GNU89 strictly — the libretro buildbot uses MSVC on Windows
+        and CI runs a c89-lint job.  Flag as errors, not suggestions: any
+        declaration after a statement in a block (the most common violation);
+        `for (int i = ...)`; compound literals; designated initializers;
+        variable-length arrays; `//` comments in NEW code (permitted by GNU89,
+        but `/* */` is the house style).  All variables must be declared at the
+        top of their block.
+
+        This is a big-endian machine emulated on little-endian hosts: reads and
+        writes to emulated memory must go through the GET8/GET16/GET32 and
+        SET8/SET16/SET32 macros, never through direct pointer casts.  Flag any
+        new direct cast into `jaguarMainRAM` or similar.
+
+        Do not trust comments in this codebase as evidence of correct hardware
+        behaviour.  If a change asserts a clock rate, register bit, or timing
+        figure, ask which section of the JTRM (`docs/jtrm-*.md`) or which
+        jag_sim netlist supports it.  System clock is 26.590906 MHz NTSC /
+        26.593900 MHz PAL; the 68000 runs at half; GPU, DSP and the PIT run at
+        the full rate.
+
+        Exempt from the C89 rules (verify against scripts/c89-lint.sh's
+        skip_file list before flagging): src/m68000/cpu*.c, src/m68000/read*.c,
+        src/bios/jag*bios*.c, and src/tom/blitter_simd_{sse2,neon}.c, which use
+        platform intrinsics deliberately.
+
+    - path: "src/core/state.h"
+      instructions: >-
+        Savestate format.  Any field added, removed or reordered breaks
+        compatibility.  Check that the change bumps the savestate version if one
+        has not already been bumped for the current release cycle (policy is one
+        bump per release, shared by all in-flight changes), and that every new
+        piece of emulated state is actually inside a saved region — a field
+        living outside the saved window is the exact defect behind #327 and #400
+        (DAC registers and the hi-res epoch were both invisible to savestates,
+        which broke run-ahead determinism).
+
+    - path: "src/jerry/{dac,dsp}.c"
+      instructions: >-
+        Audio path.  Any change here must be validated against BOTH
+        test_audio_clipping AND test_audio_presence.  A clipping check alone is
+        insufficient and has shipped a regression before: PR #170 took Iron
+        Soldier 2 from 17% saturated samples to silence, and the clipping test
+        passed because silence has zero saturation.  If the PR description does
+        not mention both, say so.  Do not accept threshold relaxations in either
+        test as a way to make a PR pass.
+
+    - path: "src/tom/{blitter,blitter_mmio,op,gpu}.c"
+      instructions: >-
+        Blitter/OP/GPU changes affect every title.  Ask whether
+        test/tools/test_blitter_compare (fast vs accurate diff) was run, and
+        whether the corpus A/B framebuffer sweep shows any pixel change.  The
+        blitter is not fully cycle-accurate by design; do not suggest
+        cycle-accuracy rewrites as review feedback.
+
+    - path: "libretro.c"
+      instructions: >-
+        The libretro API surface.  New core options must also be added to
+        libretro_core_options.h with help text, default to the stock behaviour
+        (enhancements are opt-in except for evidence-backed per-title DB
+        presets), and must not change emulated behaviour when disabled.
+
+    - path: "**/*.sh"
+      instructions: >-
+        Shell.  Require `set -u` at minimum.  Quote every variable expansion.
+        Flag bare `rm`, `cp` or `mv` in any chain — this project's shell aliases
+        them to interactive forms, which hang forever with no TTY; the house
+        style is `command rm -f` or `trash`.  Note that `exit` inside a command
+        substitution `$(...)` only exits the subshell, so a function that
+        validates and exits must set a global or the caller must check the
+        status.
+
+    - path: ".github/workflows/**"
+      instructions: >-
+        CI.  Flag any hard-coded network port at or above 32768 — the ephemeral
+        range causes EADDRINUSE flakes that look like test failures (#356).
+        Tests must bind port 0 or pick from a low fixed range.
+
+  tools:
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+
+chat:
+  auto_reply: true

--- a/.github/scripts/kimi_review.py
+++ b/.github/scripts/kimi_review.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Post a Kimi-authored review comment on a pull request.
+
+Deliberately dependency-free (stdlib + the `gh` CLI that GitHub runners ship)
+so there is no requirements file to rot and no third-party action to drift.
+
+Fails soft: any problem here is logged and the job still exits 0.  A review is
+advisory; it must never fail a PR whose code compiles and whose tests pass.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+# A diff larger than this is summarised rather than sent whole: model context is
+# finite, and a 5,000-line generated-table diff produces confident nonsense.
+MAX_DIFF_CHARS = 180_000
+
+# Paths whose diffs are noise to a reviewer. Mirrors .coderabbit.yaml's filters
+# and scripts/c89-lint.sh's skip_file: machine-generated 68K dispatch, bin2c
+# BIOS blobs, vendored libretro-common, and generated matrices.
+SKIP_PREFIXES = (
+    "src/m68000/cpuemu.c",
+    "src/m68000/cpustbl.c",
+    "src/m68000/cpudefs.c",
+    "src/m68000/readcpu.c",
+    "src/bios/jagbios.c",
+    "src/bios/jagcdbios.c",
+    "src/bios/jagdevcdbios.c",
+    "libretro-common/",
+    "docs/cart-boot-matrix.md",
+    "docs/cd-boot-matrix.md",
+    "test/baselines/",
+)
+
+SYSTEM_PROMPT = """\
+You are reviewing a pull request against the Virtual Jaguar libretro core: an \
+Atari Jaguar emulator written in C, GPLv3, targeting the libretro API.
+
+House rules that matter more here than generic advice:
+
+* C89/GNU89 is STRICT. The libretro buildbot compiles with MSVC on Windows, so \
+C99 is a build failure, not a style preference. Flag: declarations after a \
+statement in a block (by far the most common violation), `for (int i = ...)`, \
+compound literals, designated initializers, and VLAs. All variables go at the \
+top of their block.
+* The emulated machine is big-endian on little-endian hosts. Emulated memory \
+must be accessed through the GET8/GET16/GET32 and SET8/SET16/SET32 macros, \
+never a direct pointer cast.
+* NEVER treat a source comment as evidence about hardware behaviour. Clock \
+rates and register semantics in this codebase have been wrong for years at a \
+time. Ground truth is the Jaguar Technical Reference Manual (distilled in \
+docs/jtrm-*.md) and the jag_sim netlists. If a change asserts a timing figure, \
+ask what supports it.
+* src/core/state.h is the savestate format: any field added, removed or \
+reordered breaks compatibility, and emulated state that lives outside a saved \
+region is a real defect class here (it has broken run-ahead twice).
+* Changes to src/jerry/dac.c or src/jerry/dsp.c must clear BOTH the clipping \
+and the presence audio tests. Clipping alone misses the failure mode where a \
+"fix" silences a game, because silence has zero saturation.
+* Shell: `set -u`, quote expansions, and never a bare rm/cp/mv (aliased to \
+interactive forms that hang with no TTY). Note that `exit` inside `$(...)` only \
+exits the subshell.
+
+How to report:
+
+Lead with a one-line verdict. Then list only findings you are confident are \
+real, most serious first, each as `path:line — what breaks, and when`. Prefer \
+one well-evidenced defect over ten speculative nits; say plainly when you find \
+nothing substantive. Do not restate what the diff does — the author knows. Do \
+not suggest cycle-accuracy rewrites of the blitter; it is knowingly not \
+cycle-accurate. If the diff is mostly documentation, review it for claims that \
+contradict the code, not for prose style.
+"""
+
+
+def sh(args):
+    return subprocess.run(args, capture_output=True, text=True).stdout
+
+
+def filtered_diff(base, head):
+    """Diff with generated/vendored paths dropped, so the model reads signal."""
+    names = sh(["git", "diff", "--name-only", f"{base}...{head}"]).split()
+    keep = [n for n in names if not n.startswith(SKIP_PREFIXES)]
+    dropped = len(names) - len(keep)
+    if not keep:
+        return "", dropped
+    return sh(["git", "diff", f"{base}...{head}", "--"] + keep), dropped
+
+
+def call_kimi(base_url, key, key_id, model, system, user):
+    body = json.dumps(
+        {
+            "model": model,
+            "temperature": 0.2,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        }
+    ).encode()
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer " + key,
+    }
+    if key_id:
+        # Harmless where unused; some consoles issue an id alongside the secret.
+        headers["X-Key-Id"] = key_id
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/chat/completions", data=body, headers=headers
+    )
+    with urllib.request.urlopen(req, timeout=180) as r:
+        payload = json.load(r)
+    return payload["choices"][0]["message"]["content"]
+
+
+def main():
+    key = os.environ.get("KIMI_KEY_VALUE", "")
+    if not key:
+        print("KIMI_KEY_VALUE is empty -- is the secret set on this repo?")
+        return 0
+
+    repo = os.environ["REPO"]
+    pr = os.environ["PR_NUMBER"]
+
+    meta = json.loads(
+        sh(["gh", "pr", "view", pr, "--repo", repo, "--json",
+            "title,body,baseRefName,headRefOid,baseRefOid"])
+        or "{}"
+    )
+    if not meta:
+        print("could not read PR metadata")
+        return 0
+
+    base, head = meta["baseRefOid"], meta["headRefOid"]
+    diff, dropped = filtered_diff(base, head)
+    if not diff.strip():
+        print("nothing reviewable after filtering generated paths")
+        return 0
+
+    truncated = False
+    if len(diff) > MAX_DIFF_CHARS:
+        diff = diff[:MAX_DIFF_CHARS]
+        truncated = True
+
+    user = (
+        f"Pull request: {meta['title']}\n"
+        f"Target branch: {meta['baseRefName']}\n\n"
+        f"Description:\n{(meta.get('body') or '(none)')[:4000]}\n\n"
+        f"Diff:\n```diff\n{diff}\n```"
+    )
+    if truncated:
+        user += "\n\n(The diff was truncated; review what is shown and say so.)"
+
+    try:
+        review = call_kimi(
+            os.environ["KIMI_API_BASE"], key, os.environ.get("KIMI_KEY_ID"),
+            os.environ["KIMI_MODEL"], SYSTEM_PROMPT, user,
+        )
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", "replace")[:500]
+        print(f"Kimi API returned HTTP {e.code}: {detail}")
+        if e.code in (401, 403):
+            print(
+                "Auth failed. KIMI_KEY_VALUE is being sent as a bearer token. "
+                "If the provider issues an AK/SK pair needing a signed request, "
+                "the auth block in call_kimi() is what needs changing."
+            )
+        return 0
+    except Exception as e:  # noqa: BLE001 - advisory job, never fail the PR
+        print(f"Kimi review failed: {type(e).__name__}: {e}")
+        return 0
+
+    note = ""
+    if dropped:
+        note += f"\n\n<sub>{dropped} generated/vendored file(s) excluded from review.</sub>"
+    if truncated:
+        note += "\n\n<sub>Diff truncated before review — large PR.</sub>"
+
+    comment = f"## 🌙 Kimi review\n\n{review}{note}"
+    p = "/tmp/kimi-review.md"
+    with open(p, "w") as f:
+        f.write(comment)
+    r = subprocess.run(
+        ["gh", "pr", "comment", pr, "--repo", repo, "--body-file", p],
+        capture_output=True, text=True,
+    )
+    print("posted" if r.returncode == 0 else f"could not post: {r.stderr}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/kimi_review.py
+++ b/.github/scripts/kimi_review.py
@@ -165,9 +165,19 @@ def main():
         print(f"Kimi API returned HTTP {e.code}: {detail}")
         if e.code in (401, 403):
             print(
-                "Auth failed. KIMI_KEY_VALUE is being sent as a bearer token. "
-                "If the provider issues an AK/SK pair needing a signed request, "
-                "the auth block in call_kimi() is what needs changing."
+                "Auth failed against " + os.environ["KIMI_API_BASE"] + ".\n"
+                "A key from the Kimi Code console (kimi.com/code/console) is a "
+                "'Kimi for Coding' SUBSCRIPTION key and only authenticates "
+                "against https://api.kimi.com/coding/v1 -- it will 401 against "
+                "the pay-per-token host api.moonshot.ai, and vice versa. Set "
+                "the KIMI_API_BASE repo variable to match where the key was "
+                "issued."
+            )
+        elif e.code in (400, 404):
+            print(
+                "Model '" + os.environ["KIMI_MODEL"] + "' was rejected. Valid "
+                "names are tier-dependent: k3, k3-256k, kimi-for-coding, "
+                "kimi-for-coding-highspeed. Set the KIMI_MODEL repo variable."
             )
         return 0
     except Exception as e:  # noqa: BLE001 - advisory job, never fail the PR

--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -45,15 +45,23 @@ jobs:
 
       - name: Review
         env:
-          # KIMI_KEY_VALUE is the bearer token; KIMI_KEY_ID is passed through as
-          # an identifying header for providers that want it and is harmless
-          # where they don't.  If your console issues an AK/SK pair requiring a
-          # signed request instead, this step will fail with a clear 401 and the
-          # auth block below is the only thing that needs changing.
+          # Keys from the Kimi Code console (kimi.com/code/console) are for the
+          # "Kimi for Coding" SUBSCRIPTION, which is a different host from the
+          # pay-per-token Moonshot platform -- a subscription key 401s against
+          # api.moonshot.ai. Two protocol bases are offered; we use the
+          # OpenAI-compatible one:
+          #   OpenAI-compatible:    https://api.kimi.com/coding/v1
+          #   Anthropic-compatible: https://api.kimi.com/coding/
+          # The console issues a single key value; KIMI_KEY_ID is sent as an
+          # identifying header, harmless where unused.
+          #
+          # Models are tier-dependent: k3, k3-256k, kimi-for-coding,
+          # kimi-for-coding-highspeed. Override either value with a repo
+          # variable -- no code change needed.
           KIMI_KEY_VALUE: ${{ secrets.KIMI_KEY_VALUE }}
           KIMI_KEY_ID: ${{ secrets.KIMI_KEY_ID }}
-          KIMI_API_BASE: ${{ vars.KIMI_API_BASE || 'https://api.moonshot.ai/v1' }}
-          KIMI_MODEL: ${{ vars.KIMI_MODEL || 'kimi-k2-0905-preview' }}
+          KIMI_API_BASE: ${{ vars.KIMI_API_BASE || 'https://api.kimi.com/coding/v1' }}
+          KIMI_MODEL: ${{ vars.KIMI_MODEL || 'k3-256k' }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -1,0 +1,60 @@
+name: Kimi review
+
+# Second-opinion AI review, independent of Copilot (whose quota is per-requester
+# and runs out) and of CodeRabbit.  Self-contained on purpose: no third-party
+# action to drift, and the auth shape stays visible in one file.
+#
+# Runs automatically on PRs into develop/master, and on demand by commenting
+# "@kimi review" on a pull request.
+#
+# Fails SOFT: a review is advisory, so an API hiccup must never red-X a PR that
+# compiles and passes its tests.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [develop, master]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event.issue.pull_request && contains(github.event.comment.body, '@kimi review'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number
+        id: pr
+        run: |
+          set -u
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Review
+        env:
+          # KIMI_KEY_VALUE is the bearer token; KIMI_KEY_ID is passed through as
+          # an identifying header for providers that want it and is harmless
+          # where they don't.  If your console issues an AK/SK pair requiring a
+          # signed request instead, this step will fail with a clear 401 and the
+          # auth block below is the only thing that needs changing.
+          KIMI_KEY_VALUE: ${{ secrets.KIMI_KEY_VALUE }}
+          KIMI_KEY_ID: ${{ secrets.KIMI_KEY_ID }}
+          KIMI_API_BASE: ${{ vars.KIMI_API_BASE || 'https://api.moonshot.ai/v1' }}
+          KIMI_MODEL: ${{ vars.KIMI_MODEL || 'kimi-k2-0905-preview' }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: python3 .github/scripts/kimi_review.py


### PR DESCRIPTION
Copilot review is currently unavailable — every recent PR received the same body:

> Copilot was unable to review this pull request because the user who requested the review has reached their quota limit.

That is silence, not approval, and #441/#442/#443 all merged bot-unreviewed as a result. This adds two independent reviewers so one running dry doesn't mean a PR goes unreviewed.

## `.coderabbit.yaml`

Tuned to what actually breaks in this repo rather than generic defaults. Per-path instructions cover:

- **C89/MSVC strictness** — mid-block declarations called out as the most common violation, plus the rest of the C99 list, with the exemption set matching `scripts/c89-lint.sh`'s `skip_file` exactly (I diffed them).
- **Big-endian contract** — flag direct pointer casts into emulated memory instead of `GET*`/`SET*`.
- **"Never trust a source comment for hardware behaviour"** — ask for a JTRM section or a jag_sim netlist. This repo has had clock rates documented wrong for years.
- **`src/core/state.h`** — the savestate-field trap behind #327 and #400, where emulated state living outside a saved region broke run-ahead twice.
- **`dac.c`/`dsp.c`** — the audio pair rule, with PR #170's silencing regression as the reason clipping alone is insufficient.
- **Shell** — bare `rm`/`cp`/`mv`, and the `exit`-inside-`$(...)` subshell trap that bit #442 during development.
- **Workflows** — the ephemeral-port EADDRINUSE flake from #356.

Generated and vendored trees are excluded: `cpuemu.c` alone is ~1.8 MB of machine-generated 68K dispatch, and the bios sources are bin2c hex tables. Reviewing those produces confident nonsense.

Profile is `chill` deliberately — `assertive` would bury the C89 findings in style noise.

## Kimi reviewer

`.github/workflows/kimi-review.yml` + `.github/scripts/kimi_review.py`, using the `KIMI_KEY_*` secrets. Runs on PRs into `develop`/`master` and on demand via `@kimi review`.

Self-contained and dependency-free (stdlib + the `gh` CLI runners already have) rather than wrapping a third-party action: the auth shape stays visible in one file, and there's no action version to drift. It shares the generated-path skip list and the house rules with the CodeRabbit config, and asks for one well-evidenced defect over ten speculative nits.

**One assumption to confirm:** `KIMI_KEY_VALUE` is sent as the bearer token, `KIMI_KEY_ID` as an identifying header. That's the standard shape for an OpenAI-compatible endpoint, but if your console issued an AK/SK pair requiring a signed request, this will 401 — and the job prints an explicit diagnostic naming the single function to change. Endpoint and model are overridable through the `KIMI_API_BASE` and `KIMI_MODEL` repo *variables*, so retargeting needs no code change.

The job **fails soft** everywhere: empty secret, unreadable PR, HTTP error, truncated diff — all log and exit 0. An advisory review must never red-X a PR that compiles and passes its tests.

## Verified

- Python compiles; workflow YAML parses.
- Diff filter exercised against two real commits: it passes #442's five files through, and reduces `3c4992d` (the regenerated cart matrix) to zero bytes.
- No API call made from my side — I don't have the secret values, so the first live auth test is this PR itself.

## Still needed from a human

CodeRabbit needs its **GitHub App installed** on the repo before `.coderabbit.yaml` does anything. `libretro/virtualjaguar-libretro` is an org repo, so that may need a libretro org owner to approve the install rather than being a repo-admin click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
