### PR TITLE
feat(input): Tempest rotary controller on both ports (#436)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ test/tools/netlink_pair
 test/tools/netlink_game
 test/tools/joymatrix_identity
 test/tools/mouse_decode_test
+test/tools/rotary_decode_test
 # vjtrace flight-recorder analyzer/smoke tools -- built on demand by
 # test/tools/vjtrace_selftest.sh (and by hand per each tool's own header
 # comment); never tracked, same Mach-O-on-Linux-CI hazard as above.

--- a/Makefile
+++ b/Makefile
@@ -880,6 +880,7 @@ clean:
 		test/tools/test_frame_timing test/tools/test_runahead_determinism test/tools/test_pertitle_db \
 		test/tools/test_wedge_spin test/tools/i2s_lag_probe \
 		test/tools/joymatrix_identity test/tools/mouse_decode_test \
+		test/tools/rotary_decode_test \
 		test/test_quadrature \
 		test/.skipped-checks
 
@@ -934,7 +935,8 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
 		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/test_pertitle_db \
 		test/tools/i2s_lag_probe test/tools/joymatrix_identity \
-		test/test_quadrature test/tools/mouse_decode_test
+		test/test_quadrature test/tools/mouse_decode_test \
+		test/tools/rotary_decode_test
 	@# Skip ledger: truncate FIRST so a previous run's rows cannot resurface
 	@# as fresh skips (the stale-row failure mode documented for
 	@# cd_boot_matrix.sh).  Every optional check below records into it, and
@@ -1175,6 +1177,13 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# and distance out, all three wiring cases and all three poll shapes,
 	@# plus row-blindness and the v12 savestate round-trip.
 	./test/tools/mouse_decode_test ./$(TARGET) test/roms/yarc.j64 --quiet
+	@# Tempest rotary end-to-end (#436): synthetic rotation in, decoded
+	@# direction and magnitude out in BOTH directions on BOTH ports, the
+	@# row-0-only visibility that distinguishes a matrix device from the
+	@# row-blind mouse, Tempest 2000's measured 8-write scan, the
+	@# two-controller Pause unlock, the C2/C3 ID bits and a savestate
+	@# round-trip mid-rotation.
+	./test/tools/rotary_decode_test ./$(TARGET) test/roms/yarc.j64 --quiet
 	./test/test_memtrack
 	./test/test_nvmbios
 	@# Option visibility is content-type dependent; the disc half runs only
@@ -1496,6 +1505,13 @@ test/tools/mouse_decode_test: test/tools/mouse_decode_test.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/mouse_decode_test.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+
+test/tools/rotary_decode_test: test/tools/rotary_decode_test.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/rotary_decode_test.c \
 		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
 

--- a/libretro.c
+++ b/libretro.c
@@ -201,11 +201,19 @@ static uint8_t *joypad_buttons[2] = { joypad0Buttons, joypad1Buttons };
  * RETRO_DEVICE_MOUSE subclass because it is a relative-motion pointer;
  * the three subclasses are the three adapter/mouse wiring combinations
  * (docs/jaguar-mouse-adapter-mapping.md section 4d), not three different
- * devices.  Port 2 only -- see inputdev.h. */
+ * devices.  Port 2 only -- see inputdev.h.
+ *
+ * The rotary (#436) is also a RETRO_DEVICE_MOUSE subclass, driven by
+ * relative X: that is the established libretro spinner convention and it
+ * covers real spinner hardware.  RETRO_DEVICE_ANALOG as an alternate
+ * rotary source is deliberately out of scope here (design spec Q4) and
+ * belongs with #439's shared analog layer.  Rotary is offered on BOTH
+ * ports; unlike the mouse it is a genuine matrix device (inputdev.h). */
 #define RETRO_DEVICE_JAG_PAD             RETRO_DEVICE_JOYPAD
 #define RETRO_DEVICE_JAG_MOUSE_ST        RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE, 0)
 #define RETRO_DEVICE_JAG_MOUSE_AMIGA     RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE, 1)
 #define RETRO_DEVICE_JAG_MOUSE_AMIGA_AD  RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE, 2)
+#define RETRO_DEVICE_JAG_ROTARY          RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE, 3)
 
 /* Device the frontend explicitly selected via
  * retro_set_controller_port_device, or INPUTDEV_PAD when it never did.
@@ -218,6 +226,12 @@ static bool         port_device_forced[2]   = { false, false };
  * changes rather than on every check_variables() call. */
 static InputDevType port_device_active[2]   = { INPUTDEV_PAD, INPUTDEV_PAD };
 static bool         show_mouse_options      = true;
+static bool         show_rotary_options     = true;
+/* Sensitivity ladders, Q8 (256 == 1.0).  Kept separate because a spinner
+ * and a mouse want very different multipliers; the per-port scale is
+ * whichever one matches the device actually attached to that port. */
+static int32_t      mouse_scale_q8          = 256;
+static int32_t      rotary_scale_q8         = 256;
 
 /* Has this port actually received non-zero mouse state from the frontend?
  *
@@ -234,6 +248,17 @@ static bool         show_mouse_options      = true;
  * device type changes, which clears this): a mouse that has moved once is
  * a mouse the frontend is routing, and letting a pad drive the same six
  * lines at that point is the ambiguity the suppression exists to prevent.
+ *
+ * A ROTARY PORT DELIBERATELY DOES NOT USE THIS, and that is not an
+ * oversight to "fix" later.  The rule exists because a mouse port loses
+ * BOTH devices; a rotary port loses neither -- it withholds only U/D/L/R
+ * and keeps A/B/C/Option/Pause and the keypad on the RetroPad, so a
+ * frontend that routes no mouse state still leaves the port usable.  (In
+ * particular Tempest 2000's rotary unlock, Option then Pause on both
+ * controllers, is entirely buttons and works with no spinner routed.)
+ * Deferring the rotary's four-slot withholding would instead mean an
+ * un-serialized flag that test_savestate's exact-replay assertion has to
+ * reason around, for a failure mode that cannot occur.
  *
  * DELIBERATELY NOT SERIALIZED, for the same reason inputdev.h gives for
  * the device type and the sensitivity scale: this is a fact about how the
@@ -258,9 +283,17 @@ static const char *inputdev_type_name(InputDevType t)
       case INPUTDEV_MOUSE_ST:            return "Atari ST / PS2 mouse";
       case INPUTDEV_MOUSE_AMIGA_ADAPTER: return "Amiga mouse (Amiga adapter)";
       case INPUTDEV_MOUSE_AMIGA_ON_ST:   return "Amiga mouse (ST adapter)";
+      case INPUTDEV_ROTARY:              return "Tempest rotary";
       default:                           break;
    }
    return "standard joypad";
+}
+
+static bool inputdev_is_mouse_type(InputDevType t)
+{
+   return (t == INPUTDEV_MOUSE_ST
+           || t == INPUTDEV_MOUSE_AMIGA_ADAPTER
+           || t == INPUTDEV_MOUSE_AMIGA_ON_ST);
 }
 
 static void apply_port_device(int port, InputDevType type)
@@ -487,12 +520,33 @@ static bool update_option_visibility(void)
    {
       bool show_mouse_prev = show_mouse_options;
 
-      show_mouse_options = (InputDevGetType(1) != INPUTDEV_PAD);
+      show_mouse_options = inputdev_is_mouse_type(InputDevGetType(1));
 
       if (show_mouse_options != show_mouse_prev)
       {
          option_display.visible = show_mouse_options;
          option_display.key     = "virtualjaguar_mouse_sensitivity";
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
+                    &option_display);
+         updated = true;
+      }
+   }
+
+   /* Rotary sensitivity and the rotary controller-type knob mean nothing
+    * unless a rotary is attached to one port or the other (#436). */
+   {
+      bool show_rotary_prev = show_rotary_options;
+
+      show_rotary_options = (InputDevGetType(0) == INPUTDEV_ROTARY
+                             || InputDevGetType(1) == INPUTDEV_ROTARY);
+
+      if (show_rotary_options != show_rotary_prev)
+      {
+         option_display.visible = show_rotary_options;
+         option_display.key     = "virtualjaguar_rotary_sensitivity";
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
+                    &option_display);
+         option_display.key     = "virtualjaguar_rotary_id";
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
                     &option_display);
          updated = true;
@@ -736,10 +790,42 @@ static InputDevType p2_device_from_option(void)
          p2 = INPUTDEV_MOUSE_AMIGA_ON_ST;
       else if (!strcmp(var.value, "mouse_amiga_adapter"))
          p2 = INPUTDEV_MOUSE_AMIGA_ADAPTER;
+      else if (!strcmp(var.value, "rotary"))
+         p2 = INPUTDEV_ROTARY;
       /* "pad" and "auto" (with no DB row) both mean pad. */
    }
 
    return p2;
+}
+
+/* Port 1 controller type, same contract as p2_device_from_option().
+ *
+ * Port 1 offers pad or rotary only.  It needed no such helper while it was
+ * pad-only -- retro_set_controller_port_device() could hardcode
+ * INPUTDEV_PAD when the frontend released the port -- but with a rotary
+ * reachable there, that hardcode would re-detach it on a frontend's
+ * routine post-load JOYPAD assignment, which is exactly the bug the port-2
+ * helper exists to prevent.
+ *
+ * No titledb row will ever select a rotary (design spec section 4.7):
+ * selecting one removes Up and Down from row 0, so a player using a pad on
+ * that title would lose menu navigation entirely.  That is a functional
+ * break, not a preference, so the rotary is opt-in always. */
+static InputDevType p1_device_from_option(void)
+{
+   struct retro_variable var;
+   InputDevType p1 = INPUTDEV_PAD;
+
+   var.key   = "virtualjaguar_p1_device";
+   var.value = NULL;
+   if (get_variable_pertitle(&var) && var.value)
+   {
+      if (!strcmp(var.value, "rotary"))
+         p1 = INPUTDEV_ROTARY;
+      /* "pad" and "auto" both mean pad. */
+   }
+
+   return p1;
 }
 
 static void check_variables(void)
@@ -1057,14 +1143,23 @@ static void check_variables(void)
     *   3. "auto" resolves through the per-title DB, and falls back to
     *      "pad" -- which is bit-identical to a core without this feature.
     * No titledb row ships in this PR, so "auto" is "pad" for every title
-    * today and the mouse is strictly opt-in. */
+    * today and the mouse is strictly opt-in.
+    *
+    * Port 1 (#436) follows the same precedence, but offers pad or rotary
+    * only and will never get a titledb row -- see p1_device_from_option. */
    {
+      InputDevType p1 = p1_device_from_option();
       InputDevType p2 = p2_device_from_option();
 
       if (port_device_forced[1])
          p2 = port_device_frontend[1];
 
       apply_port_device(1, p2);
+
+      if (port_device_forced[0])
+         p1 = port_device_frontend[0];
+
+      apply_port_device(0, p1);
    }
 
    var.key   = "virtualjaguar_mouse_sensitivity";
@@ -1082,10 +1177,48 @@ static void check_variables(void)
          pct = 100;
       if (pct > 1600)
          pct = 1600;
-      InputDevSetScale(1, (int32_t)((pct * 256) / 100));
+      mouse_scale_q8 = (int32_t)((pct * 256) / 100);
    }
    else
-      InputDevSetScale(1, 256);
+      mouse_scale_q8 = 256;
+
+   var.key   = "virtualjaguar_rotary_sensitivity";
+   var.value = NULL;
+   if (get_variable_pertitle(&var) && var.value)
+   {
+      /* Same pre-multiply clamp as the mouse ladder above, for the same
+       * hand-edited-config reason. */
+      int pct = atoi(var.value);
+      if (pct < 1)
+         pct = 100;
+      if (pct > 1600)
+         pct = 1600;
+      rotary_scale_q8 = (int32_t)((pct * 256) / 100);
+   }
+   else
+      rotary_scale_q8 = 256;
+
+   /* One scale per port, picked by what is actually plugged into it --
+    * the two ladders are separate options because a spinner and a mouse
+    * want very different multipliers. */
+   {
+      unsigned port;
+
+      for (port = 0; port < 2; port++)
+         InputDevSetScale((int)port,
+                          InputDevGetType((int)port) == INPUTDEV_ROTARY
+                             ? rotary_scale_q8 : mouse_scale_q8);
+   }
+
+   var.key   = "virtualjaguar_rotary_id";
+   var.value = NULL;
+   {
+      int reports = (get_variable_pertitle(&var) && var.value
+                     && !strcmp(var.value, "rotary")) ? 1 : 0;
+
+      InputDevSetRotaryID(0, reports);
+      InputDevSetRotaryID(1, reports);
+   }
 
    var.key = "virtualjaguar_alt_inputs";
    var.value = NULL;
@@ -1341,15 +1474,27 @@ static void update_input(void)
     *
     * A mouse port takes NOTHING from the retropad: physically there is no
     * pad there, and leaving the host contribution would let a gamepad and
-    * a mouse drive the same six lines at once.  (A rotary port, when
-    * #436 lands, keeps its buttons and withholds only U/D/L/R, so this
-    * will have to become selective then -- it cannot simply grow another
-    * type here.)
+    * a mouse drive the same six lines at once.
     *
     * The suppression is deferred until the mouse is LIVE -- see
     * inputdev_live: reading the frontend's mouse state first and
     * suppressing only once it has been non-zero guarantees that selecting
-    * a mouse can never leave the port with no working input at all. */
+    * a mouse can never leave the port with no working input at all.
+    *
+    * A ROTARY PORT IS DIFFERENT, and this is the branch that matters most
+    * to a real user.  A rotary is a modified standard controller: it
+    * really does have A, B, C, Option, Pause and the keypad, and those
+    * stay wired to the retropad.  Only Up/Down/Left/Right are withheld,
+    * because on that controller those four lines ARE the encoder (Up and
+    * Down do not exist; Left/Right are Phase 0/Phase 1) -- so the withhold
+    * is unconditional here, with no inputdev_live deferral, for the reason
+    * spelled out at inputdev_live itself.
+    *
+    * Keeping the buttons is not a nicety.  Tempest 2000's rotary support
+    * is hidden behind an unlock that requires pressing PAUSE ON BOTH
+    * CONTROLLERS SIMULTANEOUSLY from the Options screen, and the unlock
+    * is persisted in the game's EEPROM save.  Zero the whole array for a
+    * rotary port and the user can never turn the feature on at all. */
    if (InputDevAnyAttached())
    {
       for (player = 0; player < 2; player++)
@@ -1363,28 +1508,44 @@ static void update_input(void)
 
          dx = (int32_t)input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
                                       RETRO_DEVICE_ID_MOUSE_X);
-         dy = (int32_t)input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
-                                      RETRO_DEVICE_ID_MOUSE_Y);
+         dy      = 0;
          buttons = 0;
-         if (input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
-                            RETRO_DEVICE_ID_MOUSE_LEFT))
-            buttons |= INPUTDEV_BTN_LEFT;
-         if (input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
-                            RETRO_DEVICE_ID_MOUSE_RIGHT))
-            buttons |= INPUTDEV_BTN_RIGHT;
 
-         if (dx || dy || buttons)
+         if (t == INPUTDEV_ROTARY)
          {
-            if (!inputdev_live[player])
-            {
-               inputdev_live[player] = true;
-               LOG_INF("[input] port %d: mouse is live, RetroPad released\n",
-                       player + 1);
-            }
+            /* Withhold only the four direction slots; everything from
+             * BUTTON_s (4) up is a real switch on a real rotary.  The
+             * phases are published into BUTTON_L / BUTTON_R by
+             * InputDevClock() on each $F14000 row-0 read. */
+            joypad_buttons[player][BUTTON_U] = 0x00;
+            joypad_buttons[player][BUTTON_D] = 0x00;
+            joypad_buttons[player][BUTTON_L] = 0x00;
+            joypad_buttons[player][BUTTON_R] = 0x00;
          }
+         else
+         {
+            dy = (int32_t)input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
+                                         RETRO_DEVICE_ID_MOUSE_Y);
+            if (input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
+                               RETRO_DEVICE_ID_MOUSE_LEFT))
+               buttons |= INPUTDEV_BTN_LEFT;
+            if (input_state_cb(player, RETRO_DEVICE_MOUSE, 0,
+                               RETRO_DEVICE_ID_MOUSE_RIGHT))
+               buttons |= INPUTDEV_BTN_RIGHT;
 
-         if (inputdev_live[player])
-            memset(joypad_buttons[player], 0x00, BUTTON_LAST + 1);
+            if (dx || dy || buttons)
+            {
+               if (!inputdev_live[player])
+               {
+                  inputdev_live[player] = true;
+                  LOG_INF("[input] port %d: mouse is live, RetroPad released\n",
+                          player + 1);
+               }
+            }
+
+            if (inputdev_live[player])
+               memset(joypad_buttons[player], 0x00, BUTTON_LAST + 1);
+         }
 
          InputDevFeed((int)player, dx, dy, buttons);
       }
@@ -1471,6 +1632,9 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
       case RETRO_DEVICE_JAG_MOUSE_AMIGA_AD:
          type = INPUTDEV_MOUSE_AMIGA_ADAPTER;
          break;
+      case RETRO_DEVICE_JAG_ROTARY:
+         type = INPUTDEV_ROTARY;
+         break;
       default:
          type = INPUTDEV_PAD;
          break;
@@ -1488,7 +1652,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
    port_device_forced[port]   = (type != INPUTDEV_PAD);
 
    if (type == INPUTDEV_PAD)
-      type = (port == 1) ? p2_device_from_option() : INPUTDEV_PAD;
+      type = (port == 1) ? p2_device_from_option() : p1_device_from_option();
 
    apply_port_device((int)port, type);
    update_option_visibility();
@@ -2538,23 +2702,28 @@ void retro_init(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_INPUT_BITMASKS, NULL))
       libretro_supports_bitmasks = true;
 
-   /* Controller types the frontend may assign per port (#428/#429).
-    * Port 1 is pad-only: the ST/Amiga mouse adapter is a vendor-documented
-    * PORT 2 device, every title known to read one reads port 2, and a
-    * port-1 mouse would be a configuration no software supports. */
+   /* Controller types the frontend may assign per port (#428/#429/#436).
+    * Port 1 offers pad or rotary: the ST/Amiga mouse adapter is a
+    * vendor-documented PORT 2 device, every title known to read one reads
+    * port 2, and a port-1 mouse would be a configuration no software
+    * supports -- but TR10 documents the rotary matrix for both ports and
+    * Tempest 2000's CONTROLLER TYPE menu carries independent P1 and P2
+    * toggles, so the rotary is offered on both. */
    {
       static const struct retro_controller_description port1_devices[] = {
          { "Standard Joypad", RETRO_DEVICE_JAG_PAD },
+         { "Rotary (Tempest)", RETRO_DEVICE_JAG_ROTARY },
       };
       static const struct retro_controller_description port2_devices[] = {
          { "Standard Joypad",             RETRO_DEVICE_JAG_PAD },
          { "Atari ST / PS2 Mouse",        RETRO_DEVICE_JAG_MOUSE_ST },
          { "Amiga Mouse (ST adapter)",    RETRO_DEVICE_JAG_MOUSE_AMIGA },
          { "Amiga Mouse (Amiga adapter)", RETRO_DEVICE_JAG_MOUSE_AMIGA_AD },
+         { "Rotary (Tempest)",            RETRO_DEVICE_JAG_ROTARY },
       };
       static const struct retro_controller_info ports[] = {
-         { port1_devices, 1 },
-         { port2_devices, 4 },
+         { port1_devices, 2 },
+         { port2_devices, 5 },
          { NULL, 0 },
       };
 
@@ -2610,6 +2779,9 @@ void retro_deinit(void)
    inputdev_live[0]        = false;
    inputdev_live[1]        = false;
    show_mouse_options      = true;
+   show_rotary_options     = true;
+   mouse_scale_q8          = 256;
+   rotary_scale_q8         = 256;
    headroom_logged         = false;
    video_buffer_alloc_pixels = VIDEO_BUFFER_PIXELS;
    hires_restart_notice_logged = 0;

--- a/libretro.c
+++ b/libretro.c
@@ -309,6 +309,23 @@ static void apply_port_device(int port, InputDevType type)
       port_device_active[port] = type;
       /* A new device has to earn the port back (see inputdev_live). */
       inputdev_live[port]      = false;
+      /* Re-resolve the sensitivity ladder for the device now in the port.
+       * The rotary and the mouse have separate options because a spinner
+       * and a mouse want very different multipliers, and until this line
+       * existed the only place that picked between them was
+       * check_variables().  So switching a port to "Rotary (Tempest)"
+       * from RetroArch's Controls menu -- which reaches
+       * retro_set_controller_port_device, not GET_VARIABLE_UPDATE -- left
+       * the port running at the OTHER ladder's multiplier until the next
+       * core-option change happened to fix it.  Invisible at defaults
+       * (both ladders are 256) and self-healing, but real.
+       *
+       * Both statics hold their last resolved values here; on the
+       * check_variables() path the loop after the ladders recomputes them
+       * and calls InputDevSetScale again anyway, so this is at worst one
+       * redundant assignment there. */
+      InputDevSetScale(port, type == INPUTDEV_ROTARY
+                                ? rotary_scale_q8 : mouse_scale_q8);
       if (type != INPUTDEV_PAD)
          LOG_INF("[input] port %d: %s attached\n", port + 1,
                  inputdev_type_name(type));

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -485,7 +485,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_p2_device",
       "Port 2 > Controller Type",
       "Controller Type",
-      "Which peripheral is plugged into controller port 2. 'Atari ST / PS2 Mouse' is the wiring used by the AtariAge and Brewing Academy ST adapters and by PS/2 mouse adapters. 'Amiga Mouse (ST adapter)' is an Amiga mouse plugged into an ST-wired adapter -- this is what an in-game 'Atari / Amiga' selector normally chooses between. 'Amiga Mouse (Amiga adapter)' is the rarer dedicated adapter. A mouse asserts its state in every row scan, exactly as the real row-blind adapter does, so the port-2 RetroPad is disconnected while one is selected.",
+      "Which peripheral is plugged into controller port 2. 'Atari ST / PS2 Mouse' is the wiring used by the AtariAge and Brewing Academy ST adapters and by PS/2 mouse adapters. 'Amiga Mouse (ST adapter)' is an Amiga mouse plugged into an ST-wired adapter -- this is what an in-game 'Atari / Amiga' selector normally chooses between. 'Amiga Mouse (Amiga adapter)' is the rarer dedicated adapter. A mouse asserts its state in every row scan, exactly as the real row-blind adapter does, so the port-2 RetroPad is disconnected while one is selected. 'Rotary (Tempest)' is the Tempest spinner: it removes Up and Down and reports wheel rotation on Left/Right instead, and is driven by relative mouse X. Its buttons stay on the RetroPad. Tempest 2000 hides its rotary support behind an unlock -- from SELECT GAME TYPE TO PLAY press Option on controller 1, then press Pause on BOTH controllers at once to reveal CONTROLLER TYPE. The unlock is saved to the game's EEPROM, so it is only needed once.",
       NULL,
       "input_p2",
       {
@@ -494,9 +494,59 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "mouse_st",            "Atari ST / PS2 Mouse" },
          { "mouse_amiga",         "Amiga Mouse (ST adapter)" },
          { "mouse_amiga_adapter", "Amiga Mouse (Amiga adapter)" },
+         { "rotary",              "Rotary (Tempest)" },
          { NULL, NULL },
       },
       "auto"
+   },
+   {
+      "virtualjaguar_p1_device",
+      "Port 1 > Controller Type",
+      "Controller Type",
+      "Which peripheral is plugged into controller port 1. 'Rotary (Tempest)' is the Tempest spinner: it removes Up and Down and reports wheel rotation on Left/Right instead, and is driven by relative mouse X. Its buttons (A, B, C, Option, Pause and the keypad) stay on the RetroPad, which is what a real rotary has. There is no per-title default for this option and there never will be -- selecting a rotary removes Up and Down, so it would break menu navigation for anyone using a pad. Tempest 2000 hides its rotary support behind an unlock -- from SELECT GAME TYPE TO PLAY press Option on controller 1, then press Pause on BOTH controllers at once to reveal CONTROLLER TYPE. The unlock is saved to the game's EEPROM, so it is only needed once.",
+      NULL,
+      "input_p1",
+      {
+         { "auto",   "Auto (per-title default)" },
+         { "pad",    "Standard Joypad" },
+         { "rotary", "Rotary (Tempest)" },
+         { NULL, NULL },
+      },
+      "auto"
+   },
+   {
+      "virtualjaguar_rotary_sensitivity",
+      "Rotary Sensitivity",
+      "Rotary Sensitivity",
+      "Scales spinner movement before it is converted to quadrature pulses. The emulated encoder can only emit one pulse per controller poll of its row, so raising this past what the game's poll rate can carry adds lag rather than speed.",
+      NULL,
+      "input",
+      {
+         { "25",  "25%" },
+         { "50",  "50%" },
+         { "75",  "75%" },
+         { "100", "100%" },
+         { "150", "150%" },
+         { "200", "200%" },
+         { "300", "300%" },
+         { "400", "400%" },
+         { NULL, NULL },
+      },
+      "100"
+   },
+   {
+      "virtualjaguar_rotary_id",
+      "Rotary Reports Controller Type",
+      "Rotary Reports Controller Type",
+      "Whether an emulated rotary identifies itself to software as a rotary (diode D23 fitted). Most rotary controllers ever built shipped without the diode and identify as a standard joypad, which is the default here. Tempest 2000 does not read this -- it uses its own CONTROLLER TYPE menu instead.",
+      NULL,
+      "input",
+      {
+         { "joypad", "Standard Joypad (no diode -- as most real units)" },
+         { "rotary", "Tempest Rotary (diode fitted)" },
+         { NULL, NULL },
+      },
+      "joypad"
    },
    {
       "virtualjaguar_mouse_sensitivity",

--- a/src/jerry/inputdev.c
+++ b/src/jerry/inputdev.c
@@ -10,6 +10,7 @@
 
 #include "inputdev.h"
 #include "quadrature.h"
+#include "joystick.h"
 #include "state.h"
 
 /* Wiring table.  Values are $F14000 bit positions for PORT 2, all active
@@ -59,11 +60,16 @@ typedef struct
    int32_t      scale_q8;
    uint8_t      btn_left;
    uint8_t      btn_right;
+   uint8_t      rotary_id;   /* option-derived; see InputDevSetRotaryID */
 } InputDevPort;
 
 static InputDevPort inputdev_ports[2];
 static uint32_t     inputdev_attach_mask;
 static uint8_t      inputdev_armed;
+
+/* joypadNButtons[], indexed by port.  A rotary is a matrix device and
+ * reports through these slots; the mouse never touches them. */
+static uint8_t *const inputdev_pad[2] = { joypad0Buttons, joypad1Buttons };
 
 static int inputdev_is_mouse(InputDevType t)
 {
@@ -123,10 +129,14 @@ void InputDevSetType(int port, InputDevType type)
    if (port < 0 || port > 1)
       return;
 
-   /* Mouse is port 2 only (see inputdev.h), and the rotary is reserved
-    * for #436 and not implemented in this build.  Anything else is a
-    * plain pad, i.e. not attached. */
-   if (type != INPUTDEV_PAD && !(inputdev_is_mouse(type) && port == 1))
+   /* Mouse is port 2 only (see inputdev.h); the rotary is valid on both.
+    * Anything else is a plain pad, i.e. not attached. */
+   if (inputdev_is_mouse(type))
+   {
+      if (port != 1)
+         type = INPUTDEV_PAD;
+   }
+   else if (type != INPUTDEV_ROTARY)
       type = INPUTDEV_PAD;
 
    if (inputdev_ports[port].type != type)
@@ -174,6 +184,13 @@ void InputDevSetScale(int port, int32_t scale_q8)
    inputdev_ports[port].scale_q8 = scale_q8;
 }
 
+void InputDevSetRotaryID(int port, int reports_rotary)
+{
+   if (port < 0 || port > 1)
+      return;
+   inputdev_ports[port].rotary_id = reports_rotary ? 1 : 0;
+}
+
 void InputDevFeed(int port, int32_t dx, int32_t dy, uint32_t buttons)
 {
    InputDevPort *p;
@@ -182,11 +199,35 @@ void InputDevFeed(int port, int32_t dx, int32_t dy, uint32_t buttons)
       return;
 
    p = &inputdev_ports[port];
-   if (!inputdev_is_mouse(p->type))
-      return;
 
    if (p->scale_q8 <= 0)
       p->scale_q8 = 256;
+
+   if (p->type == INPUTDEV_ROTARY)
+   {
+      /* One axis, not two: the rotary is a single wheel.  dy is ignored,
+       * and so are the mouse buttons -- a rotary's A/B/C/Option/Pause and
+       * keypad are real matrix switches and come from the retropad.
+       *
+       * DIRECTION.  TR10 gives the phase sequences as pin levels:
+       *   anticlockwise  J10 0 1 1 0 ...   clockwise  J10 0 0 1 1 ...
+       *                  J11 0 0 1 1 ...              J11 0 1 1 0 ...
+       * i.e. anticlockwise = (A,B) walking 00,10,11,01 = INCREASING Gray
+       * index = A leads B, and clockwise = decreasing.
+       *
+       * Mapping host +X to clockwise is a HOST-SIDE UX CONVENTION, not a
+       * hardware fact: pushing a spinner to the right turns the knob
+       * clockwise.  Hence the negation.  There is deliberately no invert
+       * option -- an unsourced sign knob is how a real wiring bug gets
+       * papered over instead of found. */
+      QuadFeed(&p->x, -dx, p->scale_q8);
+      (void)dy;
+      (void)buttons;
+      return;
+   }
+
+   if (!inputdev_is_mouse(p->type))
+      return;
 
    /* One libretro unit = one Gray-code state at scale 1.0.  Domin's
     * decoder increments its position by one per state transition, so one
@@ -207,24 +248,98 @@ void InputDevArm(void)
    inputdev_armed = 1;
 }
 
-void InputDevClock(void)
+/* Write a rotary port's current phase into its pad slots.
+ *
+ * POLARITY IS INVERTED RELATIVE TO THE MOUSE OVERLAY, which is the single
+ * easiest way to ship a backwards spinner.  TR10 gives phase sequences as
+ * PIN LEVELS, and "reading a zero means the appropriate button is
+ * depressed"; joystick.c does `data &= (joypadNButtons[slot] ? mask :
+ * 0xFFFF)`, so a NON-ZERO array entry pulls the bit low.  Therefore
+ * pin level 1 -> slot 0x00, pin level 0 -> slot 0xFF.  The mouse overlay
+ * drives raw $F14000 bits where "0 = asserted" applies with no inversion.
+ * Two conventions in one feature, which is exactly why QuadLevels()
+ * returns logic levels and each sink applies its own polarity here.
+ *
+ * Phase 0 -> BUTTON_L, Phase 1 -> BUTTON_R (TR10's row-0 matrix: J10/J14
+ * and J11/J15, the same slot indices on both ports).  BUTTON_U / BUTTON_D
+ * are forced clear: the controller physically has no up/down, which is
+ * why TR10 tells rotary games to use A = Up and C = Down for menus.
+ *
+ * The encoder's rest phase is (1,1) -- QUAD_REST_PHASE, chosen by #429 --
+ * so an idle rotary writes 0x00 into all four slots and is bit-identical
+ * to an idle pad. */
+static void inputdev_publish_rotary(unsigned port)
 {
+   uint8_t *pad = inputdev_pad[port];
+   int a, b;
+
+   QuadLevels(&inputdev_ports[port].x, &a, &b);
+
+   pad[BUTTON_U] = 0x00;
+   pad[BUTTON_D] = 0x00;
+   pad[BUTTON_L] = a ? 0x00 : 0xFF;
+   pad[BUTTON_R] = b ? 0x00 : 0xFF;
+}
+
+void InputDevClock(uint8_t row0, uint8_t row1)
+{
+   uint8_t  row[2];
    unsigned p;
+   int      armed, consumed;
 
    if (!inputdev_attach_mask)
       return;
-   if (!inputdev_armed)
-      return;
 
-   inputdev_armed = 0;
+   row[0]   = row0;
+   row[1]   = row1;
+   armed    = inputdev_armed ? 1 : 0;
+   consumed = 0;
 
    for (p = 0; p < 2; p++)
    {
-      if (!inputdev_is_mouse(inputdev_ports[p].type))
-         continue;
-      QuadAdvance(&inputdev_ports[p].x);
-      QuadAdvance(&inputdev_ports[p].y);
+      InputDevType t = inputdev_ports[p].type;
+
+      if (inputdev_is_mouse(t))
+      {
+         /* Row-blind: every read of ITS PORT is a sample, whatever the
+          * row, so any armed read with that port addressed advances.
+          * Both axes, independently -- they are four parallel wires, not
+          * a time-multiplexed stream. */
+         if (armed && row[p] != 0xFF)
+         {
+            QuadAdvance(&inputdev_ports[p].x);
+            QuadAdvance(&inputdev_ports[p].y);
+            consumed = 1;
+         }
+      }
+      else if (t == INPUTDEV_ROTARY)
+      {
+         /* Row-gated: a rotary's phases exist in row 0 only, so the only
+          * read that samples it is a row-0 read of its own port.  See the
+          * measured Tempest 2000 scan in inputdev.h -- advancing on all
+          * eight of its per-frame armed reads would decode as garbage,
+          * including a sign inversion at three states. */
+         if (armed && row[p] == 0)
+         {
+            QuadAdvance(&inputdev_ports[p].x);
+            consumed = 1;
+         }
+
+         /* Published on EVERY call, not only when it advanced:
+          * update_input() zeroes a rotary port's four direction slots
+          * each frame, so without an unconditional publish a rotary would
+          * read as "both phases high" for every read between the frame
+          * boundary and the next armed row-0 advance. */
+         inputdev_publish_rotary(p);
+      }
    }
+
+   /* The arm is spent only by a read some attached device could decode
+    * from (inputdev.h, ARM CONSUMPTION).  Clearing it on every offset-0
+    * read would let a port-1-only read eat the arm a port-2 mouse was
+    * owed, which changes mouse advance timing. */
+   if (consumed)
+      inputdev_armed = 0;
 }
 
 uint16_t InputDevOverlayF14000(uint16_t data)
@@ -265,14 +380,26 @@ uint16_t InputDevOverlayF14002(uint16_t data, uint8_t row0, uint8_t row1)
 {
    InputDevPort *p;
 
-   /* The mouse is row-blind, so it ignores both rows; they are here for
-    * the rotary's C2/C3 controller-type reporting (#436). */
-   (void)row0;
-   (void)row1;
-
    if (!inputdev_attach_mask)
       return data;
 
+   /* Rotary controller-type identification (TR10 "Identifying Controller
+    * Types"; see InputDevSetRotaryID).  C2 C3 = 1 0 is "Tempest Rotary",
+    * and the C-column rows differ by port: C3 is $F14002 bit 0 in row 3
+    * on port 1, and bit 2 in row 2 on port 2.  C2 is left high, which is
+    * what joystick.c already returns.
+    *
+    * joystick.c drives only bit 1 (port 1) / bit 3 (port 2) in those
+    * rows, so clearing the C bit here cannot collide with a button. */
+   if (inputdev_ports[0].type == INPUTDEV_ROTARY
+       && inputdev_ports[0].rotary_id && row0 == 3)
+      data &= (uint16_t)~(1u << 0);
+
+   if (inputdev_ports[1].type == INPUTDEV_ROTARY
+       && inputdev_ports[1].rotary_id && row1 == 2)
+      data &= (uint16_t)~(1u << 2);
+
+   /* The mouse is row-blind, so its own contribution ignores both rows. */
    p = &inputdev_ports[1];
    if (!inputdev_is_mouse(p->type))
       return data;

--- a/src/jerry/inputdev.c
+++ b/src/jerry/inputdev.c
@@ -335,9 +335,26 @@ void InputDevClock(uint8_t row0, uint8_t row1)
    }
 
    /* The arm is spent only by a read some attached device could decode
-    * from (inputdev.h, ARM CONSUMPTION).  Clearing it on every offset-0
-    * read would let a port-1-only read eat the arm a port-2 mouse was
-    * owed, which changes mouse advance timing. */
+    * from (inputdev.h, ARM CONSUMPTION).
+    *
+    * THIS GUARDS NOTHING REACHABLE TODAY, and the comment here used to
+    * claim otherwise.  The reasoning that motivated it -- a port-1-only
+    * read eating the arm a port-2 mouse was owed -- cannot happen on the
+    * bus: the row select lives in joystick_ram[1], the only writer is
+    * JoystickWriteWord at offset 0, and that path arms unconditionally.
+    * So the arm is always set at the first read after any row change,
+    * and a later read at unchanged rows re-runs this same gate to the
+    * same answer.  Measured, not argued: 2.4M random write/read
+    * sequences across six device combinations digest bit-identically
+    * with and without the `if`.
+    *
+    * It stays because it is the honest statement of the contract -- an
+    * arm is a permission for ONE decodable sample, not for one bus read
+    * -- and the next device that samples on some other condition (a
+    * lightgun latch, a second row-blind peripheral) makes the difference
+    * real.  Pinned by test_arm_is_spent_only_by_a_decodable_read in
+    * mouse_decode_test.c, which reaches it by calling InputDevArm() and
+    * InputDevClock() directly, because no aligned bus sequence can. */
    if (consumed)
       inputdev_armed = 0;
 }

--- a/src/jerry/inputdev.h
+++ b/src/jerry/inputdev.h
@@ -26,12 +26,33 @@
  *      controller-type field, so a title re-probing controller type while
  *      the right button is held misidentifies the device.
  *
+ * THE ROTARY IS THE OPPOSITE SHAPE: IT IS A MATRIX DEVICE
+ * =======================================================
+ * Jaguar Technical Reference V10, section "Rotary 'Tempest' Controller":
+ * "all existing rotary controllers are modified standard controllers,
+ * consequently they should be read just like a standard controller using
+ * Socket 0 row codes".  Rows 1-3 are an ordinary pad; only row 0 changes,
+ * where Up/Down disappear and Left/Right become Phase 0 / Phase 1.
+ *
+ * Independently corroborated by the wiring: the encoder's common wire goes
+ * to joystick port pin 4 -- the ROW STROBE -- and not to ground.  Port-1
+ * pin 4 is J0, and row 0 is the only row code that drives J0 low
+ * (J3 J2 J1 J0 = 1110), so the phases appear in row 0 and only row 0.
+ *
+ * So the rotary reuses joypadNButtons[] unchanged and must NOT borrow the
+ * mouse's row-blind overlay.  Two peripherals, one encoder, two entirely
+ * different assertion mechanisms.
+ *
  * PORT SCOPE
  * ==========
  * The mouse is a PORT 2 device only.  The adapter is vendor-documented as
  * such, every title known to read one reads port 2, and a port-1 mouse
  * would be a configuration no software supports.  InputDevSetType()
  * refuses a mouse on port 0.
+ *
+ * The rotary is offered on BOTH ports: TR10 documents the rotary matrix
+ * for both, and Tempest 2000's hidden CONTROLLER TYPE menu carries
+ * independent P1 and P2 toggles.
  *
  * `port` here is 0 for Jaguar port 1 and 1 for Jaguar port 2, matching
  * joypad0Buttons / joypad1Buttons.
@@ -56,14 +77,8 @@ typedef enum
    INPUTDEV_MOUSE_ST,            /* case 1: ST adapter + ST mouse (also PS/2)   */
    INPUTDEV_MOUSE_AMIGA_ADAPTER, /* case 2: dedicated Amiga adapter + Amiga     */
    INPUTDEV_MOUSE_AMIGA_ON_ST,   /* case 3: Amiga mouse in an ST-wired adapter  */
-   INPUTDEV_ROTARY               /* TR10 "Tempest" rotary -- RESERVED, see below */
+   INPUTDEV_ROTARY               /* TR10 "Tempest" rotary (#436)                */
 } InputDevType;
-
-/* INPUTDEV_ROTARY is declared but NOT implemented here.  It belongs to
- * issue #436, which lands as its own PR on top of this one; the constant
- * is reserved now only so that PR is a pure addition rather than a
- * renumbering.  Nothing in this build can select it: no core-option value
- * maps to it, and InputDevSetType() treats it as "not attached". */
 
 void InputDevInit(void);
 void InputDevReset(void);     /* JERRYReset path: dynamic state only        */
@@ -83,17 +98,54 @@ void InputDevFeed(int port, int32_t dx, int32_t dy, uint32_t buttons);
 /* Sensitivity, Q8 (256 == 1.0), from the core options. */
 void InputDevSetScale(int port, int32_t scale_q8);
 
+/* Whether a rotary on this port identifies itself to software as a rotary
+ * (diode D23 fitted -- TR10 supplemental).  TR10 "Identifying Controller
+ * Types": C2 C3 = 1 0 means "Tempest Rotary", 1 1 means "Standard Jaguar
+ * Joypad (or nothing connected)", so a rotary that reports itself must
+ * read C3 = 0.
+ *
+ * The C2/C3 rows DIFFER BY PORT (from TR10's port-headed tables; the
+ * "Standard Jaguar Controller Matrix" table reads "C1" for both Row 2 and
+ * Row 1, which is an OCR slip):
+ *
+ *            Row 3   Row 2   Row 1
+ *   port 1   C3      C2      C1     ($F14002 bit 0)
+ *   port 2   C2      C3      C1     ($F14002 bit 2)
+ *
+ * so "C3 = 0" is bit 0 in row 3 on port 1, and bit 2 in row 2 on port 2.
+ *
+ * Default OFF, and deliberately not load-bearing: TR10's supplemental
+ * section says most real rotaries shipped WITHOUT diode D23 and therefore
+ * identify as a standard joypad, and Tempest 2000 does not consult these
+ * bits at all -- it uses its own hidden CONTROLLER TYPE menu. */
+void InputDevSetRotaryID(int port, int reports_rotary);
+
 /* ---- bus-side hooks, called only from joystick.c ------------------- *
  *
  * THE EMISSION RULE: arm on write, advance at most one state on the next
- * offset-0 read TAKEN WITH PORT 2'S ROW SELECT ASSERTED.
+ * offset-0 read THAT THE DEVICE'S OWN POLLER COULD HAVE DECODED FROM.
  *
- * The row gate is joystick.c's `offset1 != 0xFF` test (any of rows 0-3,
- * not row 0 specifically -- the adapter is row-blind, so every row is a
- * poll of it).  Without it a title that polls port 1 rapidly would
- * advance the port-2 encoder between the port-2 poller's own samples,
- * which is precisely the lost motion the one-state ceiling exists to
- * prevent.
+ * For a MOUSE that means a read taken with its port's row select asserted
+ * -- any of rows 0-3, not row 0 specifically, because the adapter is
+ * row-blind and every row is a poll of it.  Without that gate a title that
+ * polls port 1 rapidly would advance the port-2 encoder between the port-2
+ * poller's own samples, which is precisely the lost motion the one-state
+ * ceiling exists to prevent.
+ *
+ * For a ROTARY it means a row-0 read of its own port -- see "WHY THE
+ * ROTARY ALSO NEEDS THE ROW" below.
+ *
+ * The gate lives HERE, not at the call site.  It used to be joystick.c's
+ * `offset1 != 0xFF` test, which was equivalent while the mouse was the
+ * only device and it was port-2-only; a port-1 rotary has to advance on
+ * reads that test rejects, so joystick.c now calls unconditionally and
+ * passes the decoded rows.
+ *
+ * ARM CONSUMPTION FOLLOWS THE SAME GATE.  The arm flag is cleared only
+ * when some attached device actually sampled -- not on every offset-0
+ * read.  Clearing unconditionally would let a port-1-only read eat the arm
+ * that a port-2 mouse's next read was owed, changing mouse advance timing
+ * (which test/tools/joymatrix_identity.c's mouse digest measures).
  *
  * The naive "advance once per offset-0 read" has a latent motion-loss
  * bug.  A driver that writes the row select once and then reads twice per
@@ -109,18 +161,50 @@ void InputDevSetScale(int port, int32_t scale_q8);
  *
  * Deliberately deferred: a driver that writes the row select once at init
  * and then polls read-only forever would see a frozen device.  No such
- * driver is documented.  The mitigation, if a real title needs it, is a
+ * driver is documented, and Tempest 2000 is NOT one -- measured, see
+ * below.  The mitigation, if a real title ever needs it, is a
  * stall-breaker that advances anyway after N consecutive unarmed reads;
- * it is not implemented speculatively. */
+ * it is not implemented speculatively.
+ *
+ * WHY THE ROTARY ALSO NEEDS THE ROW (#436)
+ * ========================================
+ * "One state per armed read" is the right rate limit for the mouse
+ * because the row-blind adapter is sampled by every read of its port.  It
+ * is the WRONG limit for the rotary, because a rotary's phases exist in
+ * row 0 only: the sample a rotary driver actually decodes is one row-0
+ * read, and a four-row scan issues three more armed reads that decode
+ * nothing.
+ *
+ * Measured on Tempest 2000 (vjtrace --watch 0xF14000:4:rw, 400 frames):
+ * the poll loop at $80FD2E..$80FDEE writes eight row codes per frame --
+ * $81FE/$81FD/$81FB/$81F7 (port 1 rows 0-3) and $817F/$81BF/$81DF/$81EF
+ * (port 2 rows 0-3) -- each immediately followed by a move.l, i.e. eight
+ * armed offset-0 reads per frame but exactly ONE row-0 sample per port.
+ *
+ * Draining eight states between consecutive row-0 samples makes the
+ * decoded result (states drained) mod 4, so the device works only at
+ * exactly one count per frame: two decodes as "undetermined", THREE
+ * DECODES AS -1 (a sign inversion), four and eight decode as zero.  That
+ * is precisely the jitter the emission rule exists to prevent, and no
+ * sensitivity setting can compensate for it.
+ *
+ * So InputDevClock() takes the decoded socket-0 row for each port (0-3,
+ * or 0xFF when that port's nibble is not a socket-0 code) and a rotary
+ * advances only on an armed row-0 read of its own port.  The mouse uses
+ * the same arguments only to tell "my port was addressed" from "it was
+ * not", exactly as its old call-site gate did.
+ *
+ * The row is NOT derivable inside this file: joystick_ram is private to
+ * joystick.c, and the row readback bits in the assembled $F14000 word
+ * cannot distinguish "port 1 row 0" from "port 1 not addressed" (that
+ * port's row-0 mask is 0xFFFF, i.e. it clears nothing). */
 void     InputDevArm(void);                        /* $F14000 write          */
-void     InputDevClock(void);                      /* $F14000 read, offset 0,
-                                                    * port-2 row asserted    */
+void     InputDevClock(uint8_t row0, uint8_t row1);/* $F14000 read, offset 0 */
 uint16_t InputDevOverlayF14000(uint16_t data);
 /* row0/row1 are the decoded socket-0 row (0-3) for each port, or 0xFF
  * when that port's nibble is not a socket-0 code.  The mouse ignores them
  * -- it is row-blind -- but the rotary's C2/C3 controller-type reporting
- * (#436) needs them, so the signature is final and joystick.c will not
- * have to change again. */
+ * (#436) needs them. */
 uint16_t InputDevOverlayF14002(uint16_t data, uint8_t row0, uint8_t row1);
 
 /* ---- savestate (v12 trailing chunk) -------------------------------- *
@@ -129,7 +213,14 @@ uint16_t InputDevOverlayF14002(uint16_t data, uint8_t row0, uint8_t row1);
  * machine-visible and must survive a rollback (issue #400's lesson).
  * The device type and the sensitivity scale are deliberately NOT saved:
  * both are option-derived and constant for a session, and restoring them
- * from a state would let a stale state fight the user's current option. */
+ * from a state would let a stale state fight the user's current option.
+ *
+ * The rotary (#436) adds NOTHING here and the chunk does not grow.  It
+ * uses the port's existing X axis, so its backlog/carry/phase are already
+ * in this chunk; its published phase lives in joypadNButtons[], which
+ * JoystickStateSave() already serializes; and the controller-type ID flag
+ * is option-derived like the scale.  Hence no STATE_VERSION bump beyond
+ * the v12 this chunk already introduced. */
 #define INPUTDEV_STATE_SIZE 41
 size_t InputDevStateSave(uint8_t *buf);
 size_t InputDevStateLoad(const uint8_t *buf);

--- a/src/jerry/joystick.c
+++ b/src/jerry/joystick.c
@@ -76,17 +76,22 @@ uint16_t JoystickReadWord(uint32_t offset)
 		offset1 = joypad1Offset[(joystick_ram[1] >> 4) & 0x0F];
 
 		// Non-pad devices self-clock against the game's own polling: at
-		// most one quadrature state per armed read (inputdev.h).  Gated on
-		// port 2's row select being asserted (any of rows 0-3, i.e.
-		// offset1 decoded to something other than 0xFF), because that is
-		// the only read the port-2 poller can decode from -- a title
-		// polling port 1 rapidly would otherwise advance the port-2
-		// encoder between the port-2 poller's own samples, which is
-		// exactly the lost motion the one-state ceiling exists to
-		// prevent (mapping doc section 5).  No-op when nothing but pads
-		// are attached.
-		if (offset1 != 0xFF)
-			InputDevClock();
+		// most one quadrature state per armed read (inputdev.h).  The
+		// decoded row per port is passed rather than gated on here: a
+		// mouse still advances only when ITS port's row select is
+		// asserted (any of rows 0-3 -- the adapter is row-blind, and
+		// without that a title polling port 1 rapidly would advance the
+		// port-2 encoder between the port-2 poller's own samples, the
+		// lost motion the one-state ceiling exists to prevent, mapping
+		// doc section 5), while a rotary is a matrix device whose phases
+		// exist in row 0 only and so samples on a row-0 read of its own
+		// port.  Both gates live in inputdev.c because a port-1 rotary
+		// has to advance on reads a port-2 test would reject.  No-op
+		// when nothing but pads are attached.  The two lookups above are
+		// pure table reads, hoisted (not added) so they can be passed
+		// here.
+		InputDevClock(offset0 == 0xFF ? 0xFF : offset0 / 4,
+		              offset1 == 0xFF ? 0xFF : offset1 / 4);
 
 		if (offset0 != 0xFF)
 		{

--- a/test/tools/mouse_decode_test.c
+++ b/test/tools/mouse_decode_test.c
@@ -458,8 +458,13 @@ static void test_case_discrimination(void)
  */
 static void test_port1_poll_does_not_clock(void)
 {
-   /* Port-1-only row select.  Low nibble 7 = port 1's socket-0 row 0;
-    * high nibble F is NOT a socket-0 code, so port 2 is unselected. */
+   /* Port-1-only row select.  Low nibble 7 selects a port-1 socket-0 row
+    * -- row 3, not row 0: joypad0Offset[0x7] == 0x0C, and row 0 is
+    * nibble 0xE.  Which row it is does not matter here (the mouse is
+    * row-blind and this case only needs port 2 deselected), but the
+    * comment used to say row 0 and would mislead anyone adding a port-1
+    * rotary case, where the row is load-bearing.  High nibble F is not a
+    * socket-0 code, so port 2 is unselected. */
    const uint16_t p1_row_word = 0x81F7;
    decode_result r;
    uint16_t ref;

--- a/test/tools/mouse_decode_test.c
+++ b/test/tools/mouse_decode_test.c
@@ -200,10 +200,15 @@ static void run_polls(decode_result *r, char shape, int decode_case,
 
    /* Prime the decoder with a reference sample, exactly as a real driver
     * does on its first pass: a quadrature decoder cannot report movement
-    * until it has something to compare against.  Safe to read here
-    * because the backlog is empty on entry, so this cannot advance the
-    * encoder.  For shape B this IS the one row-select write the shape is
-    * defined by -- it never writes again. */
+    * until it has something to compare against.  For shape B this IS the
+    * one row-select write the shape is defined by -- it never writes
+    * again.
+    *
+    * This read is ARMED like any other, so it advances the encoder when
+    * the caller left a non-empty backlog behind -- test_savestate does,
+    * deliberately.  Harmless here (the sample only seeds prev_x/prev_y),
+    * but it is why test_savestate's two capture reads must start from
+    * identical state to be comparable. */
    p_WriteWord(0, row_words[0]);
    prime  = p_ReadWord(0);
    prev_x = gray_index(level_of(prime, w->xa), level_of(prime, w->xb));
@@ -701,11 +706,30 @@ static void test_port1_rejects_mouse(void)
    p_SetType(0, DEV_PAD);
 }
 
+/*
+ * The magnitude and the raw phase readback are both load-bearing; see the
+ * same argument spelled out at length in rotary_decode_test.c.  In short:
+ *
+ *   - THREE units per poll at 37.5% is more than one Gray state per poll,
+ *     so every poll emitted one either way and the replay matched with
+ *     `frac` dropped from InputDevStateLoad outright.  ONE unit is
+ *     96/256, so the Q8 carry decides WHICH polls emit.
+ *   - `backlog` was 0 at every poll boundary at that magnitude, hence
+ *     equally unpinned; the extra p_Feed() below leaves states queued but
+ *     undrained at the instant of the save.
+ *   - `phase` is invisible to NET at any magnitude, because run_polls()
+ *     re-primes its reference sample on entry.  It needs a raw readback,
+ *     taken by an identical sequence from an identical state on both
+ *     sides -- the capture read is itself armed.
+ */
 static void test_savestate(void)
 {
    uint8_t *snap;
    size_t   sz;
    decode_result cont, restored;
+   const wiring *w = &case_wiring[DEV_MOUSE_ST];
+   uint16_t raw;
+   int      px_cont, py_cont, px_restored, py_restored;
    int      ok;
 
    printf("savestate round-trip mid-motion\n");
@@ -724,11 +748,12 @@ static void test_savestate(void)
       return;
    }
 
-   /* Drive the encoder into the middle of a Gray cycle with a non-empty
-    * backlog and a non-zero Q8 carry, then save. */
+   /* Drive the encoder into the middle of a Gray cycle with a non-zero Q8
+    * carry, then queue states the polls have NOT drained, then save. */
    attach(DEV_MOUSE_ST);
    p_SetScale(1, 96);               /* 37.5%: guarantees a carry remainder */
-   run_polls(&cont, 'A', DEV_MOUSE_ST, 7, 3, 2, BTN_LEFT);
+   run_polls(&cont, 'A', DEV_MOUSE_ST, 7, 1, 1, BTN_LEFT);
+   p_Feed(1, 8, 5, BTN_LEFT);       /* 3 states on X, 1 on Y, undrained */
 
    ok = p_serialize(snap, sz) ? 1 : 0;
    report(ok, "retro_serialize succeeded mid-motion");
@@ -739,7 +764,11 @@ static void test_savestate(void)
     }
 
    /* Continue from here and record what the machine does next. */
-   run_polls(&cont, 'A', DEV_MOUSE_ST, 25, 3, 2, 0);
+   p_WriteWord(0, row_words[0]);
+   raw     = p_ReadWord(0);
+   px_cont = gray_index(level_of(raw, w->xa), level_of(raw, w->xb));
+   py_cont = gray_index(level_of(raw, w->ya), level_of(raw, w->yb));
+   run_polls(&cont, 'A', DEV_MOUSE_ST, 25, 1, 1, 0);
 
    /* Now roll back and replay the identical input.  If the phase, the
     * backlog or the Q8 carry were outside the state blob, the replay
@@ -747,15 +776,21 @@ static void test_savestate(void)
    ok = p_unserialize(snap, sz) ? 1 : 0;
    report(ok, "retro_unserialize accepted the v12 state");
 
-   run_polls(&restored, 'A', DEV_MOUSE_ST, 25, 3, 2, 0);
+   p_WriteWord(0, row_words[0]);
+   raw         = p_ReadWord(0);
+   px_restored = gray_index(level_of(raw, w->xa), level_of(raw, w->xb));
+   py_restored = gray_index(level_of(raw, w->ya), level_of(raw, w->yb));
+   run_polls(&restored, 'A', DEV_MOUSE_ST, 25, 1, 1, 0);
 
    sprintf(detail,
-           "post-restore replay matches (NET_X %d vs %d, NET_Y %d vs %d, "
-           "dropped %u vs %u)",
+           "raw phase X %d vs %d, Y %d vs %d; replay NET_X %d vs %d, "
+           "NET_Y %d vs %d, dropped %u vs %u",
+           px_cont, px_restored, py_cont, py_restored,
            (int)cont.net_x, (int)restored.net_x,
            (int)cont.net_y, (int)restored.net_y,
            cont.dropped, restored.dropped);
-   report(cont.net_x == restored.net_x && cont.net_y == restored.net_y
+   report(px_cont == px_restored && py_cont == py_restored
+          && cont.net_x == restored.net_x && cont.net_y == restored.net_y
           && cont.dropped == restored.dropped && restored.dropped == 0,
           detail);
 

--- a/test/tools/mouse_decode_test.c
+++ b/test/tools/mouse_decode_test.c
@@ -71,7 +71,8 @@ typedef enum {
    DEV_PAD                 = 0,
    DEV_MOUSE_ST            = 1,
    DEV_MOUSE_AMIGA_ADAPTER = 2,
-   DEV_MOUSE_AMIGA_ON_ST   = 3
+   DEV_MOUSE_AMIGA_ON_ST   = 3,
+   DEV_ROTARY              = 4
 } InputDevType;
 
 #define BTN_LEFT   0x01
@@ -107,6 +108,8 @@ static void     (*p_SetScale)(int, int32_t);
 static void     (*p_Reset)(void);
 static void     (*p_Feed)(int, int32_t, int32_t, uint32_t);
 static InputDevType (*p_GetType)(int);
+static void     (*p_Arm)(void);
+static void     (*p_Clock)(uint8_t, uint8_t);
 static int      (*p_AnyAttached)(void);
 static size_t   (*p_StateSave)(uint8_t *);
 
@@ -498,6 +501,102 @@ static void test_port1_poll_does_not_clock(void)
    report(r.net_x == 30 && r.dropped == 0, detail);
 }
 
+/*
+ * THE ARM IS SPENT ONLY BY A READ SOME ATTACHED DEVICE COULD DECODE FROM.
+ *
+ * inputdev.h, ARM CONSUMPTION.  InputDevClock() clears the armed flag
+ * under `if (consumed)`, not unconditionally.  A read that addressed no
+ * attached device -- port 1's row select while the mouse sits on port 2,
+ * or a non-row-0 read while port 1 holds a rotary -- must leave the arm
+ * standing for the read that device is actually owed.  Spending it there
+ * drops that device's next Gray state, and a dropped state is lost
+ * motion, not lag: the decoder cannot recover it.
+ *
+ * WHY THIS DRIVES THE TWO HOOKS DIRECTLY
+ * ======================================
+ * Measured, not assumed: NO sequence of aligned $F14000 / $F14002
+ * accesses can tell the guarded clear from an unconditional one.  The row
+ * select lives in joystick_ram[1], only an offset-0 write changes it, and
+ * every offset-0 write calls InputDevArm() -- so the arm is always 1 at
+ * the first read after any row change, and a later read at unchanged rows
+ * re-runs the same gate to the same answer.  A 2.4M-operation random
+ * write/read sweep across six device combinations digests bit-identically
+ * with the guard deleted.
+ *
+ * The guard is therefore a contract about InputDevClock()'s OWN inputs,
+ * and is pinned at that boundary: InputDevArm() and InputDevClock() model
+ * the driver's row-select write and the undecodable read that followed
+ * it, while every assertion below is still a $F14000 register read taken
+ * through JoystickReadWord().  Do not "simplify" this to a bus-only
+ * sequence -- there isn't one, which is exactly why the guard shipped
+ * untested.
+ */
+static void test_arm_is_spent_only_by_a_decodable_read(int rotary_on_port1)
+{
+   uint16_t before, after, settled;
+   const char *ctx;
+
+   ctx = rotary_on_port1
+       ? "with a rotary on port 1 (row 3, which no rotary can sample)"
+       : "with a bare pad on port 1";
+
+   printf("arm consumption is gated on the same read that samples (%s)\n",
+          ctx);
+
+   if (!p_Arm || !p_Clock)
+   {
+      report(0, "InputDevArm / InputDevClock resolvable");
+      return;
+   }
+
+   attach(DEV_MOUSE_ST);
+   if (rotary_on_port1)
+      p_SetType(0, DEV_ROTARY);
+   p_Feed(1, 40, 0, 0);
+
+   /* Settle on a known phase with the arm already spent: the write arms,
+    * the first read consumes it and advances, the second is unarmed and
+    * so is a pure sample. */
+   p_WriteWord(0, row_words[0]);
+   (void)p_ReadWord(0);
+   before = (uint16_t)(p_ReadWord(0) & 0xF000u);
+
+   /* The driver's row-select write, then a read that addressed only port
+    * 1 -- nothing the port-2 mouse could have decoded from. */
+   p_Arm();
+   p_Clock((uint8_t)(rotary_on_port1 ? 3 : 0), 0xFF);
+
+   /* The mouse's own next read.  Rows are still port 2 row 0, so this is
+    * the read the arm was owed to. */
+   after = (uint16_t)(p_ReadWord(0) & 0xF000u);
+
+   sprintf(detail,
+           "a read no attached device could decode from does not spend the "
+           "arm the port-2 mouse was owed %s ($F14000 bits 12-15 $%X -> $%X, "
+           "expect a change)",
+           ctx, (unsigned)(before >> 12), (unsigned)(after >> 12));
+   report(after != before, detail);
+
+   /* The other half.  A guard that simply never cleared the arm would
+    * pass the check above, so pin the consuming case too: once a read the
+    * mouse DID sample has spent the arm, the reads that follow it are
+    * unarmed and the phase stands still. */
+   p_Arm();
+   p_Clock(0xFF, 0);                                /* the mouse samples  */
+   after   = (uint16_t)(p_ReadWord(0) & 0xF000u);
+   settled = (uint16_t)(p_ReadWord(0) & 0xF000u);
+
+   sprintf(detail,
+           "a read the mouse did sample DOES spend the arm: the reads after "
+           "it are unarmed and hold the phase ($%X then $%X)",
+           (unsigned)(after >> 12), (unsigned)(settled >> 12));
+   report(after == settled, detail);
+
+   p_SetType(0, DEV_PAD);
+   p_SetType(1, DEV_PAD);
+   p_Reset();
+}
+
 static void test_pad_is_inert(void)
 {
    decode_result r;
@@ -725,6 +824,9 @@ int main(int argc, char **argv)
    p_AnyAttached = (int (*)(void))harness_dlsym(&cfg, "InputDevAnyAttached");
    p_StateSave   = (size_t (*)(uint8_t *))
                       harness_dlsym(&cfg, "InputDevStateSave");
+   p_Arm         = (void (*)(void))harness_dlsym(&cfg, "InputDevArm");
+   p_Clock       = (void (*)(uint8_t, uint8_t))
+                      harness_dlsym(&cfg, "InputDevClock");
 
    p_serialize_size = (size_t (*)(void))harness_dlsym(&cfg, "retro_serialize_size");
    p_serialize      = (bool (*)(void *, size_t))harness_dlsym(&cfg, "retro_serialize");
@@ -752,6 +854,8 @@ int main(int argc, char **argv)
 
    test_case_discrimination();
    test_port1_poll_does_not_clock();
+   test_arm_is_spent_only_by_a_decodable_read(0);
+   test_arm_is_spent_only_by_a_decodable_read(1);
    test_savestate();
    test_chunk_size();
    test_port1_rejects_mouse();

--- a/test/tools/rotary_decode_test.c
+++ b/test/tools/rotary_decode_test.c
@@ -1,0 +1,744 @@
+/*
+ * test/tools/rotary_decode_test.c -- Tempest rotary end-to-end decode test.
+ *
+ * WHAT THIS PROVES
+ * ================
+ * Synthetic host rotation goes in through InputDevFeed(); a quadrature
+ * decoder written here -- independently of src/jerry/quadrature.c, from
+ * the phase sequences in the Jaguar Technical Reference V10 section
+ * "Rotary 'Tempest' Controller" -- reads it back out of $F14000 exactly as
+ * a 68K driver would, and the decoded direction and distance are asserted.
+ * Both directions, both ports.
+ *
+ * THE CLAIM THAT DISTINGUISHES THE ROTARY FROM THE MOUSE
+ * =====================================================
+ * The mouse adapter is ROW-BLIND: it does not connect Jaguar pins 1-4, so
+ * it asserts the same lines in all four rows and mouse_decode_test asserts
+ * exactly that.  The rotary is the opposite shape -- TR10 calls it "a
+ * modified standard controller ... read just like a standard controller
+ * using Socket 0 row codes", and the encoder's common wire goes to the ROW
+ * STROBE (port pin 4 = J0), which is driven low by row 0 and no other row.
+ *
+ * So the rotary must be visible in row 0 and INVISIBLE in rows 1-3, where
+ * the port must keep behaving as an ordinary pad.  test_row_scope() below
+ * asserts both halves.  If someone ever "simplifies" the rotary onto the
+ * mouse's row-independent overlay, that test fails.
+ *
+ * THE ROW-GATED EMISSION RULE (the regression for the real defect)
+ * ===============================================================
+ * Measured on Tempest 2000 (vjtrace --watch 0xF14000:4:rw, 400 frames):
+ * the poll loop at $80FD2E..$80FDEE writes EIGHT row codes per frame --
+ * port 1 rows 0-3 then port 2 rows 0-3 -- each followed immediately by a
+ * move.l.  That is eight armed offset-0 reads per frame but exactly ONE
+ * row-0 sample per port.
+ *
+ * A rotary clocked "one state per armed read" would therefore drain up to
+ * eight states between the samples a driver actually decodes, making the
+ * decoded result (states drained) mod 4: two decodes as "undetermined",
+ * THREE DECODES AS -1 (a sign inversion), four and eight decode as zero.
+ * test_t2k_scan_shape() replays that exact eight-write scan and asserts
+ * one clean count per scan.
+ *
+ * Poll shape: Tempest 2000 is shape A/C (row select rewritten before every
+ * read), NOT the read-only shape B, so the design spec's stall-breaker
+ * branch is not taken.  test_poll_shapes() pins that: shape B is frozen by
+ * design and is the detector that would justify adding one.
+ *
+ * USAGE
+ *   ./test/tools/rotary_decode_test ./virtualjaguar_libretro.dylib [rom]
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "../harness/harness.h"
+
+/* Mirrors src/jerry/inputdev.h; the tool must not include emulator
+ * headers it would then be testing against itself.  An enum rather than
+ * #defines because the TYPE is load-bearing as well as the values:
+ * InputDevSetType's second parameter and InputDevGetType's return value
+ * are this enum, and UBSan's -fsanitize=function compares a dlsym'd
+ * pointer's declared signature against the callee's, so `int` there aborts
+ * the whole suite.  Values are still restated by hand, so a renumbering in
+ * the header cannot silently propagate into this test. */
+typedef enum {
+   DEV_PAD                 = 0,
+   DEV_MOUSE_ST            = 1,
+   DEV_MOUSE_AMIGA_ADAPTER = 2,
+   DEV_MOUSE_AMIGA_ON_ST   = 3,
+   DEV_ROTARY              = 4
+} InputDevType;
+
+/* Mirrors the joypadNButtons[] slot enum in src/jerry/joystick.h. */
+#define SLOT_U       0
+#define SLOT_D       1
+#define SLOT_L       2
+#define SLOT_R       3
+#define SLOT_1       7   /* row 1, column 3 -- a keypad digit */
+#define SLOT_PAUSE  20
+
+/* Socket-0 row codes.  Bit 15 enables the row-select outputs, bit 8 is
+ * the audio-enable bit both real drivers set; the low byte is
+ * (port2 nibble << 4) | port1 nibble, and 0xF means "that port is not a
+ * socket-0 code", i.e. not scanned.  These are the literal values
+ * Tempest 2000's own poll loop writes. */
+static const uint16_t row_word_p1[4] = { 0x81FE, 0x81FD, 0x81FB, 0x81F7 };
+static const uint16_t row_word_p2[4] = { 0x817F, 0x81BF, 0x81DF, 0x81EF };
+
+/* $F14000 phase bits per port (TR10's row-0 matrix).  Phase 0 is the "A"
+ * line and Phase 1 the "B" line. */
+typedef struct { int a, b; } phase_bits;
+static const phase_bits port_bits[2] = {
+   /* port 1: J10 / J11 */ { 10, 11 },
+   /* port 2: J14 / J15 */ { 14, 15 }
+};
+
+/* $F14002 controller-type bit per port, and the row in which C3 appears.
+ * TR10 "Identifying Controller Types": C2 C3 = 1 0 is "Tempest Rotary".
+ * The C-column rows differ by port -- port 1 reads C3/C2/C1 in rows
+ * 3/2/1, port 2 reads C2/C3/C1 in rows 3/2/1. */
+static const int   ctype_bit[2] = { 0, 2 };
+static const int   c3_row[2]    = { 3, 2 };
+static const int   c2_row[2]    = { 2, 3 };
+
+static const char *port_name[2] = { "port 1", "port 2" };
+
+/* ---- core entry points ---------------------------------------------- */
+
+static uint16_t (*p_ReadWord)(uint32_t);
+static void     (*p_WriteWord)(uint32_t, uint16_t);
+static void     (*p_SetType)(int, InputDevType);
+static void     (*p_SetScale)(int, int32_t);
+static void     (*p_SetRotaryID)(int, int);
+static void     (*p_Reset)(void);
+static void     (*p_Feed)(int, int32_t, int32_t, uint32_t);
+static InputDevType (*p_GetType)(int);
+static int      (*p_AnyAttached)(void);
+
+static uint8_t  *p_joypad[2];
+
+static size_t (*p_serialize_size)(void);
+static bool   (*p_serialize)(void *, size_t);
+static bool   (*p_unserialize)(const void *, size_t);
+
+/* ---- reporting ------------------------------------------------------- */
+
+static int  failures;
+static char detail[320];
+
+static void report(int cond, const char *what)
+{
+   if (cond)
+      printf("  ok   %s\n", what);
+   else
+   {
+      printf("  FAIL %s\n", what);
+      failures++;
+   }
+}
+
+/* ---- decoder (independent of src/jerry/quadrature.c) ----------------- */
+
+/* (A,B) logic levels -> Gray index.  0=(0,0) 1=(1,0) 2=(1,1) 3=(0,1).
+ * TR10's anticlockwise sequence walks this table forwards. */
+static int gray_index(int a, int b)
+{
+   if (!a && !b) return 0;
+   if ( a && !b) return 1;
+   if ( a &&  b) return 2;
+   return 3;
+}
+
+static int level_of(uint16_t data, int bit)
+{
+   return (int)((data >> bit) & 1u);
+}
+
+typedef struct
+{
+   int32_t  net;        /* +ve = anticlockwise (increasing index, A leads B) */
+   unsigned dropped;    /* two-state jumps: Domin's "undetermined" entry     */
+   unsigned polls;
+} decode_result;
+
+static int32_t decode_step(int *prev, int idx, unsigned *dropped)
+{
+   int d;
+
+   if (*prev < 0)
+   {
+      *prev = idx;
+      return 0;
+   }
+
+   d     = (idx - *prev) & 3;
+   *prev = idx;
+
+   if (d == 0) return 0;
+   if (d == 1) return 1;
+   if (d == 3) return -1;
+
+   (*dropped)++;
+   return 0;
+}
+
+static uint16_t row_word(int port, int row)
+{
+   return port ? row_word_p2[row] : row_word_p1[row];
+}
+
+static int sample_phase(int port, uint16_t data)
+{
+   return gray_index(level_of(data, port_bits[port].a),
+                     level_of(data, port_bits[port].b));
+}
+
+static void attach(int port, InputDevType type)
+{
+   p_SetType(port, type);
+   p_SetScale(port, 256);
+   p_SetRotaryID(port, 0);
+   p_Reset();
+   memset(p_joypad[port], 0x00, 21);
+}
+
+/*
+ * Poll `polls` times against row 0 of `port`, feeding `d_per_poll` units
+ * of rotation before each.  shape: 'A' one read per poll after a write,
+ * 'B' write once then read-only, 'C' write then TWO reads per poll.
+ */
+static void run_polls(decode_result *r, int port, char shape,
+                      unsigned polls, int32_t d_per_poll)
+{
+   int      prev = -1;
+   unsigned i;
+   uint16_t w    = row_word(port, 0);
+
+   memset(r, 0, sizeof(*r));
+
+   /* Prime the decoder with a reference sample, as any real driver must:
+    * a quadrature decoder cannot report movement until it has something
+    * to compare against.  The backlog is empty here, so this read cannot
+    * advance the encoder.  For shape B this IS the single row-select
+    * write that defines the shape. */
+   p_WriteWord(0, w);
+   prev = sample_phase(port, p_ReadWord(0));
+
+   for (i = 0; i < polls; i++)
+   {
+      uint16_t d0;
+
+      if (d_per_poll)
+         p_Feed(port, d_per_poll, 0, 0);
+
+      if (shape != 'B')
+         p_WriteWord(0, w);
+
+      d0 = p_ReadWord(0);
+      if (shape == 'C')
+         d0 = p_ReadWord(0);     /* second read is the decoded one */
+
+      r->net += decode_step(&prev, sample_phase(port, d0), &r->dropped);
+      r->polls++;
+   }
+}
+
+/* ---- individual checks ----------------------------------------------- */
+
+static void test_directions(int port)
+{
+   decode_result r;
+
+   printf("%s rotary: direction and distance\n", port_name[port]);
+
+   /* TR10: anticlockwise = A leads B = increasing Gray index.  The host
+    * mapping is +X = clockwise (a spinner pushed right turns clockwise),
+    * so a positive feed must decode NEGATIVE here. */
+   attach(port, DEV_ROTARY);
+   run_polls(&r, port, 'A', 40, 1);
+   sprintf(detail,
+           "+40 host units over 40 polls decode as clockwise "
+           "(net=%d, expect -40), dropped=%u", (int)r.net, r.dropped);
+   report(r.net == -40 && r.dropped == 0, detail);
+
+   attach(port, DEV_ROTARY);
+   run_polls(&r, port, 'A', 40, -1);
+   sprintf(detail,
+           "-40 host units over 40 polls decode as anticlockwise "
+           "(net=%d, expect +40), dropped=%u", (int)r.net, r.dropped);
+   report(r.net == 40 && r.dropped == 0, detail);
+
+   /* Rate ceiling: four units per poll is four times what one poll can
+    * carry.  The result must be exactly one state per poll -- lag -- and
+    * never a jump, an overshoot or a sign flip. */
+   attach(port, DEV_ROTARY);
+   run_polls(&r, port, 'A', 30, 4);
+   sprintf(detail,
+           "4 units/poll x 30 polls lags rather than jitters "
+           "(net=%d, expect -30), dropped=%u", (int)r.net, r.dropped);
+   report(r.net == -30 && r.dropped == 0, detail);
+}
+
+static void test_poll_shapes(int port)
+{
+   decode_result ra, rb, rc;
+
+   printf("%s rotary: poll shapes (the emission rule)\n", port_name[port]);
+
+   attach(port, DEV_ROTARY);
+   run_polls(&ra, port, 'A', 40, 1);
+
+   attach(port, DEV_ROTARY);
+   run_polls(&rc, port, 'C', 40, 1);
+
+   sprintf(detail,
+           "shape C (write + TWO reads) decodes as shape A: A=%d C=%d, "
+           "dropped A=%u C=%u",
+           (int)ra.net, (int)rc.net, ra.dropped, rc.dropped);
+   report(rc.net == ra.net && ra.dropped == 0 && rc.dropped == 0, detail);
+
+   /* Shape B is the design spec's deferred case and the detector for
+    * whether a stall-breaker is ever needed.  Tempest 2000 is NOT this
+    * shape -- measured, see the file header -- so no stall-breaker is
+    * implemented and "frozen" is a recorded, tested property. */
+   attach(port, DEV_ROTARY);
+   run_polls(&rb, port, 'B', 40, 1);
+   sprintf(detail,
+           "shape B (write once, then read-only) is frozen by design: "
+           "net=%d (expect 0)", (int)rb.net);
+   report(rb.net == 0, detail);
+}
+
+/*
+ * THE DISCRIMINATOR: the rotary is a matrix device, not a row-blind one.
+ */
+static void test_row_scope(int port)
+{
+   decode_result r;
+   uint16_t      v[4];
+   int           row, phase_rows, pad_rows;
+
+   printf("%s rotary: visible in row 0 ONLY (not row-blind)\n",
+          port_name[port]);
+
+   /* Drive to a phase in which at least one phase line is asserted, so
+    * "the rotary is invisible in rows 1-3" is not trivially true of an
+    * idle encoder.  Then read every row without feeding, so the phase is
+    * constant across the sweep. */
+   attach(port, DEV_ROTARY);
+   run_polls(&r, port, 'A', 21, 1);
+
+   for (row = 0; row < 4; row++)
+   {
+      p_WriteWord(0, row_word(port, row));
+      v[row] = p_ReadWord(0);
+   }
+
+   phase_rows = 0;
+   pad_rows   = 0;
+   for (row = 0; row < 4; row++)
+   {
+      int asserted = (!level_of(v[row], port_bits[port].a)
+                      || !level_of(v[row], port_bits[port].b));
+      if (row == 0)
+         phase_rows = asserted;
+      else if (asserted)
+         pad_rows++;
+   }
+
+   sprintf(detail,
+           "phase lines assert in row 0 ($%04X) and in NO other row "
+           "(rows 1-3: $%04X $%04X $%04X)",
+           v[0], v[1], v[2], v[3]);
+   report(phase_rows && pad_rows == 0, detail);
+
+   /* And rows 1-3 still behave as an ordinary pad: a keypad digit poked
+    * into the matrix must read back.  This is the half that fails if the
+    * rotary is ever moved onto the mouse's row-blind overlay, which would
+    * bury the keypad under the phase lines. */
+   p_joypad[port][SLOT_1] = 0xFF;
+   p_WriteWord(0, row_word(port, 1));
+   v[1] = p_ReadWord(0);
+   p_joypad[port][SLOT_1] = 0x00;
+
+   sprintf(detail,
+           "rows 1-3 still decode as a standard pad (keypad '1' pulls "
+           "bit %d low in row 1: $%04X)", port_bits[port].b, v[1]);
+   report(!level_of(v[1], port_bits[port].b), detail);
+
+   /* Up and Down do not exist on a rotary.  TR10 notes this is why rotary
+    * games are told to use A = Up and C = Down for menus. */
+   p_joypad[port][SLOT_U] = 0xFF;
+   p_joypad[port][SLOT_D] = 0xFF;
+   attach(port, DEV_ROTARY);
+   run_polls(&r, port, 'A', 5, 1);
+   report(p_joypad[port][SLOT_U] == 0x00 && p_joypad[port][SLOT_D] == 0x00,
+          "Up and Down never assert on a rotary port");
+}
+
+/*
+ * Replay Tempest 2000's measured scan: eight row-select writes per frame
+ * (port 1 rows 0-3, then port 2 rows 0-3), each followed by a move.l --
+ * one offset-0 read and one offset-2 read.  Exactly ONE row-0 sample per
+ * port per scan.
+ *
+ * This is the regression for the row-gated advance.  Clocked "one state
+ * per armed read" the encoder drains up to 8 states between the samples
+ * the driver decodes, so the decoded value is (drained mod 4): 2 is
+ * dropped, 3 inverts the sign, 4 and 8 read as no movement at all.
+ */
+static void test_t2k_scan_shape(int port)
+{
+   int      prev = -1;
+   unsigned scan, dropped = 0;
+   int32_t  net = 0;
+   int      row, half;
+
+   printf("%s rotary: Tempest 2000's measured 8-write scan\n",
+          port_name[port]);
+
+   attach(port, DEV_ROTARY);
+
+   /* Prime from a row-0 sample, as the driver's first pass does. */
+   p_WriteWord(0, row_word(port, 0));
+   prev = sample_phase(port, p_ReadWord(0));
+
+   for (scan = 0; scan < 40; scan++)
+   {
+      p_Feed(port, 1, 0, 0);        /* one unit of rotation per frame */
+
+      /* half 0 = port-1 rows 0-3, half 1 = port-2 rows 0-3, in the order
+       * the measured loop issues them.  Each write is followed by a
+       * move.l, i.e. one offset-0 read and one offset-2 read. */
+      for (half = 0; half < 2; half++)
+      {
+         for (row = 0; row < 4; row++)
+         {
+            uint16_t d0;
+
+            p_WriteWord(0, half ? row_word_p2[row] : row_word_p1[row]);
+            d0 = p_ReadWord(0);
+            p_ReadWord(2);
+
+            /* The driver decodes the rotary from this sample, and only
+             * from this one: its own port's row 0. */
+            if (half == port && row == 0)
+               net += decode_step(&prev, sample_phase(port, d0), &dropped);
+         }
+      }
+   }
+
+   sprintf(detail,
+           "one clean count per scan across 40 scans (net=%d, expect -40), "
+           "dropped=%u -- a per-read clock would decode garbage here",
+           (int)net, dropped);
+   report(net == -40 && dropped == 0, detail);
+}
+
+/*
+ * Tempest 2000's rotary support is hidden behind an unlock that needs
+ * PAUSE ON BOTH CONTROLLERS AT ONCE.  It is the first thing a user does
+ * and the easiest thing this feature can break, so it is asserted here:
+ * a rotary port must still be able to report Pause while the other port
+ * is a pad also reporting Pause.
+ */
+static void test_pause_unlock(void)
+{
+   uint16_t d2;
+   int      p1_pause, p2_pause;
+
+   printf("Tempest 2000 unlock: Pause on BOTH controllers at once\n");
+
+   attach(0, DEV_ROTARY);
+   attach(1, DEV_PAD);
+
+   p_joypad[0][SLOT_PAUSE] = 0xFF;
+   p_joypad[1][SLOT_PAUSE] = 0xFF;
+
+   /* Row 0 of both ports at once: port-1 nibble 0xE, port-2 nibble 0x7. */
+   p_WriteWord(0, 0x817E);
+   p_ReadWord(0);
+   d2 = p_ReadWord(2);
+
+   p1_pause = !level_of(d2, 0);   /* port 1 Pause -> $F14002 bit 0 */
+   p2_pause = !level_of(d2, 2);   /* port 2 Pause -> $F14002 bit 2 */
+
+   sprintf(detail,
+           "rotary on port 1 + pad on port 2 both report Pause "
+           "($F14002=$%04X, p1=%d p2=%d)", d2, p1_pause, p2_pause);
+   report(p1_pause && p2_pause, detail);
+
+   p_joypad[0][SLOT_PAUSE] = 0x00;
+   p_joypad[1][SLOT_PAUSE] = 0x00;
+   attach(0, DEV_PAD);
+}
+
+static void test_controller_id(int port)
+{
+   uint16_t d2_c3, d2_c2;
+   int      bit = ctype_bit[port];
+
+   printf("%s rotary: controller-type identification\n", port_name[port]);
+
+   /* Default (no diode): C2 C3 = 1 1, i.e. "standard joypad", which is
+    * what most rotary controllers ever built actually report. */
+   attach(port, DEV_ROTARY);
+   p_SetRotaryID(port, 0);
+
+   p_WriteWord(0, row_word(port, c3_row[port]));
+   p_ReadWord(0);
+   d2_c3 = p_ReadWord(2);
+
+   sprintf(detail,
+           "with the diode absent (default) C3 reads 1 -- standard joypad "
+           "($F14002=$%04X bit %d)", d2_c3, bit);
+   report(level_of(d2_c3, bit) == 1, detail);
+
+   /* With the diode fitted: C3 = 0, C2 = 1 -> "Tempest Rotary". */
+   p_SetRotaryID(port, 1);
+
+   p_WriteWord(0, row_word(port, c3_row[port]));
+   p_ReadWord(0);
+   d2_c3 = p_ReadWord(2);
+
+   p_WriteWord(0, row_word(port, c2_row[port]));
+   p_ReadWord(0);
+   d2_c2 = p_ReadWord(2);
+
+   sprintf(detail,
+           "with the diode fitted C2 C3 = 1 0 in the right rows for this "
+           "port (row %d bit %d = 0 -> $%04X; row %d bit %d = 1 -> $%04X)",
+           c3_row[port], bit, d2_c3, c2_row[port], bit, d2_c2);
+   report(level_of(d2_c3, bit) == 0 && level_of(d2_c2, bit) == 1, detail);
+
+   p_SetRotaryID(port, 0);
+}
+
+static void test_port_isolation(void)
+{
+   decode_result r;
+   uint16_t      before, after;
+
+   printf("a rotary on one port does not perturb the other\n");
+
+   attach(0, DEV_PAD);
+   attach(1, DEV_ROTARY);
+
+   /* Port 1 is a plain pad with nothing pressed; its bits must read the
+    * same before and after the port-2 rotary is driven. */
+   p_WriteWord(0, row_word(0, 0));
+   before = (uint16_t)(p_ReadWord(0) & 0x0F00u);
+
+   run_polls(&r, 1, 'A', 25, 1);
+
+   p_WriteWord(0, row_word(0, 0));
+   after = (uint16_t)(p_ReadWord(0) & 0x0F00u);
+
+   sprintf(detail,
+           "port-1 direction bits unchanged by a port-2 rotary "
+           "($%04X vs $%04X), while port 2 decoded net=%d",
+           before, after, (int)r.net);
+   report(before == after && before == 0x0F00u && r.net == -25, detail);
+
+   attach(1, DEV_PAD);
+}
+
+static void test_pad_is_inert(void)
+{
+   decode_result r;
+   unsigned      i;
+
+   printf("no device selected -> nothing reaches the matrix\n");
+
+   p_SetType(0, DEV_PAD);
+   p_SetType(1, DEV_PAD);
+   p_Reset();
+   memset(p_joypad[0], 0x00, 21);
+   memset(p_joypad[1], 0x00, 21);
+
+   report(p_GetType(0) == DEV_PAD && p_GetType(1) == DEV_PAD
+          && p_AnyAttached() == 0,
+          "both ports report pad and nothing is attached");
+
+   for (i = 0; i < 20; i++)
+   {
+      p_Feed(0, 100, 100, 3);
+      p_Feed(1, 100, 100, 3);
+   }
+
+   run_polls(&r, 0, 'A', 20, 0);
+   sprintf(detail, "no rotation reaches $F14000 (net=%d)", (int)r.net);
+   report(r.net == 0, detail);
+}
+
+static void test_mouse_still_row_blind(void)
+{
+   decode_result r;
+   uint16_t      v[4];
+   int           row, rows_asserting = 0;
+
+   printf("the mouse is still row-blind (the two shapes stay distinct)\n");
+
+   attach(1, DEV_MOUSE_ST);
+   run_polls(&r, 1, 'A', 21, 1);
+
+   for (row = 0; row < 4; row++)
+   {
+      p_WriteWord(0, row_word(1, row));
+      v[row] = p_ReadWord(0);
+      if ((uint16_t)(v[row] & 0xF000u) != 0xF000u)
+         rows_asserting++;
+   }
+
+   sprintf(detail,
+           "a port-2 mouse asserts in ALL FOUR rows ($%04X $%04X $%04X "
+           "$%04X) where the rotary asserts in one",
+           v[0], v[1], v[2], v[3]);
+   report(rows_asserting == 4, detail);
+
+   attach(1, DEV_PAD);
+}
+
+static void test_savestate(void)
+{
+   uint8_t      *snap;
+   size_t        sz;
+   decode_result cont, restored;
+   int           ok;
+
+   printf("savestate round-trip mid-rotation\n");
+
+   if (!p_serialize || !p_unserialize || !p_serialize_size)
+   {
+      report(0, "retro_serialize/retro_unserialize resolvable");
+      return;
+   }
+
+   sz   = p_serialize_size();
+   snap = (uint8_t *)malloc(sz);
+   if (!snap)
+   {
+      report(0, "allocate state buffer");
+      return;
+   }
+
+   /* Stop in the middle of a Gray cycle with a non-empty backlog and a
+    * non-zero Q8 carry, then save. */
+   attach(0, DEV_ROTARY);
+   p_SetScale(0, 96);              /* 37.5%: guarantees a carry remainder */
+   run_polls(&cont, 0, 'A', 7, 3);
+
+   ok = p_serialize(snap, sz) ? 1 : 0;
+   report(ok, "retro_serialize succeeded mid-rotation");
+   if (!ok)
+   {
+      free(snap);
+      return;
+   }
+
+   run_polls(&cont, 0, 'A', 25, 3);
+
+   ok = p_unserialize(snap, sz) ? 1 : 0;
+   report(ok, "retro_unserialize accepted the state");
+
+   run_polls(&restored, 0, 'A', 25, 3);
+
+   sprintf(detail,
+           "post-restore replay matches (net %d vs %d, dropped %u vs %u) "
+           "-- phase, backlog and Q8 carry all survived the rollback",
+           (int)cont.net, (int)restored.net, cont.dropped, restored.dropped);
+   report(cont.net == restored.net && cont.dropped == restored.dropped
+          && restored.dropped == 0, detail);
+
+   free(snap);
+   p_SetScale(0, 256);
+   attach(0, DEV_PAD);
+}
+
+int main(int argc, char **argv)
+{
+   harness_config cfg = HARNESS_CONFIG_DEFAULT;
+   harness_result result;
+   char           summary[128];
+   int            port;
+
+   cfg.frames = 0;
+   if (!harness_init_from_args(&cfg, argc, argv))
+      return 1;
+
+   if (!cfg.rom_path)
+      cfg.rom_path = "test/roms/yarc.j64";
+   if (!harness_load_rom(&cfg))
+      return 1;
+
+   p_ReadWord    = (uint16_t (*)(uint32_t))harness_dlsym(&cfg, "JoystickReadWord");
+   p_WriteWord   = (void (*)(uint32_t, uint16_t))harness_dlsym(&cfg, "JoystickWriteWord");
+   p_SetType     = (void (*)(int, InputDevType))
+                      harness_dlsym(&cfg, "InputDevSetType");
+   p_SetScale    = (void (*)(int, int32_t))harness_dlsym(&cfg, "InputDevSetScale");
+   p_SetRotaryID = (void (*)(int, int))harness_dlsym(&cfg, "InputDevSetRotaryID");
+   p_Reset       = (void (*)(void))harness_dlsym(&cfg, "InputDevReset");
+   p_Feed        = (void (*)(int, int32_t, int32_t, uint32_t))
+                      harness_dlsym(&cfg, "InputDevFeed");
+   p_GetType     = (InputDevType (*)(int))harness_dlsym(&cfg, "InputDevGetType");
+   p_AnyAttached = (int (*)(void))harness_dlsym(&cfg, "InputDevAnyAttached");
+
+   p_joypad[0] = (uint8_t *)harness_dlsym(&cfg, "joypad0Buttons");
+   p_joypad[1] = (uint8_t *)harness_dlsym(&cfg, "joypad1Buttons");
+
+   p_serialize_size = (size_t (*)(void))harness_dlsym(&cfg, "retro_serialize_size");
+   p_serialize      = (bool (*)(void *, size_t))harness_dlsym(&cfg, "retro_serialize");
+   p_unserialize    = (bool (*)(const void *, size_t))
+                         harness_dlsym(&cfg, "retro_unserialize");
+
+   if (!p_ReadWord || !p_WriteWord || !p_SetType || !p_SetScale
+       || !p_SetRotaryID || !p_Reset || !p_Feed || !p_GetType
+       || !p_AnyAttached || !p_joypad[0] || !p_joypad[1])
+   {
+      fprintf(stderr,
+              "rotary_decode_test: missing test-ABI symbols.  The wide test "
+              "ABI must export Joystick*, InputDev* and joypadNButtons "
+              "(exports-test.list and link-test.T).  Build with "
+              "TEST_EXPORTS=1.\n");
+      harness_shutdown(&cfg);
+      return 1;
+   }
+
+   /* The rotary is valid on BOTH ports, unlike the mouse. */
+   for (port = 0; port < 2; port++)
+   {
+      sprintf(detail, "InputDevSetType accepts a rotary on %s",
+              port_name[port]);
+      p_SetType(port, DEV_ROTARY);
+      report(p_GetType(port) == DEV_ROTARY, detail);
+      p_SetType(port, DEV_PAD);
+   }
+
+   for (port = 0; port < 2; port++)
+   {
+      test_directions(port);
+      test_poll_shapes(port);
+      test_row_scope(port);
+      test_t2k_scan_shape(port);
+      test_controller_id(port);
+      attach(port, DEV_PAD);
+   }
+
+   test_pause_unlock();
+   test_port_isolation();
+   test_mouse_still_row_blind();
+   test_savestate();
+   test_pad_is_inert();
+
+   sprintf(summary, "%d failure(s)", failures);
+   result.status = failures ? "FAIL" : "PASS";
+   result.name   = "rotary_decode";
+   result.detail = summary;
+   harness_report(&cfg, &result, 1);
+
+   harness_shutdown(&cfg);
+   return failures ? 1 : 0;
+}

--- a/test/tools/rotary_decode_test.c
+++ b/test/tools/rotary_decode_test.c
@@ -24,6 +24,18 @@
  * asserts both halves.  If someone ever "simplifies" the rotary onto the
  * mouse's row-independent overlay, that test fails.
  *
+ * THE ONE THING A DECODER CANNOT SEE
+ * ==================================
+ * Every check below decodes DIFFERENCES between Gray indices, and a
+ * global polarity inversion of both phase lines is a +2 mod 4 shift of
+ * the index -- which differencing cancels.  joymatrix_identity.c closed
+ * that hole for the mouse with EXPECT_DIGEST_FULL_WITH_MOUSE; the rotary
+ * closes it with test_idle_rest_phase() instead of a fourth digest
+ * constant, by asserting the one absolute fact the shift moves: an idle
+ * encoder rests at QUAD_REST_PHASE (1,1), both lines high, bit-identical
+ * to an idle pad.  Under the inversion an idle rotary holds Left and
+ * Right down from the first scan.
+ *
  * THE ROW-GATED EMISSION RULE (the regression for the real defect)
  * ===============================================================
  * Measured on Tempest 2000 (vjtrace --watch 0xF14000:4:rw, 400 frames):
@@ -221,9 +233,14 @@ static void run_polls(decode_result *r, int port, char shape,
 
    /* Prime the decoder with a reference sample, as any real driver must:
     * a quadrature decoder cannot report movement until it has something
-    * to compare against.  The backlog is empty here, so this read cannot
-    * advance the encoder.  For shape B this IS the single row-select
-    * write that defines the shape. */
+    * to compare against.  For shape B this IS the single row-select write
+    * that defines the shape.
+    *
+    * This read is ARMED like any other, so it advances the encoder when
+    * the caller left a non-empty backlog behind -- test_savestate does,
+    * deliberately.  Harmless here (the sample only seeds `prev`), but it
+    * is why test_savestate's two capture reads must start from identical
+    * state to be comparable. */
    p_WriteWord(0, w);
    prev = sample_phase(port, p_ReadWord(0));
 
@@ -370,13 +387,61 @@ static void test_row_scope(int port)
    report(!level_of(v[1], port_bits[port].b), detail);
 
    /* Up and Down do not exist on a rotary.  TR10 notes this is why rotary
-    * games are told to use A = Up and C = Down for menus. */
+    * games are told to use A = Up and C = Down for menus.
+    *
+    * The two pokes go AFTER attach(), which memsets the pad array: set
+    * before it they are erased by the attach itself, and the assertion
+    * then reads slots that were never 0xFF in the first place -- true
+    * with inputdev_publish_rotary's two clears deleted outright. */
+   attach(port, DEV_ROTARY);
    p_joypad[port][SLOT_U] = 0xFF;
    p_joypad[port][SLOT_D] = 0xFF;
-   attach(port, DEV_ROTARY);
    run_polls(&r, port, 'A', 5, 1);
    report(p_joypad[port][SLOT_U] == 0x00 && p_joypad[port][SLOT_D] == 0x00,
           "Up and Down never assert on a rotary port");
+}
+
+/*
+ * IDLE POLARITY -- the one shape a GLOBAL phase inversion cannot hide in.
+ *
+ * Inverting both phase lines at once shifts the Gray index by +2 mod 4,
+ * and every other check in this file decodes DIFFERENCES between indices,
+ * which that shift cancels out of.  What it cannot cancel is the rest
+ * position: QUAD_REST_PHASE is (1,1), the only state with both lines
+ * high, chosen so an idle rotary is bit-identical to an idle pad
+ * (inputdev.c, "The encoder's rest phase is (1,1)").  Under the inversion
+ * an idle rotary instead writes 0xFF into both phase slots and holds Left
+ * and Right down from the moment the port is first scanned.
+ *
+ * The four slots are poked to 0xFF AFTER attach() so this cannot pass
+ * vacuously on a publish that never ran: with inputdev_publish_rotary
+ * removed the pokes survive and the assertion fails.
+ */
+static void test_idle_rest_phase(int port)
+{
+   uint16_t v;
+
+   printf("%s rotary: idle rests with BOTH phase lines high\n",
+          port_name[port]);
+
+   attach(port, DEV_ROTARY);
+
+   p_joypad[port][SLOT_U] = 0xFF;
+   p_joypad[port][SLOT_D] = 0xFF;
+   p_joypad[port][SLOT_L] = 0xFF;
+   p_joypad[port][SLOT_R] = 0xFF;
+
+   p_WriteWord(0, row_word(port, 0));
+   v = p_ReadWord(0);
+
+   sprintf(detail,
+           "a freshly attached, unmoved rotary clears all four direction "
+           "slots and leaves phase bits %d/%d HIGH (row 0 = $%04X)",
+           port_bits[port].a, port_bits[port].b, v);
+   report(p_joypad[port][SLOT_U] == 0x00 && p_joypad[port][SLOT_D] == 0x00
+          && p_joypad[port][SLOT_L] == 0x00 && p_joypad[port][SLOT_R] == 0x00
+          && level_of(v, port_bits[port].a) == 1
+          && level_of(v, port_bits[port].b) == 1, detail);
 }
 
 /*
@@ -389,6 +454,17 @@ static void test_row_scope(int port)
  * per armed read" the encoder drains up to 8 states between the samples
  * the driver decodes, so the decoded value is (drained mod 4): 2 is
  * dropped, 3 inverts the sign, 4 and 8 read as no movement at all.
+ *
+ * THE MAGNITUDE IS PART OF THE TEST.  Feeding ONE unit per scan makes
+ * this vacuous: the backlog never exceeds 1, so the row-0 read drains it
+ * and QuadAdvance() no-ops on the other seven armed reads whether they
+ * are gated or not.  Widening the gate by a single row then still decodes
+ * a clean -40.  Four units per scan keeps the backlog non-empty across
+ * the whole scan, so every ungated read is a real state and the decoded
+ * result collapses (two states between samples is Domin's "undetermined"
+ * entry -- dropped, net 0).  The expected count is unchanged at one per
+ * scan, because that is what the gate is for: the excess queues in the
+ * backlog and the sample rate, not the feed rate, sets the drain rate.
  */
 static void test_t2k_scan_shape(int port)
 {
@@ -408,7 +484,9 @@ static void test_t2k_scan_shape(int port)
 
    for (scan = 0; scan < 40; scan++)
    {
-      p_Feed(port, 1, 0, 0);        /* one unit of rotation per frame */
+      /* Four units per frame -- four times what one scan can drain, so
+       * the backlog stays non-empty for all eight reads.  See above. */
+      p_Feed(port, 4, 0, 0);
 
       /* half 0 = port-1 rows 0-3, half 1 = port-2 rows 0-3, in the order
        * the measured loop issues them.  Each write is followed by a
@@ -432,9 +510,9 @@ static void test_t2k_scan_shape(int port)
    }
 
    sprintf(detail,
-           "one clean count per scan across 40 scans (net=%d, expect -40), "
-           "dropped=%u -- a per-read clock would decode garbage here",
-           (int)net, dropped);
+           "one clean count per scan across 40 scans at 4 units/scan "
+           "(net=%d, expect -40), dropped=%u -- a per-read clock would "
+           "decode garbage here", (int)net, dropped);
    report(net == -40 && dropped == 0, detail);
 }
 
@@ -602,11 +680,37 @@ static void test_mouse_still_row_blind(void)
    attach(1, DEV_PAD);
 }
 
+/*
+ * SAVESTATE -- and why the magnitude and the phase readback are both
+ * load-bearing.
+ *
+ * quad_axis carries three fields (backlog, frac, phase) and this check is
+ * the only thing asserting that InputDevStateLoad restores them.  Three
+ * traps make an obvious version of it prove nothing:
+ *
+ *   1. A feed of THREE units at 37.5% is 288/256 -- more than one state
+ *      per poll -- so every poll emits exactly one state regardless of
+ *      what the carry or the backlog held, and the replay matches with
+ *      `frac` and `backlog` dropped from the load entirely.  ONE unit per
+ *      poll is 96/256, so a state comes out only every third-ish poll and
+ *      the Q8 carry decides WHICH ones -- now `frac` moves `net`.
+ *   2. `backlog` was 0 at every poll boundary at that magnitude, so it
+ *      was equally unpinned.  The extra p_Feed() below leaves states
+ *      queued but undrained at the instant of the save.
+ *   3. `phase` is invisible to `net` no matter what the magnitude is,
+ *      because run_polls() re-primes its reference sample on entry.  It
+ *      needs a raw readback, taken by an IDENTICAL sequence from an
+ *      IDENTICAL state on both sides -- the capture read is itself armed
+ *      and advances the encoder when the backlog is non-empty, so an
+ *      asymmetric capture would differ by one state on its own.
+ */
 static void test_savestate(void)
 {
    uint8_t      *snap;
    size_t        sz;
    decode_result cont, restored;
+   uint16_t      w0;
+   int           phase_cont, phase_restored;
    int           ok;
 
    printf("savestate round-trip mid-rotation\n");
@@ -625,11 +729,12 @@ static void test_savestate(void)
       return;
    }
 
-   /* Stop in the middle of a Gray cycle with a non-empty backlog and a
-    * non-zero Q8 carry, then save. */
+   /* Stop mid-Gray-cycle with a non-zero Q8 carry (trap 1) and states
+    * still queued in the backlog (trap 2), then save. */
    attach(0, DEV_ROTARY);
    p_SetScale(0, 96);              /* 37.5%: guarantees a carry remainder */
-   run_polls(&cont, 0, 'A', 7, 3);
+   run_polls(&cont, 0, 'A', 7, 1);
+   p_Feed(0, 8, 0, 0);             /* 3 states queued, none drained yet */
 
    ok = p_serialize(snap, sz) ? 1 : 0;
    report(ok, "retro_serialize succeeded mid-rotation");
@@ -639,18 +744,28 @@ static void test_savestate(void)
       return;
    }
 
-   run_polls(&cont, 0, 'A', 25, 3);
+   w0 = row_word(0, 0);
+
+   p_WriteWord(0, w0);
+   phase_cont = sample_phase(0, p_ReadWord(0));
+   run_polls(&cont, 0, 'A', 25, 1);
 
    ok = p_unserialize(snap, sz) ? 1 : 0;
    report(ok, "retro_unserialize accepted the state");
 
-   run_polls(&restored, 0, 'A', 25, 3);
+   /* Identical sequence from the identical state -- see trap 3. */
+   p_WriteWord(0, w0);
+   phase_restored = sample_phase(0, p_ReadWord(0));
+   run_polls(&restored, 0, 'A', 25, 1);
 
    sprintf(detail,
-           "post-restore replay matches (net %d vs %d, dropped %u vs %u) "
-           "-- phase, backlog and Q8 carry all survived the rollback",
+           "raw phase reads back the same (%d vs %d) and the replay "
+           "matches (net %d vs %d, dropped %u vs %u) -- phase, backlog "
+           "and Q8 carry all survived the rollback",
+           phase_cont, phase_restored,
            (int)cont.net, (int)restored.net, cont.dropped, restored.dropped);
-   report(cont.net == restored.net && cont.dropped == restored.dropped
+   report(phase_cont == phase_restored
+          && cont.net == restored.net && cont.dropped == restored.dropped
           && restored.dropped == 0, detail);
 
    free(snap);
@@ -722,6 +837,7 @@ int main(int argc, char **argv)
       test_directions(port);
       test_poll_shapes(port);
       test_row_scope(port);
+      test_idle_rest_phase(port);
       test_t2k_scan_shape(port);
       test_controller_id(port);
       attach(port, DEV_PAD);


### PR DESCRIPTION
## What this is

PR 3 of 4 of the input-devices track (epic #428): the **Tempest rotary** (#436).

Implements step **7** of `docs/superpowers/specs/2026-08-14-input-devices-mouse-rotary-design.md`. Step 1 (the guardrail) is #446, steps 2-6 (the mouse) are #449, and steps 8-9 (titledb auto-select + docs) are PR 4.

### Stacking on #446 and #449

This branches off `feat/429-mouse-support`, **not** `develop`. Until #446 and #449 merge, the diff shown here **includes their commits** (`test/tools/joymatrix_identity.c`, `src/jerry/quadrature.{c,h}`, `src/jerry/inputdev.{c,h}`, the libretro device scaffolding and the v12 savestate chunk). That work is not being re-landed. Once both merge this rebases away to my one commit.

Refs #436, #428.

---

## The load-bearing fact: the rotary is a matrix device and the mouse is not

These two peripherals share an encoder and nothing else, and keeping that distinction load-bearing is most of this PR.

The **mouse adapter is row-blind**. It does not connect Jaguar pins 1-4 -- exactly the port-2 row-select outputs -- so all six input lines carry its state identically in every row. It cannot be expressed as pad slots, and #449 gives it a row-independent overlay on the raw `$F14000` bits.

The **rotary is the opposite shape**. TR10, section "Rotary 'Tempest' Controller":

> Although originally intended to be a bank switching design all existing rotary controllers are modified standard controllers, consequently they should be read just like a standard controller using Socket 0 row codes ...

Two independent corroborations that this is genuine, and not a detail to generalise away:

- **Wiring** (Zerosquare, AtariAge "Rotary trouble"): the encoder's common wire goes to joystick port **pin 4** -- the row strobe -- "not ground. If you used an actual ground, it won't work properly." Port-1 pin 4 is `J0`, and row 0 is the only row code that drives `J0` low (`J3 J2 J1 J0 = 1110`). So the phases appear in row 0 and **only** row 0.
- **Domin's `oneaxis.s`** reads socket A with `move.w #$817f,JOYSTICK`, masks down to just the L and R bits and indexes a 16-entry `(old<<2)|new` table whose four double-transition entries are commented "undetermined" -- the same decoder shape, and therefore the same rate ceiling, as the mouse.

So the rotary **reuses `joypadNButtons[]` untouched**. No new assertion mechanism:

| Signal | Slot | Port 1 bit | Port 2 bit |
|---|---|---|---|
| Phase 0 | `BUTTON_L` | 10 (J10) | 14 (J14) |
| Phase 1 | `BUTTON_R` | 11 (J11) | 15 (J15) |

`BUTTON_U` / `BUTTON_D` are forced clear -- the controller physically has no up/down, which is why TR10 tells rotary games to use `A = Up` and `C = Down` for menus. Rows 1-3 remain an ordinary pad.

**Polarity is inverted relative to the mouse path**, which is the single easiest way to ship a backwards spinner. TR10 gives the phase sequences as pin levels and "reading a zero means the appropriate button is depressed"; `joystick.c` does `data &= (joypadNButtons[slot] ? mask : 0xFFFF)`, so a *non-zero* array entry pulls the bit low. Hence `pin level 1 -> 0x00`, `pin level 0 -> 0xFF`. `QuadLevels()` returns logic levels precisely so each sink applies its own polarity at one visible place. The encoder itself is `src/jerry/quadrature.{c,h}` from PR A2, reused as-is -- one axis, not two, and no second encoder.

---

## Which poll-shape branch I took, and the evidence

The spec (section 10, step 7) carries a defined branch: if Tempest 2000 polls read-only -- row select written once at init, then reads forever -- the arm-on-write emission rule cannot clock and the stall-breaker must be implemented here.

**Measured, not assumed.** `vjtrace --watch 0xF14000:4:rw` over 400 frames of `Tempest 2000 (1994).jag`:

| Write pc | value | selects | Read pc | count |
|---|---|---|---|---|
| `80FD2E` | `$81FE` | port 1 row 0 | `80FD36` | 330 |
| `80FD42` | `$81FD` | port 1 row 1 | `80FD4A` | 330 |
| `80FD56` | `$81FB` | port 1 row 2 | `80FD5E` | 330 |
| `80FD6C` | `$81F7` | port 1 row 3 | `80FD74` | 330 |
| `80FDA2` | `$817F` | port 2 row 0 | `80FDAA` | 330 |
| `80FDB8` | `$81BF` | port 2 row 1 | `80FDC0` | 330 |
| `80FDD0` | `$81DF` | port 2 row 2 | `80FDD8` | 330 |
| `80FDE6` | `$81EF` | port 2 row 3 | `80FDEE` | 330 |

330 scans over 331 frames -- one full eight-row scan per frame, every read preceded by a row-select write from the paired instruction, each read a `move.l` (one offset-0 access and one offset-2 access).

**Branch taken: shape A/C. The stall-breaker is NOT implemented.** Shape B does not occur, and `rotary_decode_test` pins that as a recorded property rather than an assumption: shape B is asserted to decode zero motion, so it remains the detector that would justify adding one if a real title ever needs it.

---

## What the measurement also exposed: a defect the spec did not model

Eight armed offset-0 reads per frame, but exactly **one row-0 sample per port**. A rotary's phases exist in row 0 only, so the three other reads in each port's scan decode nothing.

Clocked with the mouse's rule -- one state per armed read -- the encoder drains up to eight states between the samples a driver actually decodes, making the decoded result `(states drained) mod 4`:

| states drained between samples | decoded |
|---|---|
| 1 | +1, correct |
| 2 | "undetermined", discarded |
| 3 | **-1 -- a sign inversion** |
| 4, 8 | 0, no movement at all |

The device would work at exactly one count per frame and nowhere else, and no sensitivity setting can compensate. That is precisely the jitter the spec's section 3 emission rule exists to prevent.

So `InputDevClock()` now takes the decoded socket-0 row per port and **a rotary advances only on an armed row-0 read of its own port**. The row-blind mouse ignores both arguments, exactly as it already ignores them in `InputDevOverlayF14002()`.

### This required a change to `joystick.c`, and that was against my brief

My instructions said `joystick.c` is final because `InputDevOverlayF14002()` already carries the `row0`/`row1` arguments the rotary needs -- which is true of the C2/C3 controller-type reporting, the need the spec author checked, but not of this second need for row information. **Flagging it explicitly for review.** The change:

```c
 offset0 = joypad0Offset[joystick_ram[1] & 0x0F];
 offset1 = joypad1Offset[(joystick_ram[1] >> 4) & 0x0F];

 InputDevClock(offset0 == 0xFF ? 0xFF : offset0 / 4,
               offset1 == 0xFF ? 0xFF : offset1 / 4);
```

Two pure table lookups **hoisted, not added**, and one call signature widened. `joystick.c` gains **no lines** and loses none, preserving the spec's section 12 constraint in substance. `InputDevClock()` is a PR-2 symbol not yet in `develop`, so widening it breaks no shipped ABI.

Alternatives considered and rejected:

- **Advance from the `$F14002` overlay, which already has the rows.** Works for Tempest 2000 and any `move.l` driver, but a driver reading only `move.w $F14000` never reaches that hook and the rotary freezes **silently**. Choosing a shape-dependent mechanism immediately after empirically discovering that poll shape varies is the wrong direction, and eight of the nine rotary titles are homebrew I have no ROM for.
- **Decode the row from the assembled `$F14000` word.** Port 2 works (bit 7 is clear in row 0), but port 1's row-0 mask is `0xFFFF` -- it clears nothing -- so "port 1 row 0" is indistinguishable from "port 1 not addressed". Dead end, and port 1 is the primary case.
- **Read `joystick_ram` from `inputdev.c`.** It is `static` in `joystick.c`.

**If the hoist is rejected, the honest fallback is the `$F14002` oracle with its known silent-freeze hole** -- please say which you prefer rather than merging a rotary that only works at 60 counts/s.

---

## Guardrail: both digests unchanged

The headline check. With no device selected, `$F14000`/`$F14002` must be bit-identical to before -- and the `joystick.c` hoist is exactly the kind of change that could perturb it.

```
harness: core Virtual Jaguar v3.3.0 5c0403a-dirty (./virtualjaguar_libretro.dylib)

=== Results: 3 passed, 0 failed, 0 skipped ===
  PASS: [joymatrix_identity_full] digest 0xC24DDCDE (expected 0xC24DDCDE); 524288 reads, seed 0x1D872B41, 256 row bytes x 64 vectors
  PASS: [joymatrix_identity_port1] port-1 bits digest 0xD0CD02E2 (expected 0xD0CD02E2); $F14000 bits 8-11 + $F14002 bits 0-1
  PASS: [joymatrix_identity_port1_with_mouse] port-1 bits with an ST mouse on port 2: 0xD0CD02E2 (expected 0xD0CD02E2); port-2 bits did move (full 0xE0E2711A)
```

Neither expected digest was touched. The hoisted lookups are pure table reads, and this is the proof rather than the claim.

---

## Savestate: no bump, no growth

**`STATE_VERSION` stays at 12 and the trailing chunk stays 41 bytes.** This was checked, not assumed -- the finding is that the rotary introduces no new machine-visible state:

| State | Where it already lives |
|---|---|
| backlog / Q8 carry / phase | the port's existing `quad_axis x`, already in the v12 chunk |
| published phase | `joypadNButtons[]`, already serialized by `JoystickStateSave()` |
| controller-type ID flag | option-derived, like the sensitivity scale -- deliberately not saved |

Measured headroom after this change, from the core's own one-shot report:

```
[state] v12 payload 2396971 / 2621440 bytes (224469 free)
```

Identical to A2's measurement, confirming zero bytes added. No second version bump inside one release.

---

## The two known Tempest 2000 rotary bugs are reproduced deliberately

BigPEmu ships a hash-gated script patching two defects: the **high-score initials-entry screen is uncontrollable under rotary** (that screen consumes only the rotary input path), and the **bonus games' rotary accumulators never decay**, so spin velocity runs away.

**Both are game logic sitting above the decode path, and a correct row-0 quadrature implementation reproduces them automatically. That is the intended outcome.** Our contract is the hardware: a title that misbehaves on a real rotary should misbehave here. Fixing them requires ROM-address patching keyed to a specific dump -- which is exactly why BigPEmu hash-gates its script -- and that is **#370's per-title-hooks layer, not this PR's**. Nothing of BigPEmu's was downloaded, decompiled or copied; only the defect descriptions, which are facts about the game.

Independent corroboration of the second bug's class from a rotary builder: detentless optical encoders cause "drifting in the menu ... it's really hard to select what you want" -- the same runaway-accumulation signature.

---

## User-facing surface

Device selection goes through the **existing** `virtualjaguar_p2_device` scaffolding from PR A2 -- no second mechanism.

- `virtualjaguar_p2_device` gains a `rotary` value.
- `virtualjaguar_p1_device` is new: `auto` / `pad` / `rotary`. Port 1 gets no mouse (vendor-documented port-2 device), but TR10 documents the rotary matrix for both ports and Tempest 2000's menu carries independent P1/P2 toggles.
- `virtualjaguar_rotary_sensitivity` (25-400%) and `virtualjaguar_rotary_id`, both hidden unless a rotary is attached.
- `RETRO_DEVICE_JAG_ROTARY = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE, 3)`, driven by **relative mouse X** -- the established libretro spinner convention, per the spec's decision. `RETRO_DEVICE_ANALOG` as an alternate source is explicitly out of scope (spec Q4) and belongs with #439's shared analog layer.

**No titledb row, ever** (spec section 4.7): selecting a rotary removes Up and Down, so a per-title default would break menu navigation for anyone using a pad. That is a functional break, not a preference. Nothing in `src/core/titledb.c` is touched.

**Direction** is a host-side UX convention, stated as such rather than dressed up as a hardware fact: host +X maps to clockwise, because pushing a spinner right turns the knob clockwise. TR10 fixes the hardware half -- anticlockwise is A-leads-B, increasing Gray index. There is deliberately **no invert option**; an unsourced sign knob is how a real wiring bug gets papered over instead of found.

`update_input()` grows a third branch. A rotary port keeps **A, B, C, Option, Pause and the keypad** from the retropad and withholds only U/D/L/R, because those four lines *are* the encoder. This is not a nicety: Tempest 2000's rotary support is hidden behind an unlock requiring **Pause on both controllers simultaneously** from the Options screen, persisted in the game's EEPROM. Zero the whole array for a rotary port and the user can never turn the feature on at all. It has its own assertion below.

---

## Verification

### `test/tools/rotary_decode_test` (new, wired into `make test`)

Shaped like A2's `mouse_decode_test`: synthetic rotation in, decoded direction and magnitude out, **both directions**, **both ports**. The decoder is written independently of `src/jerry/quadrature.c`, from TR10's phase sequences, and discards two-state jumps the way Domin's table does -- so any emitted jump shows up as `dropped` and fails the run.

```
  ok   InputDevSetType accepts a rotary on port 1
  ok   InputDevSetType accepts a rotary on port 2
port 1 rotary: direction and distance
  ok   +40 host units over 40 polls decode as clockwise (net=-40, expect -40), dropped=0
  ok   -40 host units over 40 polls decode as anticlockwise (net=40, expect +40), dropped=0
  ok   4 units/poll x 30 polls lags rather than jitters (net=-30, expect -30), dropped=0
port 1 rotary: poll shapes (the emission rule)
  ok   shape C (write + TWO reads) decodes as shape A: A=-40 C=-40, dropped A=0 C=0
  ok   shape B (write once, then read-only) is frozen by design: net=0 (expect 0)
port 1 rotary: visible in row 0 ONLY (not row-blind)
  ok   phase lines assert in row 0 ($FBFF) and in NO other row (rows 1-3: $FFFD $FFFB $FFF7)
  ok   rows 1-3 still decode as a standard pad (keypad '1' pulls bit 11 low in row 1: $F7FD)
  ok   Up and Down never assert on a rotary port
port 1 rotary: Tempest 2000's measured 8-write scan
  ok   one clean count per scan across 40 scans (net=-40, expect -40), dropped=0 -- a per-read clock would decode garbage here
port 1 rotary: controller-type identification
  ok   with the diode absent (default) C3 reads 1 -- standard joypad ($F14002=$FF7F bit 0)
  ok   with the diode fitted C2 C3 = 1 0 in the right rows for this port (row 3 bit 0 = 0 -> $FF7E; row 2 bit 0 = 1 -> $FF7F)
port 2 rotary: direction and distance
  ok   +40 host units over 40 polls decode as clockwise (net=-40, expect -40), dropped=0
  ok   -40 host units over 40 polls decode as anticlockwise (net=40, expect +40), dropped=0
  ok   4 units/poll x 30 polls lags rather than jitters (net=-30, expect -30), dropped=0
port 2 rotary: poll shapes (the emission rule)
  ok   shape C (write + TWO reads) decodes as shape A: A=-40 C=-40, dropped A=0 C=0
  ok   shape B (write once, then read-only) is frozen by design: net=0 (expect 0)
port 2 rotary: visible in row 0 ONLY (not row-blind)
  ok   phase lines assert in row 0 ($BF7F) and in NO other row (rows 1-3: $FFBF $FFDF $FFEF)
  ok   rows 1-3 still decode as a standard pad (keypad '1' pulls bit 15 low in row 1: $7FBF)
  ok   Up and Down never assert on a rotary port
port 2 rotary: Tempest 2000's measured 8-write scan
  ok   one clean count per scan across 40 scans (net=-40, expect -40), dropped=0 -- a per-read clock would decode garbage here
port 2 rotary: controller-type identification
  ok   with the diode absent (default) C3 reads 1 -- standard joypad ($F14002=$FF7F bit 2)
  ok   with the diode fitted C2 C3 = 1 0 in the right rows for this port (row 2 bit 2 = 0 -> $FF7B; row 3 bit 2 = 1 -> $FF7F)
Tempest 2000 unlock: Pause on BOTH controllers at once
  ok   rotary on port 1 + pad on port 2 both report Pause ($F14002=$FF7A, p1=1 p2=1)
a rotary on one port does not perturb the other
  ok   port-1 direction bits unchanged by a port-2 rotary ($0F00 vs $0F00), while port 2 decoded net=-25
the mouse is still row-blind (the two shapes stay distinct)
  ok   a port-2 mouse asserts in ALL FOUR rows ($2F7F $2FBF $2FDF $2FEF) where the rotary asserts in one
savestate round-trip mid-rotation
  ok   retro_serialize succeeded mid-rotation
  ok   retro_unserialize accepted the state
  ok   post-restore replay matches (net -25 vs -25, dropped 0 vs 0) -- phase, backlog and Q8 carry all survived the rollback
no device selected -> nothing reaches the matrix
  ok   both ports report pad and nothing is attached
  ok   no rotation reaches $F14000 (net=0)

=== Results: 1 passed, 0 failed, 0 skipped ===
  PASS: [rotary_decode] 0 failure(s)
```

The two assertions that carry the most weight:

- **row-0-only visibility, asserted both ways** -- the phase lines assert in row 0 and in no other row, *and* rows 1-3 still decode a poked keypad digit. That pair is what fails if the rotary is ever "simplified" onto the mouse's row-blind overlay. `test_mouse_still_row_blind` asserts the converse on the same build, so the two shapes cannot quietly converge.
- **the measured eight-write scan**, replayed literally, decoding one clean count per scan. That is the regression for the defect above.

### C89 lint

```
$ bash scripts/c89-lint.sh src/jerry/inputdev.c src/jerry/joystick.c src/jerry/quadrature.c libretro.c
C89 lint passed
```

### Build

`DEVELOPER_DIR=/Library/Developer/CommandLineTools make -j$(getconf _NPROCESSORS_ONLN)` -- clean, no warnings.

### Full suite, with the private ROM corpus symlinked in

```
$ DEVELOPER_DIR=/Library/Developer/CommandLineTools make -j10 TEST_EXPORTS=1 test
TEST_EXIT=0
...
=== Skipped checks: none -- every optional check ran ===
```

`Skipped checks: none`, so the audio, CD and determinism rows genuinely ran rather than silently skipping. The symlink was removed afterwards; its target was not touched.

### Production ABI unchanged

```
$ nm -gU virtualjaguar_libretro.dylib | wc -l
      46
$ nm -gU virtualjaguar_libretro.dylib | grep -c "_retro_"
46
$ nm -gU virtualjaguar_libretro.dylib | grep -c "InputDev\|Quad\|Joystick"
0
```

46 exported symbols, all `retro_*`, zero internals leaked -- matching A2's measurement. The `InputDev*` / `Quad*` / `Joystick*` exports exist only in the wide test ABI.

---

## What is NOT verified

Stating this plainly, as A2 did.

- **No real-frontend test.** Everything above is headless. The rotary has not been driven from RetroArch with an actual mouse or spinner.
- **Tempest 2000 has not been played.** The spec names the section 4.4 two-controller Pause unlock as step 7's acceptance test: perform the unlock, set `P1 ROTARY`, confirm play, then confirm the P2 toggle. `test_pause_unlock` asserts the machine-level precondition (a rotary port and a pad port can both report Pause in the same read), but it cannot tell you the menu item appears or that the spinner feels right.
- **Direction sense is unconfirmed against the game.** TR10 fixes anticlockwise = A-leads-B; which way Tempest 2000 wants the ship to travel is a question only playing it answers. If it is backwards, the fix is the one negation in `InputDevFeed()`.
- **Per-port togglability for P2 is inferred**, from the menu structure rather than observed in the source screenshots.
- **Sensitivity default of 100% is untuned.** A real rotary has no canonical pulses-per-revolution -- Atari's never shipped, so every unit is an aftermarket build (36 PPR detentless, 30 detents and 24 detents are all attested). The default is a starting point, not a measurement.
- **The eight other rotary titles** (Downfall+, Impulse X, Kobayashi Maru, Project W, Rebooteroids, Virtual Xperience's Pong, Kaboom, the Arkanoid ST port) are not in the private corpus and none was exercised. Only Tempest 2000's poll shape is measured; the row-gated rule is shape-independent by construction, but that is an argument, not a test.
