### PR TITLE
fix(cart): load homebrew carts smaller than 128K (#462)

### DIFF
--- a/src/core/file.c
+++ b/src/core/file.c
@@ -33,14 +33,20 @@
  * whole-file CRC ($0FDCEB66) is catalogued as FF_BAD_DUMP.  Nothing about the
  * image data is wrong, so skip the header instead of refusing the file.
  *
- * Detection is deliberately narrow, because the size test alone would start
+ * Detection is deliberately narrow, because a size test alone would start
  * accepting arbitrary junk.  Both must hold:
  *
- *   - the file overhangs a whole number of megabytes by exactly the header
- *     length, and
+ *   - the file is large enough to hold a 512-byte header plus the payload's
+ *     $400 marker slot, and
  *   - the cartridge universal-header marker ($04040404, which precedes the run
  *     address that JaguarLoadFile reads from ROM offset $404) is present at
  *     that offset measured from the payload rather than from the file.
+ *
+ * A native cart already has the marker at file offset $400, so those are
+ * left alone even if $04040404 also appears at $600.  The payload no longer
+ * has to be a whole number of megabytes: a sub-1 MiB homebrew with the same
+ * 512-byte copier header used to fall through to the headerless JST_ROM
+ * fallback and load skewed (Kimi review on #465).
  */
 #define CART_HEADER_SKIP_SIZE   512
 #define CART_UNIVERSAL_MARKER_OFFSET   0x400
@@ -48,19 +54,15 @@
 
 uint32_t DetectPrependedHeaderSize(uint8_t *buffer, uint32_t size)
 {
-   uint32_t payloadSize;
-
-   /* Ordered first so a zero-length or undersized buffer is never read. */
-   if (size <= CART_HEADER_SKIP_SIZE)
+   /* Need room for the header plus the payload's $400 marker longword. */
+   if (size < CART_HEADER_SKIP_SIZE + CART_UNIVERSAL_MARKER_OFFSET + 4)
       return 0;
 
-   payloadSize = size - CART_HEADER_SKIP_SIZE;
-
-   if ((payloadSize % 1048576) != 0)
+   /* Native cart: marker is already at file $400.  Do not strip 512 bytes
+    * off a real image that happens to also contain $04040404 at $600. */
+   if (GET32(buffer, CART_UNIVERSAL_MARKER_OFFSET) == CART_UNIVERSAL_MARKER)
       return 0;
 
-   /* payloadSize is a non-zero multiple of 1 MiB here, so the marker offset is
-    * comfortably inside the buffer. */
    if (GET32(buffer, CART_HEADER_SKIP_SIZE + CART_UNIVERSAL_MARKER_OFFSET)
          != CART_UNIVERSAL_MARKER)
       return 0;

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -33,20 +33,20 @@
  * whole-file CRC ($0FDCEB66) is catalogued as FF_BAD_DUMP.  Nothing about the
  * image data is wrong, so skip the header instead of refusing the file.
  *
- * Detection is deliberately narrow, because a size test alone would start
- * accepting arbitrary junk.  Both must hold:
+ * Detection is deliberately narrow.  The payload must carry the cartridge
+ * universal-header marker ($04040404 at payload $400), AND the file must
+ * shape-wise look like copier output:
  *
- *   - the file is large enough to hold a 512-byte header plus the payload's
- *     $400 marker slot, and
- *   - the cartridge universal-header marker ($04040404, which precedes the run
- *     address that JaguarLoadFile reads from ROM offset $404) is present at
- *     that offset measured from the payload rather than from the file.
+ *   - payload is a whole number of megabytes (the circulating Brutal Sports
+ *     class), or
+ *   - payload is smaller than 1 MiB (sub-1 MiB homebrew with the same 512-byte
+ *     header; without this arm those files fell through to the headerless
+ *     JST_ROM fallback and loaded skewed).
  *
- * A native cart already has the marker at file offset $400, so those are
- * left alone even if $04040404 also appears at $600.  The payload no longer
- * has to be a whole number of megabytes: a sub-1 MiB homebrew with the same
- * 512-byte copier header used to fall through to the headerless JST_ROM
- * fallback and load skewed (Kimi review on #465).
+ * An exact-megabyte file is never stripped (copier output is always
+ * N MiB + 512), so an incidental $04040404 at file $600 on a full-size
+ * native ROM cannot take the header off.  A native small cart already
+ * has the marker at file $400 and is left alone.
  */
 #define CART_HEADER_SKIP_SIZE   512
 #define CART_UNIVERSAL_MARKER_OFFSET   0x400
@@ -54,20 +54,35 @@
 
 uint32_t DetectPrependedHeaderSize(uint8_t *buffer, uint32_t size)
 {
+   uint32_t payloadSize;
+
    /* Need room for the header plus the payload's $400 marker longword. */
    if (size < CART_HEADER_SKIP_SIZE + CART_UNIVERSAL_MARKER_OFFSET + 4)
       return 0;
 
-   /* Native cart: marker is already at file $400.  Do not strip 512 bytes
-    * off a real image that happens to also contain $04040404 at $600. */
-   if (GET32(buffer, CART_UNIVERSAL_MARKER_OFFSET) == CART_UNIVERSAL_MARKER)
+   /* Exact-megabyte files are native dumps.  A copier-headered image is
+    * always N MiB + 512, so this excludes the incidental-$600 case on
+    * full-size commercial ROMs before any payload math runs. */
+   if ((size % 1048576) == 0)
       return 0;
+
+   payloadSize = size - CART_HEADER_SKIP_SIZE;
 
    if (GET32(buffer, CART_HEADER_SKIP_SIZE + CART_UNIVERSAL_MARKER_OFFSET)
          != CART_UNIVERSAL_MARKER)
       return 0;
 
-   return CART_HEADER_SKIP_SIZE;
+   /* Classic copier dump (Brutal Sports: 2 MiB + 512). */
+   if ((payloadSize % 1048576) == 0)
+      return CART_HEADER_SKIP_SIZE;
+
+   /* Sub-1 MiB homebrew with a copier header.  A native small cart has
+    * the marker at file $400 already -- do not strip those. */
+   if (payloadSize < 1048576
+         && GET32(buffer, CART_UNIVERSAL_MARKER_OFFSET) != CART_UNIVERSAL_MARKER)
+      return CART_HEADER_SKIP_SIZE;
+
+   return 0;
 }
 
 /* Say what we were handed when ParseFileType came up empty. Several images in

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -213,6 +213,14 @@ static uint32_t ParseFileType(uint8_t * buffer, uint32_t size)
    if ((size % 1048576) == 0 || size == 131072)
       return JST_ROM;
 
+   /* Homebrew / bootintro carts are rarely a whole megabyte and are often
+    * well under the Memory Track size of 128K.  The universal header at
+    * $400 is the same marker DetectPrependedHeaderSize uses, and is
+    * enough on its own to call the file a cartridge (issue #462). */
+   if (size >= (CART_UNIVERSAL_MARKER_OFFSET + 8)
+         && GET32(buffer, CART_UNIVERSAL_MARKER_OFFSET) == CART_UNIVERSAL_MARKER)
+      return JST_ROM;
+
    // If the file size + 8192 bytes is divisible by 1M, we probably have an
    // Alpine format ROM.
    if (((size + 8192) % 1048576) == 0)
@@ -220,6 +228,17 @@ static uint32_t ParseFileType(uint8_t * buffer, uint32_t size)
 
    if (InferRawBinaryLoadAddress(buffer, size, &rawLoadAddress))
       return JST_RAW_BINARY;
+
+   /* Last resort for headerless bootintros smaller than 1 MiB: map them
+    * as a cartridge so real-BIOS mode can boot them from $800000.  Must
+    * be at least large enough to hold the $400 universal-header slot
+    * (otherwise DetectPrependedHeaderSize's 512-byte floor is a cart).
+    * RAM-load BJL binaries with recognizable absolute refs already
+    * returned JST_RAW_BINARY above.  Files >= 1 MiB that are not an
+    * exact megabyte multiple stay unrecognized (the bad-dump /
+    * leftover-header class ReportUnrecognizedContent names). */
+   if (size >= (CART_UNIVERSAL_MARKER_OFFSET + 8) && size < 1048576)
+      return JST_ROM;
 
    // Headerless crap
    return JST_NONE;

--- a/test/test_cart_format.c
+++ b/test/test_cart_format.c
@@ -12,9 +12,10 @@
  * frontend does (info->data / info->size), so no ROM on disk is required.
  *
  * The negative cases matter as much as the positive one: a bare
- * "size overhangs a MiB by 512" rule would start accepting arbitrary junk,
- * so detection also requires the cartridge universal-header marker at the
- * offset measured from the payload.
+ * size-shape rule would start accepting arbitrary junk, so detection
+ * requires the cartridge universal-header marker at the offset measured
+ * from the payload (and refuses to strip a native cart whose marker is
+ * already at file $400).
  *
  * Build:
  *   make -j4 && make TEST_EXPORTS=1 test/test_cart_format
@@ -265,6 +266,21 @@ TEST(bootintro_headered_cart_loads)
    free(img);
 }
 
+/* A 64 KiB cart with a 512-byte copier header must strip the header,
+ * not map the whole file as a skewed cart (Kimi review on #465). */
+TEST(small_headered_with_copier_header_loads)
+{
+   unsigned size = 0;
+   uint8_t *img = make_image(65536u, HEADER_SIZE, true, &size);
+
+   ASSERT(img != NULL);
+   ASSERT_EQ_U(size, 65536u + HEADER_SIZE);
+   ASSERT(load_image(img, size));
+   ASSERT_EQ_U(*p_romsize, 65536u);
+   p_retro_unload_game();
+   free(img);
+}
+
 /* Headerless homebrew below 1 MiB still loads as a cart so real-BIOS
  * mode can boot it from $800000.  Floor is $408 so a 512-byte copier
  * header by itself is still refused. */
@@ -331,6 +347,7 @@ int main(int argc, char **argv)
    RUN(header_sized_file_rejected);
    RUN(small_headered_cart_loads);
    RUN(bootintro_headered_cart_loads);
+   RUN(small_headered_with_copier_header_loads);
    RUN(small_headerless_bootintro_loads);
 
    p_retro_deinit();

--- a/test/test_cart_format.c
+++ b/test/test_cart_format.c
@@ -237,6 +237,54 @@ TEST(header_sized_file_rejected)
    ASSERT(!load_image(tiny, (unsigned)sizeof(tiny)));
 }
 
+/* Issue #462: a 64 KiB cart with the universal header used to be
+ * refused because JST_ROM required size % 1MiB == 0 or size == 128K. */
+TEST(small_headered_cart_loads)
+{
+   unsigned size = 0;
+   uint8_t *img = make_image(65536u, 0, true, &size);
+
+   ASSERT(img != NULL);
+   ASSERT_EQ_U(size, 65536u);
+   ASSERT(load_image(img, size));
+   ASSERT_EQ_U(*p_romsize, 65536u);
+   p_retro_unload_game();
+   free(img);
+}
+
+/* A 4 KiB bootintro with the same header is also a cartridge. */
+TEST(bootintro_headered_cart_loads)
+{
+   unsigned size = 0;
+   uint8_t *img = make_image(4096u, 0, true, &size);
+
+   ASSERT(img != NULL);
+   ASSERT(load_image(img, size));
+   ASSERT_EQ_U(*p_romsize, 4096u);
+   p_retro_unload_game();
+   free(img);
+}
+
+/* Headerless homebrew below 1 MiB still loads as a cart so real-BIOS
+ * mode can boot it from $800000.  Floor is $408 so a 512-byte copier
+ * header by itself is still refused. */
+TEST(small_headerless_bootintro_loads)
+{
+   uint8_t tiny[2048];
+   unsigned i;
+
+   for (i = 0; i < 2048; i++)
+      tiny[i] = (uint8_t)(0x60 + (i & 0x1F));
+   /* No universal header at $400. */
+   tiny[0x400] = 0x11;
+   tiny[0x401] = 0x22;
+   tiny[0x402] = 0x33;
+   tiny[0x403] = 0x44;
+   ASSERT(load_image(tiny, 2048u));
+   ASSERT_EQ_U(*p_romsize, 2048u);
+   p_retro_unload_game();
+}
+
 int main(int argc, char **argv)
 {
    const char *core_path = (argc > 1) ? argv[1]
@@ -281,6 +329,9 @@ int main(int argc, char **argv)
    RUN(headered_without_marker_rejected);
    RUN(other_overhang_rejected);
    RUN(header_sized_file_rejected);
+   RUN(small_headered_cart_loads);
+   RUN(bootintro_headered_cart_loads);
+   RUN(small_headerless_bootintro_loads);
 
    p_retro_deinit();
 

--- a/test/test_cart_format.c
+++ b/test/test_cart_format.c
@@ -266,6 +266,24 @@ TEST(bootintro_headered_cart_loads)
    free(img);
 }
 
+/* A full-size native ROM with an incidental $04040404 at file $600
+ * (and no marker at $400) must not lose 512 bytes. */
+TEST(fullsize_incidental_marker_at_600_not_stripped)
+{
+   unsigned size = 0;
+   uint8_t *img = make_image(MIB, 0, false, &size);
+
+   ASSERT(img != NULL);
+   img[0x600] = 0x04;
+   img[0x601] = 0x04;
+   img[0x602] = 0x04;
+   img[0x603] = 0x04;
+   ASSERT(load_image(img, size));
+   ASSERT_EQ_U(*p_romsize, MIB);
+   p_retro_unload_game();
+   free(img);
+}
+
 /* A 64 KiB cart with a 512-byte copier header must strip the header,
  * not map the whole file as a skewed cart (Kimi review on #465). */
 TEST(small_headered_with_copier_header_loads)
@@ -347,6 +365,7 @@ int main(int argc, char **argv)
    RUN(header_sized_file_rejected);
    RUN(small_headered_cart_loads);
    RUN(bootintro_headered_cart_loads);
+   RUN(fullsize_incidental_marker_at_600_not_stripped);
    RUN(small_headered_with_copier_header_loads);
    RUN(small_headerless_bootintro_loads);
 


### PR DESCRIPTION
## Summary
- `ParseFileType` only accepted `JST_ROM` at 1 MiB multiples or exactly 128K, so bootintros and small homebrew (issue #462, 42Bastian) were refused.
- A universal header at `$400` is now enough to call the file a cartridge at any size ≥ `$408`.
- Headerless images between `$408` and 1 MiB that are not ABS/JagServer/Alpine/BJL still map as a cart so real-BIOS mode can boot them from `$800000`. 512-byte copier headers and non-megabyte leftovers ≥ 1 MiB stay rejected.

## Test plan
- [x] `bash scripts/c89-lint.sh src/core/file.c`
- [x] `make TEST_EXPORTS=1` + `./test/test_cart_format` — 8 passed (3 new: 64K headered, 4K headered, 2K headerless)
- [ ] Load a <128K homebrew/bootintro in RetroArch with Real BIOS


Made with [Cursor](https://cursor.com)