### PR TITLE
fix(build): stamp the whole build config, not just TEST_EXPORTS (#457)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ test/acid/tests/**/*.jag
 /test/tools/hires_state_digest
 /test/tools/hires_shot
 test/tools/__pycache__/
+.build-config
 .link-mode
 
 # gcov instrumentation output (make coverage)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,10 +127,26 @@ wide one — and also adds `-DVJ_TRACE`, so it changes object *content*, not jus
 the export list.
 
 Switching in **either** direction is handled automatically: the Makefile stamps
-the mode into `.link-mode` and, when it differs, deletes the library **and every
-object** before the build. Both `make` → `make TEST_EXPORTS=1 test` and
-`make TEST_EXPORTS=1` → `make` work with no `make clean`. Cost is one full
-rebuild per flip (~21s at `-j8` without ccache).
+the build configuration into `.build-config` and, when it differs, deletes the
+library **and every object** before the build. Both `make` →
+`make TEST_EXPORTS=1 test` and `make TEST_EXPORTS=1` → `make` work with no
+`make clean`. Cost is one full rebuild per flip (~21s at `-j8` without ccache).
+
+The stamp covers **every** compile-affecting switch, not just `TEST_EXPORTS`
+(`BUILD_AXES` in the Makefile: `TEST_EXPORTS BENCH_PROFILE DEBUG BLITTER_TRACE
+COVERAGE RELEASE_DEBUG_INFO DEBUG_PRESENTATION STATIC_LINKING platform`).
+**Adding a new switch that changes `CFLAGS` means adding it to that list** —
+forgetting costs a silent chimera binary, not a build error. It stamps variable
+*names*, not `$(CFLAGS)`: `DEBUG=1` puts a per-second `-DBUILD_TIMESTAMP` in
+the flags, so stamping flags would flush the tree on every single build.
+
+Before issue #457 the stamp tracked `TEST_EXPORTS` alone, which left the same
+hazard one level up: `make DEBUG=1` after a release build recompiled **zero**
+objects (a "debug build" that was entirely `-O2` with no debug info), and
+toggling `BENCH_PROFILE` recompiled nothing, so `timing_probe` tools reported
+`timing_halfline_callbacks counter not found` — which reads as a broken tool
+rather than an ignored flag. `VJ_EXPECT_BUILD` cannot catch either: the git rev
+is identical across the flip, so the guard passes on a wrong binary.
 
 The flush is deliberately unconditional rather than a list of "objects that use
 vjtrace". That list is what broke before: it omitted `src/tom/blit_memo.o`, so

--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,29 @@ MACHO_EXPORTS := exports.list
 endif
 MACHO_EXPORTS_FLAGS := -Wl,-exported_symbols_list,$(MACHO_EXPORTS)
 
-# Records which ABI the library in the tree was last linked with; see the
-# mode-switch hook next to the link rule below.
-LINK_MODE := $(if $(filter 1,$(TEST_EXPORTS)),test,prod)
-LINK_MODE_STAMP := .link-mode
+# Records the build configuration the objects in the tree were last
+# compiled under; see the mode-switch hook next to the link rule below.
+#
+# Every variable listed here changes how objects are COMPILED (or which
+# symbols survive the link), so flipping any one of them invalidates
+# every existing .o.  Adding a new such switch means adding it here --
+# that is the whole maintenance burden, and forgetting costs a silent
+# chimera binary rather than a build error.
+#
+# It is deliberately a list of *variable names* and not $(CFLAGS)
+# itself.  Stamping the flags would look more future-proof but breaks
+# on DEBUG=1, whose CFLAGS carry a -DBUILD_TIMESTAMP that changes every
+# second: the stamp would never match and every single build would
+# flush the tree.  Values here are plain tokens (1, or a platform
+# name), so the comparison also stays free of shell quoting hazards --
+# CFLAGS contains -DINLINE="inline".
+BUILD_AXES := TEST_EXPORTS BENCH_PROFILE DEBUG BLITTER_TRACE COVERAGE \
+              RELEASE_DEBUG_INFO DEBUG_PRESENTATION STATIC_LINKING platform
+BUILD_CONFIG := $(strip $(foreach v,$(BUILD_AXES),$(v)=$($(v))))
+BUILD_CONFIG_STAMP := .build-config
+# Superseded .link-mode, which tracked TEST_EXPORTS alone; removed by the
+# hook below so a tree built before this change doesn't keep a dead file.
+LEGACY_LINK_MODE_STAMP := .link-mode
 
 # Unix
 ifeq ($(platform), unix)
@@ -794,14 +813,30 @@ $(LIBRARY_NAME)_CXXFLAGS += $(CXXFLAGS) $(COMMON_FLAGS)
 ${LIBRARY_NAME}_FILES = $(SOURCES_CXX) $(SOURCES_C)
 include $(THEOS_MAKE_PATH)/library.mk
 else
-# Force a re-link when the exported ABI changes.  Almost every object is
-# identical either way, so a plain `make` followed by `make TEST_EXPORTS=1
-# test` would otherwise reuse the production-slim library -- it is newer
-# than every object, so nothing relinks -- and the white-box tests fail
-# with "Missing: m68k_execute".  Delete the library outright rather than
-# relying on a stamp file's mtime: the stamp and the library can land in
-# the same second, which is exactly the timestamp-granularity trap this is
-# meant to close.  Runs at parse time, once TARGET is known.
+# Force a rebuild when the build configuration changes ($(BUILD_AXES)).
+# Almost every object is identical across an ABI flip, so a plain `make`
+# followed by `make TEST_EXPORTS=1 test` would otherwise reuse the
+# production-slim library -- it is newer than every object, so nothing
+# relinks -- and the white-box tests fail with "Missing: m68k_execute".
+# Delete the library outright rather than relying on a stamp file's mtime:
+# the stamp and the library can land in the same second, which is exactly
+# the timestamp-granularity trap this is meant to close.  Runs at parse
+# time, once TARGET is known.
+#
+# The stamp covers every compile-affecting switch, not just TEST_EXPORTS
+# (issue #457).  It originally tracked TEST_EXPORTS alone, which left the
+# same hazard open one level up:
+#   BENCH_PROFILE -- `make TEST_EXPORTS=1` then
+#     `make BENCH_PROFILE=1 TEST_EXPORTS=1` recompiled nothing, so no
+#     object got -DBENCH_PROFILE, no PERF_COUNTER registered, and every
+#     timing_probe tool died with "timing_halfline_callbacks counter not
+#     found" -- which reads as a broken tool, not an ignored flag.
+#   DEBUG -- `make` then `make DEBUG=1` recompiled *zero* objects: a
+#     "debug build" that is entirely -O2 with no debug info.  The reverse
+#     leaves -O0 objects in a release binary and silently invalidates any
+#     performance measurement taken from it.
+# VJ_EXPECT_BUILD cannot catch either: the git rev is identical across the
+# flip, so the guard passes while the binary is wrong.
 #
 # TEST_EXPORTS also changes object *content*, not just the export list:
 # it adds -DVJ_TRACE to CFLAGS (see the line above), so vjtrace.o defines
@@ -843,9 +878,9 @@ MAKEFLAGS_LETTERS := $(filter-out -%,$(firstword $(MAKEFLAGS)))
 DRY_RUN := $(strip $(findstring n,$(MAKEFLAGS_LETTERS)) \
                    $(filter -n --dry-run --just-print --recon,$(MAKEFLAGS)))
 $(if $(DRY_RUN),,\
-$(shell [ "$$(cat $(LINK_MODE_STAMP) 2>/dev/null)" = "$(LINK_MODE)" ] \
-        || { printf '%s' "$(LINK_MODE)" > $(LINK_MODE_STAMP); \
-             rm -f $(TARGET) $(OBJECTS); }))
+$(shell [ "$$(cat $(BUILD_CONFIG_STAMP) 2>/dev/null)" = "$(BUILD_CONFIG)" ] \
+        || { printf '%s' "$(BUILD_CONFIG)" > $(BUILD_CONFIG_STAMP); \
+             rm -f $(TARGET) $(OBJECTS) $(LEGACY_LINK_MODE_STAMP); }))
 
 all: $(TARGET)
 $(TARGET): $(OBJECTS)
@@ -860,7 +895,7 @@ endif
 $(CORE_DIR)/libretro.o: $(VERSION_H)
 
 clean:
-	rm -f $(TARGET) $(OBJECTS) $(LINK_MODE_STAMP) \
+	rm -f $(TARGET) $(OBJECTS) $(BUILD_CONFIG_STAMP) $(LEGACY_LINK_MODE_STAMP) \
 		test/test_cheat test/test_event_queue test/test_blitter_simd \
 		test/test_dsp_mac40 test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops \
 		test/test_dsp_ops test/test_dsp_unit test/test_hle_bios \


### PR DESCRIPTION
Closes #457.

#454 flushed every object when `TEST_EXPORTS` changed. The stamp it added tracked that one flag:

```make
LINK_MODE := $(if $(filter 1,$(TEST_EXPORTS)),test,prod)
```

which left the identical stale-object hazard open one level up for every *other* switch that changes `CFLAGS`. #454's comment argues at length that a curated **object** list is unsafe; the stamp then hard-coded a curated **flag** list with the same failure mode.

## What was broken

- **`BENCH_PROFILE`** — `make TEST_EXPORTS=1` then `make BENCH_PROFILE=1 TEST_EXPORTS=1` recompiled nothing, so no object got `-DBENCH_PROFILE`, no `PERF_COUNTER` registered, and every `timing_probe` tool died with `timing_halfline_callbacks counter not found`. That reads as a broken tool, not an ignored flag. (Hit while running the #378 overclock grid.)
- **`DEBUG`** — `make` then `make DEBUG=1` recompiled **zero** objects: a "debug build" entirely `-O2` with no debug info. A debugger then shows optimised control flow, and *"it doesn't reproduce in a debug build"* becomes an available wrong conclusion. The reverse direction leaves `-O0` objects in a release binary and silently invalidates any performance measurement taken from it.
- **`platform`** — `make platform=ios-arm64` after a host build reused host objects. Not previously reported; the axis list closes it too.

`VJ_EXPECT_BUILD` catches none of these — the git rev is identical across the flip, so the guard passes while the binary is wrong.

## The fix

```make
BUILD_AXES := TEST_EXPORTS BENCH_PROFILE DEBUG BLITTER_TRACE COVERAGE \
              RELEASE_DEBUG_INFO DEBUG_PRESENTATION STATIC_LINKING platform
BUILD_CONFIG := $(strip $(foreach v,$(BUILD_AXES),$(v)=$($(v))))
```

**Variable names, not `$(CFLAGS)`.** The issue floated stamping the flags as more future-proof. It isn't: `DEBUG=1` puts a per-second `-DBUILD_TIMESTAMP` into `CFLAGS`, so a flags-based stamp would never match itself and every single build would flush the whole tree. Plain tokens also keep the shell comparison free of quoting hazards — `CFLAGS` contains `-DINLINE="inline"`.

The residual maintenance burden is real and is now stated in both the Makefile and `CLAUDE.md`: **a new compile-affecting switch must be added to `BUILD_AXES`**. Forgetting costs a silent chimera binary rather than a build error.

## Verification

Every flip recompiles all 67 objects; every repeat recompiles zero:

| step | objects recompiled |
|---|---|
| cold `make` / repeat | 67 / **0** |
| `make DEBUG=1` / repeat | 67 / **0** |
| back to plain `make` | 67 |
| `make TEST_EXPORTS=1` | 67 |
| `+ BENCH_PROFILE=1` / repeat | 67 / **0** |
| plain `make` (the #454 link failure) | 67, links clean |

The binaries are correct, not merely rebuilt:

- `BENCH_PROFILE=1` registers counters with no manual clean — `M68K cycles 221435.2 +/- 2.5 … OK` instead of "counter not found";
- `DEBUG=1` emits real debug info (`DW_TAG_compile_unit` present in `blitter.o`).

`make -n` still does **not** flush, under both MAKEFLAGS encodings (the make-3.81 quirk #454 documented) — a dry run that silently cost a full rebuild would be a regression in its own right.

`make TEST_EXPORTS=1 test` exits 0 with *"Skipped checks: none — every optional check ran"*. `scripts/c89-lint.sh` passes (no C changed).

Legacy `.link-mode` is removed by the hook and by `clean`, so trees built before this don't keep a dead file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)