### PR TITLE
fix(ci): an advisory reviewer must never red-X a PR

### DIFF
--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -27,6 +27,12 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event.issue.pull_request && contains(github.event.comment.body, '@kimi review'))
     runs-on: ubuntu-latest
+    # The script soft-fails on purpose, but that only covers failures the
+    # script is alive to see.  Anything earlier -- checkout, a runner
+    # hiccup, a missing secret -- used to red-X the PR, which is the one
+    # thing this workflow's header says it must never do.  Same pattern the
+    # sanitizer job uses for the same reason: advisory, not gating.
+    continue-on-error: true
     steps:
       - name: Resolve PR number
         id: pr
@@ -38,6 +44,41 @@ jobs:
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi
 
+      # GitHub computes refs/pull/N/merge asynchronously, so a job that starts
+      # immediately after a push -- especially a force-push, where mergeability
+      # goes back to UNKNOWN -- can reach checkout before the ref exists.
+      # actions/checkout's own retry (3 tries over ~40s) is not always enough:
+      # PR #450 burned all three and failed the job outright.
+      #
+      # That failure mode is worse than it looks.  It happens in `checkout`,
+      # BEFORE kimi_review.py runs, so none of the script's soft-fail handling
+      # applies and the advisory reviewer red-Xes a PR that compiles and passes
+      # its tests -- exactly what this workflow's design forbids.
+      - name: Resolve the ref to review
+        id: ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -u
+          n='${{ steps.pr.outputs.number }}'
+          url="https://github.com/${{ github.repository }}"
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if git ls-remote --exit-code "$url" "refs/pull/$n/merge" >/dev/null 2>&1; then
+              echo "ref=refs/pull/$n/merge" >> "$GITHUB_OUTPUT"
+              echo "merge ref available after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "refs/pull/$n/merge not computed yet (attempt $i); waiting 10s"
+            sleep 10
+          done
+          # Fall back rather than fail.  The head ref reviews the same diff;
+          # what it loses is the merge ref's useful property that an open PR
+          # picks up a reviewer fix landed on its base without a rebase.  Say
+          # so, because a silent downgrade is how the base-branch behaviour
+          # would quietly stop being true.
+          echo "ref=refs/pull/$n/head" >> "$GITHUB_OUTPUT"
+          echo "::warning title=Reviewing the head ref::refs/pull/$n/merge was still not computed after 100s; reviewing refs/pull/$n/head instead. The diff is the same, but this run does not pick up base-branch changes."
+
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -47,7 +88,7 @@ jobs:
           # script, so an "@kimi review" comment would run the wrong tree.
           # The merge ref is right for both, and it is what makes a PR pick up
           # a reviewer fix that has landed on its base without needing a rebase.
-          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
+          ref: ${{ steps.ref.outputs.ref }}
           fetch-depth: 0
 
       - name: Review


### PR DESCRIPTION
## Why this is a second PR

#455 was squash-merged with only its first commit. The second one — the part that stops the reviewer red-Xing a PR — was pushed a few minutes after the merge and never reached develop. This is that commit, rebased, with its rationale corrected.

## The fix

`continue-on-error: true` on the job.

The reviewer soft-fails by design, but that only ever covered failures `kimi_review.py` was alive to see. #450's job died in **checkout**, before the script ran:

```
fatal: couldn't find remote ref refs/pull/450/merge   (x3, exit 128)
```

so an advisory review red-X'd a PR that compiled and passed its tests — the one thing this workflow's own header says it must never do. `continue-on-error` covers the whole class: a runner hiccup, a missing secret, a checkout that cannot resolve. Same pattern the sanitizer job already uses.

## On the cause — stated carefully, because I got it wrong the first time

I originally wrote that GitHub had not finished computing `refs/pull/N/merge` after a force-push. The timestamps say otherwise:

```
05:47:54Z  run created (pull_request event)
05:48:09Z  PR #450 merged                    <- 15 seconds later
05:50:18Z  checkout fails
```

The merge ref was gone because **the PR had already been merged and its branch deleted** while the job sat queued. Same error string, different cause; I asserted the one that fit my prior instead of reading the timeline.

That matters for how to read the second half of this diff. The added resolve-and-fall-back step guards a race that is real in principle but **has not been observed in this repo**, and it cannot rescue the merged-and-deleted case at all — if the branch is gone, `refs/pull/N/head` is gone too. I kept it because reviewing the head ref beats failing when the merge ref genuinely is still being computed, and because it announces the downgrade rather than silently losing the merge ref's useful property (an open PR picking up a base-branch reviewer fix without a rebase). But `continue-on-error` is the part doing the work, and the 100s of polling is dead time in the only scenario we have actually seen. Trim it if you'd rather.

## Testing

Workflow parsed with `yaml.safe_load`; `continue-on-error: True` and the step order confirmed. That check is not ceremonial — the first version of the fallback `echo` broke the YAML block scalar with a column-0 line continuation.

Not exercised against the live API: Kimi is still out of quota for this billing cycle (HTTP 403 `access_terminated_error`), which is also why #447, #450 and #451 got no machine review at all.

Follows #455.
