### PR TITLE
feat(input): ST/Amiga mouse on port 2 (#429)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ test/tools/fmv_seek_probe
 test/tools/sram_test
 test/tools/netlink_pair
 test/tools/netlink_game
+test/tools/joymatrix_identity
+test/tools/mouse_decode_test
 # vjtrace flight-recorder analyzer/smoke tools -- built on demand by
 # test/tools/vjtrace_selftest.sh (and by hand per each tool's own header
 # comment); never tracked, same Mach-O-on-Linux-CI hazard as above.

--- a/Makefile
+++ b/Makefile
@@ -852,7 +852,8 @@ clean:
 		test/tools/test_memory_map test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/tools/test_dsp_audio_diag \
 		test/tools/test_frame_timing test/tools/test_runahead_determinism test/tools/test_pertitle_db \
 		test/tools/test_wedge_spin test/tools/i2s_lag_probe \
-		test/tools/joymatrix_identity \
+		test/tools/joymatrix_identity test/tools/mouse_decode_test \
+		test/test_quadrature \
 		test/.skipped-checks
 
 # Self-contained unit tests (parser + list management + simulated
@@ -905,7 +906,8 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
 		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/test_pertitle_db \
-		test/tools/i2s_lag_probe test/tools/joymatrix_identity
+		test/tools/i2s_lag_probe test/tools/joymatrix_identity \
+		test/test_quadrature test/tools/mouse_decode_test
 	@# Skip ledger: truncate FIRST so a previous run's rows cannot resurface
 	@# as fresh skips (the stale-row failure mode documented for
 	@# cd_boot_matrix.sh).  Every optional check below records into it, and
@@ -1138,6 +1140,14 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# an FNV digest measured on develop.  Committed before any device code
 	@# so later PRs are measured against a number that predates them.
 	./test/tools/joymatrix_identity ./$(TARGET) test/roms/yarc.j64 --quiet
+	@# Quadrature encoder unit test (no core): the Gray sequence in both
+	@# directions, the one-state-per-advance rate policy, the backlog
+	@# clamp and the Q8 carry.
+	./test/test_quadrature
+	@# ST/Amiga mouse end-to-end: synthetic deltas in, decoded direction
+	@# and distance out, all three wiring cases and all three poll shapes,
+	@# plus row-blindness and the v12 savestate round-trip.
+	./test/tools/mouse_decode_test ./$(TARGET) test/roms/yarc.j64 --quiet
 	./test/test_memtrack
 	./test/test_nvmbios
 	@# Option visibility is content-type dependent; the disc half runs only
@@ -1453,6 +1463,16 @@ test/tools/joymatrix_identity: test/tools/joymatrix_identity.c \
 		-o $@ test/tools/joymatrix_identity.c \
 		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+
+test/tools/mouse_decode_test: test/tools/mouse_decode_test.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/mouse_decode_test.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+
+test/test_quadrature: test/test_quadrature.c src/jerry/quadrature.c src/jerry/quadrature.h
+	$(CC) -O2 -Wall $(INCFLAGS) -o $@ test/test_quadrature.c src/jerry/quadrature.c
 
 test/tools/test_option_visibility: test/tools/test_option_visibility.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -852,6 +852,7 @@ clean:
 		test/tools/test_memory_map test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/tools/test_dsp_audio_diag \
 		test/tools/test_frame_timing test/tools/test_runahead_determinism test/tools/test_pertitle_db \
 		test/tools/test_wedge_spin test/tools/i2s_lag_probe \
+		test/tools/joymatrix_identity \
 		test/.skipped-checks
 
 # Self-contained unit tests (parser + list management + simulated
@@ -904,7 +905,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
 		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/test_pertitle_db \
-		test/tools/i2s_lag_probe
+		test/tools/i2s_lag_probe test/tools/joymatrix_identity
 	@# Skip ledger: truncate FIRST so a previous run's rows cannot resurface
 	@# as fresh skips (the stale-row failure mode documented for
 	@# cd_boot_matrix.sh).  Every optional check below records into it, and
@@ -1132,6 +1133,11 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	./test/test_cart_format ./$(TARGET)
 	./test/test_audio_dac
 	./test/tools/test_memory_map ./$(TARGET)
+	@# $F14000/$F14002 identity guardrail for the input-devices track
+	@# (#428/#429/#436): sweeps the whole joystick read domain and asserts
+	@# an FNV digest measured on develop.  Committed before any device code
+	@# so later PRs are measured against a number that predates them.
+	./test/tools/joymatrix_identity ./$(TARGET) test/roms/yarc.j64 --quiet
 	./test/test_memtrack
 	./test/test_nvmbios
 	@# Option visibility is content-type dependent; the disc half runs only
@@ -1436,6 +1442,15 @@ test/tools/test_pertitle_db: test/tools/test_pertitle_db.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_pertitle_db.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+
+# $F14000 / $F14002 identity guardrail (#428 input-devices track).  Needs
+# the wide test ABI's Joystick* / joypad0Buttons / joypad1Buttons exports.
+test/tools/joymatrix_identity: test/tools/joymatrix_identity.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/joymatrix_identity.c \
 		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
 

--- a/Makefile
+++ b/Makefile
@@ -1458,6 +1458,7 @@ test/tools/test_pertitle_db: test/tools/test_pertitle_db.c \
 # $F14000 / $F14002 identity guardrail (#428 input-devices track).  Needs
 # the wide test ABI's Joystick* / joypad0Buttons / joypad1Buttons exports.
 test/tools/joymatrix_identity: test/tools/joymatrix_identity.c \
+		src/jerry/inputdev.h \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/joymatrix_identity.c \

--- a/Makefile.common
+++ b/Makefile.common
@@ -59,6 +59,8 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/bios/jagcdbios.c \
 	$(CORE_DIR)/src/bios/jagdevcdbios.c \
 	$(CORE_DIR)/src/jerry/joystick.c \
+	$(CORE_DIR)/src/jerry/quadrature.c \
+	$(CORE_DIR)/src/jerry/inputdev.c \
 	$(CORE_DIR)/src/core/settings.c \
 	$(CORE_DIR)/src/core/memtrack.c \
 	$(CORE_DIR)/src/core/jaggd.c \

--- a/exports-test.list
+++ b/exports-test.list
@@ -62,7 +62,9 @@ _jaguar_cd_*
 _ResolveBootConfig
 _BlitterCompare*
 _DAC*
-_JoystickState*
+_Joystick*
+_joypad0Buttons
+_joypad1Buttons
 _MTState*
 _NVMBios*
 _NVM_*

--- a/exports-test.list
+++ b/exports-test.list
@@ -65,6 +65,8 @@ _DAC*
 _Joystick*
 _joypad0Buttons
 _joypad1Buttons
+_InputDev*
+_Quad*
 _MTState*
 _NVMBios*
 _NVM_*

--- a/libretro.c
+++ b/libretro.c
@@ -36,6 +36,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "jlink_netpacket.h"
 #include "uart.h"
 #include "joystick.h"
+#include "inputdev.h"
 #include "settings.h"
 #include "shadowfb.h"
 #include "blit_memo.h"
@@ -191,6 +192,61 @@ static bool show_cd_options        = true;
 static bool show_cart_bios_option  = true;
 static bool enable_alt_inputs = false;
 static uint8_t *joypad_buttons[2] = { joypad0Buttons, joypad1Buttons };
+
+/* ---- non-pad input devices (#428/#429) ------------------------------
+ *
+ * Subclass IDs for RETRO_ENVIRONMENT_SET_CONTROLLER_INFO.  The mouse is a
+ * RETRO_DEVICE_MOUSE subclass because it is a relative-motion pointer;
+ * the three subclasses are the three adapter/mouse wiring combinations
+ * (docs/jaguar-mouse-adapter-mapping.md section 4d), not three different
+ * devices.  Port 2 only -- see inputdev.h. */
+#define RETRO_DEVICE_JAG_PAD             RETRO_DEVICE_JOYPAD
+#define RETRO_DEVICE_JAG_MOUSE_ST        RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE, 0)
+#define RETRO_DEVICE_JAG_MOUSE_AMIGA     RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE, 1)
+#define RETRO_DEVICE_JAG_MOUSE_AMIGA_AD  RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE, 2)
+
+/* Device the frontend explicitly selected via
+ * retro_set_controller_port_device, or INPUTDEV_PAD when it never did.
+ * An explicit frontend selection outranks the core option (a frontend
+ * that sets a port device is making a deliberate statement); otherwise
+ * the option decides.  Not serialized: option/frontend derived. */
+static InputDevType port_device_frontend[2] = { INPUTDEV_PAD, INPUTDEV_PAD };
+static bool         port_device_forced[2]   = { false, false };
+/* Device actually attached, so the resolution is logged only when it
+ * changes rather than on every check_variables() call. */
+static InputDevType port_device_active[2]   = { INPUTDEV_PAD, INPUTDEV_PAD };
+static bool         show_mouse_options      = true;
+
+static const char *inputdev_type_name(InputDevType t)
+{
+   switch (t)
+   {
+      case INPUTDEV_MOUSE_ST:            return "Atari ST / PS2 mouse";
+      case INPUTDEV_MOUSE_AMIGA_ADAPTER: return "Amiga mouse (Amiga adapter)";
+      case INPUTDEV_MOUSE_AMIGA_ON_ST:   return "Amiga mouse (ST adapter)";
+      default:                           break;
+   }
+   return "standard joypad";
+}
+
+static void apply_port_device(int port, InputDevType type)
+{
+   InputDevSetType(port, type);
+
+   /* Read back: InputDevSetType refuses a mouse on port 1, so the
+    * resolved type is whatever it actually accepted. */
+   type = InputDevGetType(port);
+
+   if (type != port_device_active[port])
+   {
+      port_device_active[port] = type;
+      if (type != INPUTDEV_PAD)
+         LOG_INF("[input] port %d: %s attached\n", port + 1,
+                 inputdev_type_name(type));
+      else
+         LOG_INF("[input] port %d: standard joypad\n", port + 1);
+   }
+}
 
 static int number_keys[12] = {
    RETROK_MINUS,
@@ -382,6 +438,25 @@ static bool update_option_visibility(void)
       {
          option_display.visible = show_cart_bios_option;
          option_display.key     = "virtualjaguar_bios";
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
+                    &option_display);
+         updated = true;
+      }
+   }
+
+   /* Mouse sensitivity only means anything while a mouse is attached to
+    * port 2.  Resolved from the live device rather than the option string
+    * so a frontend-set port device (retro_set_controller_port_device)
+    * reveals it too. */
+   {
+      bool show_mouse_prev = show_mouse_options;
+
+      show_mouse_options = (InputDevGetType(1) != INPUTDEV_PAD);
+
+      if (show_mouse_options != show_mouse_prev)
+      {
+         option_display.visible = show_mouse_options;
+         option_display.key     = "virtualjaguar_mouse_sensitivity";
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
                     &option_display);
          updated = true;
@@ -905,6 +980,49 @@ static void check_variables(void)
    else
       vjs.cdReadSpeed = CDSPEED_2X;
 
+   /* Port 2 controller type (#429).  Precedence, per the design spec:
+    *   1. a device the frontend explicitly set via
+    *      retro_set_controller_port_device wins until it changes it again;
+    *   2. otherwise this option;
+    *   3. "auto" resolves through the per-title DB, and falls back to
+    *      "pad" -- which is bit-identical to a core without this feature.
+    * No titledb row ships in this PR, so "auto" is "pad" for every title
+    * today and the mouse is strictly opt-in. */
+   {
+      InputDevType p2 = INPUTDEV_PAD;
+
+      var.key   = "virtualjaguar_p2_device";
+      var.value = NULL;
+      if (get_variable_pertitle(&var) && var.value)
+      {
+         if (!strcmp(var.value, "mouse_st"))
+            p2 = INPUTDEV_MOUSE_ST;
+         else if (!strcmp(var.value, "mouse_amiga"))
+            p2 = INPUTDEV_MOUSE_AMIGA_ON_ST;
+         else if (!strcmp(var.value, "mouse_amiga_adapter"))
+            p2 = INPUTDEV_MOUSE_AMIGA_ADAPTER;
+         /* "pad" and "auto" (with no DB row) both mean pad. */
+      }
+
+      if (port_device_forced[1])
+         p2 = port_device_frontend[1];
+
+      apply_port_device(1, p2);
+   }
+
+   var.key   = "virtualjaguar_mouse_sensitivity";
+   var.value = NULL;
+   if (get_variable_pertitle(&var) && var.value)
+   {
+      /* Percent -> Q8 (256 == 1.0). */
+      int pct = atoi(var.value);
+      if (pct < 1)
+         pct = 100;
+      InputDevSetScale(1, (int32_t)((pct * 256) / 100));
+   }
+   else
+      InputDevSetScale(1, 256);
+
    var.key = "virtualjaguar_alt_inputs";
    var.value = NULL;
    if (get_variable_pertitle(&var) && var.value)
@@ -1147,6 +1265,50 @@ static void update_input(void)
       if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_RIGHTBRACKET)? 1 : 0))
          joypad1Buttons[BUTTON_d] = 0xff;
    }
+
+   /* ---- non-pad devices (#428/#429) --------------------------------
+    *
+    * Runs after every retropad fill path so it cannot be bypassed by one
+    * of them.  There are three (the plain bitmask branch, the
+    * enable_alt_inputs remap branch including its analog-as-button cases,
+    * and the numpad_to_kb sub-path that writes slots 4-15 straight from
+    * RETRO_DEVICE_KEYBOARD) and missing any one of them would keep
+    * injecting host presses into a port with no pad plugged into it.
+    *
+    * A mouse port takes NOTHING from the retropad: physically there is no
+    * pad there, and leaving the host contribution would let a gamepad and
+    * a mouse drive the same six lines at once.  (A rotary port, when
+    * #436 lands, keeps its buttons and withholds only U/D/L/R, so this
+    * will have to become selective then -- it cannot simply grow another
+    * type here.) */
+   if (InputDevAnyAttached())
+   {
+      for (player = 0; player < 2; player++)
+      {
+         InputDevType t = InputDevGetType((int)player);
+         int32_t  dx, dy;
+         uint32_t buttons;
+
+         if (t == INPUTDEV_PAD)
+            continue;
+
+         memset(joypad_buttons[player], 0x00, BUTTON_LAST + 1);
+
+         dx = (int32_t)input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
+                                      RETRO_DEVICE_ID_MOUSE_X);
+         dy = (int32_t)input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
+                                      RETRO_DEVICE_ID_MOUSE_Y);
+         buttons = 0;
+         if (input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
+                            RETRO_DEVICE_ID_MOUSE_LEFT))
+            buttons |= INPUTDEV_BTN_LEFT;
+         if (input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
+                            RETRO_DEVICE_ID_MOUSE_RIGHT))
+            buttons |= INPUTDEV_BTN_RIGHT;
+
+         InputDevFeed((int)player, dx, dy, buttons);
+      }
+   }
 }
 
 /************************************
@@ -1188,8 +1350,35 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 
 void retro_set_controller_port_device(unsigned port, unsigned device)
 {
-   (void)port;
-   (void)device;
+   InputDevType type = INPUTDEV_PAD;
+
+   if (port > 1)
+      return;
+
+   switch (device)
+   {
+      case RETRO_DEVICE_JAG_MOUSE_ST:
+      case RETRO_DEVICE_MOUSE:  /* a plain mouse means the ST wiring */
+         type = INPUTDEV_MOUSE_ST;
+         break;
+      case RETRO_DEVICE_JAG_MOUSE_AMIGA:
+         type = INPUTDEV_MOUSE_AMIGA_ON_ST;
+         break;
+      case RETRO_DEVICE_JAG_MOUSE_AMIGA_AD:
+         type = INPUTDEV_MOUSE_AMIGA_ADAPTER;
+         break;
+      default:
+         type = INPUTDEV_PAD;
+         break;
+   }
+
+   /* A frontend that sets JOYPAD/NONE is releasing its claim, so the core
+    * option takes over again on the next check_variables(). */
+   port_device_frontend[port] = type;
+   port_device_forced[port]   = (type != INPUTDEV_PAD);
+
+   apply_port_device((int)port, type);
+   update_option_visibility();
 }
 
 size_t retro_serialize_size(void)
@@ -1269,9 +1458,30 @@ bool retro_serialize(void *data, size_t size)
       STATE_SAVE_VAR(buf, hiresEpoch);
    }
 
+   /* v12: input-device chunk (src/jerry/inputdev.c).  The quadrature
+    * accumulator and phase are machine-visible -- the phase IS what the
+    * game reads at $F14000 -- so a state restored without them replays
+    * different motion. */
+   buf += InputDevStateSave(buf);
+
    written = (size_t)(buf - start);
    if (written > STATE_SIZE)
       return false;
+
+   /* One-shot headroom report.  The trailing chunks in this function grow
+    * every release and the only backstop is the hard fail above, so make
+    * the margin visible in a log rather than assumed. */
+   {
+      static bool headroom_logged = false;
+      if (!headroom_logged)
+      {
+         headroom_logged = true;
+         LOG_INF("[state] v%u payload %lu / %lu bytes (%lu free)\n",
+                 (unsigned)STATE_VERSION, (unsigned long)written,
+                 (unsigned long)STATE_SIZE,
+                 (unsigned long)(STATE_SIZE - written));
+      }
+   }
 
    /* Zero-fill remaining bytes for deterministic save states */
    if (written < STATE_SIZE)
@@ -1388,6 +1598,16 @@ bool retro_unserialize(const void *data, size_t size)
    }
    else
       ShadowHiresSetEpoch(0);
+
+   /* v12: input-device chunk.  Older states load with the encoders reset
+    * and no button held, which is exactly what a pre-v12 core was: the
+    * device type itself is option-derived and never serialized, so the
+    * user's currently selected mouse stays attached either way. */
+   if (version >= STATE_VERSION_INPUT_DEVICES)
+      buf += InputDevStateLoad(buf);
+   else
+      InputDevReset();
+
    /* tomRam8 was restored raw above; recompute the DRAM/refresh timing
     * that bus_arbiter derives from MEMCON1/MEMCON2 so it matches the
     * loaded state (dram_row_miss/rom_clocks/dram_refresh_clks from
@@ -2206,6 +2426,29 @@ void retro_init(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_INPUT_BITMASKS, NULL))
       libretro_supports_bitmasks = true;
 
+   /* Controller types the frontend may assign per port (#428/#429).
+    * Port 1 is pad-only: the ST/Amiga mouse adapter is a vendor-documented
+    * PORT 2 device, every title known to read one reads port 2, and a
+    * port-1 mouse would be a configuration no software supports. */
+   {
+      static const struct retro_controller_description port1_devices[] = {
+         { "Standard Joypad", RETRO_DEVICE_JAG_PAD },
+      };
+      static const struct retro_controller_description port2_devices[] = {
+         { "Standard Joypad",             RETRO_DEVICE_JAG_PAD },
+         { "Atari ST / PS2 Mouse",        RETRO_DEVICE_JAG_MOUSE_ST },
+         { "Amiga Mouse (ST adapter)",    RETRO_DEVICE_JAG_MOUSE_AMIGA },
+         { "Amiga Mouse (Amiga adapter)", RETRO_DEVICE_JAG_MOUSE_AMIGA_AD },
+      };
+      static const struct retro_controller_info ports[] = {
+         { port1_devices, 1 },
+         { port2_devices, 4 },
+         { NULL, 0 },
+      };
+
+      environ_cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void *)ports);
+   }
+
    /* Reset all bus-arbiter state (iOS cannot dlclose cores, so statics
     * persist across loads).  Must run before check_variables() applies
     * the core option — retro_load_game calls that after retro_init. */
@@ -2242,6 +2485,17 @@ void retro_deinit(void)
    ShadowFBShutdown();
    ShadowHiresShutdown();
    BlitMemoShutdown();
+   /* Non-pad input devices: encoders, phases, attach mask, armed flag and
+    * the option-derived type/scale all go back to their load-time values
+    * (iOS cannot dlclose a core). */
+   InputDevShutdown();
+   port_device_frontend[0] = INPUTDEV_PAD;
+   port_device_frontend[1] = INPUTDEV_PAD;
+   port_device_forced[0]   = false;
+   port_device_forced[1]   = false;
+   port_device_active[0]   = INPUTDEV_PAD;
+   port_device_active[1]   = INPUTDEV_PAD;
+   show_mouse_options      = true;
    video_buffer_alloc_pixels = VIDEO_BUFFER_PIXELS;
    hires_restart_notice_logged = 0;
 

--- a/libretro.c
+++ b/libretro.c
@@ -217,6 +217,29 @@ static bool         port_device_forced[2]   = { false, false };
 static InputDevType port_device_active[2]   = { INPUTDEV_PAD, INPUTDEV_PAD };
 static bool         show_mouse_options      = true;
 
+/* Has this port actually received non-zero mouse state from the frontend?
+ *
+ * THE RULE: selecting a mouse must never leave the port with no working
+ * input.  A frontend that does not route mouse state to the port (it never
+ * called retro_set_controller_port_device with a mouse, the user has no
+ * mouse, or the port is mapped to a gamepad) would otherwise lose BOTH
+ * devices -- the pad because update_input() suppresses it, and the mouse
+ * because nothing ever feeds it.  So the pad suppression is deferred until
+ * the mouse has proven live, i.e. until the frontend reports a non-zero
+ * delta or a button.  Until then port 2 keeps its RetroPad.
+ *
+ * Once live it stays suppressed for the rest of the session (or until the
+ * device type changes, which clears this): a mouse that has moved once is
+ * a mouse the frontend is routing, and letting a pad drive the same six
+ * lines at that point is the ambiguity the suppression exists to prevent.
+ *
+ * File-scope static -- reset in retro_deinit (iOS cannot dlclose a core). */
+static bool         inputdev_live[2]        = { false, false };
+
+/* One-shot savestate headroom report (retro_serialize).  File-scope rather
+ * than function-local so retro_deinit can put it back. */
+static bool         headroom_logged         = false;
+
 static const char *inputdev_type_name(InputDevType t)
 {
    switch (t)
@@ -240,6 +263,8 @@ static void apply_port_device(int port, InputDevType type)
    if (type != port_device_active[port])
    {
       port_device_active[port] = type;
+      /* A new device has to earn the port back (see inputdev_live). */
+      inputdev_live[port]      = false;
       if (type != INPUTDEV_PAD)
          LOG_INF("[input] port %d: %s attached\n", port + 1,
                  inputdev_type_name(type));
@@ -672,6 +697,40 @@ static bool get_variable_pertitle(struct retro_variable *var)
    return ok;
 }
 
+/* Port 2 controller type as the CORE OPTION alone resolves it, with no
+ * regard for what the frontend may have set.  Factored out of
+ * check_variables() because retro_set_controller_port_device() has to be
+ * able to re-resolve the option the moment the frontend releases its claim
+ * -- nothing schedules a check_variables() for it, so deferring to "the
+ * next one" meant a frontend's routine post-load JOYPAD/NONE assignment
+ * detached the mouse for the rest of the session.
+ *
+ * Called from retro_set_controller_port_device() it can run before
+ * retro_load_game(): TitleDBOverride() returns NULL with no title loaded,
+ * so it degrades to a plain GET_VARIABLE.  The "auto -> per-title DB" leg
+ * of the documented precedence genuinely cannot fire on that early call;
+ * the check_variables() during retro_load_game() resolves it properly. */
+static InputDevType p2_device_from_option(void)
+{
+   struct retro_variable var;
+   InputDevType p2 = INPUTDEV_PAD;
+
+   var.key   = "virtualjaguar_p2_device";
+   var.value = NULL;
+   if (get_variable_pertitle(&var) && var.value)
+   {
+      if (!strcmp(var.value, "mouse_st"))
+         p2 = INPUTDEV_MOUSE_ST;
+      else if (!strcmp(var.value, "mouse_amiga"))
+         p2 = INPUTDEV_MOUSE_AMIGA_ON_ST;
+      else if (!strcmp(var.value, "mouse_amiga_adapter"))
+         p2 = INPUTDEV_MOUSE_AMIGA_ADAPTER;
+      /* "pad" and "auto" (with no DB row) both mean pad. */
+   }
+
+   return p2;
+}
+
 static void check_variables(void)
 {
    unsigned i;
@@ -989,20 +1048,7 @@ static void check_variables(void)
     * No titledb row ships in this PR, so "auto" is "pad" for every title
     * today and the mouse is strictly opt-in. */
    {
-      InputDevType p2 = INPUTDEV_PAD;
-
-      var.key   = "virtualjaguar_p2_device";
-      var.value = NULL;
-      if (get_variable_pertitle(&var) && var.value)
-      {
-         if (!strcmp(var.value, "mouse_st"))
-            p2 = INPUTDEV_MOUSE_ST;
-         else if (!strcmp(var.value, "mouse_amiga"))
-            p2 = INPUTDEV_MOUSE_AMIGA_ON_ST;
-         else if (!strcmp(var.value, "mouse_amiga_adapter"))
-            p2 = INPUTDEV_MOUSE_AMIGA_ADAPTER;
-         /* "pad" and "auto" (with no DB row) both mean pad. */
-      }
+      InputDevType p2 = p2_device_from_option();
 
       if (port_device_forced[1])
          p2 = port_device_frontend[1];
@@ -1014,10 +1060,17 @@ static void check_variables(void)
    var.value = NULL;
    if (get_variable_pertitle(&var) && var.value)
    {
-      /* Percent -> Q8 (256 == 1.0). */
+      /* Percent -> Q8 (256 == 1.0).  Clamp BEFORE the multiply: the
+       * option value comes from the frontend's config file, which a user
+       * can hand-edit to anything, and InputDevSetScale's own clamp fires
+       * only after this multiply has already overflowed a signed int.
+       * 1600% is InputDevSetScale's 4096 ceiling expressed as a percent
+       * (4096 * 100 / 256), so nothing reachable is lost. */
       int pct = atoi(var.value);
       if (pct < 1)
          pct = 100;
+      if (pct > 1600)
+         pct = 1600;
       InputDevSetScale(1, (int32_t)((pct * 256) / 100));
    }
    else
@@ -1280,7 +1333,12 @@ static void update_input(void)
     * a mouse drive the same six lines at once.  (A rotary port, when
     * #436 lands, keeps its buttons and withholds only U/D/L/R, so this
     * will have to become selective then -- it cannot simply grow another
-    * type here.) */
+    * type here.)
+    *
+    * The suppression is deferred until the mouse is LIVE -- see
+    * inputdev_live: reading the frontend's mouse state first and
+    * suppressing only once it has been non-zero guarantees that selecting
+    * a mouse can never leave the port with no working input at all. */
    if (InputDevAnyAttached())
    {
       for (player = 0; player < 2; player++)
@@ -1291,8 +1349,6 @@ static void update_input(void)
 
          if (t == INPUTDEV_PAD)
             continue;
-
-         memset(joypad_buttons[player], 0x00, BUTTON_LAST + 1);
 
          dx = (int32_t)input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
                                       RETRO_DEVICE_ID_MOUSE_X);
@@ -1305,6 +1361,19 @@ static void update_input(void)
          if (input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
                             RETRO_DEVICE_ID_MOUSE_RIGHT))
             buttons |= INPUTDEV_BTN_RIGHT;
+
+         if (dx || dy || buttons)
+         {
+            if (!inputdev_live[player])
+            {
+               inputdev_live[player] = true;
+               LOG_INF("[input] port %d: mouse is live, RetroPad released\n",
+                       player + 1);
+            }
+         }
+
+         if (inputdev_live[player])
+            memset(joypad_buttons[player], 0x00, BUTTON_LAST + 1);
 
          InputDevFeed((int)player, dx, dy, buttons);
       }
@@ -1373,9 +1442,18 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
    }
 
    /* A frontend that sets JOYPAD/NONE is releasing its claim, so the core
-    * option takes over again on the next check_variables(). */
+    * option takes over again -- IMMEDIATELY, not "on the next
+    * check_variables()".  Nothing schedules one: check_variables() runs
+    * from retro_load_game() and from retro_run() only behind
+    * GET_VARIABLE_UPDATE.  RetroArch issues a per-port controller init
+    * right after load, so forcing PAD here used to detach the mouse the
+    * core option had just attached, for the whole session -- which is why
+    * the feature was never seen working in a frontend. */
    port_device_frontend[port] = type;
    port_device_forced[port]   = (type != INPUTDEV_PAD);
+
+   if (type == INPUTDEV_PAD)
+      type = (port == 1) ? p2_device_from_option() : INPUTDEV_PAD;
 
    apply_port_device((int)port, type);
    update_option_visibility();
@@ -1472,7 +1550,6 @@ bool retro_serialize(void *data, size_t size)
     * every release and the only backstop is the hard fail above, so make
     * the margin visible in a log rather than assumed. */
    {
-      static bool headroom_logged = false;
       if (!headroom_logged)
       {
          headroom_logged = true;
@@ -2495,7 +2572,10 @@ void retro_deinit(void)
    port_device_forced[1]   = false;
    port_device_active[0]   = INPUTDEV_PAD;
    port_device_active[1]   = INPUTDEV_PAD;
+   inputdev_live[0]        = false;
+   inputdev_live[1]        = false;
    show_mouse_options      = true;
+   headroom_logged         = false;
    video_buffer_alloc_pixels = VIDEO_BUFFER_PIXELS;
    hires_restart_notice_logged = 0;
 

--- a/libretro.c
+++ b/libretro.c
@@ -233,6 +233,15 @@ static bool         show_mouse_options      = true;
  * a mouse the frontend is routing, and letting a pad drive the same six
  * lines at that point is the ambiguity the suppression exists to prevent.
  *
+ * DELIBERATELY NOT SERIALIZED, for the same reason inputdev.h gives for
+ * the device type and the sensitivity scale: this is a fact about how the
+ * HOST is routing input, not about the emulated machine, and restoring it
+ * from a state would let a stale state fight the current session.  The
+ * asymmetry with the v12 chunk is bounded and benign -- a state saved
+ * while the mouse was live loads with port 2's pad un-suppressed until
+ * the mouse next moves, i.e. at most a frame of pad contribution, and
+ * only if the frontend is routing a pad there at all.
+ *
  * File-scope static -- reset in retro_deinit (iOS cannot dlclose a core). */
 static bool         inputdev_live[2]        = { false, false };
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -482,6 +482,43 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "virtualjaguar_p2_device",
+      "Port 2 > Controller Type",
+      "Controller Type",
+      "Which peripheral is plugged into controller port 2. 'Atari ST / PS2 Mouse' is the wiring used by the AtariAge and Brewing Academy ST adapters and by PS/2 mouse adapters. 'Amiga Mouse (ST adapter)' is an Amiga mouse plugged into an ST-wired adapter -- this is what an in-game 'Atari / Amiga' selector normally chooses between. 'Amiga Mouse (Amiga adapter)' is the rarer dedicated adapter. A mouse asserts its state in every row scan, exactly as the real row-blind adapter does, so the port-2 RetroPad is disconnected while one is selected.",
+      NULL,
+      "input_p2",
+      {
+         { "auto",                "Auto (per-title default)" },
+         { "pad",                 "Standard Joypad" },
+         { "mouse_st",            "Atari ST / PS2 Mouse" },
+         { "mouse_amiga",         "Amiga Mouse (ST adapter)" },
+         { "mouse_amiga_adapter", "Amiga Mouse (Amiga adapter)" },
+         { NULL, NULL },
+      },
+      "auto"
+   },
+   {
+      "virtualjaguar_mouse_sensitivity",
+      "Port 2 > Mouse Sensitivity",
+      "Mouse Sensitivity",
+      "Scales mouse movement before it is converted to quadrature pulses. The emulated device can only emit one pulse per controller poll, so raising this past what the game's poll rate can carry adds lag rather than speed.",
+      NULL,
+      "input_p2",
+      {
+         { "25",  "25%" },
+         { "50",  "50%" },
+         { "75",  "75%" },
+         { "100", "100%" },
+         { "150", "150%" },
+         { "200", "200%" },
+         { "300", "300%" },
+         { "400", "400%" },
+         { NULL, NULL },
+      },
+      "100"
+   },
+   {
       "virtualjaguar_p1_numpad_to_kb",
       "Port 1 > Numpad Buttons to Keyboard Keys",
       "Numpad Buttons to Keyboard Keys",

--- a/link-test.T
+++ b/link-test.T
@@ -68,6 +68,8 @@
       Joystick*;
       joypad0Buttons;
       joypad1Buttons;
+      InputDev*;
+      Quad*;
       MTState*;
       NVMBios*;
       NVM_*;

--- a/link-test.T
+++ b/link-test.T
@@ -65,7 +65,9 @@
       ResolveBootConfig;
       BlitterCompare*;
       DAC*;
-      JoystickState*;
+      Joystick*;
+      joypad0Buttons;
+      joypad1Buttons;
       MTState*;
       NVMBios*;
       NVM_*;

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -35,19 +35,27 @@ extern "C" {
  *     all in-flight changes since the last release use v7.
  * v8: trailing Jaguar GameDrive chunk (bank pages + SPI mailbox engine,
  *     jaggd.c).  One shared bump — all in-flight changes since the
- *     v3.1.0 release use v8.  This is the newest RELEASED layout (v3.2.0).
- * v9: DAC block gained the I2S ring (dac.c).  develop only.
+ *     v3.1.0 release use v8.  Released in v3.2.0.
+ * v9: DAC block gained the I2S ring (dac.c).
  * v10: trailing blitter busy-window counter (blitter timing model).
- *     develop only.
  * v11: trailing hi-res shadow-surface epoch (shadowfb.c).  The epoch is a
  *     modulo-256 age stamp that gates which supersampled blocks resolve,
  *     and ShadowHiresFrameTick() drops every cached block when it wraps.
  *     That clear is visible in the presented frame, so a state restored
  *     without it replays the wrap at a different frame and diverges —
  *     which is exactly the determinism we advertise as
- *     savestate_features = 3.  See issue #400. */
+ *     savestate_features = 3.  See issue #400.
+ *     v9-v11 all shipped together: this is the newest RELEASED layout
+ *     (v3.3.0).  (The note that used to sit on v8 calling it the newest
+ *     released layout, and the "develop only" tags on v9-v11, were stale
+ *     from before the v3.3.0 cut.)
+ * v12: trailing input-device chunk (src/jerry/inputdev.c).  The
+ *     quadrature accumulator and phase are machine-visible — the phase IS
+ *     what the game reads at $F14000 — so a state restored without them
+ *     replays different motion.  Older states load with the encoders
+ *     reset, which is what a pre-v12 core was.  develop only. */
 #define STATE_MAGIC     0x564A5353  /* "VJSS" */
-#define STATE_VERSION   11
+#define STATE_VERSION   12
 /* Oldest layout retro_unserialize still accepts.  States between
  * STATE_MIN_VERSION and STATE_VERSION load by reading each chunk in the
  * layout the header version names (see DACStateLoad, CDROMStateLoad);
@@ -118,6 +126,11 @@ extern "C" {
  * (shadowfb.c).  Issue #400: without it, the epoch wrap's cache clear
  * replays at a different frame after a rollback and the picture diverges. */
 #define STATE_VERSION_HIRES_EPOCH 11
+/* First version carrying the trailing input-device chunk (inputdev.c):
+ * per-port quadrature backlog / Q8 carry / Gray phase, the mouse button
+ * latches, and the emission-clock armed flag.  Older states load with
+ * InputDevReset() -- encoders at phase 0, no button held. */
+#define STATE_VERSION_INPUT_DEVICES 12
 
 /* Header flags */
 #define STATE_FLAG_MEMTRACK  0x01

--- a/src/jerry/inputdev.c
+++ b/src/jerry/inputdev.c
@@ -1,0 +1,332 @@
+/*
+ * src/jerry/inputdev.c -- per-port non-pad input device model.
+ *
+ * See inputdev.h for the row-blindness argument, the port scope and the
+ * emission rule.  Bit assignments below come from
+ * docs/jaguar-mouse-adapter-mapping.md section 4d and are NOT guesses.
+ */
+
+#include <string.h>
+
+#include "inputdev.h"
+#include "quadrature.h"
+#include "state.h"
+
+/* Wiring table.  Values are $F14000 bit positions for PORT 2, all active
+ * low (0 = asserted).  Written as a literal table so the three cases
+ * cannot drift apart.
+ *
+ *   case 1  ST adapter + ST mouse, and the PS/2 adapter (vendor-documented
+ *           as "select Atari ST mouse")     X = 13/12   Y = 14/15
+ *   case 2  dedicated Amiga adapter + Amiga X = 13/12   Y = 15/14
+ *   case 3  Amiga mouse in an ST-wired
+ *           adapter -- what an in-game
+ *           "Atari / Amiga" selector picks  X = 13/15   Y = 12/14
+ *
+ * Do NOT "fix" the case-1 Y-phase assignment from Domin's twomice2.s
+ * variable names: that source labels bit 15 YA and bit 14 YB, the reverse
+ * of the wiring diagram, and its own decode table absorbs the difference
+ * (mapping doc section 8 C).  The table below follows the physical wiring,
+ * which two independent sources agree on.
+ *
+ * UNVERIFIED -- case 2's Y sign.  The dedicated Amiga adapter lands the
+ * Amiga's V (Y phase A) on bit 15 and VQ (Y phase B) on bit 14, i.e. the
+ * A/B pair is swapped relative to case 1, which inverts Y.  Domin
+ * nonetheless drives both with one software mode, so either ST and Amiga
+ * mice differ in encoder orientation and the swap cancels it, or the
+ * wiki's (YA)/(YB) labels on the Amiga column are editorial rather than
+ * measured, or he simply tolerated an inverted Y.  No document settles it
+ * and NO FIXTURE IN THIS REPO CAN: case-2 hardware is rare and no
+ * available title is known to target it.  The table implements the wiring
+ * literally, as recorded, rather than guessing a sign.  Do not "correct"
+ * it without a source. */
+typedef struct
+{
+   uint8_t xa, xb, ya, yb;
+} MouseWiring;
+
+static const MouseWiring mouse_wiring[3] = {
+   /* INPUTDEV_MOUSE_ST            */ { 13, 12, 14, 15 },
+   /* INPUTDEV_MOUSE_AMIGA_ADAPTER */ { 13, 12, 15, 14 },
+   /* INPUTDEV_MOUSE_AMIGA_ON_ST   */ { 13, 15, 12, 14 }
+};
+
+typedef struct
+{
+   InputDevType type;
+   quad_axis    x;
+   quad_axis    y;
+   int32_t      scale_q8;
+   uint8_t      btn_left;
+   uint8_t      btn_right;
+} InputDevPort;
+
+static InputDevPort inputdev_ports[2];
+static uint32_t     inputdev_attach_mask;
+static uint8_t      inputdev_armed;
+
+static int inputdev_is_mouse(InputDevType t)
+{
+   return (t == INPUTDEV_MOUSE_ST
+           || t == INPUTDEV_MOUSE_AMIGA_ADAPTER
+           || t == INPUTDEV_MOUSE_AMIGA_ON_ST) ? 1 : 0;
+}
+
+/* Dynamic (machine-visible) state only: encoders, button latches and the
+ * armed flag.  The device type and the sensitivity scale are owned by the
+ * core options and survive a machine reset, exactly as a physical mouse
+ * stays plugged in across a console reset. */
+static void inputdev_reset_dynamic(void)
+{
+   unsigned p;
+
+   for (p = 0; p < 2; p++)
+   {
+      QuadReset(&inputdev_ports[p].x);
+      QuadReset(&inputdev_ports[p].y);
+      inputdev_ports[p].btn_left  = 0;
+      inputdev_ports[p].btn_right = 0;
+   }
+
+   inputdev_armed = 0;
+}
+
+void InputDevInit(void)
+{
+   unsigned p;
+
+   for (p = 0; p < 2; p++)
+      if (inputdev_ports[p].scale_q8 <= 0)
+         inputdev_ports[p].scale_q8 = 256;
+
+   inputdev_reset_dynamic();
+}
+
+void InputDevReset(void)
+{
+   inputdev_reset_dynamic();
+}
+
+void InputDevShutdown(void)
+{
+   /* iOS cannot dlclose a core, so every static has to go back to its
+    * load-time value here -- including the option-derived ones. */
+   memset(inputdev_ports, 0, sizeof(inputdev_ports));
+   inputdev_ports[0].scale_q8 = 256;
+   inputdev_ports[1].scale_q8 = 256;
+   inputdev_attach_mask       = 0;
+   inputdev_armed             = 0;
+}
+
+void InputDevSetType(int port, InputDevType type)
+{
+   if (port < 0 || port > 1)
+      return;
+
+   /* Mouse is port 2 only (see inputdev.h), and the rotary is reserved
+    * for #436 and not implemented in this build.  Anything else is a
+    * plain pad, i.e. not attached. */
+   if (type != INPUTDEV_PAD && !(inputdev_is_mouse(type) && port == 1))
+      type = INPUTDEV_PAD;
+
+   if (inputdev_ports[port].type != type)
+   {
+      inputdev_ports[port].type = type;
+      QuadReset(&inputdev_ports[port].x);
+      QuadReset(&inputdev_ports[port].y);
+      inputdev_ports[port].btn_left  = 0;
+      inputdev_ports[port].btn_right = 0;
+   }
+
+   if (type == INPUTDEV_PAD)
+      inputdev_attach_mask &= ~(1u << port);
+   else
+      inputdev_attach_mask |= (1u << port);
+}
+
+InputDevType InputDevGetType(int port)
+{
+   if (port < 0 || port > 1)
+      return INPUTDEV_PAD;
+   return inputdev_ports[port].type;
+}
+
+int InputDevAnyAttached(void)
+{
+   return inputdev_attach_mask ? 1 : 0;
+}
+
+void InputDevSetScale(int port, int32_t scale_q8)
+{
+   if (port < 0 || port > 1)
+      return;
+   if (scale_q8 < 1)
+      scale_q8 = 1;
+   if (scale_q8 > 4096)
+      scale_q8 = 4096;
+   inputdev_ports[port].scale_q8 = scale_q8;
+}
+
+void InputDevFeed(int port, int32_t dx, int32_t dy, uint32_t buttons)
+{
+   InputDevPort *p;
+
+   if (port < 0 || port > 1)
+      return;
+
+   p = &inputdev_ports[port];
+   if (!inputdev_is_mouse(p->type))
+      return;
+
+   if (p->scale_q8 <= 0)
+      p->scale_q8 = 256;
+
+   /* One libretro unit = one Gray-code state at scale 1.0.  Domin's
+    * decoder increments its position by one per state transition, so one
+    * host "pixel" of motion maps to one decoded count.  Positive dx is
+    * right and positive dy is down in libretro, and A-leads-B (increasing
+    * phase) is right/down on the wire, so the mapping is direct. */
+   QuadFeed(&p->x, dx, p->scale_q8);
+   QuadFeed(&p->y, dy, p->scale_q8);
+
+   p->btn_left  = (buttons & INPUTDEV_BTN_LEFT)  ? 1 : 0;
+   p->btn_right = (buttons & INPUTDEV_BTN_RIGHT) ? 1 : 0;
+}
+
+void InputDevArm(void)
+{
+   if (!inputdev_attach_mask)
+      return;
+   inputdev_armed = 1;
+}
+
+void InputDevClock(void)
+{
+   unsigned p;
+
+   if (!inputdev_attach_mask)
+      return;
+   if (!inputdev_armed)
+      return;
+
+   inputdev_armed = 0;
+
+   for (p = 0; p < 2; p++)
+   {
+      if (!inputdev_is_mouse(inputdev_ports[p].type))
+         continue;
+      QuadAdvance(&inputdev_ports[p].x);
+      QuadAdvance(&inputdev_ports[p].y);
+   }
+}
+
+uint16_t InputDevOverlayF14000(uint16_t data)
+{
+   const MouseWiring *w;
+   InputDevPort *p;
+   int ax, bx, ay, by;
+
+   if (!inputdev_attach_mask)
+      return data;
+
+   p = &inputdev_ports[1];
+   if (!inputdev_is_mouse(p->type))
+      return data;
+
+   w = &mouse_wiring[(int)p->type - (int)INPUTDEV_MOUSE_ST];
+
+   QuadLevels(&p->x, &ax, &bx);
+   QuadLevels(&p->y, &ay, &by);
+
+   /* Active low: a logic 0 on the wire pulls the register bit low.  No
+    * row test -- the adapter never sees the row select, so it asserts
+    * identically in every row (including the "not a socket-0 code" case,
+    * where the pad matrix contributes nothing at all). */
+   if (!ax)
+      data &= (uint16_t)~(1u << w->xa);
+   if (!bx)
+      data &= (uint16_t)~(1u << w->xb);
+   if (!ay)
+      data &= (uint16_t)~(1u << w->ya);
+   if (!by)
+      data &= (uint16_t)~(1u << w->yb);
+
+   return data;
+}
+
+uint16_t InputDevOverlayF14002(uint16_t data, uint8_t row0, uint8_t row1)
+{
+   InputDevPort *p;
+
+   /* The mouse is row-blind, so it ignores both rows; they are here for
+    * the rotary's C2/C3 controller-type reporting (#436). */
+   (void)row0;
+   (void)row1;
+
+   if (!inputdev_attach_mask)
+      return data;
+
+   p = &inputdev_ports[1];
+   if (!inputdev_is_mouse(p->type))
+      return data;
+
+   /* LMB -> B3 ($F14002 bit 3), RMB -> B2 (bit 2), in EVERY row.
+    *
+    * Both of these are faithful hardware quirks, not oversights:
+    * joystick.c decodes bit 3 as A / B / C / Option depending on the row,
+    * so a held LMB reads as all four; and bit 2 is the C1/C2/C3
+    * controller-type field in rows 1-3, so a held RMB changes the
+    * reported controller type.  Do not add a row test to "fix" either. */
+   if (p->btn_left)
+      data &= (uint16_t)~(1u << 3);
+   if (p->btn_right)
+      data &= (uint16_t)~(1u << 2);
+
+   return data;
+}
+
+size_t InputDevStateSave(uint8_t *buf)
+{
+   uint8_t *start = buf;
+   unsigned p;
+
+   for (p = 0; p < 2; p++)
+   {
+      STATE_SAVE_VAR(buf, inputdev_ports[p].x.backlog);
+      STATE_SAVE_VAR(buf, inputdev_ports[p].x.frac);
+      STATE_SAVE_VAR(buf, inputdev_ports[p].x.phase);
+      STATE_SAVE_VAR(buf, inputdev_ports[p].y.backlog);
+      STATE_SAVE_VAR(buf, inputdev_ports[p].y.frac);
+      STATE_SAVE_VAR(buf, inputdev_ports[p].y.phase);
+      STATE_SAVE_VAR(buf, inputdev_ports[p].btn_left);
+      STATE_SAVE_VAR(buf, inputdev_ports[p].btn_right);
+   }
+
+   STATE_SAVE_VAR(buf, inputdev_armed);
+
+   return (size_t)(buf - start);
+}
+
+size_t InputDevStateLoad(const uint8_t *buf)
+{
+   const uint8_t *start = buf;
+   unsigned p;
+
+   for (p = 0; p < 2; p++)
+   {
+      STATE_LOAD_VAR(buf, inputdev_ports[p].x.backlog);
+      STATE_LOAD_VAR(buf, inputdev_ports[p].x.frac);
+      STATE_LOAD_VAR(buf, inputdev_ports[p].x.phase);
+      STATE_LOAD_VAR(buf, inputdev_ports[p].y.backlog);
+      STATE_LOAD_VAR(buf, inputdev_ports[p].y.frac);
+      STATE_LOAD_VAR(buf, inputdev_ports[p].y.phase);
+      STATE_LOAD_VAR(buf, inputdev_ports[p].btn_left);
+      STATE_LOAD_VAR(buf, inputdev_ports[p].btn_right);
+      inputdev_ports[p].x.phase &= 3;
+      inputdev_ports[p].y.phase &= 3;
+   }
+
+   STATE_LOAD_VAR(buf, inputdev_armed);
+
+   return (size_t)(buf - start);
+}

--- a/src/jerry/inputdev.c
+++ b/src/jerry/inputdev.c
@@ -136,6 +136,13 @@ void InputDevSetType(int port, InputDevType type)
       QuadReset(&inputdev_ports[port].y);
       inputdev_ports[port].btn_left  = 0;
       inputdev_ports[port].btn_right = 0;
+      /* The arm flag is part of the dynamic state too: without this a
+       * mouse -> pad -> mouse round trip leaves a stale arm behind, worth
+       * one unrequested advance on the next read.  Cleared only on a real
+       * type change -- apply_port_device() calls this on every
+       * check_variables(), and an unconditional clear there would eat a
+       * legitimate arm in the common path. */
+      inputdev_armed = 0;
    }
 
    if (type == INPUTDEV_PAD)
@@ -307,6 +314,27 @@ size_t InputDevStateSave(uint8_t *buf)
    return (size_t)(buf - start);
 }
 
+/* A savestate is untrusted input.  `phase` was already masked on load;
+ * `backlog` and `frac` need the same treatment, because QuadFeed() clamps
+ * only AFTER `q->backlog += states`, so a corrupt backlog near INT32_MAX
+ * overflows before the clamp can see it.  The invariants are the ones
+ * QuadFeed/QuadAdvance maintain: |backlog| <= QUAD_MAX_BACKLOG and
+ * |frac| < 256 (it is a Q8 remainder). */
+static void inputdev_sanitize_axis(quad_axis *q)
+{
+   q->phase &= 3;
+
+   if (q->backlog >  QUAD_MAX_BACKLOG)
+      q->backlog =  QUAD_MAX_BACKLOG;
+   if (q->backlog < -QUAD_MAX_BACKLOG)
+      q->backlog = -QUAD_MAX_BACKLOG;
+
+   if (q->frac >  255)
+      q->frac =  255;
+   if (q->frac < -255)
+      q->frac = -255;
+}
+
 size_t InputDevStateLoad(const uint8_t *buf)
 {
    const uint8_t *start = buf;
@@ -322,8 +350,8 @@ size_t InputDevStateLoad(const uint8_t *buf)
       STATE_LOAD_VAR(buf, inputdev_ports[p].y.phase);
       STATE_LOAD_VAR(buf, inputdev_ports[p].btn_left);
       STATE_LOAD_VAR(buf, inputdev_ports[p].btn_right);
-      inputdev_ports[p].x.phase &= 3;
-      inputdev_ports[p].y.phase &= 3;
+      inputdev_sanitize_axis(&inputdev_ports[p].x);
+      inputdev_sanitize_axis(&inputdev_ports[p].y);
    }
 
    STATE_LOAD_VAR(buf, inputdev_armed);

--- a/src/jerry/inputdev.h
+++ b/src/jerry/inputdev.h
@@ -1,0 +1,133 @@
+/*
+ * src/jerry/inputdev.h -- per-port non-pad input device model.
+ *
+ * THE LOAD-BEARING FACT: THE MOUSE ADAPTER IS ROW-BLIND
+ * ====================================================
+ * docs/jaguar-mouse-adapter-mapping.md section 7.  Neither the ST nor the
+ * Amiga adapter connects Jaguar connector pins 1-4 -- and those are exactly
+ * J4..J7, the port-2 row-select OUTPUTS.  The adapter cannot see the row
+ * select at all.  All six port-2 input lines (J12, J13, J14, J15, B2, B3)
+ * therefore carry the mouse's state continuously and IDENTICALLY in rows
+ * 0, 1, 2 and 3.
+ *
+ * A Jaguar pad is a matrix.  A mouse adapter is not.  So the mouse cannot
+ * be expressed as joypadNButtons[] slots: doing that would return the
+ * mouse in row 0 and nothing in rows 1-3, where real hardware returns the
+ * same bits.  The device instead drives the raw $F14000 / $F14002 bits
+ * through a row-independent overlay applied after the matrix decode.
+ *
+ * Three consequences we deliberately reproduce rather than "fix":
+ *   1. In rows 1-3 the direction bits read as keypad presses (*, 7, 4, 1 /
+ *      2, 5, 8, 0 / 3, 6, 9, #).  A title doing a full four-row scan while
+ *      the mouse moves sees phantom digits.  That is hardware.
+ *   2. LMB reads as A and B and C and Option, because $F14002 bit 3
+ *      decodes per-row in joystick.c.
+ *   3. RMB holds $F14002 bit 2 low in rows 1-3, which is the C1/C2/C3
+ *      controller-type field, so a title re-probing controller type while
+ *      the right button is held misidentifies the device.
+ *
+ * PORT SCOPE
+ * ==========
+ * The mouse is a PORT 2 device only.  The adapter is vendor-documented as
+ * such, every title known to read one reads port 2, and a port-1 mouse
+ * would be a configuration no software supports.  InputDevSetType()
+ * refuses a mouse on port 0.
+ *
+ * `port` here is 0 for Jaguar port 1 and 1 for Jaguar port 2, matching
+ * joypad0Buttons / joypad1Buttons.
+ */
+
+#ifndef __INPUTDEV_H__
+#define __INPUTDEV_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Wiring cases are docs/jaguar-mouse-adapter-mapping.md section 4d,
+ * verbatim.  Values are persisted only in core-option strings, never in
+ * the savestate, so they may be renumbered. */
+typedef enum
+{
+   INPUTDEV_PAD = 0,             /* standard Jaguar joypad -- today's behaviour */
+   INPUTDEV_MOUSE_ST,            /* case 1: ST adapter + ST mouse (also PS/2)   */
+   INPUTDEV_MOUSE_AMIGA_ADAPTER, /* case 2: dedicated Amiga adapter + Amiga     */
+   INPUTDEV_MOUSE_AMIGA_ON_ST,   /* case 3: Amiga mouse in an ST-wired adapter  */
+   INPUTDEV_ROTARY               /* TR10 "Tempest" rotary -- RESERVED, see below */
+} InputDevType;
+
+/* INPUTDEV_ROTARY is declared but NOT implemented here.  It belongs to
+ * issue #436, which lands as its own PR on top of this one; the constant
+ * is reserved now only so that PR is a pure addition rather than a
+ * renumbering.  Nothing in this build can select it: no core-option value
+ * maps to it, and InputDevSetType() treats it as "not attached". */
+
+void InputDevInit(void);
+void InputDevReset(void);     /* JERRYReset path: dynamic state only        */
+void InputDevShutdown(void);  /* retro_deinit: clear every static (iOS)     */
+
+/* Selection.  port is 0 (Jaguar port 1) or 1 (Jaguar port 2). */
+void         InputDevSetType(int port, InputDevType type);
+InputDevType InputDevGetType(int port);
+int          InputDevAnyAttached(void);  /* 0 => bit-identical to pad-only */
+
+/* Per-frame host feed, called from update_input() in libretro.c.  dx/dy
+ * are libretro relative units; buttons is a bitmask of INPUTDEV_BTN_*. */
+#define INPUTDEV_BTN_LEFT   0x01
+#define INPUTDEV_BTN_RIGHT  0x02
+void InputDevFeed(int port, int32_t dx, int32_t dy, uint32_t buttons);
+
+/* Sensitivity, Q8 (256 == 1.0), from the core options. */
+void InputDevSetScale(int port, int32_t scale_q8);
+
+/* ---- bus-side hooks, called only from joystick.c ------------------- *
+ *
+ * THE EMISSION RULE: arm on write, advance at most one state on the next
+ * offset-0 read.
+ *
+ * The naive "advance once per offset-0 read" has a latent motion-loss
+ * bug.  A driver that writes the row select once and then reads twice per
+ * poll (one read for directions, one for buttons -- a very common shape)
+ * would advance the phase twice between decode steps, producing exactly
+ * the two-state jump a quadrature decoder discards.  That reads as
+ * jitter, which is worse than lag.
+ *
+ * Write-then-read (every documented driver) yields exactly one advance
+ * per poll.  Extra reads without an intervening write return the same
+ * phase, which the decoder reads as "no movement" -- harmless -- instead
+ * of a discarded diagonal.
+ *
+ * Deliberately deferred: a driver that writes the row select once at init
+ * and then polls read-only forever would see a frozen device.  No such
+ * driver is documented.  The mitigation, if a real title needs it, is a
+ * stall-breaker that advances anyway after N consecutive unarmed reads;
+ * it is not implemented speculatively. */
+void     InputDevArm(void);                        /* $F14000 write          */
+void     InputDevClock(void);                      /* $F14000 read, offset 0 */
+uint16_t InputDevOverlayF14000(uint16_t data);
+/* row0/row1 are the decoded socket-0 row (0-3) for each port, or 0xFF
+ * when that port's nibble is not a socket-0 code.  The mouse ignores them
+ * -- it is row-blind -- but the rotary's C2/C3 controller-type reporting
+ * (#436) needs them, so the signature is final and joystick.c will not
+ * have to change again. */
+uint16_t InputDevOverlayF14002(uint16_t data, uint8_t row0, uint8_t row1);
+
+/* ---- savestate (v12 trailing chunk) -------------------------------- *
+ * The quadrature phase IS what the game reads at $F14000, and the
+ * backlog/carry determine every future read, so all three are
+ * machine-visible and must survive a rollback (issue #400's lesson).
+ * The device type and the sensitivity scale are deliberately NOT saved:
+ * both are option-derived and constant for a session, and restoring them
+ * from a state would let a stale state fight the user's current option. */
+#define INPUTDEV_STATE_SIZE 41
+size_t InputDevStateSave(uint8_t *buf);
+size_t InputDevStateLoad(const uint8_t *buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INPUTDEV_H__ */

--- a/src/jerry/inputdev.h
+++ b/src/jerry/inputdev.h
@@ -86,7 +86,14 @@ void InputDevSetScale(int port, int32_t scale_q8);
 /* ---- bus-side hooks, called only from joystick.c ------------------- *
  *
  * THE EMISSION RULE: arm on write, advance at most one state on the next
- * offset-0 read.
+ * offset-0 read TAKEN WITH PORT 2'S ROW SELECT ASSERTED.
+ *
+ * The row gate is joystick.c's `offset1 != 0xFF` test (any of rows 0-3,
+ * not row 0 specifically -- the adapter is row-blind, so every row is a
+ * poll of it).  Without it a title that polls port 1 rapidly would
+ * advance the port-2 encoder between the port-2 poller's own samples,
+ * which is precisely the lost motion the one-state ceiling exists to
+ * prevent.
  *
  * The naive "advance once per offset-0 read" has a latent motion-loss
  * bug.  A driver that writes the row select once and then reads twice per
@@ -106,7 +113,8 @@ void InputDevSetScale(int port, int32_t scale_q8);
  * stall-breaker that advances anyway after N consecutive unarmed reads;
  * it is not implemented speculatively. */
 void     InputDevArm(void);                        /* $F14000 write          */
-void     InputDevClock(void);                      /* $F14000 read, offset 0 */
+void     InputDevClock(void);                      /* $F14000 read, offset 0,
+                                                    * port-2 row asserted    */
 uint16_t InputDevOverlayF14000(uint16_t data);
 /* row0/row1 are the decoded socket-0 row (0-3) for each port, or 0xFF
  * when that port's nibble is not a socket-0 code.  The mouse ignores them

--- a/src/jerry/jerry.c
+++ b/src/jerry/jerry.c
@@ -166,6 +166,7 @@
 #include "perf_counters.h"
 
 PERF_COUNTER(timing_jerry_irqs);
+#include "inputdev.h"
 #include "joystick.h"
 #include "jlink.h"
 #include "uart.h"
@@ -381,6 +382,7 @@ void JERRYI2SCallback(void)
 void JERRYInit(void)
 {
    JoystickInit();
+   InputDevInit();
    MTInit();
    memcpy(&jerry_ram_8[0xD000], waveTableROM, 0x1000);
 
@@ -399,6 +401,7 @@ void JERRYInit(void)
 void JERRYReset(void)
 {
    JoystickReset();
+   InputDevReset();
    EepromReset();
    MTReset();
    JERRYResetI2S();

--- a/src/jerry/joystick.c
+++ b/src/jerry/joystick.c
@@ -15,6 +15,7 @@
 
 #include <string.h>			// For memset()
 #include "joystick.h"
+#include "inputdev.h"
 #include "settings.h"
 
 // Global vars
@@ -69,6 +70,11 @@ uint16_t JoystickReadWord(uint32_t offset)
 		if (!joysticksEnabled)
 			return 0xFFFF;
 
+		// Non-pad devices self-clock against the game's own polling: at
+		// most one quadrature state per armed read (inputdev.h).  No-op
+		// when nothing but pads are attached.
+		InputDevClock();
+
 		// Joystick data returns active low for buttons pressed, high for non-
 		// pressed.
 		offset0 = joypad0Offset[joystick_ram[1] & 0x0F];
@@ -98,7 +104,8 @@ uint16_t JoystickReadWord(uint32_t offset)
 			data &= msk2[offset1 / 4];
 		}
 
-		return data;
+		// Row-independent overlay for a non-pad device (inputdev.h).
+		return InputDevOverlayF14000(data);
 	}
 	else if (offset == 2)
 	{
@@ -132,7 +139,10 @@ uint16_t JoystickReadWord(uint32_t offset)
 				data &= (joypad1Buttons[mask[offset1][1]] ? 0xFFFB : 0xFFFF);
 		}
 
-		return data;
+		// offset0/offset1 already hold the decoded row (0-3), or 0xFF when
+		// that port's nibble is not a socket-0 code -- both divisions above
+		// happen in place.
+		return InputDevOverlayF14002(data, offset0, offset1);
 	}
 
 	return 0xFFFF;
@@ -149,6 +159,8 @@ void JoystickWriteWord(uint32_t offset, uint16_t data)
 	{
 		audioEnabled     = ((data & 0x0100) ? true : false);
 		joysticksEnabled = ((data & 0x8000) ? true : false);
+		// Arm the non-pad emission clock (inputdev.h).
+		InputDevArm();
 	}
 }
 

--- a/src/jerry/joystick.c
+++ b/src/jerry/joystick.c
@@ -70,15 +70,23 @@ uint16_t JoystickReadWord(uint32_t offset)
 		if (!joysticksEnabled)
 			return 0xFFFF;
 
-		// Non-pad devices self-clock against the game's own polling: at
-		// most one quadrature state per armed read (inputdev.h).  No-op
-		// when nothing but pads are attached.
-		InputDevClock();
-
 		// Joystick data returns active low for buttons pressed, high for non-
 		// pressed.
 		offset0 = joypad0Offset[joystick_ram[1] & 0x0F];
 		offset1 = joypad1Offset[(joystick_ram[1] >> 4) & 0x0F];
+
+		// Non-pad devices self-clock against the game's own polling: at
+		// most one quadrature state per armed read (inputdev.h).  Gated on
+		// port 2's row select being asserted (any of rows 0-3, i.e.
+		// offset1 decoded to something other than 0xFF), because that is
+		// the only read the port-2 poller can decode from -- a title
+		// polling port 1 rapidly would otherwise advance the port-2
+		// encoder between the port-2 poller's own samples, which is
+		// exactly the lost motion the one-state ceiling exists to
+		// prevent (mapping doc section 5).  No-op when nothing but pads
+		// are attached.
+		if (offset1 != 0xFF)
+			InputDevClock();
 
 		if (offset0 != 0xFF)
 		{

--- a/src/jerry/quadrature.c
+++ b/src/jerry/quadrature.c
@@ -19,7 +19,7 @@ void QuadReset(quad_axis *q)
 
    q->backlog = 0;
    q->frac    = 0;
-   q->phase   = 0;
+   q->phase   = QUAD_REST_PHASE;   /* (1,1): idle reads as no assertion */
 }
 
 void QuadFeed(quad_axis *q, int32_t delta, int32_t scale_q8)

--- a/src/jerry/quadrature.c
+++ b/src/jerry/quadrature.c
@@ -1,0 +1,87 @@
+/*
+ * src/jerry/quadrature.c -- 2-bit Gray-code quadrature encoder.
+ *
+ * See quadrature.h for the phase table, the direction convention and the
+ * rationale for the one-state-per-advance rate policy.
+ */
+
+#include "quadrature.h"
+
+/* Phase index -> A / B logic levels.  Kept as tables rather than bit
+ * arithmetic so the sequence is readable against the manual's waveform. */
+static const uint8_t quad_level_a[4] = { 0, 1, 1, 0 };
+static const uint8_t quad_level_b[4] = { 0, 0, 1, 1 };
+
+void QuadReset(quad_axis *q)
+{
+   if (!q)
+      return;
+
+   q->backlog = 0;
+   q->frac    = 0;
+   q->phase   = 0;
+}
+
+void QuadFeed(quad_axis *q, int32_t delta, int32_t scale_q8)
+{
+   int32_t acc;
+   int32_t states;
+
+   if (!q || delta == 0)
+      return;
+
+   /* Clamp the incoming delta so `delta * scale_q8` cannot overflow an
+    * int32 even at the top of the sensitivity ladder.  The bound is the
+    * int16_t range because that is what a libretro relative axis can
+    * actually report; 32767 * 4096 (InputDevSetScale's ceiling) is
+    * 1.34e8, comfortably inside int32.  A frontend reporting a
+    * full-range delta in one frame is already far past anything
+    * QUAD_MAX_BACKLOG will let through. */
+   if (delta >  32767)
+      delta =  32767;
+   if (delta < -32767)
+      delta = -32767;
+
+   acc    = q->frac + (delta * scale_q8);
+   /* Truncating division: the remainder keeps the sign of the dividend,
+    * so the carry stays consistent in both directions (a -0.5-state feed
+    * yields 0 states and a -128 carry, and the next one completes it). */
+   states = acc / 256;
+   q->frac = acc - (states * 256);
+
+   q->backlog += states;
+
+   if (q->backlog >  QUAD_MAX_BACKLOG)
+      q->backlog =  QUAD_MAX_BACKLOG;
+   if (q->backlog < -QUAD_MAX_BACKLOG)
+      q->backlog = -QUAD_MAX_BACKLOG;
+}
+
+int QuadAdvance(quad_axis *q)
+{
+   if (!q || q->backlog == 0)
+      return 0;
+
+   if (q->backlog > 0)
+   {
+      q->phase = (uint8_t)((q->phase + 1) & 3);
+      q->backlog--;
+   }
+   else
+   {
+      q->phase = (uint8_t)((q->phase + 3) & 3);
+      q->backlog++;
+   }
+
+   return 1;
+}
+
+void QuadLevels(const quad_axis *q, int *a, int *b)
+{
+   uint8_t phase = q ? (uint8_t)(q->phase & 3) : (uint8_t)0;
+
+   if (a)
+      *a = (int)quad_level_a[phase];
+   if (b)
+      *b = (int)quad_level_b[phase];
+}

--- a/src/jerry/quadrature.h
+++ b/src/jerry/quadrature.h
@@ -1,0 +1,87 @@
+/*
+ * src/jerry/quadrature.h -- 2-bit Gray-code quadrature encoder.
+ *
+ * Pure and host-testable: no dependency on any emulator header, no Jaguar
+ * types.  Both the ST/Amiga mouse adapter (#429) and the Tempest rotary
+ * (#436) hang a two-phase optical encoder off the same port input lines,
+ * and both emit the SAME Gray code -- docs/jaguar-mouse-adapter-mapping.md
+ * section 5 derives it from Domin's driver, and the Jaguar Technical
+ * Reference V10 specifies it bit-for-bit for the rotary.  One encoder
+ * serves both.
+ *
+ * Phase table (index -> logic levels on the A and B lines):
+ *
+ *     index | A | B
+ *     ------+---+---
+ *       0   | 0 | 0
+ *       1   | 1 | 0
+ *       2   | 1 | 1
+ *       3   | 0 | 1
+ *
+ * Positive direction = index increasing = A leads B.
+ * Negative direction = index decreasing = B leads A.
+ *
+ * For the mouse (mapping doc section 5, from Domin's dirtab_horizontal /
+ * dirtab_vertical): A leads B = right on X, down on Y.
+ *
+ * WHY ONE STATE PER ADVANCE IS THE WHOLE RATE POLICY
+ * ==================================================
+ * The binding constraint is the game's decoder, not the physical device.
+ * A transition of TWO Gray states between consecutive polls indexes the
+ * "undetermined" entry of Domin's 16-entry table and is silently
+ * discarded -- direction is unrecoverable from it.  So emitting faster
+ * than the title polls does not merely lag, it loses motion, and near the
+ * threshold it loses motion non-uniformly, which reads as jitter.
+ * QuadAdvance() therefore moves at most one state, ever.  Excess motion
+ * queues in `backlog` and drains at whatever rate the title polls at,
+ * which is correct for every poll rate without having to know it.
+ */
+
+#ifndef __QUADRATURE_H__
+#define __QUADRATURE_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Backlog ceiling, in Gray-code states.  A poll-rate-clocked encoder can
+ * only drain one state per poll (see above), so an unbounded accumulator
+ * turns a fast flick into seconds of pointer drift after the hand has
+ * stopped.  64 states is ~53 ms of lag at Domin's 1200 Hz poll rate and
+ * ~1 s at a VBL-only 60 Hz poll rate -- past which the device is already
+ * unusable, so clamping there loses nothing a user wants. */
+#define QUAD_MAX_BACKLOG 64
+
+typedef struct
+{
+   int32_t backlog;   /* pending Gray states, signed; +ve = positive dir */
+   int32_t frac;      /* Q8 sensitivity remainder, carried between feeds */
+   uint8_t phase;     /* current Gray index 0..3 (table above)           */
+} quad_axis;
+
+void QuadReset(quad_axis *q);
+
+/* Add host-relative motion.  `delta` is in raw libretro device units;
+ * `scale_q8` is a Q8 multiplier (256 == 1.0) from the sensitivity option.
+ * The Q8 remainder is carried so a <1.0 scale decimates smoothly instead
+ * of quantising every small movement to zero. */
+void QuadFeed(quad_axis *q, int32_t delta, int32_t scale_q8);
+
+/* Advance at most ONE Gray-code state toward draining the backlog.
+ * Returns 1 if the phase changed. */
+int QuadAdvance(quad_axis *q);
+
+/* Current phase as two levels.  a/b are 0 or 1 -- LOGIC LEVELS, not
+ * active-low bit values.  Callers apply the polarity their sink needs:
+ * the mouse overlay drives raw $F14000 bits where 0 = asserted, while a
+ * joypadNButtons[] slot is non-zero to pull its bit low.  Two conventions
+ * in one feature, which is why this returns levels and not bits. */
+void QuadLevels(const quad_axis *q, int *a, int *b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __QUADRATURE_H__ */

--- a/src/jerry/quadrature.h
+++ b/src/jerry/quadrature.h
@@ -54,6 +54,25 @@ extern "C" {
  * unusable, so clamping there loses nothing a user wants. */
 #define QUAD_MAX_BACKLOG 64
 
+/* REST PHASE -- where QuadReset() parks the encoder.
+ *
+ * Index 2 is (A=1, B=1), the only one of the four states with BOTH lines
+ * at logic 1.  That matters because the mouse overlay is active low: it
+ * clears a $F14000 bit when the level is 0, so parking at index 0 (0,0)
+ * would leave an IDLE mouse asserting all four direction lines -- row 0
+ * reading U+D+L+R held, rows 1-3 reading four keypad digits held -- after
+ * every JERRYReset, every device change and every pre-v12 state load.
+ * At index 2 an idle mouse is bit-identical to an idle pad, which is the
+ * property #429's acceptance condition is written around.
+ *
+ * NO SOURCE NAMES A REST PHASE.  A real encoder stops wherever the last
+ * motion left it, and neither the mapping doc nor the JTRM specifies a
+ * power-on state, so this is a free choice made on the "indistinguishable
+ * from idle" argument above rather than a documented fact.  #436's rotary
+ * shares this module and may want to revisit it -- it is a detent device,
+ * not a mouse, so its rest position is a different question. */
+#define QUAD_REST_PHASE 2
+
 typedef struct
 {
    int32_t backlog;   /* pending Gray states, signed; +ve = positive dir */

--- a/test/test_quadrature.c
+++ b/test/test_quadrature.c
@@ -56,7 +56,7 @@ static void test_sequence_forward(void)
    for (i = 0; i < 8; i++)
    {
       int a, b;
-      int expect = (i + 1) & 3;
+      int expect = (QUAD_REST_PHASE + i + 1) & 3;
 
       if (!QuadAdvance(&q))
       {
@@ -68,7 +68,7 @@ static void test_sequence_forward(void)
          ok = 0;
    }
 
-   check(ok, "8 advances walk 0,1,2,3,0,1,2,3 with the table's levels");
+   check(ok, "8 advances walk the Gray table upward from the rest phase");
    check(q.backlog == 0, "backlog fully drained after 8 advances");
    check(QuadAdvance(&q) == 0, "an empty backlog does not advance");
 }
@@ -87,7 +87,7 @@ static void test_sequence_reverse(void)
    for (i = 0; i < 8; i++)
    {
       int a, b;
-      int expect = (4 - ((i + 1) & 3)) & 3;   /* 3,2,1,0,3,2,1,0 */
+      int expect = (QUAD_REST_PHASE - (i + 1)) & 3;   /* downward */
 
       if (!QuadAdvance(&q))
       {
@@ -99,7 +99,7 @@ static void test_sequence_reverse(void)
          ok = 0;
    }
 
-   check(ok, "8 advances walk 3,2,1,0,3,2,1,0 with the table's levels");
+   check(ok, "8 advances walk the Gray table downward from the rest phase");
    check(q.backlog == 0, "backlog fully drained after 8 advances");
 }
 
@@ -215,8 +215,18 @@ static void test_reset(void)
    QuadAdvance(&q);
    QuadFeed(&q, 1, 64);
    QuadReset(&q);
-   check(q.backlog == 0 && q.frac == 0 && q.phase == 0,
-         "QuadReset zeroes backlog, carry and phase");
+   check(q.backlog == 0 && q.frac == 0 && q.phase == QUAD_REST_PHASE,
+         "QuadReset zeroes backlog and carry and parks at the rest phase");
+
+   /* The rest phase must be the (1,1) state: the mouse overlay is active
+    * low, so any other parking position leaves an IDLE mouse asserting
+    * direction lines at $F14000 -- see QUAD_REST_PHASE in quadrature.h. */
+   {
+      int a = -1, b = -1;
+      QuadLevels(&q, &a, &b);
+      check(a == 1 && b == 1,
+            "the rest phase drives both lines high (idle asserts nothing)");
+   }
 }
 
 int main(void)

--- a/test/test_quadrature.c
+++ b/test/test_quadrature.c
@@ -1,0 +1,241 @@
+/*
+ * test/test_quadrature.c -- unit test for the Gray-code quadrature encoder.
+ *
+ * Standalone: compiles src/jerry/quadrature.c directly, no core, no
+ * dlopen.  Asserts the properties the mouse (#429) and the rotary (#436)
+ * both depend on:
+ *
+ *   1. the Gray sequence, forwards and backwards, against the table in
+ *      quadrature.h (which is docs/jaguar-mouse-adapter-mapping.md
+ *      section 5 and the Technical Reference V10's rotary sequence -- the
+ *      two agree bit-for-bit);
+ *   2. QuadAdvance() moves AT MOST one state, ever.  This is the whole
+ *      rate policy: a two-state jump indexes the "undetermined" entry of
+ *      a real decoder's table and is silently discarded, so emitting one
+ *      is worse than emitting nothing;
+ *   3. the backlog clamp;
+ *   4. the Q8 remainder carry, so a <1.0 sensitivity decimates smoothly
+ *      instead of quantising every small movement to zero.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../src/jerry/quadrature.h"
+
+static int failures;
+
+static void check(int cond, const char *what)
+{
+   if (cond)
+      printf("  ok   %s\n", what);
+   else
+   {
+      printf("  FAIL %s\n", what);
+      failures++;
+   }
+}
+
+/* Reference phase table, written out independently of the implementation
+ * so a change to either side has to be deliberate. */
+static const int ref_a[4] = { 0, 1, 1, 0 };
+static const int ref_b[4] = { 0, 0, 1, 1 };
+
+static void test_sequence_forward(void)
+{
+   quad_axis q;
+   int i;
+   int ok = 1;
+
+   printf("Gray sequence, positive direction (A leads B)\n");
+
+   QuadReset(&q);
+   QuadFeed(&q, 8, 256);
+
+   for (i = 0; i < 8; i++)
+   {
+      int a, b;
+      int expect = (i + 1) & 3;
+
+      if (!QuadAdvance(&q))
+      {
+         ok = 0;
+         break;
+      }
+      QuadLevels(&q, &a, &b);
+      if (a != ref_a[expect] || b != ref_b[expect])
+         ok = 0;
+   }
+
+   check(ok, "8 advances walk 0,1,2,3,0,1,2,3 with the table's levels");
+   check(q.backlog == 0, "backlog fully drained after 8 advances");
+   check(QuadAdvance(&q) == 0, "an empty backlog does not advance");
+}
+
+static void test_sequence_reverse(void)
+{
+   quad_axis q;
+   int i;
+   int ok = 1;
+
+   printf("Gray sequence, negative direction (B leads A)\n");
+
+   QuadReset(&q);
+   QuadFeed(&q, -8, 256);
+
+   for (i = 0; i < 8; i++)
+   {
+      int a, b;
+      int expect = (4 - ((i + 1) & 3)) & 3;   /* 3,2,1,0,3,2,1,0 */
+
+      if (!QuadAdvance(&q))
+      {
+         ok = 0;
+         break;
+      }
+      QuadLevels(&q, &a, &b);
+      if (a != ref_a[expect] || b != ref_b[expect])
+         ok = 0;
+   }
+
+   check(ok, "8 advances walk 3,2,1,0,3,2,1,0 with the table's levels");
+   check(q.backlog == 0, "backlog fully drained after 8 advances");
+}
+
+static void test_one_state_per_advance(void)
+{
+   quad_axis q;
+   int i;
+   int ok = 1;
+
+   printf("one state per advance (the rate policy)\n");
+
+   /* Motion arriving faster than it can drain: 100 units fed per poll,
+    * one poll per iteration.  Every advance must still move exactly one
+    * state -- this is the case where a naive implementation would "catch
+    * up" by jumping, which a real decoder discards outright. */
+   QuadReset(&q);
+
+   for (i = 0; i < 200; i++)
+   {
+      uint8_t before;
+      int step;
+
+      QuadFeed(&q, 100, 256);
+      before = q.phase;
+      QuadAdvance(&q);
+      step = ((int)q.phase - (int)before + 4) & 3;
+      if (step != 1)
+         ok = 0;
+   }
+
+   check(ok, "200 saturated polls each move exactly 1 state (never a jump)");
+
+   /* And when the backlog IS empty, an advance is a no-op rather than a
+    * wrap: a decoder reads "no movement", which is harmless. */
+   ok = 1;
+   QuadReset(&q);
+   QuadFeed(&q, 3, 256);
+   for (i = 0; i < 10; i++)
+   {
+      uint8_t before = q.phase;
+      int step;
+
+      QuadAdvance(&q);
+      step = ((int)q.phase - (int)before + 4) & 3;
+      if (step > 1)
+         ok = 0;
+      if (i >= 3 && step != 0)
+         ok = 0;
+   }
+
+   check(ok, "advances past an empty backlog hold the phase steady");
+}
+
+static void test_backlog_clamp(void)
+{
+   quad_axis q;
+
+   printf("backlog clamp\n");
+
+   QuadReset(&q);
+   QuadFeed(&q, 100000, 256);
+   check(q.backlog == QUAD_MAX_BACKLOG, "positive backlog clamps at +64");
+
+   QuadReset(&q);
+   QuadFeed(&q, -100000, 256);
+   check(q.backlog == -QUAD_MAX_BACKLOG, "negative backlog clamps at -64");
+}
+
+static void test_q8_carry(void)
+{
+   quad_axis q;
+   int i;
+   int advanced = 0;
+
+   printf("Q8 sensitivity carry\n");
+
+   /* 25% sensitivity: four one-unit feeds must produce exactly one state,
+    * not zero (which is what dropping the remainder would give). */
+   QuadReset(&q);
+   for (i = 0; i < 4; i++)
+      QuadFeed(&q, 1, 64);
+   check(q.backlog == 1, "4 x (1 unit @ 25%) accumulates exactly 1 state");
+
+   QuadReset(&q);
+   for (i = 0; i < 4; i++)
+      QuadFeed(&q, -1, 64);
+   check(q.backlog == -1, "4 x (-1 unit @ 25%) accumulates exactly -1 state");
+
+   /* 200% doubles. */
+   QuadReset(&q);
+   QuadFeed(&q, 3, 512);
+   check(q.backlog == 6, "3 units @ 200% is 6 states");
+
+   /* A single sub-unit feed emits nothing yet but is not lost. */
+   QuadReset(&q);
+   QuadFeed(&q, 1, 64);
+   check(q.backlog == 0, "1 unit @ 25% emits nothing yet");
+   for (i = 0; i < 3; i++)
+      QuadFeed(&q, 1, 64);
+   while (QuadAdvance(&q))
+      advanced++;
+   check(advanced == 1, "...and the carried remainder completes the state");
+}
+
+static void test_reset(void)
+{
+   quad_axis q;
+
+   printf("reset\n");
+
+   QuadReset(&q);
+   QuadFeed(&q, 7, 256);
+   QuadAdvance(&q);
+   QuadFeed(&q, 1, 64);
+   QuadReset(&q);
+   check(q.backlog == 0 && q.frac == 0 && q.phase == 0,
+         "QuadReset zeroes backlog, carry and phase");
+}
+
+int main(void)
+{
+   printf("=== quadrature encoder ===\n");
+
+   test_sequence_forward();
+   test_sequence_reverse();
+   test_one_state_per_advance();
+   test_backlog_clamp();
+   test_q8_carry();
+   test_reset();
+
+   if (failures)
+   {
+      printf("FAILED: %d check(s)\n", failures);
+      return 1;
+   }
+
+   printf("All quadrature checks passed\n");
+   return 0;
+}

--- a/test/tools/joymatrix_identity.c
+++ b/test/tools/joymatrix_identity.c
@@ -49,8 +49,8 @@
  * value is a varying non-zero, so a change from truthiness to `== 1` also
  * trips the digest.
  *
- * TWO ASSERTIONS
- * ==============
+ * THREE ASSERTIONS
+ * ================
  *   full digest  -- everything above.  "Nothing changed at all."
  *   port-1 digest -- the same sweep folding only port 1's own bits
  *                   ($F14000 bits 8-11, $F14002 bits 0-1).  A port-2
@@ -58,6 +58,14 @@
  *                   pad-only build so a later PR cannot derive its own
  *                   baseline from a build that already carries the
  *                   perturbation.
+ *   port-1 digest with a MOUSE attached to port 2 -- the same constant.
+ *                   Added once the device layer existed (#429): a
+ *                   row-blind port-2 overlay drives $F14000 bits 12-15
+ *                   and $F14002 bits 2-3 in every row, and this asserts
+ *                   that none of that reaches port 1's own bits.  Skipped
+ *                   with a printed note if the InputDev* test-ABI symbols
+ *                   are absent, so this file still runs on a build that
+ *                   predates the device layer.
  *
  * The digest is a pure function of the sweep, so it is reproducible on any
  * host: reads are folded byte-by-byte in a fixed order (endian-independent)
@@ -131,68 +139,26 @@ static uint32_t rng_next(void)
    return x;
 }
 
-int main(int argc, char **argv)
+/* ---- the sweep ------------------------------------------------------- *
+ * Factored out so it can be run a second time with a port-2 device
+ * attached.  The RNG is re-seeded here, so both runs see the identical
+ * button vectors in the identical order -- that is what makes the two
+ * port-1 digests directly comparable. */
+
+static uint16_t (*p_JoystickReadWord)(uint32_t);
+static void     (*p_JoystickWriteWord)(uint32_t, uint16_t);
+static uint8_t  *p_joypad0Buttons;
+static uint8_t  *p_joypad1Buttons;
+static struct VJSettings *p_vjs;
+
+static void run_sweep(uint32_t *out_full, uint32_t *out_port1,
+                      unsigned long *out_reads)
 {
-   harness_config cfg = HARNESS_CONFIG_DEFAULT;
-   harness_result results[2];
-   unsigned num_results = 0;
-   int print_only = 0;
-   int i;
-   int ok_full, ok_port1;
-
-   uint16_t (*p_JoystickReadWord)(uint32_t);
-   void     (*p_JoystickWriteWord)(uint32_t, uint16_t);
-   uint8_t  *p_joypad0Buttons;
-   uint8_t  *p_joypad1Buttons;
-   struct VJSettings *p_vjs;
-
    uint32_t digest_full  = FNV1A_OFFSET;
    uint32_t digest_port1 = FNV1A_OFFSET;
    unsigned long reads   = 0;
-
    int ntsc_idx;
    unsigned hi_idx, lo, vec, slot, off;
-   char detail_full[192];
-   char detail_port1[192];
-
-   for (i = 1; i < argc; i++)
-   {
-      if (strcmp(argv[i], "--print") == 0)
-         print_only = 1;
-   }
-
-   cfg.frames = 0;
-   if (!harness_init_from_args(&cfg, argc, argv))
-      return 1;
-
-   /* A ROM is loaded purely so the core is properly initialised (and so
-    * harness_shutdown's retro_deinit is balanced).  No frame is ever run,
-    * so update_input() never touches joypadNButtons -- the sweep owns
-    * every input this test reads. */
-   if (!cfg.rom_path)
-      cfg.rom_path = "test/roms/yarc.j64";
-   if (!harness_load_rom(&cfg))
-      return 1;
-
-   p_JoystickReadWord  = (uint16_t (*)(uint32_t))
-                            harness_dlsym(&cfg, "JoystickReadWord");
-   p_JoystickWriteWord = (void (*)(uint32_t, uint16_t))
-                            harness_dlsym(&cfg, "JoystickWriteWord");
-   p_joypad0Buttons    = (uint8_t *)harness_dlsym(&cfg, "joypad0Buttons");
-   p_joypad1Buttons    = (uint8_t *)harness_dlsym(&cfg, "joypad1Buttons");
-   p_vjs               = (struct VJSettings *)harness_dlsym(&cfg, "vjs");
-
-   if (!p_JoystickReadWord || !p_JoystickWriteWord ||
-       !p_joypad0Buttons || !p_joypad1Buttons || !p_vjs)
-   {
-      fprintf(stderr,
-              "joymatrix_identity: missing test-ABI symbols.  The wide test "
-              "ABI must export Joystick* / joypad0Buttons / joypad1Buttons "
-              "(exports-test.list and link-test.T).  Build with "
-              "TEST_EXPORTS=1.\n");
-      harness_shutdown(&cfg);
-      return 1;
-   }
 
    rng_state = SWEEP_SEED;
 
@@ -239,6 +205,73 @@ int main(int argc, char **argv)
       }
    }
 
+   *out_full  = digest_full;
+   *out_port1 = digest_port1;
+   *out_reads = reads;
+}
+
+int main(int argc, char **argv)
+{
+   harness_config cfg = HARNESS_CONFIG_DEFAULT;
+   harness_result results[3];
+   unsigned num_results = 0;
+   int print_only = 0;
+   int i;
+   int ok_full, ok_port1;
+
+   void (*p_InputDevSetType)(int, int);
+   void (*p_InputDevReset)(void);
+   void (*p_InputDevFeed)(int, int32_t, int32_t, uint32_t);
+
+   uint32_t digest_full  = FNV1A_OFFSET;
+   uint32_t digest_port1 = FNV1A_OFFSET;
+   unsigned long reads   = 0;
+
+   char detail_full[192];
+   char detail_port1[192];
+   char detail_mouse[192];
+
+   for (i = 1; i < argc; i++)
+   {
+      if (strcmp(argv[i], "--print") == 0)
+         print_only = 1;
+   }
+
+   cfg.frames = 0;
+   if (!harness_init_from_args(&cfg, argc, argv))
+      return 1;
+
+   /* A ROM is loaded purely so the core is properly initialised (and so
+    * harness_shutdown's retro_deinit is balanced).  No frame is ever run,
+    * so update_input() never touches joypadNButtons -- the sweep owns
+    * every input this test reads. */
+   if (!cfg.rom_path)
+      cfg.rom_path = "test/roms/yarc.j64";
+   if (!harness_load_rom(&cfg))
+      return 1;
+
+   p_JoystickReadWord  = (uint16_t (*)(uint32_t))
+                            harness_dlsym(&cfg, "JoystickReadWord");
+   p_JoystickWriteWord = (void (*)(uint32_t, uint16_t))
+                            harness_dlsym(&cfg, "JoystickWriteWord");
+   p_joypad0Buttons    = (uint8_t *)harness_dlsym(&cfg, "joypad0Buttons");
+   p_joypad1Buttons    = (uint8_t *)harness_dlsym(&cfg, "joypad1Buttons");
+   p_vjs               = (struct VJSettings *)harness_dlsym(&cfg, "vjs");
+
+   if (!p_JoystickReadWord || !p_JoystickWriteWord ||
+       !p_joypad0Buttons || !p_joypad1Buttons || !p_vjs)
+   {
+      fprintf(stderr,
+              "joymatrix_identity: missing test-ABI symbols.  The wide test "
+              "ABI must export Joystick* / joypad0Buttons / joypad1Buttons "
+              "(exports-test.list and link-test.T).  Build with "
+              "TEST_EXPORTS=1.\n");
+      harness_shutdown(&cfg);
+      return 1;
+   }
+
+   run_sweep(&digest_full, &digest_port1, &reads);
+
    ok_full  = (digest_full  == EXPECT_DIGEST_FULL);
    ok_port1 = (digest_port1 == EXPECT_DIGEST_PORT1);
 
@@ -275,6 +308,51 @@ int main(int argc, char **argv)
    results[num_results].name   = "joymatrix_identity_port1";
    results[num_results].detail = detail_port1;
    num_results++;
+
+   /* Third assertion: a port-2 mouse must not perturb port 1's own bits.
+    * The mouse's overlay drives $F14000 bits 12-15 and $F14002 bits 2-3
+    * in EVERY row (it is row-blind), which is precisely the shape of
+    * change that could leak sideways if a mask were written wrong. */
+   p_InputDevSetType = (void (*)(int, int))
+                          harness_dlsym(&cfg, "InputDevSetType");
+   p_InputDevReset   = (void (*)(void))harness_dlsym(&cfg, "InputDevReset");
+   p_InputDevFeed    = (void (*)(int, int32_t, int32_t, uint32_t))
+                          harness_dlsym(&cfg, "InputDevFeed");
+
+   if (p_InputDevSetType && p_InputDevReset && p_InputDevFeed)
+   {
+      uint32_t mouse_full, mouse_port1;
+      unsigned long mouse_reads;
+      int ok_mouse;
+
+      p_InputDevSetType(1, 1);          /* INPUTDEV_MOUSE_ST */
+      p_InputDevReset();
+      /* Enough motion that the encoder is draining throughout the sweep,
+       * with both buttons held, so every mouse-driven bit is live. */
+      p_InputDevFeed(1, 4000, -4000, 0x03);
+
+      run_sweep(&mouse_full, &mouse_port1, &mouse_reads);
+
+      p_InputDevSetType(1, 0);          /* INPUTDEV_PAD */
+      p_InputDevReset();
+
+      ok_mouse = (mouse_port1 == EXPECT_DIGEST_PORT1);
+      sprintf(detail_mouse,
+              "port-1 bits with an ST mouse on port 2: 0x%08X (expected "
+              "0x%08X); port-2 bits did move (full 0x%08X)",
+              mouse_port1, (unsigned)EXPECT_DIGEST_PORT1, mouse_full);
+
+      results[num_results].status = ok_mouse ? "PASS" : "FAIL";
+      results[num_results].name   = "joymatrix_identity_port1_with_mouse";
+      results[num_results].detail = detail_mouse;
+      num_results++;
+
+      if (!ok_mouse)
+         ok_port1 = 0;
+   }
+   else
+      printf("joymatrix_identity: InputDev* not in the test ABI -- skipping "
+             "the port-2-mouse isolation assertion (build predates #429)\n");
 
    harness_report(&cfg, results, num_results);
 

--- a/test/tools/joymatrix_identity.c
+++ b/test/tools/joymatrix_identity.c
@@ -110,6 +110,19 @@ static const uint8_t sweep_hi_bytes[4] = { 0x00, 0x01, 0x80, 0x81 };
 #define EXPECT_DIGEST_FULL    0xC24DDCDEu
 #define EXPECT_DIGEST_PORT1   0xD0CD02E2u
 
+/* Third sweep: the same domain with an ST mouse attached to port 2.  This
+ * one is NOT a develop measurement -- it is measured on the device layer
+ * and is the only assertion that pins the mouse's own bits.
+ *
+ * Why it has to exist: every check in mouse_decode_test compares Gray
+ * indices modulo 4, so inverting the active-low polarity on the direction
+ * lines (inputdev.c, `if (!ax)` -> `if (ax)`) shifts the index by a
+ * constant +2 mod 4 and every one of them still passes -- test_directions,
+ * test_rate_ceiling, test_poll_shapes, test_case_discrimination, and even
+ * `phase_seen != 0x0F`, which reads $D under the inversion.  This digest
+ * folds the raw register words, so a constant phase offset moves it. */
+#define EXPECT_DIGEST_FULL_WITH_MOUSE 0x5E1858EAu
+
 /* ---- FNV-1a ---------------------------------------------------------- */
 
 #define FNV1A_OFFSET 2166136261u
@@ -216,11 +229,11 @@ static void run_sweep(uint32_t *out_full, uint32_t *out_port1,
 int main(int argc, char **argv)
 {
    harness_config cfg = HARNESS_CONFIG_DEFAULT;
-   harness_result results[3];
+   harness_result results[4];
    unsigned num_results = 0;
    int print_only = 0;
    int i;
-   int ok_full, ok_port1;
+   int ok_full, ok_port1, ok_mouse_port1, ok_mouse_full;
 
    void (*p_InputDevSetType)(int, InputDevType);
    void (*p_InputDevReset)(void);
@@ -230,9 +243,14 @@ int main(int argc, char **argv)
    uint32_t digest_port1 = FNV1A_OFFSET;
    unsigned long reads   = 0;
 
+   uint32_t mouse_full   = FNV1A_OFFSET;
+   uint32_t mouse_port1  = FNV1A_OFFSET;
+   unsigned long mouse_reads = 0;
+
    char detail_full[192];
    char detail_port1[192];
    char detail_mouse[192];
+   char detail_mouse_full[192];
 
    for (i = 1; i < argc; i++)
    {
@@ -273,10 +291,55 @@ int main(int argc, char **argv)
       return 1;
    }
 
+   /* The device-layer symbols are resolved BEFORE the pad-only sweep so a
+    * build that cannot run the mouse assertion fails loudly here rather
+    * than half-running.  A skip is exit 77 (never a silent 0): the live
+    * trigger for this branch is an exports-test.list / link-test.T
+    * divergence, which is a build bug in this repo, not an environment. */
+   p_InputDevSetType = (void (*)(int, InputDevType))
+                          harness_dlsym(&cfg, "InputDevSetType");
+   p_InputDevReset   = (void (*)(void))harness_dlsym(&cfg, "InputDevReset");
+   p_InputDevFeed    = (void (*)(int, int32_t, int32_t, uint32_t))
+                          harness_dlsym(&cfg, "InputDevFeed");
+
+   if (!p_InputDevSetType || !p_InputDevReset || !p_InputDevFeed)
+   {
+      fprintf(stderr,
+              "joymatrix_identity: InputDevSetType/Reset/Feed are not in the "
+              "test ABI, so the port-2-mouse assertions cannot run.  Since "
+              "#429 these are part of the wide ABI -- check exports-test.list "
+              "and link-test.T.  Exiting 77 (skip), NOT 0.\n");
+      harness_shutdown(&cfg);
+      return 77;
+   }
+
    run_sweep(&digest_full, &digest_port1, &reads);
 
-   ok_full  = (digest_full  == EXPECT_DIGEST_FULL);
-   ok_port1 = (digest_port1 == EXPECT_DIGEST_PORT1);
+   /* Second sweep, identical domain, with an ST mouse on port 2.
+    *
+    * The feed is clamped to QUAD_MAX_BACKLOG (64) by QuadFeed, and the
+    * encoder is clocked at most once per read whose port-2 row select is
+    * asserted, so it drains over the first 64 qualifying polls of the
+    * ~131,072 in the sweep and then holds a fixed phase for the rest.
+    * That is deliberate and sufficient: the polarity class this digest
+    * exists to catch shifts the held phase by a constant, which moves the
+    * folded bits on every one of those reads.  (Re-feeding inside
+    * run_sweep() would put mouse-specific code in the function that also
+    * produces digests 1 and 2 -- the one place this file must not
+    * perturb.)  Both buttons are held for the whole sweep. */
+   p_InputDevSetType(1, INPUTDEV_MOUSE_ST);
+   p_InputDevReset();
+   p_InputDevFeed(1, 4000, -4000, 0x03);
+
+   run_sweep(&mouse_full, &mouse_port1, &mouse_reads);
+
+   p_InputDevSetType(1, INPUTDEV_PAD);
+   p_InputDevReset();
+
+   ok_full        = (digest_full  == EXPECT_DIGEST_FULL);
+   ok_port1       = (digest_port1 == EXPECT_DIGEST_PORT1);
+   ok_mouse_port1 = (mouse_port1  == EXPECT_DIGEST_PORT1);
+   ok_mouse_full  = (mouse_full   == EXPECT_DIGEST_FULL_WITH_MOUSE);
 
    if (print_only)
    {
@@ -284,10 +347,14 @@ int main(int argc, char **argv)
              " x %d vectors x 4 offsets = %lu reads (seed 0x%08X)\n",
              2, 4, SWEEP_ROW_BYTES, SWEEP_VECTORS, reads,
              (unsigned)SWEEP_SEED);
-      printf("joymatrix_identity: EXPECT_DIGEST_FULL  = 0x%08Xu\n",
+      printf("joymatrix_identity: EXPECT_DIGEST_FULL            = 0x%08Xu\n",
              digest_full);
-      printf("joymatrix_identity: EXPECT_DIGEST_PORT1 = 0x%08Xu\n",
+      printf("joymatrix_identity: EXPECT_DIGEST_PORT1           = 0x%08Xu\n",
              digest_port1);
+      printf("joymatrix_identity: EXPECT_DIGEST_FULL_WITH_MOUSE = 0x%08Xu\n",
+             mouse_full);
+      printf("joymatrix_identity: (port-1 bits with the mouse    = 0x%08X, "
+             "must equal EXPECT_DIGEST_PORT1)\n", mouse_port1);
       harness_shutdown(&cfg);
       return 0;
    }
@@ -316,48 +383,38 @@ int main(int argc, char **argv)
     * The mouse's overlay drives $F14000 bits 12-15 and $F14002 bits 2-3
     * in EVERY row (it is row-blind), which is precisely the shape of
     * change that could leak sideways if a mask were written wrong. */
-   p_InputDevSetType = (void (*)(int, InputDevType))
-                          harness_dlsym(&cfg, "InputDevSetType");
-   p_InputDevReset   = (void (*)(void))harness_dlsym(&cfg, "InputDevReset");
-   p_InputDevFeed    = (void (*)(int, int32_t, int32_t, uint32_t))
-                          harness_dlsym(&cfg, "InputDevFeed");
+   sprintf(detail_mouse,
+           "port-1 bits with an ST mouse on port 2: 0x%08X (expected 0x%08X)",
+           mouse_port1, (unsigned)EXPECT_DIGEST_PORT1);
 
-   if (p_InputDevSetType && p_InputDevReset && p_InputDevFeed)
-   {
-      uint32_t mouse_full, mouse_port1;
-      unsigned long mouse_reads;
-      int ok_mouse;
+   results[num_results].status = ok_mouse_port1 ? "PASS" : "FAIL";
+   results[num_results].name   = "joymatrix_identity_port1_with_mouse";
+   results[num_results].detail = detail_mouse;
+   num_results++;
 
-      p_InputDevSetType(1, INPUTDEV_MOUSE_ST);
-      p_InputDevReset();
-      /* Enough motion that the encoder is draining throughout the sweep,
-       * with both buttons held, so every mouse-driven bit is live. */
-      p_InputDevFeed(1, 4000, -4000, 0x03);
+   /* Fourth assertion: the mouse's OWN bits.  Without this the third one
+    * only proves the mouse did not break port 1 -- a mouse that emitted
+    * nothing at all, or emitted the right waveform with inverted
+    * polarity, would pass it. */
+   sprintf(detail_mouse_full,
+           "full digest with an ST mouse on port 2: 0x%08X (expected 0x%08X); "
+           "%lu reads",
+           mouse_full, (unsigned)EXPECT_DIGEST_FULL_WITH_MOUSE, mouse_reads);
 
-      run_sweep(&mouse_full, &mouse_port1, &mouse_reads);
-
-      p_InputDevSetType(1, INPUTDEV_PAD);
-      p_InputDevReset();
-
-      ok_mouse = (mouse_port1 == EXPECT_DIGEST_PORT1);
-      sprintf(detail_mouse,
-              "port-1 bits with an ST mouse on port 2: 0x%08X (expected "
-              "0x%08X); port-2 bits did move (full 0x%08X)",
-              mouse_port1, (unsigned)EXPECT_DIGEST_PORT1, mouse_full);
-
-      results[num_results].status = ok_mouse ? "PASS" : "FAIL";
-      results[num_results].name   = "joymatrix_identity_port1_with_mouse";
-      results[num_results].detail = detail_mouse;
-      num_results++;
-
-      if (!ok_mouse)
-         ok_port1 = 0;
-   }
-   else
-      printf("joymatrix_identity: InputDev* not in the test ABI -- skipping "
-             "the port-2-mouse isolation assertion (build predates #429)\n");
+   results[num_results].status = ok_mouse_full ? "PASS" : "FAIL";
+   results[num_results].name   = "joymatrix_identity_full_with_mouse";
+   results[num_results].detail = detail_mouse_full;
+   num_results++;
 
    harness_report(&cfg, results, num_results);
+
+   if (!ok_mouse_port1 || !ok_mouse_full)
+      fprintf(stderr,
+              "joymatrix_identity: the port-2 MOUSE overlay changed.  A "
+              "moved full-with-mouse digest with digests 1 and 2 intact "
+              "means the device layer changed, not the joystick path -- "
+              "check the wiring table and the active-low polarity in "
+              "src/jerry/inputdev.c before re-baselining anything.\n");
 
    if (!ok_full || !ok_port1)
       fprintf(stderr,
@@ -367,5 +424,8 @@ int main(int argc, char **argv)
               "commit; do not silently update the constants.\n");
 
    harness_shutdown(&cfg);
-   return (ok_full && ok_port1) ? 0 : 1;
+   /* All four assertions gate the exit status.  (An earlier revision folded
+    * the mouse result into ok_port1 instead; a FAIL row that does not reach
+    * the exit code is the skip-as-pass class wearing a different hat.) */
+   return (ok_full && ok_port1 && ok_mouse_port1 && ok_mouse_full) ? 0 : 1;
 }

--- a/test/tools/joymatrix_identity.c
+++ b/test/tools/joymatrix_identity.c
@@ -1,0 +1,290 @@
+/*
+ * test/tools/joymatrix_identity.c -- $F14000 / $F14002 identity guardrail.
+ *
+ * WHAT THIS IS FOR
+ * ================
+ * The input-devices track (#428) adds an ST/Amiga mouse (#429) and a
+ * Tempest rotary (#436) to the joystick read path.  Both issues name the
+ * same acceptance condition: with no such device selected, $F14000 and
+ * $F14002 must behave EXACTLY as they do today.
+ *
+ * This tool is that condition expressed as a number.  It sweeps the whole
+ * input domain of JoystickReadWord()/JoystickWriteWord() and folds every
+ * result into an FNV-1a digest, which is asserted against a constant
+ * measured on develop.  Any perturbation of the joystick path -- a changed
+ * mask, a bit asserted in the wrong row, an overlay that fires when it
+ * should not -- moves the digest.
+ *
+ * It is committed BEFORE any device code exists, so later PRs are measured
+ * against a number that predates them.
+ *
+ * WHAT IS SWEPT
+ * =============
+ * These are exactly the inputs JoystickReadWord() reads.  Nothing else
+ * reaches it, which is what makes one hard-coded constant valid on every
+ * host:
+ *
+ *   joystick_ram[1]        all 256 values -- both row-select nibbles, so
+ *                          every (port-1 row, port-2 row) pair including
+ *                          the 0xFF "not a socket-0 code" cases
+ *   write-word bit 15      output enable.  It gates the early return in
+ *                          JoystickReadWord, i.e. the one structural risk
+ *                          the device layer runs (see the design spec's
+ *                          "joysticksEnabled is deliberately NOT touched")
+ *   write-word bit 8       audio enable, swept alongside it
+ *   joypad0Buttons[0..20]  64 seeded pseudo-random vectors, ALL 21 slots
+ *   joypad1Buttons[0..20]  (indices 0-15 are reached as offsetN + i,
+ *                          16-20 as BUTTON_A..BUTTON_PAUSE at $F14002)
+ *   vjs.hardwareTypeNTSC   both ways -- $F14002 bakes the NTSC bit into
+ *                          its return value, so a one-sided sweep would
+ *                          make the digest host-config-dependent
+ *
+ * and for each combination it reads register offsets 0, 1, 2 and 3.
+ * Offsets 1 and 3 hit the fallthrough `return 0xFFFF` today; folding them
+ * pins that too.
+ *
+ * A button slot is filled from a random BIT (pressed / released), not a
+ * random byte: a uniform byte would be non-zero 255 times in 256 and the
+ * sweep would essentially never exercise "released".  When pressed, the
+ * value is a varying non-zero, so a change from truthiness to `== 1` also
+ * trips the digest.
+ *
+ * TWO ASSERTIONS
+ * ==============
+ *   full digest  -- everything above.  "Nothing changed at all."
+ *   port-1 digest -- the same sweep folding only port 1's own bits
+ *                   ($F14000 bits 8-11, $F14002 bits 0-1).  A port-2
+ *                   device must not perturb port 1; measured here on a
+ *                   pad-only build so a later PR cannot derive its own
+ *                   baseline from a build that already carries the
+ *                   perturbation.
+ *
+ * The digest is a pure function of the sweep, so it is reproducible on any
+ * host: reads are folded byte-by-byte in a fixed order (endian-independent)
+ * and the PRNG is explicit fixed-width unsigned arithmetic, never rand().
+ * The loop order below is part of the digest's definition -- changing it
+ * changes the constants.
+ *
+ * USAGE
+ *   ./test/tools/joymatrix_identity ./virtualjaguar_libretro.dylib [rom]
+ *   --print   report the measured digests and exit 0 without asserting
+ *             (use when a change to the sweep itself needs re-baselining;
+ *             never for verification)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../harness/harness.h"
+#include "settings.h"
+
+/* ---- sweep parameters (part of the digest's definition) ------------- */
+
+#define SWEEP_ROW_BYTES   256      /* joystick_ram[1], all values         */
+#define SWEEP_VECTORS      64      /* button vectors per write word       */
+#define SWEEP_SEED  0x1D872B41u    /* xorshift32 seed                     */
+#define BUTTON_SLOTS       21      /* BUTTON_U .. BUTTON_PAUSE            */
+
+/* High byte of the write word: bit 15 (output enable) and bit 8 (audio),
+ * both set and clear. */
+static const uint8_t sweep_hi_bytes[4] = { 0x00, 0x01, 0x80, 0x81 };
+
+/* Expected digests, measured on develop at 1aa9c43 (the merge-base of
+ * this branch) with the joystick path untouched.  If you change the sweep
+ * above, re-measure with --print and update BOTH of these in the same
+ * commit; if you did NOT change the sweep, a mismatch is a real change in
+ * $F14000/$F14002 behaviour and must be explained, not re-baselined. */
+#define EXPECT_DIGEST_FULL    0xC24DDCDEu
+#define EXPECT_DIGEST_PORT1   0xD0CD02E2u
+
+/* ---- FNV-1a ---------------------------------------------------------- */
+
+#define FNV1A_OFFSET 2166136261u
+#define FNV1A_PRIME  16777619u
+
+static void fold_byte(uint32_t *h, uint8_t b)
+{
+   *h ^= (uint32_t)b;
+   *h *= FNV1A_PRIME;
+}
+
+/* Fixed byte order -> the digest does not depend on host endianness. */
+static void fold_word(uint32_t *h, uint16_t w)
+{
+   fold_byte(h, (uint8_t)((w >> 8) & 0xFF));
+   fold_byte(h, (uint8_t)(w & 0xFF));
+}
+
+/* ---- xorshift32 (explicit, reproducible; never rand()) --------------- */
+
+static uint32_t rng_state;
+
+static uint32_t rng_next(void)
+{
+   uint32_t x = rng_state;
+   x ^= x << 13;
+   x ^= x >> 17;
+   x ^= x << 5;
+   rng_state = x;
+   return x;
+}
+
+int main(int argc, char **argv)
+{
+   harness_config cfg = HARNESS_CONFIG_DEFAULT;
+   harness_result results[2];
+   unsigned num_results = 0;
+   int print_only = 0;
+   int i;
+   int ok_full, ok_port1;
+
+   uint16_t (*p_JoystickReadWord)(uint32_t);
+   void     (*p_JoystickWriteWord)(uint32_t, uint16_t);
+   uint8_t  *p_joypad0Buttons;
+   uint8_t  *p_joypad1Buttons;
+   struct VJSettings *p_vjs;
+
+   uint32_t digest_full  = FNV1A_OFFSET;
+   uint32_t digest_port1 = FNV1A_OFFSET;
+   unsigned long reads   = 0;
+
+   int ntsc_idx;
+   unsigned hi_idx, lo, vec, slot, off;
+   char detail_full[192];
+   char detail_port1[192];
+
+   for (i = 1; i < argc; i++)
+   {
+      if (strcmp(argv[i], "--print") == 0)
+         print_only = 1;
+   }
+
+   cfg.frames = 0;
+   if (!harness_init_from_args(&cfg, argc, argv))
+      return 1;
+
+   /* A ROM is loaded purely so the core is properly initialised (and so
+    * harness_shutdown's retro_deinit is balanced).  No frame is ever run,
+    * so update_input() never touches joypadNButtons -- the sweep owns
+    * every input this test reads. */
+   if (!cfg.rom_path)
+      cfg.rom_path = "test/roms/yarc.j64";
+   if (!harness_load_rom(&cfg))
+      return 1;
+
+   p_JoystickReadWord  = (uint16_t (*)(uint32_t))
+                            harness_dlsym(&cfg, "JoystickReadWord");
+   p_JoystickWriteWord = (void (*)(uint32_t, uint16_t))
+                            harness_dlsym(&cfg, "JoystickWriteWord");
+   p_joypad0Buttons    = (uint8_t *)harness_dlsym(&cfg, "joypad0Buttons");
+   p_joypad1Buttons    = (uint8_t *)harness_dlsym(&cfg, "joypad1Buttons");
+   p_vjs               = (struct VJSettings *)harness_dlsym(&cfg, "vjs");
+
+   if (!p_JoystickReadWord || !p_JoystickWriteWord ||
+       !p_joypad0Buttons || !p_joypad1Buttons || !p_vjs)
+   {
+      fprintf(stderr,
+              "joymatrix_identity: missing test-ABI symbols.  The wide test "
+              "ABI must export Joystick* / joypad0Buttons / joypad1Buttons "
+              "(exports-test.list and link-test.T).  Build with "
+              "TEST_EXPORTS=1.\n");
+      harness_shutdown(&cfg);
+      return 1;
+   }
+
+   rng_state = SWEEP_SEED;
+
+   for (ntsc_idx = 0; ntsc_idx < 2; ntsc_idx++)
+   {
+      p_vjs->hardwareTypeNTSC = (ntsc_idx == 0) ? true : false;
+
+      for (hi_idx = 0; hi_idx < 4; hi_idx++)
+      {
+         for (lo = 0; lo < SWEEP_ROW_BYTES; lo++)
+         {
+            uint16_t word = (uint16_t)(((uint16_t)sweep_hi_bytes[hi_idx] << 8)
+                                       | (uint16_t)lo);
+
+            for (vec = 0; vec < SWEEP_VECTORS; vec++)
+            {
+               for (slot = 0; slot < BUTTON_SLOTS; slot++)
+               {
+                  uint32_t r0 = rng_next();
+                  uint32_t r1 = rng_next();
+                  p_joypad0Buttons[slot] = (r0 & 1u)
+                     ? (uint8_t)(1u + ((r0 >> 1) & 0x7Fu)) : (uint8_t)0;
+                  p_joypad1Buttons[slot] = (r1 & 1u)
+                     ? (uint8_t)(1u + ((r1 >> 1) & 0x7Fu)) : (uint8_t)0;
+               }
+
+               p_JoystickWriteWord(0, word);
+
+               for (off = 0; off < 4; off++)
+               {
+                  uint16_t got = p_JoystickReadWord(off);
+                  fold_word(&digest_full, got);
+                  reads++;
+
+                  /* Port-1 sub-digest: only port 1's own bits.
+                   * $F14000 bits 8-11 (J8..J11), $F14002 bits 0-1 (B0/B1). */
+                  if (off == 0)
+                     fold_word(&digest_port1, (uint16_t)(got & 0x0F00u));
+                  else if (off == 2)
+                     fold_word(&digest_port1, (uint16_t)(got & 0x0003u));
+               }
+            }
+         }
+      }
+   }
+
+   ok_full  = (digest_full  == EXPECT_DIGEST_FULL);
+   ok_port1 = (digest_port1 == EXPECT_DIGEST_PORT1);
+
+   if (print_only)
+   {
+      printf("joymatrix_identity: sweep = %d ntsc x %d hi-bytes x %d row bytes"
+             " x %d vectors x 4 offsets = %lu reads (seed 0x%08X)\n",
+             2, 4, SWEEP_ROW_BYTES, SWEEP_VECTORS, reads,
+             (unsigned)SWEEP_SEED);
+      printf("joymatrix_identity: EXPECT_DIGEST_FULL  = 0x%08Xu\n",
+             digest_full);
+      printf("joymatrix_identity: EXPECT_DIGEST_PORT1 = 0x%08Xu\n",
+             digest_port1);
+      harness_shutdown(&cfg);
+      return 0;
+   }
+
+   sprintf(detail_full,
+           "digest 0x%08X (expected 0x%08X); %lu reads, seed 0x%08X, "
+           "%d row bytes x %d vectors",
+           digest_full, (unsigned)EXPECT_DIGEST_FULL, reads,
+           (unsigned)SWEEP_SEED, SWEEP_ROW_BYTES, SWEEP_VECTORS);
+   sprintf(detail_port1,
+           "port-1 bits digest 0x%08X (expected 0x%08X); "
+           "$F14000 bits 8-11 + $F14002 bits 0-1",
+           digest_port1, (unsigned)EXPECT_DIGEST_PORT1);
+
+   results[num_results].status = ok_full ? "PASS" : "FAIL";
+   results[num_results].name   = "joymatrix_identity_full";
+   results[num_results].detail = detail_full;
+   num_results++;
+
+   results[num_results].status = ok_port1 ? "PASS" : "FAIL";
+   results[num_results].name   = "joymatrix_identity_port1";
+   results[num_results].detail = detail_port1;
+   num_results++;
+
+   harness_report(&cfg, results, num_results);
+
+   if (!ok_full || !ok_port1)
+      fprintf(stderr,
+              "joymatrix_identity: $F14000/$F14002 behaviour CHANGED.  This "
+              "test exists to catch exactly that.  If the change is "
+              "deliberate, say so and re-baseline with --print in the same "
+              "commit; do not silently update the constants.\n");
+
+   harness_shutdown(&cfg);
+   return (ok_full && ok_port1) ? 0 : 1;
+}

--- a/test/tools/joymatrix_identity.c
+++ b/test/tools/joymatrix_identity.c
@@ -86,6 +86,9 @@
 #include <stdint.h>
 
 #include "../harness/harness.h"
+/* For InputDevType: dlsym'd pointers must carry the real signature, or
+ * UBSan -fsanitize=function aborts the suite on a type mismatch. */
+#include "../../src/jerry/inputdev.h"
 #include "settings.h"
 
 /* ---- sweep parameters (part of the digest's definition) ------------- */
@@ -219,7 +222,7 @@ int main(int argc, char **argv)
    int i;
    int ok_full, ok_port1;
 
-   void (*p_InputDevSetType)(int, int);
+   void (*p_InputDevSetType)(int, InputDevType);
    void (*p_InputDevReset)(void);
    void (*p_InputDevFeed)(int, int32_t, int32_t, uint32_t);
 
@@ -313,7 +316,7 @@ int main(int argc, char **argv)
     * The mouse's overlay drives $F14000 bits 12-15 and $F14002 bits 2-3
     * in EVERY row (it is row-blind), which is precisely the shape of
     * change that could leak sideways if a mask were written wrong. */
-   p_InputDevSetType = (void (*)(int, int))
+   p_InputDevSetType = (void (*)(int, InputDevType))
                           harness_dlsym(&cfg, "InputDevSetType");
    p_InputDevReset   = (void (*)(void))harness_dlsym(&cfg, "InputDevReset");
    p_InputDevFeed    = (void (*)(int, int32_t, int32_t, uint32_t))
@@ -325,7 +328,7 @@ int main(int argc, char **argv)
       unsigned long mouse_reads;
       int ok_mouse;
 
-      p_InputDevSetType(1, 1);          /* INPUTDEV_MOUSE_ST */
+      p_InputDevSetType(1, INPUTDEV_MOUSE_ST);
       p_InputDevReset();
       /* Enough motion that the encoder is draining throughout the sweep,
        * with both buttons held, so every mouse-driven bit is live. */
@@ -333,7 +336,7 @@ int main(int argc, char **argv)
 
       run_sweep(&mouse_full, &mouse_port1, &mouse_reads);
 
-      p_InputDevSetType(1, 0);          /* INPUTDEV_PAD */
+      p_InputDevSetType(1, INPUTDEV_PAD);
       p_InputDevReset();
 
       ok_mouse = (mouse_port1 == EXPECT_DIGEST_PORT1);

--- a/test/tools/mouse_decode_test.c
+++ b/test/tools/mouse_decode_test.c
@@ -59,11 +59,19 @@
 #include "../harness/harness.h"
 
 /* Mirrors src/jerry/inputdev.h; the tool must not include emulator
- * headers it would then be testing against itself. */
-#define DEV_PAD                 0
-#define DEV_MOUSE_ST            1
-#define DEV_MOUSE_AMIGA_ADAPTER 2
-#define DEV_MOUSE_AMIGA_ON_ST   3
+ * headers it would then be testing against itself.  An enum rather than
+ * four #defines because the TYPE is load-bearing as well as the values:
+ * InputDevSetType's second parameter is this enum, and UBSan's
+ * -fsanitize=function compares a dlsym'd pointer's declared signature
+ * against the callee's, so `int` there aborts the whole suite.  Values are
+ * still restated by hand, so a renumbering in the header cannot silently
+ * propagate into this test. */
+typedef enum {
+   DEV_PAD                 = 0,
+   DEV_MOUSE_ST            = 1,
+   DEV_MOUSE_AMIGA_ADAPTER = 2,
+   DEV_MOUSE_AMIGA_ON_ST   = 3
+} InputDevType;
 
 #define BTN_LEFT   0x01
 #define BTN_RIGHT  0x02
@@ -93,7 +101,7 @@ static const char *case_name[4] = {
 
 static uint16_t (*p_ReadWord)(uint32_t);
 static void     (*p_WriteWord)(uint32_t, uint16_t);
-static void     (*p_SetType)(int, int);
+static void     (*p_SetType)(int, InputDevType);
 static void     (*p_SetScale)(int, int32_t);
 static void     (*p_Reset)(void);
 static void     (*p_Feed)(int, int32_t, int32_t, uint32_t);
@@ -586,7 +594,7 @@ int main(int argc, char **argv)
 
    p_ReadWord    = (uint16_t (*)(uint32_t))harness_dlsym(&cfg, "JoystickReadWord");
    p_WriteWord   = (void (*)(uint32_t, uint16_t))harness_dlsym(&cfg, "JoystickWriteWord");
-   p_SetType     = (void (*)(int, int))harness_dlsym(&cfg, "InputDevSetType");
+   p_SetType     = (void (*)(int, InputDevType))harness_dlsym(&cfg, "InputDevSetType");
    p_SetScale    = (void (*)(int, int32_t))harness_dlsym(&cfg, "InputDevSetScale");
    p_Reset       = (void (*)(void))harness_dlsym(&cfg, "InputDevReset");
    p_Feed        = (void (*)(int, int32_t, int32_t, uint32_t))

--- a/test/tools/mouse_decode_test.c
+++ b/test/tools/mouse_decode_test.c
@@ -1,0 +1,637 @@
+/*
+ * test/tools/mouse_decode_test.c -- ST/Amiga mouse end-to-end decode test.
+ *
+ * WHAT THIS PROVES
+ * ================
+ * Synthetic host deltas go in through InputDevFeed(); a quadrature decoder
+ * written here -- independently of src/jerry/quadrature.c, from the truth
+ * table in docs/jaguar-mouse-adapter-mapping.md section 5 -- reads them
+ * back out of $F14000 / $F14002 exactly as a 68K driver would, and the
+ * decoded direction and distance are asserted.  Both directions on both
+ * axes, all three wiring cases, three poll shapes.
+ *
+ * The decoder here is deliberately NOT a call into the encoder: it walks
+ * the register bits, converts (A,B) levels to a Gray index and takes the
+ * modulo-4 difference between consecutive samples, discarding two-state
+ * jumps the way Domin's 16-entry table discards its "undetermined"
+ * entries.  If the emulated device ever emits a two-state jump, DROPPED
+ * goes non-zero and the run fails -- which is the property the whole
+ * emission rule exists to guarantee.
+ *
+ * POLL SHAPES (the emission rule's regression)
+ * ============================================
+ *   A  write $817F, then ONE read per poll        (Domin's own loop)
+ *   B  write $817F once at init, then read-only   (the deferred case)
+ *   C  write $817F, then TWO reads per poll,
+ *      decoding on the second                     (the common driver shape)
+ *
+ * Shape C is why the rule is "arm on write, advance on the next read"
+ * rather than "advance once per read".  Under the naive rule shape C
+ * advances the phase twice between decode steps, i.e. emits exactly the
+ * two-state jump a decoder throws away -- roughly half the motion lost,
+ * as jitter.  Under the real rule shape C decodes identically to shape A
+ * with DROPPED == 0.  Both are asserted below.
+ *
+ * Shape B is expected to decode ZERO motion: a driver that never rewrites
+ * the row select never arms the clock.  No such driver is documented; the
+ * assertion is here as the detector that would justify adding the
+ * stall-breaker, so that "frozen" is a recorded, tested property rather
+ * than a surprise.
+ *
+ * ROW-BLINDNESS
+ * =============
+ * The adapter does not connect Jaguar pins 1-4, so it never sees the row
+ * select and asserts identically in all four rows.  Every read below is
+ * repeated across row codes $817F / $81BF / $81DF / $81EF and the mouse
+ * bits are asserted equal in all four -- for the direction lines and for
+ * both buttons.  That is the check that fails if anyone later "fixes" the
+ * phantom-keypad or the LMB-reads-as-A-B-C-Option behaviour.
+ *
+ * USAGE
+ *   ./test/tools/mouse_decode_test ./virtualjaguar_libretro.dylib [rom]
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../harness/harness.h"
+
+/* Mirrors src/jerry/inputdev.h; the tool must not include emulator
+ * headers it would then be testing against itself. */
+#define DEV_PAD                 0
+#define DEV_MOUSE_ST            1
+#define DEV_MOUSE_AMIGA_ADAPTER 2
+#define DEV_MOUSE_AMIGA_ON_ST   3
+
+#define BTN_LEFT   0x01
+#define BTN_RIGHT  0x02
+
+/* Mirrors INPUTDEV_STATE_SIZE in src/jerry/inputdev.h, restated here
+ * on purpose: 2 ports x (2 axes x (int32 backlog + int32 carry +
+ * uint8 phase) + 2 button latches) + 1 armed byte. */
+#define INPUTDEV_STATE_SIZE_EXPECTED 41
+
+/* Port-2 socket-0 row codes: rows 0, 1, 2, 3 (mapping doc section 2). */
+static const uint16_t row_words[4] = { 0x817F, 0x81BF, 0x81DF, 0x81EF };
+
+/* $F14000 bit pairs per wiring case (mapping doc section 4d). */
+typedef struct { int xa, xb, ya, yb; } wiring;
+static const wiring case_wiring[4] = {
+   /* DEV_PAD, unused                 */ {  0,  0,  0,  0 },
+   /* DEV_MOUSE_ST                    */ { 13, 12, 14, 15 },
+   /* DEV_MOUSE_AMIGA_ADAPTER         */ { 13, 12, 15, 14 },
+   /* DEV_MOUSE_AMIGA_ON_ST           */ { 13, 15, 12, 14 }
+};
+
+static const char *case_name[4] = {
+   "pad", "mouse_st", "mouse_amiga_adapter", "mouse_amiga (case 3)"
+};
+
+/* ---- core entry points ---------------------------------------------- */
+
+static uint16_t (*p_ReadWord)(uint32_t);
+static void     (*p_WriteWord)(uint32_t, uint16_t);
+static void     (*p_SetType)(int, int);
+static void     (*p_SetScale)(int, int32_t);
+static void     (*p_Reset)(void);
+static void     (*p_Feed)(int, int32_t, int32_t, uint32_t);
+static int      (*p_GetType)(int);
+static int      (*p_AnyAttached)(void);
+static size_t   (*p_StateSave)(uint8_t *);
+
+static size_t (*p_serialize_size)(void);
+static int    (*p_serialize)(void *, size_t);
+static int    (*p_unserialize)(const void *, size_t);
+
+/* ---- reporting ------------------------------------------------------- */
+
+static int failures;
+static char detail[256];
+
+static void report(int cond, const char *what)
+{
+   if (cond)
+      printf("  ok   %s\n", what);
+   else
+   {
+      printf("  FAIL %s\n", what);
+      failures++;
+   }
+}
+
+/* ---- decoder (independent of src/jerry/quadrature.c) ----------------- */
+
+/* (A,B) logic levels -> Gray index.  0=(0,0) 1=(1,0) 2=(1,1) 3=(0,1). */
+static int gray_index(int a, int b)
+{
+   if (!a && !b) return 0;
+   if ( a && !b) return 1;
+   if ( a &&  b) return 2;
+   return 3;
+}
+
+static int level_of(uint16_t data, int bit)
+{
+   return (int)((data >> bit) & 1u);
+}
+
+typedef struct
+{
+   int32_t  net_x, net_y;
+   unsigned dropped;
+   unsigned polls;
+} decode_result;
+
+/* One step of the decoder for one axis.  Returns the signed movement, and
+ * bumps *dropped on an undetermined (two-state) transition. */
+static int32_t decode_step(int *prev, int idx, unsigned *dropped)
+{
+   int d;
+
+   if (*prev < 0)
+   {
+      *prev = idx;
+      return 0;
+   }
+
+   d = (idx - *prev) & 3;
+   *prev = idx;
+
+   if (d == 0) return 0;
+   if (d == 1) return 1;
+   if (d == 3) return -1;
+
+   (*dropped)++;   /* d == 2: Domin's "undetermined" entry, discarded */
+   return 0;
+}
+
+/*
+ * Run `polls` poll iterations, feeding `feed_fn`-supplied deltas.
+ * shape: 'A' | 'B' | 'C'.  `decode_case` selects which wiring's bit pairs
+ * the decoder uses -- normally the same as the attached device, but the
+ * axis-independence check deliberately mismatches them.
+ */
+static void run_polls(decode_result *r, char shape, int decode_case,
+                      unsigned polls, int32_t dx_per_poll,
+                      int32_t dy_per_poll, uint32_t buttons)
+{
+   const wiring *w = &case_wiring[decode_case];
+   int prev_x = -1, prev_y = -1;
+   unsigned i, row;
+
+   uint16_t prime;
+
+   (void)row;
+   memset(r, 0, sizeof(*r));
+
+   /* Prime the decoder with a reference sample, exactly as a real driver
+    * does on its first pass: a quadrature decoder cannot report movement
+    * until it has something to compare against.  Safe to read here
+    * because the backlog is empty on entry, so this cannot advance the
+    * encoder.  For shape B this IS the one row-select write the shape is
+    * defined by -- it never writes again. */
+   p_WriteWord(0, row_words[0]);
+   prime  = p_ReadWord(0);
+   prev_x = gray_index(level_of(prime, w->xa), level_of(prime, w->xb));
+   prev_y = gray_index(level_of(prime, w->ya), level_of(prime, w->yb));
+
+   for (i = 0; i < polls; i++)
+   {
+      uint16_t d0;
+      int ax, bx, ay, by;
+
+      if (dx_per_poll || dy_per_poll || buttons)
+         p_Feed(1, dx_per_poll, dy_per_poll, buttons);
+
+      if (shape != 'B')
+         p_WriteWord(0, row_words[0]);
+
+      d0 = p_ReadWord(0);
+      if (shape == 'C')
+         d0 = p_ReadWord(0);          /* second read is the decoded one */
+
+      ax = level_of(d0, w->xa);
+      bx = level_of(d0, w->xb);
+      ay = level_of(d0, w->ya);
+      by = level_of(d0, w->yb);
+
+      r->net_x += decode_step(&prev_x, gray_index(ax, bx), &r->dropped);
+      r->net_y += decode_step(&prev_y, gray_index(ay, by), &r->dropped);
+      r->polls++;
+   }
+}
+
+/*
+ * Row-blindness sweep.  Run only once the backlog has drained, so the
+ * four row reads cannot themselves advance the encoder and the phase is
+ * genuinely constant across the sweep -- otherwise this would be testing
+ * the emission clock, not the adapter's wiring.
+ *
+ * Returns 1 if all four rows agree on $F14000 bits 12-15; fills
+ * btn_l/btn_r with the per-row LMB/RMB assertion.
+ */
+static int sweep_rows(int *btn_l, int *btn_r)
+{
+   uint16_t ref = 0;
+   unsigned row;
+   int      agree = 1;
+
+   for (row = 0; row < 4; row++)
+   {
+      uint16_t v, d2;
+
+      p_WriteWord(0, row_words[row]);
+      v  = p_ReadWord(0);
+      d2 = p_ReadWord(2);
+
+      if (row == 0)
+         ref = (uint16_t)(v & 0xF000u);
+      else if ((uint16_t)(v & 0xF000u) != ref)
+         agree = 0;
+
+      btn_l[row] = ((d2 >> 3) & 1u) ? 0 : 1;
+      btn_r[row] = ((d2 >> 2) & 1u) ? 0 : 1;
+   }
+
+   return agree;
+}
+
+/* ---- individual checks ----------------------------------------------- */
+
+static void attach(int type)
+{
+   p_SetType(1, type);
+   p_SetScale(1, 256);
+   p_Reset();
+}
+
+static void test_directions(int type)
+{
+   decode_result r;
+   int c = type;
+
+   printf("%s: direction and distance\n", case_name[type]);
+
+   /* +X: 1 unit per poll for 40 polls drains exactly, so NET == 40. */
+   attach(type);
+   run_polls(&r, 'A', c, 40, 1, 0, 0);
+   sprintf(detail, "+X 40 units over 40 polls -> NET_X=%d NET_Y=%d dropped=%u",
+           (int)r.net_x, (int)r.net_y, r.dropped);
+   report(r.net_x == 40 && r.net_y == 0 && r.dropped == 0, detail);
+
+   attach(type);
+   run_polls(&r, 'A', c, 40, -1, 0, 0);
+   sprintf(detail, "-X 40 units over 40 polls -> NET_X=%d NET_Y=%d dropped=%u",
+           (int)r.net_x, (int)r.net_y, r.dropped);
+   report(r.net_x == -40 && r.net_y == 0 && r.dropped == 0, detail);
+
+   attach(type);
+   run_polls(&r, 'A', c, 40, 0, 1, 0);
+   sprintf(detail, "+Y 40 units over 40 polls -> NET_X=%d NET_Y=%d dropped=%u",
+           (int)r.net_x, (int)r.net_y, r.dropped);
+   report(r.net_y == 40 && r.net_x == 0 && r.dropped == 0, detail);
+
+   attach(type);
+   run_polls(&r, 'A', c, 40, 0, -1, 0);
+   sprintf(detail, "-Y 40 units over 40 polls -> NET_X=%d NET_Y=%d dropped=%u",
+           (int)r.net_x, (int)r.net_y, r.dropped);
+   report(r.net_y == -40 && r.net_x == 0 && r.dropped == 0, detail);
+
+   /* Diagonal: both axes advance independently and concurrently -- they
+    * are four parallel wires, not a time-multiplexed stream. */
+   attach(type);
+   run_polls(&r, 'A', c, 40, 1, -1, 0);
+   sprintf(detail, "diagonal 40 polls -> NET_X=%d NET_Y=%d dropped=%u",
+           (int)r.net_x, (int)r.net_y, r.dropped);
+   report(r.net_x == 40 && r.net_y == -40 && r.dropped == 0, detail);
+}
+
+static void test_rate_ceiling(int type)
+{
+   decode_result r;
+
+   printf("%s: rate ceiling (lag, never overshoot, never a sign flip)\n",
+          case_name[type]);
+
+   /* 4 units per poll is four times what one poll can carry.  The result
+    * must be exactly one state per poll -- lag -- and never a jump. */
+   attach(type);
+   run_polls(&r, 'A', type, 30, 4, 0, 0);
+   sprintf(detail, "4 units/poll x 30 polls -> NET_X=%d (expect 30), dropped=%u",
+           (int)r.net_x, r.dropped);
+   report(r.net_x == 30 && r.dropped == 0, detail);
+
+   attach(type);
+   run_polls(&r, 'A', type, 30, -4, 0, 0);
+   sprintf(detail, "-4 units/poll x 30 polls -> NET_X=%d (expect -30), dropped=%u",
+           (int)r.net_x, r.dropped);
+   report(r.net_x == -30 && r.dropped == 0, detail);
+}
+
+static void test_poll_shapes(int type)
+{
+   decode_result ra, rb, rc;
+
+   printf("%s: poll shapes (the emission rule)\n", case_name[type]);
+
+   attach(type);
+   run_polls(&ra, 'A', type, 40, 1, 0, 0);
+
+   attach(type);
+   run_polls(&rc, 'C', type, 40, 1, 0, 0);
+
+   sprintf(detail,
+           "shape C (write + TWO reads) decodes as shape A: A=%d C=%d, "
+           "dropped A=%u C=%u",
+           (int)ra.net_x, (int)rc.net_x, ra.dropped, rc.dropped);
+   report(rc.net_x == ra.net_x && rc.dropped == 0 && ra.dropped == 0, detail);
+
+   attach(type);
+   run_polls(&rb, 'B', type, 40, 1, 0, 0);
+   sprintf(detail,
+           "shape B (write once, then read-only) is frozen by design: "
+           "NET_X=%d (expect 0)", (int)rb.net_x);
+   report(rb.net_x == 0, detail);
+}
+
+static void test_row_blindness(int type)
+{
+   decode_result r;
+   int bl[4], br[4];
+   int agree;
+   int phase_seen;
+
+   printf("%s: row-blindness\n", case_name[type]);
+
+   /* Drive to a phase that is NOT all-ones on the mouse bits (so "the
+    * rows agree" is not trivially true of an idle adapter), with the
+    * backlog fully drained, then hold both buttons. */
+   attach(type);
+   run_polls(&r, 'A', type, 21, 1, 0, BTN_LEFT | BTN_RIGHT);
+
+   agree = sweep_rows(bl, br);
+
+   p_WriteWord(0, row_words[0]);
+   phase_seen = (int)((p_ReadWord(0) >> 12) & 0x0Fu);
+
+   sprintf(detail,
+           "$F14000 bits 12-15 read identically in rows 0-3 (value $%X)",
+           phase_seen);
+   report(agree && phase_seen != 0x0F, detail);
+
+   sprintf(detail, "LMB asserts $F14002 bit 3 in every row (%d%d%d%d)",
+           bl[0], bl[1], bl[2], bl[3]);
+   report(bl[0] && bl[1] && bl[2] && bl[3], detail);
+
+   sprintf(detail, "RMB asserts $F14002 bit 2 in every row (%d%d%d%d)",
+           br[0], br[1], br[2], br[3]);
+   report(br[0] && br[1] && br[2] && br[3], detail);
+
+   /* Released buttons must not assert. */
+   attach(type);
+   run_polls(&r, 'A', type, 10, 1, 0, 0);
+   sweep_rows(bl, br);
+   report(!bl[0] && !bl[1] && !bl[2] && !bl[3]
+          && !br[0] && !br[1] && !br[2] && !br[3],
+          "released buttons leave $F14002 bits 2 and 3 high in every row");
+}
+
+static void test_case_discrimination(void)
+{
+   decode_result r;
+
+   printf("wiring cases are genuinely distinct\n");
+
+   /* Case 3 (Amiga mouse in an ST-wired adapter) pairs X = {13,15} and
+    * Y = {12,14}; case 1 pairs X = {13,12} and Y = {14,15}.  Each case-1
+    * "pair" therefore straddles one line from each real axis, so pure X
+    * motion decodes as an oscillation on both and nets out to nothing.
+    * This is the discriminator the mapping doc's section 8 A names: a
+    * user on the wrong option value sees a cursor that barely moves, not
+    * a merely inverted one. */
+   attach(DEV_MOUSE_AMIGA_ON_ST);
+   run_polls(&r, 'A', DEV_MOUSE_ST, 40, 1, 0, 0);
+   sprintf(detail,
+           "case-3 wiring read with a case-1 decoder does not decode cleanly "
+           "(NET_X=%d NET_Y=%d dropped=%u; the matching decoder gives 40/0/0)",
+           (int)r.net_x, (int)r.net_y, r.dropped);
+   report(!(r.net_x == 40 && r.net_y == 0 && r.dropped == 0), detail);
+
+   /* Cases 1 and 2 share their lines and differ only in Y phase sense,
+    * so a case-2 device read with a case-1 decoder must invert Y and
+    * leave X alone.  UNVERIFIED per the mapping doc section 8 B: this
+    * asserts the table as implemented, not a measured hardware fact. */
+   attach(DEV_MOUSE_AMIGA_ADAPTER);
+   run_polls(&r, 'A', DEV_MOUSE_ST, 40, 0, 1, 0);
+   sprintf(detail,
+           "case-2 wiring read with a case-1 decoder inverts Y only "
+           "(NET_X=%d NET_Y=%d)", (int)r.net_x, (int)r.net_y);
+   report(r.net_x == 0 && r.net_y == -40, detail);
+}
+
+static void test_pad_is_inert(void)
+{
+   decode_result r;
+   int bl[4], br[4];
+   unsigned i;
+
+   printf("no device selected -> the overlay is inert\n");
+
+   p_SetType(1, DEV_PAD);
+   p_Reset();
+
+   report(p_GetType(1) == DEV_PAD && p_AnyAttached() == 0,
+          "port 2 reports pad and nothing is attached");
+
+   /* Feeding a detached port must do nothing at all. */
+   for (i = 0; i < 20; i++)
+      p_Feed(1, 100, 100, BTN_LEFT | BTN_RIGHT);
+
+   run_polls(&r, 'A', DEV_MOUSE_ST, 20, 0, 0, 0);
+   sweep_rows(bl, br);
+   sprintf(detail, "no motion or buttons reach $F14000/$F14002 "
+           "(NET_X=%d NET_Y=%d LMB=%d RMB=%d)",
+           (int)r.net_x, (int)r.net_y, bl[0], br[0]);
+   report(r.net_x == 0 && r.net_y == 0 && !bl[0] && !br[0], detail);
+}
+
+static void test_port1_rejects_mouse(void)
+{
+   printf("port scope\n");
+   p_SetType(0, DEV_MOUSE_ST);
+   report(p_GetType(0) == DEV_PAD,
+          "InputDevSetType refuses a mouse on port 1 "
+          "(vendor-documented port-2 device)");
+   p_SetType(0, DEV_PAD);
+}
+
+static void test_savestate(void)
+{
+   uint8_t *snap;
+   size_t   sz;
+   decode_result cont, restored;
+   int      ok;
+
+   printf("savestate round-trip mid-motion\n");
+
+   if (!p_serialize || !p_unserialize || !p_serialize_size)
+   {
+      report(0, "retro_serialize/retro_unserialize resolvable");
+      return;
+   }
+
+   sz   = p_serialize_size();
+   snap = (uint8_t *)malloc(sz);
+   if (!snap)
+   {
+      report(0, "allocate state buffer");
+      return;
+   }
+
+   /* Drive the encoder into the middle of a Gray cycle with a non-empty
+    * backlog and a non-zero Q8 carry, then save. */
+   attach(DEV_MOUSE_ST);
+   p_SetScale(1, 96);               /* 37.5%: guarantees a carry remainder */
+   run_polls(&cont, 'A', DEV_MOUSE_ST, 7, 3, 2, BTN_LEFT);
+
+   ok = p_serialize(snap, sz) ? 1 : 0;
+   report(ok, "retro_serialize succeeded mid-motion");
+   if (!ok)
+   {
+      free(snap);
+      return;
+    }
+
+   /* Continue from here and record what the machine does next. */
+   run_polls(&cont, 'A', DEV_MOUSE_ST, 25, 3, 2, 0);
+
+   /* Now roll back and replay the identical input.  If the phase, the
+    * backlog or the Q8 carry were outside the state blob, the replay
+    * diverges -- issue #400's failure mode exactly. */
+   ok = p_unserialize(snap, sz) ? 1 : 0;
+   report(ok, "retro_unserialize accepted the v12 state");
+
+   run_polls(&restored, 'A', DEV_MOUSE_ST, 25, 3, 2, 0);
+
+   sprintf(detail,
+           "post-restore replay matches (NET_X %d vs %d, NET_Y %d vs %d, "
+           "dropped %u vs %u)",
+           (int)cont.net_x, (int)restored.net_x,
+           (int)cont.net_y, (int)restored.net_y,
+           cont.dropped, restored.dropped);
+   report(cont.net_x == restored.net_x && cont.net_y == restored.net_y
+          && cont.dropped == restored.dropped && restored.dropped == 0,
+          detail);
+
+   /* An older (v11) state must still load.  v11 is what shipped in
+    * v3.3.0, i.e. what real users' existing saves carry, and the v12
+    * chunk is TRAILING precisely so those keep working: a v11 header
+    * simply means "stop before the input-device chunk".  Patch the
+    * header's version field down and re-load. */
+   if (p_serialize(snap, sz))
+   {
+      uint32_t v11 = 11;
+
+      memcpy(snap + 4, &v11, sizeof(v11));   /* header: magic, version, ... */
+      report(p_unserialize(snap, sz) ? 1 : 0,
+             "a v11 state (the v3.3.0 release layout) still loads");
+   }
+   else
+      report(0, "re-serialize for the v11 downgrade check");
+
+   free(snap);
+   p_SetScale(1, 256);
+}
+
+static void test_chunk_size(void)
+{
+   uint8_t scratch[256];
+   size_t  n;
+
+   printf("state chunk\n");
+
+   if (!p_StateSave)
+   {
+      report(0, "InputDevStateSave resolvable");
+      return;
+   }
+
+   memset(scratch, 0, sizeof(scratch));
+   n = p_StateSave(scratch);
+   sprintf(detail,
+           "InputDevStateSave wrote %u bytes; inputdev.h advertises "
+           "INPUTDEV_STATE_SIZE = %d (a mismatch means the trailing chunk "
+           "grew without its constant)",
+           (unsigned)n, INPUTDEV_STATE_SIZE_EXPECTED);
+   report(n == (size_t)INPUTDEV_STATE_SIZE_EXPECTED, detail);
+}
+
+int main(int argc, char **argv)
+{
+   harness_config cfg = HARNESS_CONFIG_DEFAULT;
+   harness_result result;
+   char summary[128];
+   int t;
+
+   cfg.frames = 0;
+   if (!harness_init_from_args(&cfg, argc, argv))
+      return 1;
+
+   if (!cfg.rom_path)
+      cfg.rom_path = "test/roms/yarc.j64";
+   if (!harness_load_rom(&cfg))
+      return 1;
+
+   p_ReadWord    = (uint16_t (*)(uint32_t))harness_dlsym(&cfg, "JoystickReadWord");
+   p_WriteWord   = (void (*)(uint32_t, uint16_t))harness_dlsym(&cfg, "JoystickWriteWord");
+   p_SetType     = (void (*)(int, int))harness_dlsym(&cfg, "InputDevSetType");
+   p_SetScale    = (void (*)(int, int32_t))harness_dlsym(&cfg, "InputDevSetScale");
+   p_Reset       = (void (*)(void))harness_dlsym(&cfg, "InputDevReset");
+   p_Feed        = (void (*)(int, int32_t, int32_t, uint32_t))
+                      harness_dlsym(&cfg, "InputDevFeed");
+   p_GetType     = (int (*)(int))harness_dlsym(&cfg, "InputDevGetType");
+   p_AnyAttached = (int (*)(void))harness_dlsym(&cfg, "InputDevAnyAttached");
+   p_StateSave   = (size_t (*)(uint8_t *))
+                      harness_dlsym(&cfg, "InputDevStateSave");
+
+   p_serialize_size = (size_t (*)(void))harness_dlsym(&cfg, "retro_serialize_size");
+   p_serialize      = (int (*)(void *, size_t))harness_dlsym(&cfg, "retro_serialize");
+   p_unserialize    = (int (*)(const void *, size_t))
+                         harness_dlsym(&cfg, "retro_unserialize");
+
+   if (!p_ReadWord || !p_WriteWord || !p_SetType || !p_SetScale
+       || !p_Reset || !p_Feed || !p_GetType || !p_AnyAttached)
+   {
+      fprintf(stderr,
+              "mouse_decode_test: missing test-ABI symbols.  The wide test "
+              "ABI must export Joystick* and InputDev* (exports-test.list "
+              "and link-test.T).  Build with TEST_EXPORTS=1.\n");
+      harness_shutdown(&cfg);
+      return 1;
+   }
+
+   for (t = DEV_MOUSE_ST; t <= DEV_MOUSE_AMIGA_ON_ST; t++)
+   {
+      test_directions(t);
+      test_rate_ceiling(t);
+      test_poll_shapes(t);
+      test_row_blindness(t);
+   }
+
+   test_case_discrimination();
+   test_savestate();
+   test_chunk_size();
+   test_port1_rejects_mouse();
+   test_pad_is_inert();
+
+   sprintf(summary, "%d failure(s)", failures);
+   result.status = failures ? "FAIL" : "PASS";
+   result.name   = "mouse_decode";
+   result.detail = summary;
+   harness_report(&cfg, &result, 1);
+
+   harness_shutdown(&cfg);
+   return failures ? 1 : 0;
+}

--- a/test/tools/mouse_decode_test.c
+++ b/test/tools/mouse_decode_test.c
@@ -55,6 +55,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "../harness/harness.h"
 
@@ -105,13 +106,13 @@ static void     (*p_SetType)(int, InputDevType);
 static void     (*p_SetScale)(int, int32_t);
 static void     (*p_Reset)(void);
 static void     (*p_Feed)(int, int32_t, int32_t, uint32_t);
-static int      (*p_GetType)(int);
+static InputDevType (*p_GetType)(int);
 static int      (*p_AnyAttached)(void);
 static size_t   (*p_StateSave)(uint8_t *);
 
 static size_t (*p_serialize_size)(void);
-static int    (*p_serialize)(void *, size_t);
-static int    (*p_unserialize)(const void *, size_t);
+static bool   (*p_serialize)(void *, size_t);
+static bool   (*p_unserialize)(const void *, size_t);
 
 /* ---- reporting ------------------------------------------------------- */
 
@@ -720,14 +721,14 @@ int main(int argc, char **argv)
    p_Reset       = (void (*)(void))harness_dlsym(&cfg, "InputDevReset");
    p_Feed        = (void (*)(int, int32_t, int32_t, uint32_t))
                       harness_dlsym(&cfg, "InputDevFeed");
-   p_GetType     = (int (*)(int))harness_dlsym(&cfg, "InputDevGetType");
+   p_GetType     = (InputDevType (*)(int))harness_dlsym(&cfg, "InputDevGetType");
    p_AnyAttached = (int (*)(void))harness_dlsym(&cfg, "InputDevAnyAttached");
    p_StateSave   = (size_t (*)(uint8_t *))
                       harness_dlsym(&cfg, "InputDevStateSave");
 
    p_serialize_size = (size_t (*)(void))harness_dlsym(&cfg, "retro_serialize_size");
-   p_serialize      = (int (*)(void *, size_t))harness_dlsym(&cfg, "retro_serialize");
-   p_unserialize    = (int (*)(const void *, size_t))
+   p_serialize      = (bool (*)(void *, size_t))harness_dlsym(&cfg, "retro_serialize");
+   p_unserialize    = (bool (*)(const void *, size_t))
                          harness_dlsym(&cfg, "retro_unserialize");
 
    if (!p_ReadWord || !p_WriteWord || !p_SetType || !p_SetScale

--- a/test/tools/mouse_decode_test.c
+++ b/test/tools/mouse_decode_test.c
@@ -523,6 +523,69 @@ static void test_pad_is_inert(void)
    report(r.net_x == 0 && r.net_y == 0 && !bl[0] && !br[0], detail);
 }
 
+/*
+ * THE FRONTEND MUST NOT BE ABLE TO SILENTLY DETACH THE MOUSE.
+ *
+ * retro_set_controller_port_device used to force INPUTDEV_PAD on any
+ * JOYPAD/NONE assignment and defer to "the next check_variables()".
+ * Nothing schedules one, and RetroArch issues a per-port controller init
+ * right after load -- so the mouse the core option had just attached was
+ * detached for the entire session.  That is the regression that shipped;
+ * this pins it.
+ *
+ * The core option is set AFTER the load deliberately: the harness's
+ * environment callback serves cfg.options live, so this measures what
+ * retro_set_controller_port_device resolves at call time, which is the
+ * thing under test.
+ */
+static void test_frontend_pad_assignment_rereads_option(harness_config *cfg,
+                                                        void (*p_SetPort)(unsigned, unsigned))
+{
+   /* Mirrors libretro.h; this file deliberately includes no emulator or
+    * libretro headers (see the InputDevType comment above). */
+   const unsigned DEV_NONE_ID   = 0;
+   const unsigned DEV_JOYPAD_ID = 1;
+   const unsigned DEV_MOUSE_ID  = 2;
+
+   printf("frontend port-device assignment vs the core option\n");
+
+   if (!p_SetPort)
+   {
+      report(0, "retro_set_controller_port_device resolvable");
+      return;
+   }
+
+   harness_set_option(cfg, "virtualjaguar_p2_device", "mouse_st");
+
+   /* virtualjaguar_p2_device = mouse_st is now in effect.  A frontend
+    * assigning JOYPAD to port 2 -- exactly RetroArch's post-load per-port
+    * init -- must leave the option's mouse attached. */
+   p_SetPort(1, DEV_JOYPAD_ID);
+   sprintf(detail,
+           "RETRO_DEVICE_JOYPAD on port 2 re-reads the core option instead of "
+           "forcing pad (type=%d, expect %d)", p_GetType(1), (int)DEV_MOUSE_ST);
+   report(p_GetType(1) == DEV_MOUSE_ST, detail);
+
+   p_SetPort(1, DEV_NONE_ID);
+   sprintf(detail,
+           "RETRO_DEVICE_NONE on port 2 likewise (type=%d, expect %d)",
+           p_GetType(1), (int)DEV_MOUSE_ST);
+   report(p_GetType(1) == DEV_MOUSE_ST, detail);
+
+   /* An explicit frontend mouse still outranks the option, and port 1 is
+    * never given a mouse whatever the frontend says. */
+   p_SetPort(1, DEV_MOUSE_ID);
+   report(p_GetType(1) == DEV_MOUSE_ST,
+          "an explicit frontend mouse on port 2 is honoured");
+
+   p_SetPort(0, DEV_MOUSE_ID);
+   report(p_GetType(0) == DEV_PAD,
+          "a frontend mouse on port 1 is still refused");
+
+   p_SetPort(0, DEV_JOYPAD_ID);
+   p_SetPort(1, DEV_JOYPAD_ID);
+}
+
 static void test_port1_rejects_mouse(void)
 {
    printf("port scope\n");
@@ -692,6 +755,10 @@ int main(int argc, char **argv)
    test_chunk_size();
    test_port1_rejects_mouse();
    test_pad_is_inert();
+   /* Last: it leaves a core option set, which nothing after it should see. */
+   test_frontend_pad_assignment_rereads_option(
+      &cfg, (void (*)(unsigned, unsigned))
+               harness_dlsym(&cfg, "retro_set_controller_port_device"));
 
    sprintf(summary, "%d failure(s)", failures);
    result.status = failures ? "FAIL" : "PASS";

--- a/test/tools/mouse_decode_test.c
+++ b/test/tools/mouse_decode_test.c
@@ -439,6 +439,64 @@ static void test_case_discrimination(void)
    report(r.net_x == 0 && r.net_y == -40, detail);
 }
 
+/*
+ * THE EMISSION CLOCK IS GATED ON PORT 2'S ROW SELECT (mapping doc §5).
+ *
+ * §5 requires at most one Gray state per $F14000 read taken with port 2's
+ * row select asserted.  Ungated, a title polling PORT 1 rapidly advances
+ * the port-2 encoder between the port-2 poller's own samples -- which does
+ * not merely lag, it loses motion outright, because the decoder discards
+ * the resulting two-state jumps.
+ *
+ * This test fails without the gate: with it, 200 port-1 polls leave the
+ * phase untouched and the queued motion intact; without it, those polls
+ * drain the 40-state backlog and the following port-2 run decodes nothing.
+ */
+static void test_port1_poll_does_not_clock(void)
+{
+   /* Port-1-only row select.  Low nibble 7 = port 1's socket-0 row 0;
+    * high nibble F is NOT a socket-0 code, so port 2 is unselected. */
+   const uint16_t p1_row_word = 0x81F7;
+   decode_result r;
+   uint16_t ref;
+   unsigned i;
+   int held = 1;
+
+   printf("emission clock is gated on port 2's row select\n");
+
+   attach(DEV_MOUSE_ST);
+   p_Feed(1, 40, 0, 0);
+
+   /* Sample the mouse bits without clocking: a read with no intervening
+    * write is unarmed, so it cannot advance the encoder.  The first read
+    * consumes the arm left by the write; the second is the sample. */
+   p_WriteWord(0, row_words[0]);
+   (void)p_ReadWord(0);
+   ref = (uint16_t)(p_ReadWord(0) & 0xF000u);
+
+   for (i = 0; i < 200; i++)
+   {
+      p_WriteWord(0, p1_row_word);
+      if ((uint16_t)(p_ReadWord(0) & 0xF000u) != ref)
+         held = 0;
+   }
+
+   sprintf(detail,
+           "200 port-1 row polls do not advance the port-2 encoder "
+           "($F14000 bits 12-15 held at $%X)",
+           (unsigned)((ref >> 12) & 0x0Fu));
+   report(held, detail);
+
+   /* The queued motion is still there afterwards.  run_polls primes with
+    * one port-2 write+read (one state) and then polls 30 times, so a
+    * backlog that survived the port-1 traffic decodes exactly 30. */
+   run_polls(&r, 'A', DEV_MOUSE_ST, 30, 0, 0, 0);
+   sprintf(detail,
+           "the motion queued before them is not lost (NET_X=%d expect 30, "
+           "dropped=%u)", (int)r.net_x, r.dropped);
+   report(r.net_x == 30 && r.dropped == 0, detail);
+}
+
 static void test_pad_is_inert(void)
 {
    decode_result r;
@@ -629,6 +687,7 @@ int main(int argc, char **argv)
    }
 
    test_case_discrimination();
+   test_port1_poll_does_not_clock();
    test_savestate();
    test_chunk_size();
    test_port1_rejects_mouse();


### PR DESCRIPTION
## What this is

PR 2 of 4 of the input-devices track (epic #428): the **ST/Amiga mouse** (#429).

Implements steps **2-6** of `docs/superpowers/specs/2026-08-14-input-devices-mouse-rotary-design.md` — the quadrature encoder, the device model, the libretro layer, the mouse test, and the savestate chunk. Step 1 (the guardrail) is #446. **Step 7 (the Tempest rotary, #436) is deliberately not here** — it is PR 3. Steps 8-9 (titledb auto-select + docs) are PR 4.

Background reading: `docs/jaguar-mouse-adapter-mapping.md` (spike #433), which is the sourced pin -> `$F14000` bit mapping this is built from. No bit assignment in this PR is guessed.

### Stacking on #446

This branches off `test/429-input-guardrail`, **not** `develop`, so the guardrail is merged and green before anything can perturb `$F14000`. Until #446 merges, the diff shown here **includes A1's commit** (`test/tools/joymatrix_identity.c`, the `Makefile` test wiring, and the first pass at both export lists) — that work is not being re-landed, it is just not in `develop` yet. Once #446 merges this rebases away to my one commit.

---

## The load-bearing fact: the adapter is row-blind

Neither the ST nor the Amiga adapter connects Jaguar connector **pins 1-4** — and those are exactly `J4`..`J7`, the port-2 row-select *outputs* (mapping doc section 7). The adapter cannot see the row select at all. All six port-2 input lines (`J12`, `J13`, `J14`, `J15`, `B2`, `B3`) carry the mouse's state **continuously and identically in rows 0, 1, 2 and 3**.

**A Jaguar pad is a matrix; a mouse adapter is not.** So the mouse is not expressible as `joypadNButtons[]` slots. Setting `joypad1Buttons[BUTTON_U/D/L/R]` would return the mouse in row 0 and **nothing** in rows 1-3, where real hardware returns the same bits — a divergence running the *opposite* way from the one it appears to fix. The device instead drives raw `$F14000` bits 12-15 and `$F14002` bits 2-3 through a **row-independent overlay**, applied after the existing matrix decode and after the `joysticksEnabled` early return.

Three consequences are reproduced rather than "fixed", each with a comment at the site saying so:

| Behaviour | Why it is correct |
|---|---|
| In rows 1-3 the direction bits read as **keypad digits** (`*`/7/4/1, 2/5/8/0, 3/6/9/`#`) | Those are the same four wires. A title doing a full four-row scan while the mouse moves sees phantom digits on hardware. |
| LMB reads as **A and B and C and Option** | `joystick.c` decodes `$F14002` bit 3 per-row; a real adapter holds it low in every row. |
| RMB perturbs the **C1/C2/C3 controller-type** field | `B2` is the type-ID bit in rows 1-3, so a title re-probing controller type while RMB is held misidentifies the device. |

`joysticksEnabled` is deliberately **not** touched (spec section 2.4): the overlay sits strictly after the enable check, which is what makes the guardrail true by construction rather than by measurement.

---

## The emission rule: arm on write, advance on the next read

**Not** "advance one state per offset-0 read." That naive rule has a latent motion-loss bug and it was rejected on purpose.

The binding constraint is the game's decoder, not the device. A **two**-state Gray jump between consecutive polls indexes the "undetermined" entry of Domin's 16-entry table and is **silently discarded** — direction is unrecoverable. A driver that writes the row select once and then reads twice per poll (one read for directions, one for buttons — a very common shape) would, under "one per read", advance the phase twice between decode steps and emit exactly that discarded jump. That reads as **jitter**, which is worse than lag.

So:

- `JoystickWriteWord(offset == 0)` -> `InputDevArm()` sets an armed flag.
- `JoystickReadWord(offset == 0)` -> `InputDevClock()`: if armed, advance **at most one** Gray state per axis and clear the flag.

Extra reads without an intervening write return the same phase, which a decoder reads as "no movement" — harmless — instead of a discarded diagonal. `test/tools/mouse_decode_test` drives all three poll shapes and asserts it:

```
mouse_st: poll shapes (the emission rule)
  ok   shape C (write + TWO reads) decodes as shape A: A=40 C=40, dropped A=0 C=0
  ok   shape B (write once, then read-only) is frozen by design: NET_X=0 (expect 0)
```

Shape B (write the row select once at init, then poll read-only forever) is **frozen by design and asserted as such**. No such driver is documented; the assertion exists as the detector that would justify adding the stall-breaker, so "frozen" is a recorded, tested property rather than a surprise for whoever does the rotary.

---

## The guardrail still matches, exactly

**The headline result.** #446's digests are asserted unchanged, constants untouched:

```
=== Results: 3 passed, 0 failed, 0 skipped ===
  PASS: [joymatrix_identity_full] digest 0xC24DDCDE (expected 0xC24DDCDE); 524288 reads, seed 0x1D872B41, 256 row bytes x 64 vectors
  PASS: [joymatrix_identity_port1] port-1 bits digest 0xD0CD02E2 (expected 0xD0CD02E2); $F14000 bits 8-11 + $F14002 bits 0-1
  PASS: [joymatrix_identity_port1_with_mouse] port-1 bits with an ST mouse on port 2: 0xD0CD02E2 (expected 0xD0CD02E2); port-2 bits did move (full 0xE0E2711A)
```

The third row is the second assertion spec section 8 deferred until the device layer existed. It re-runs the identical sweep with an ST mouse attached to port 2 and a draining encoder, and asserts the port-1 sub-digest is *still* `0xD0CD02E2`. The pair matters: the **full** digest moves to `0xE0E2711A`, so the mouse is provably **live**; the **port-1** digest does not move, so it is provably **isolated**. A pass on the port-1 row alone could just mean the mouse did nothing.

---

## Savestate: v12

`STATE_VERSION` was 11 (`src/core/state.h`), and v11 **shipped** in v3.3.0, so a bump is correct rather than a shared in-flight version.

A **trailing** 41-byte chunk, appended after the v11 hi-res epoch — the mid-layout `JoystickStateSave` chunk does not change size. Per port: the X and Y quadrature backlog, Q8 carry and Gray phase, plus the two button latches; then one global armed byte.

The phase **is** what the game reads at `$F14000`, and the backlog and carry determine every future read, so all of it is machine-visible. A rollback without it replays different motion — issue #400's exact failure class, where the enhancement path's epoch sat outside the blob.

Deliberately **not** saved: the device type and the sensitivity scale. Both are option-derived and constant for a session; restoring them from a state would let a stale state fight the user's current option.

### STATE_SIZE headroom — measured, not assumed

Spec section 7.3 flagged this as unverified. A one-shot `LOG_INF` in `retro_serialize` now reports it:

```
[state] v12 payload 2396971 / 2621440 bytes (224469 free)
```

**224,469 bytes free (8.6%)**, with the v12 chunk costing 41 of them.

Backward compatibility is asserted, not assumed — `test_state_compat` still passes v1/v2/v3 loads and now reports `serialize_writes_current_version ... version=12` / `future_state_rejected ... version 13`, and `mouse_decode_test` writes a state, patches its header down to 11 and asserts it still loads (the v3.3.0 release layout, i.e. what real users' saves carry).

---

## Wiring cases, and the one thing that stays unresolved

Three cases ship as option values, from a literal table so they cannot drift apart (mapping doc section 4d):

| Option value | Case | X pair (A, B) | Y pair (A, B) |
|---|---|---|---|
| `mouse_st` (ST adapter + ST mouse, **and PS/2**) | 1 | 13, 12 | 14, 15 |
| `mouse_amiga` (Amiga mouse in an ST-wired adapter) | 3 | 13, 15 | 12, 14 |
| `mouse_amiga_adapter` (dedicated Amiga adapter) | 2 | 13, 12 | 15, 14 |

`mouse_amiga` maps to **case 3** because the shipping AtariAge adapter is ST-wired and an in-game "Atari / Amiga" selector exists to compensate — that is the case such a selector picks between.

### UNVERIFIED: the case-2 Y sign

Case 2 lands the Amiga's `V` (Y phase A) on bit 15 and `VQ` (Y phase B) on bit 14, i.e. A/B swapped relative to case 1, which **inverts Y**. Domin nonetheless drives both with one software mode. Three explanations exist, none sourced: ST and Amiga mice differ in encoder orientation and the swap cancels it; the vendor wiki's `(YA)`/`(YB)` labels on the Amiga column are editorial rather than measured; or he simply tolerated an inverted Y.

**No document settles it and no fixture in this repo can** — case-2 hardware is rare and no available title is known to target it. Per the design spec this is implemented **literally per the wiring diagram**, with an `UNVERIFIED` block at the table entry saying exactly that and telling the next reader not to "correct" it without a source. No invert toggle: a knob for an unsourced sign would just let users paper over a wiring bug.

The test asserts the case-2 behaviour with wording that keeps this honest — *"asserts the table as implemented, not a measured hardware fact."*

---

## Verification

All commands run with `DEVELOPER_DIR=/Library/Developer/CommandLineTools`.

### C89 lint

```
$ bash scripts/c89-lint.sh src/jerry/quadrature.c src/jerry/inputdev.c \
      src/jerry/joystick.c src/jerry/jerry.c libretro.c \
      test/test_quadrature.c test/tools/mouse_decode_test.c \
      test/tools/joymatrix_identity.c
C89 lint passed
```

### Build

```
$ make -j$(getconf _NPROCESSORS_ONLN)
make exit=0    (0 warnings, 0 errors)
```

### Full suite

```
$ make TEST_EXPORTS=1 test
suite exit=0
0 FAIL lines
```

Run with the private ROM corpus linked in, so the audio clipping / presence, run-ahead determinism and CD rows all actually executed rather than reporting SKIP (skip ledger empty).

### Production ABI unchanged by a plain make

```
$ make -j$(getconf _NPROCESSORS_ONLN)
$ nm -gU virtualjaguar_libretro.dylib | wc -l
      46
$ nm -gU virtualjaguar_libretro.dylib | awk '{print $3}' | grep -v '^_retro_'
(no output)
```

Every exported symbol is `retro_*`. The `InputDev*` / `Quad*` additions to `exports-test.list` and `link-test.T` extend the **test** ABI only; `scripts/check-export-lists.py` reports `export lists in sync (73 symbols)`.

### The mouse test — synthetic deltas in, decoded direction + distance out

`test/tools/mouse_decode_test` implements a quadrature decoder **independently of `src/jerry/quadrature.c`** — it walks the register bits, converts (A,B) levels to a Gray index and takes the modulo-4 difference between consecutive samples, discarding two-state jumps the way Domin's table discards its "undetermined" entries. If the emulated device ever emits a two-state jump, `dropped` goes non-zero and the run fails.

Abridged (the same block runs for all three wiring cases):

```
mouse_st: direction and distance
  ok   +X 40 units over 40 polls -> NET_X=40 NET_Y=0 dropped=0
  ok   -X 40 units over 40 polls -> NET_X=-40 NET_Y=0 dropped=0
  ok   +Y 40 units over 40 polls -> NET_X=0 NET_Y=40 dropped=0
  ok   -Y 40 units over 40 polls -> NET_X=0 NET_Y=-40 dropped=0
  ok   diagonal 40 polls -> NET_X=40 NET_Y=-40 dropped=0
mouse_st: rate ceiling (lag, never overshoot, never a sign flip)
  ok   4 units/poll x 30 polls -> NET_X=30 (expect 30), dropped=0
  ok   -4 units/poll x 30 polls -> NET_X=-30 (expect -30), dropped=0
mouse_st: poll shapes (the emission rule)
  ok   shape C (write + TWO reads) decodes as shape A: A=40 C=40, dropped A=0 C=0
  ok   shape B (write once, then read-only) is frozen by design: NET_X=0 (expect 0)
mouse_st: row-blindness
  ok   $F14000 bits 12-15 read identically in rows 0-3 (value $2)
  ok   LMB asserts $F14002 bit 3 in every row (1111)
  ok   RMB asserts $F14002 bit 2 in every row (1111)
  ok   released buttons leave $F14002 bits 2 and 3 high in every row

[ ... identical blocks for mouse_amiga_adapter and mouse_amiga (case 3) ... ]

wiring cases are genuinely distinct
  ok   case-3 wiring read with a case-1 decoder does not decode cleanly (NET_X=0 NET_Y=0 dropped=0; the matching decoder gives 40/0/0)
  ok   case-2 wiring read with a case-1 decoder inverts Y only (NET_X=0 NET_Y=-40)
savestate round-trip mid-motion
  ok   retro_serialize succeeded mid-motion
  ok   retro_unserialize accepted the v12 state
  ok   post-restore replay matches (NET_X 25 vs 25, NET_Y 19 vs 19, dropped 0 vs 0)
  ok   a v11 state (the v3.3.0 release layout) still loads
state chunk
  ok   InputDevStateSave wrote 41 bytes; inputdev.h advertises INPUTDEV_STATE_SIZE = 41
port scope
  ok   InputDevSetType refuses a mouse on port 1 (vendor-documented port-2 device)
no device selected -> the overlay is inert
  ok   port 2 reports pad and nothing is attached
  ok   no motion or buttons reach $F14000/$F14002 (NET_X=0 NET_Y=0 LMB=0 RMB=0)

=== Results: 1 passed, 0 failed, 0 skipped ===
  PASS: [mouse_decode] 0 failure(s)
```

The savestate round-trip is a genuine rollback: it drives the encoder to a mid-cycle phase with a non-empty backlog **and** a non-zero Q8 carry (37.5% sensitivity), saves, runs 25 more polls, restores, and replays the identical input — a mismatch is what a missing accumulator would produce.

### Encoder unit test

`test/test_quadrature` compiles `src/jerry/quadrature.c` directly, no core, no `dlopen`:

```
=== quadrature encoder ===
Gray sequence, positive direction (A leads B)
  ok   8 advances walk 0,1,2,3,0,1,2,3 with the table's levels
  ok   backlog fully drained after 8 advances
  ok   an empty backlog does not advance
Gray sequence, negative direction (B leads A)
  ok   8 advances walk 3,2,1,0,3,2,1,0 with the table's levels
  ok   backlog fully drained after 8 advances
one state per advance (the rate policy)
  ok   200 saturated polls each move exactly 1 state (never a jump)
  ok   advances past an empty backlog hold the phase steady
backlog clamp
  ok   positive backlog clamps at +64
  ok   negative backlog clamps at -64
Q8 sensitivity carry
  ok   4 x (1 unit @ 25%) accumulates exactly 1 state
  ok   4 x (-1 unit @ 25%) accumulates exactly -1 state
  ok   3 units @ 200% is 6 states
  ok   1 unit @ 25% emits nothing yet
  ok   ...and the carried remainder completes the state
reset
  ok   QuadReset zeroes backlog, carry and phase
All quadrature checks passed
```

Both tests are wired into `make test`.

---

## What is NOT verified

**Not yet exercised in a real frontend.** Everything above drives `InputDevFeed()` directly. The open question is whether RetroArch returns non-zero for `input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X)` when the mouse is selected via the **core option** rather than by the frontend assigning port 2's device — RetroArch has historically bound a mouse to port index 0, and several cores read mouse state from port 0 for that reason. If port index 1 yields zeros, the core-option path is inert and only the Controls-menu path works.

No speculative port-0 fallback has been added: that would be a guess about frontend behaviour, and a wrong guess would let a **port-1 pad drive port 2's lines** — a worse bug than the one it would paper over. This wants one experiment in RetroArch (set the option with port 2 left as JOYPAD, versus setting port 2 to "Atari ST / PS2 Mouse" in Controls) before the feature is called done.

Also still open, and belonging to later steps rather than this one:

- **Which case Elansar's `*`/`#` selector actually means.** Only running Elansar and watching the cursor can answer it (clean axis-aligned motion vs the coupled, near-motionless signature the case-discrimination test above shows). Expect case 3.
- **Whether JagDoomEX actually reads the mouse.** That is the precondition for the titledb row, and the row is PR 4's, not this one's — `auto` resolves to `pad` for every title today, so the mouse is strictly opt-in.

---

## What changed

| File | |
|---|---|
| `src/jerry/quadrature.{c,h}` | **new** — pure 2-bit Gray-code encoder, no emulator headers. Shared with the rotary when #436 lands. |
| `src/jerry/inputdev.{c,h}` | **new** — device model, the three-case wiring table, the overlays, the emission clock, the v12 chunk. |
| `src/jerry/joystick.c` | **+22 / -2** — `InputDevArm()` in `JoystickWriteWord`, the row-gated `InputDevClock()` in `JoystickReadWord`, and the two overlay calls (which replace the two bare `return data;` lines, hence the 2 removed). Behaviour on a pad-only build is unchanged: every entry point short-circuits on `inputdev_attach_mask`. Note `InputDevArm()` lives in `JoystickWriteWord`, which has no `joysticksEnabled` early return — an earlier revision of this row claimed all the additions sat behind one. |
| `src/jerry/jerry.c` | `InputDevInit()` / `InputDevReset()` alongside the existing `Joystick*` calls. |
| `libretro.c` | subclass IDs, `SET_CONTROLLER_INFO`, `retro_set_controller_port_device`, option reads, visibility, the `update_input` feed + pad suppression, `InputDevShutdown()` in `retro_deinit`, the v12 save/load. |
| `libretro_core_options.h` | `virtualjaguar_p2_device`, `virtualjaguar_mouse_sensitivity`. |
| `src/core/state.h` | `STATE_VERSION` 11 -> 12, `STATE_VERSION_INPUT_DEVICES`, stale v9-v11 prose corrected. |
| `test/test_quadrature.c`, `test/tools/mouse_decode_test.c` | **new** tests, wired into `make test`. |
| `test/tools/joymatrix_identity.c` | third and fourth assertions with a mouse attached: port-1 isolation, and `EXPECT_DIGEST_FULL_WITH_MOUSE = 0x5E1858EA` pinning the mouse's own bits (the only assertion that catches an inverted active-low polarity). `EXPECT_DIGEST_FULL` and `EXPECT_DIGEST_PORT1` untouched and re-measured identical. |
| `exports-test.list`, `link-test.T` | `InputDev*` / `Quad*` — test ABI only. |

`InputDevShutdown()` is called from `retro_deinit` and clears every static including the option-derived ones, per the standing iOS rule (no `dlclose`, so statics persist across loads).

### Pad suppression

`update_input()` withholds the retropad from a mouse port entirely — physically there is no pad there, and leaving the host contribution would let a gamepad and a mouse drive the same six lines at once. There are **three** fill paths (the plain bitmask branch, the `enable_alt_inputs` remap branch including its analog-as-button cases, and the `numpad_to_kb` sub-path that writes slots 4-15 straight from `RETRO_DEVICE_KEYBOARD`); the suppression runs after all of them so none can be missed. A comment notes that the rotary will need this to become *selective* (buttons kept, only U/D/L/R withheld) rather than growing another type here.

### For whoever takes #436

`INPUTDEV_ROTARY` is declared in the enum but explicitly **not implemented** — reserved so PR 3 is a pure addition rather than a renumbering. Nothing in this build can select it: no option value maps to it, and `InputDevSetType()` treats it as not-attached. `InputDevOverlayF14002()` already takes the decoded `row0`/`row1` arguments the rotary's C2/C3 controller-type reporting needs (the mouse ignores them), so `joystick.c` will not have to change again.

Refs #429, #428. Stacked on #446.


