### PR TITLE
fix(timing): sync DSP on 68K reads of DSP local RAM (#456)

### DIFF
--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -460,6 +460,12 @@ static void M68KGPURAMSyncRead(unsigned int address, unsigned int length)
    if (address < GPU_WORK_RAM_BASE + 0x1000
        && address + length > GPU_WORK_RAM_BASE)
       GPUSyncToM68K();
+   /* Same handshake on the DSP side (issue #456 / #408 H3): a 68K poll
+    * of dspfinished must see the DSP that has already run up to this
+    * point in the slice, not the leftover of the previous one. */
+   if (address < DSP_WORK_RAM_BASE + 0x2000
+       && address + length > DSP_WORK_RAM_BASE)
+      DSPSyncToM68K();
 }
 
 unsigned int m68k_read_memory_8(unsigned int address)
@@ -640,6 +646,9 @@ static void M68KGPURAMSync(unsigned int address, unsigned int length)
    if (address < GPU_WORK_RAM_BASE + 0x1000
        && address + length > GPU_WORK_RAM_BASE)
       GPUSyncToM68K();
+   if (address < DSP_WORK_RAM_BASE + 0x2000
+       && address + length > DSP_WORK_RAM_BASE)
+      DSPSyncToM68K();
 }
 
 /* GPU and DSP local RAM are 32-bit memories, but an external bus master sees
@@ -1647,9 +1656,10 @@ void JaguarExecuteNew(void)
          timeDelta = timeToJerryEvent;
          riscCycles = SCALE_RISC_CYCLES(USEC_TO_RISC_CYCLES(timeDelta));
          GPUBeginSlice(riscCycles);
+         DSPBeginSlice(riscCycles);
          M68KExecuteWithStalls(USEC_TO_M68K_CYCLES(timeDelta));
          GPUExec(GPUSliceRemaining());
-         DSPExec(riscCycles);
+         DSPExec(DSPSliceRemaining());
          SubtractEventTimes(timeDelta, EVENT_MAIN);
          HandleNextEvent(EVENT_JERRY);
       }
@@ -1658,9 +1668,10 @@ void JaguarExecuteNew(void)
          timeDelta = timeToMainEvent;
          riscCycles = SCALE_RISC_CYCLES(USEC_TO_RISC_CYCLES(timeDelta));
          GPUBeginSlice(riscCycles);
+         DSPBeginSlice(riscCycles);
          M68KExecuteWithStalls(USEC_TO_M68K_CYCLES(timeDelta));
          GPUExec(GPUSliceRemaining());
-         DSPExec(riscCycles);
+         DSPExec(DSPSliceRemaining());
          SubtractEventTimes(timeDelta, EVENT_JERRY);
          HandleNextEvent(EVENT_MAIN);
       }

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -460,9 +460,11 @@ static void M68KGPURAMSyncRead(unsigned int address, unsigned int length)
    if (address < GPU_WORK_RAM_BASE + 0x1000
        && address + length > GPU_WORK_RAM_BASE)
       GPUSyncToM68K();
-   /* Same handshake on the DSP side (issue #456 / #408 H3): a 68K poll
-    * of dspfinished must see the DSP that has already run up to this
-    * point in the slice, not the leftover of the previous one. */
+   /* Same handshake on the DSP side (issue #456 / #408 H3).  Doom's
+    * MiniLoop polls `DSPRead(&dspfinished)`; `_dspfinished` is a long
+    * in dspbase.gas (`.org $f1b000`, DSP local RAM), not D_CTRL /
+    * $F1A100.  The 68K read has to see the DSP that has already run
+    * up to this point in the slice, not the leftover of the previous one. */
    if (address < DSP_WORK_RAM_BASE + 0x2000
        && address + length > DSP_WORK_RAM_BASE)
       DSPSyncToM68K();

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -1638,10 +1638,11 @@ void JaguarExecuteNew(void)
       double timeDelta;
       uint32_t riscCycles;
 
-      /* GPUBeginSlice/GPUSliceRemaining: part of the GPU's slice may already
-       * have been run from GPUSyncToM68K(), so the end-of-slice call runs only
-       * what is left.  The total per slice is unchanged -- see the comment on
-       * gpuSliceBudget in gpu.c.
+      /* GPUBeginSlice/DSPBeginSlice + *SliceRemaining: part of each
+       * RISC slice may already have been run from GPUSyncToM68K() /
+       * DSPSyncToM68K() on a 68K access into local RAM, so the
+       * end-of-slice call runs only what is left.  The total per slice
+       * is unchanged -- see gpuSliceBudget in gpu.c and issue #456.
        *
        * Clock scales (issue #314) apply here, where the budgets are
        * handed out: the RISC scale widens the GPU+DSP compute budget per

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -305,6 +305,8 @@ static uint32_t dspgo_poll_count;
 #define BRANCH_CONDITION(x)		dsp_branch_condition_table[(x) + ((jaguar_flags & 7) << 5)]
 
 static uint32_t dsp_in_exec = 0;
+static int32_t dspSliceBudget;
+static int32_t dspSliceSpent;
 static uint32_t dsp_releaseTimeSlice_flag = 0;
 /* DSP execution liveness counter for the crash watchdog's wedge
  * predicate -- see gpu.c gpu_exec_opcode_count for rationale and the
@@ -975,6 +977,8 @@ void DSPReset(void)
 	dsp_control			  = 0x00002000;				// Report DSP version 2
 	dsp_div_control		  = 0x00000000;
 	dsp_in_exec			  = 0;
+	dspSliceBudget		  = 0;
+	dspSliceSpent		  = 0;
 
 	dsp_reg = dsp_reg_bank_0;
 	dsp_alternate_reg = dsp_reg_bank_1;
@@ -1008,6 +1012,42 @@ void DSPReset(void)
 
 void DSPDone(void)
 {
+}
+
+void DSPBeginSlice(uint32_t riscCycles)
+{
+	dspSliceBudget = (int32_t)riscCycles;
+	dspSliceSpent  = 0;
+}
+
+int32_t DSPSliceRemaining(void)
+{
+	int32_t left = dspSliceBudget - dspSliceSpent;
+	return (left > 0 ? left : 0);
+}
+
+/* Advance the DSP to the 68000's position inside the current slice.
+ * Mirror of GPUSyncToM68K (issue #406 / PR #445): without this a 68K
+ * poll of a DSP mailbox samples stale state from the previous slice,
+ * which is #408 H3 and issue #456.  Same 2:1 RISC:68K clock ratio. */
+void DSPSyncToM68K(void)
+{
+	int32_t target, run;
+
+	if (!DSP_RUNNING || dsp_in_exec)
+		return;
+
+	target = (int32_t)(((int64_t)m68k_cycles_run() * 2 * riscClockScalePct)
+	                   / m68kClockScalePct);
+	if (target > dspSliceBudget)
+		target = dspSliceBudget;
+
+	run = target - dspSliceSpent;
+	if (run <= 0)
+		return;
+
+	dspSliceSpent += run;
+	DSPExec(run);
 }
 
 /* DSP execution core */

--- a/src/jerry/dsp.h
+++ b/src/jerry/dsp.h
@@ -22,6 +22,11 @@ void DSPExec(int32_t);
 void DSPDone(void);
 void DSPUpdateRegisterBanks(void);
 void DSPSetIRQLine(int irqline, int state);
+/* Slice bookkeeping for the 68K->DSP-local-RAM sync; mirror of
+ * GPUBeginSlice / GPUSliceRemaining / GPUSyncToM68K (issue #456). */
+void DSPBeginSlice(uint32_t riscCycles);
+int32_t DSPSliceRemaining(void);
+void DSPSyncToM68K(void);
 uint8_t DSPReadByte(uint32_t offset, uint32_t who);
 uint16_t DSPReadWord(uint32_t offset, uint32_t who);
 uint32_t DSPReadLong(uint32_t offset, uint32_t who);


### PR DESCRIPTION
## Summary
- DSP-side of the closed #406 GPU-sync class, and exactly #408 hypothesis H3 (\`dspfinished\` handshake completing instantly).
- \`DSPBeginSlice\` / \`DSPSyncToM68K\` / \`DSPSliceRemaining\` mirror the GPU slice bookkeeping. 68K reads **and** writes that overlap DSP local RAM (\`$F1B000–$F1CFFF\`) catch the DSP up to the 68K's position in the current slice.
- End-of-slice \`DSPExec\` runs only the remainder, so total RISC cycles per slice are unchanged.

## Test plan
- [x] \`bash scripts/c89-lint.sh src/jerry/dsp.c src/core/jaguar.c\`
- [x] Iron Soldier 1 \`test_audio_presence\` (RMS 1174.2, envelope 200–25000) and \`test_audio_clipping\` (0% saturated)
- [x] Iron Soldier 2 \`test_audio_clipping\` (0% saturated, RMS 2598)
- [x] \`test_dsp_mac40\`
- [ ] Doom attract demo under \`dram_timing\` / \`VJ_DRAM_SCALE\` sweep — this is the #406 class on the DSP side
- [ ] Hover Strike / Doom menu tap-repeat (#399) after this lands, before treating #401 as still 2x


Made with [Cursor](https://cursor.com)