### PR TITLE
feat(input): per-axis dead zone, offset and response exponent (#439)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ test/tools/netlink_game
 test/tools/joymatrix_identity
 test/tools/mouse_decode_test
 test/tools/rotary_decode_test
+test/tools/tuning_identity
 # vjtrace flight-recorder analyzer/smoke tools -- built on demand by
 # test/tools/vjtrace_selftest.sh (and by hand per each tool's own header
 # comment); never tracked, same Mach-O-on-Linux-CI hazard as above.

--- a/Makefile
+++ b/Makefile
@@ -923,8 +923,8 @@ clean:
 		test/test_titledb test/test_titlehook test/tools/test_hook_gate \
 		test/tools/test_wedge_spin test/tools/i2s_lag_probe \
 		test/tools/joymatrix_identity test/tools/mouse_decode_test \
-		test/tools/rotary_decode_test \
-		test/test_quadrature \
+		test/tools/rotary_decode_test test/tools/tuning_identity \
+		test/test_quadrature test/test_axistune \
 		test/.skipped-checks
 
 # Self-contained unit tests (parser + list management + simulated
@@ -980,8 +980,8 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/test_pertitle_db \
 		test/tools/test_hook_gate \
 		test/tools/i2s_lag_probe test/tools/joymatrix_identity \
-		test/test_quadrature test/tools/mouse_decode_test \
-		test/tools/rotary_decode_test \
+		test/test_quadrature test/test_axistune test/tools/mouse_decode_test \
+		test/tools/rotary_decode_test test/tools/tuning_identity \
 		tools/jagcd/jagcd-chd-check
 	@# Skip ledger: truncate FIRST so a previous run's rows cannot resurface
 	@# as fresh skips (the stale-row failure mode documented for
@@ -1259,6 +1259,16 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# two-controller Pause unlock, the C2/C3 ID bits and a savestate
 	@# round-trip mid-rotation.
 	./test/tools/rotary_decode_test ./$(TARGET) test/roms/yarc.j64 --quiet
+	@# Per-axis input tuning (#439), no core: the identity at defaults over
+	@# the whole int16 range, the dead zone as a gate rather than a re-base,
+	@# the curve's fixed point at QUAD_MAX_BACKLOG and its exact values.
+	./test/test_axistune
+	@# ...and the same feature measured end to end through $F14000: the
+	@# digital pad is bit-identical with tuning at ANY setting, the analog
+	@# paths are bit-identical at defaults, and a non-default tuning does
+	@# move the analog digest (the negative control that stops the two
+	@# equalities passing on a disconnected layer).
+	./test/tools/tuning_identity ./$(TARGET) test/roms/yarc.j64 --quiet
 	./test/test_memtrack
 	./test/test_nvmbios
 	@# Option visibility is content-type dependent; the disc half runs only
@@ -1632,6 +1642,20 @@ test/tools/rotary_decode_test: test/tools/rotary_decode_test.c \
 
 test/test_quadrature: test/test_quadrature.c src/jerry/quadrature.c src/jerry/quadrature.h
 	$(CC) -O2 -Wall $(INCFLAGS) -o $@ test/test_quadrature.c src/jerry/quadrature.c
+
+test/test_axistune: test/test_axistune.c src/jerry/axistune.c src/jerry/axistune.h \
+		src/jerry/quadrature.h
+	$(CC) -O2 -Wall $(INCFLAGS) -o $@ test/test_axistune.c src/jerry/axistune.c
+
+# #439's guardrail: needs the wide test ABI's InputDev* / Joystick* /
+# joypad0Buttons / joypad1Buttons exports.
+test/tools/tuning_identity: test/tools/tuning_identity.c \
+		src/jerry/inputdev.h src/jerry/axistune.h \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/tuning_identity.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
 
 test/tools/test_option_visibility: test/tools/test_option_visibility.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile.common
+++ b/Makefile.common
@@ -81,6 +81,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/bios/jagdevcdbios.c \
 	$(CORE_DIR)/src/jerry/joystick.c \
 	$(CORE_DIR)/src/jerry/quadrature.c \
+	$(CORE_DIR)/src/jerry/axistune.c \
 	$(CORE_DIR)/src/jerry/inputdev.c \
 	$(CORE_DIR)/src/core/settings.c \
 	$(CORE_DIR)/src/core/memtrack.c \

--- a/libretro.c
+++ b/libretro.c
@@ -242,6 +242,21 @@ static bool         show_rotary_options     = true;
 static int32_t      mouse_scale_q8          = 256;
 static int32_t      rotary_scale_q8         = 256;
 
+/* Per-axis tuning (#439), resolved from the options and applied to
+ * whichever device is actually in each port -- the same "one ladder per
+ * device kind, selected by what is plugged in" shape as the scales above.
+ * A rotary is one wheel, so it has a single tune and no Y entry.
+ *
+ * Held as raw ints rather than axis_tune structs because libretro.c has no
+ * business knowing that layout; InputDevSetTune() clamps and stores them.
+ * Index 0 is X, index 1 is Y, matching INPUTDEV_AXIS_*. */
+static int32_t      mouse_deadzone[2]       = { 0, 0 };
+static int32_t      mouse_offset[2]         = { 0, 0 };
+static int32_t      mouse_exponent_q8[2]    = { 256, 256 };
+static int32_t      rotary_deadzone         = 0;
+static int32_t      rotary_offset           = 0;
+static int32_t      rotary_exponent_q8      = 256;
+
 /* Has this port actually received non-zero mouse state from the frontend?
  *
  * THE RULE: selecting a mouse must never leave the port with no working
@@ -305,6 +320,36 @@ static bool inputdev_is_mouse_type(InputDevType t)
            || t == INPUTDEV_MOUSE_AMIGA_ON_ST);
 }
 
+/* Push the sensitivity ladder AND the per-axis tuning (#439) that belong to
+ * whatever device is currently in `port`.
+ *
+ * The two are resolved together, in one function called from both paths,
+ * because they are selected by the same fact -- what is plugged into the
+ * port -- and a second place that picks between the two devices' ladders is
+ * exactly how the bug documented in apply_port_device() came about. */
+static void apply_port_tuning(int port)
+{
+   if (InputDevGetType(port) == INPUTDEV_ROTARY)
+   {
+      InputDevSetScale(port, rotary_scale_q8);
+      /* A rotary is one wheel and never reads its Y tune, but both axes are
+       * set so a rotary -> mouse switch on port 2 cannot inherit a stale Y
+       * tune from whatever was configured before. */
+      InputDevSetTune(port, INPUTDEV_AXIS_X, rotary_deadzone,
+                      rotary_offset, rotary_exponent_q8);
+      InputDevSetTune(port, INPUTDEV_AXIS_Y, rotary_deadzone,
+                      rotary_offset, rotary_exponent_q8);
+   }
+   else
+   {
+      InputDevSetScale(port, mouse_scale_q8);
+      InputDevSetTune(port, INPUTDEV_AXIS_X, mouse_deadzone[0],
+                      mouse_offset[0], mouse_exponent_q8[0]);
+      InputDevSetTune(port, INPUTDEV_AXIS_Y, mouse_deadzone[1],
+                      mouse_offset[1], mouse_exponent_q8[1]);
+   }
+}
+
 static void apply_port_device(int port, InputDevType type)
 {
    InputDevSetType(port, type);
@@ -318,7 +363,7 @@ static void apply_port_device(int port, InputDevType type)
       port_device_active[port] = type;
       /* A new device has to earn the port back (see inputdev_live). */
       inputdev_live[port]      = false;
-      /* Re-resolve the sensitivity ladder for the device now in the port.
+      /* Re-resolve the ladders for the device now in the port.
        * The rotary and the mouse have separate options because a spinner
        * and a mouse want very different multipliers, and until this line
        * existed the only place that picked between them was
@@ -329,12 +374,11 @@ static void apply_port_device(int port, InputDevType type)
        * core-option change happened to fix it.  Invisible at defaults
        * (both ladders are 256) and self-healing, but real.
        *
-       * Both statics hold their last resolved values here; on the
+       * The statics hold their last resolved values here; on the
        * check_variables() path the loop after the ladders recomputes them
-       * and calls InputDevSetScale again anyway, so this is at worst one
-       * redundant assignment there. */
-      InputDevSetScale(port, type == INPUTDEV_ROTARY
-                                ? rotary_scale_q8 : mouse_scale_q8);
+       * and calls apply_port_tuning again anyway, so this is at worst one
+       * redundant pass there. */
+      apply_port_tuning(port);
       if (type != INPUTDEV_PAD)
          LOG_INF("[input] port %d: %s attached\n", port + 1,
                  inputdev_type_name(type));
@@ -539,11 +583,20 @@ static bool update_option_visibility(void)
       }
    }
 
-   /* Mouse sensitivity only means anything while a mouse is attached to
-    * port 2.  Resolved from the live device rather than the option string
-    * so a frontend-set port device (retro_set_controller_port_device)
-    * reveals it too. */
+   /* Mouse sensitivity and the per-axis tuning (#439) only mean anything
+    * while a mouse is attached to port 2.  Resolved from the live device
+    * rather than the option string so a frontend-set port device
+    * (retro_set_controller_port_device) reveals them too. */
    {
+      static const char * const mouse_keys[] = {
+         "virtualjaguar_mouse_sensitivity",
+         "virtualjaguar_mouse_deadzone_x",
+         "virtualjaguar_mouse_deadzone_y",
+         "virtualjaguar_mouse_offset_x",
+         "virtualjaguar_mouse_offset_y",
+         "virtualjaguar_mouse_exponent_x",
+         "virtualjaguar_mouse_exponent_y",
+      };
       bool show_mouse_prev = show_mouse_options;
 
       show_mouse_options = inputdev_is_mouse_type(InputDevGetType(1));
@@ -551,16 +604,27 @@ static bool update_option_visibility(void)
       if (show_mouse_options != show_mouse_prev)
       {
          option_display.visible = show_mouse_options;
-         option_display.key     = "virtualjaguar_mouse_sensitivity";
-         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
-                    &option_display);
+         for (i = 0; i < ARRAY_SIZE(mouse_keys); i++)
+         {
+            option_display.key = mouse_keys[i];
+            environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
+                       &option_display);
+         }
          updated = true;
       }
    }
 
-   /* Rotary sensitivity and the rotary controller-type knob mean nothing
-    * unless a rotary is attached to one port or the other (#436). */
+   /* Rotary sensitivity, its per-axis tuning (#439) and the rotary
+    * controller-type knob mean nothing unless a rotary is attached to one
+    * port or the other (#436). */
    {
+      static const char * const rotary_keys[] = {
+         "virtualjaguar_rotary_sensitivity",
+         "virtualjaguar_rotary_id",
+         "virtualjaguar_rotary_deadzone",
+         "virtualjaguar_rotary_offset",
+         "virtualjaguar_rotary_exponent",
+      };
       bool show_rotary_prev = show_rotary_options;
 
       show_rotary_options = (InputDevGetType(0) == INPUTDEV_ROTARY
@@ -569,12 +633,12 @@ static bool update_option_visibility(void)
       if (show_rotary_options != show_rotary_prev)
       {
          option_display.visible = show_rotary_options;
-         option_display.key     = "virtualjaguar_rotary_sensitivity";
-         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
-                    &option_display);
-         option_display.key     = "virtualjaguar_rotary_id";
-         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
-                    &option_display);
+         for (i = 0; i < ARRAY_SIZE(rotary_keys); i++)
+         {
+            option_display.key = rotary_keys[i];
+            environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
+                       &option_display);
+         }
          updated = true;
       }
    }
@@ -852,6 +916,49 @@ static InputDevType p1_device_from_option(void)
    }
 
    return p1;
+}
+
+/* Per-axis tuning option readers (#439).
+ *
+ * Deliberately thin: the clamps that decide what is a legal dead zone,
+ * offset or exponent live in AxisTuneSet(), one layer down, so a
+ * hand-edited config is bounded in exactly one place no matter which
+ * option it came through.  These only have to survive a missing or
+ * non-numeric string. */
+static int32_t read_tune_units(const char *key)
+{
+   struct retro_variable var;
+
+   var.key   = key;
+   var.value = NULL;
+
+   if (get_variable_pertitle(&var) && var.value)
+      return (int32_t)atoi(var.value);
+
+   return 0;
+}
+
+static int32_t read_tune_exponent(const char *key)
+{
+   struct retro_variable var;
+   int pct = 100;
+
+   var.key   = key;
+   var.value = NULL;
+
+   if (get_variable_pertitle(&var) && var.value)
+      pct = atoi(var.value);
+
+   /* Percent -> Q8 (256 == 1.0), the same conversion the sensitivity
+    * ladders use, and clamped BEFORE the multiply for the same reason
+    * they are.  800% is AxisTuneSet's own 2048 ceiling expressed as a
+    * percent, so nothing reachable is lost. */
+   if (pct < 1)
+      pct = 100;
+   if (pct > 800)
+      pct = 800;
+
+   return (int32_t)((pct * 256) / 100);
 }
 
 static void check_variables(void)
@@ -1248,16 +1355,28 @@ static void check_variables(void)
    else
       rotary_scale_q8 = 256;
 
-   /* One scale per port, picked by what is actually plugged into it --
-    * the two ladders are separate options because a spinner and a mouse
-    * want very different multipliers. */
+   /* Per-axis tuning (#439).  Read unconditionally: every one of these
+    * defaults to the identity, so a build where nobody touched the menu
+    * resolves to exactly the pre-#439 numbers. */
+   mouse_deadzone[0]    = read_tune_units("virtualjaguar_mouse_deadzone_x");
+   mouse_deadzone[1]    = read_tune_units("virtualjaguar_mouse_deadzone_y");
+   mouse_offset[0]      = read_tune_units("virtualjaguar_mouse_offset_x");
+   mouse_offset[1]      = read_tune_units("virtualjaguar_mouse_offset_y");
+   mouse_exponent_q8[0] = read_tune_exponent("virtualjaguar_mouse_exponent_x");
+   mouse_exponent_q8[1] = read_tune_exponent("virtualjaguar_mouse_exponent_y");
+
+   rotary_deadzone      = read_tune_units("virtualjaguar_rotary_deadzone");
+   rotary_offset        = read_tune_units("virtualjaguar_rotary_offset");
+   rotary_exponent_q8   = read_tune_exponent("virtualjaguar_rotary_exponent");
+
+   /* One scale and one tuning set per port, picked by what is actually
+    * plugged into it -- the two ladders are separate options because a
+    * spinner and a mouse want very different multipliers. */
    {
       unsigned port;
 
       for (port = 0; port < 2; port++)
-         InputDevSetScale((int)port,
-                          InputDevGetType((int)port) == INPUTDEV_ROTARY
-                             ? rotary_scale_q8 : mouse_scale_q8);
+         apply_port_tuning((int)port);
    }
 
    var.key   = "virtualjaguar_rotary_id";
@@ -2868,6 +2987,17 @@ void retro_deinit(void)
    show_rotary_options     = true;
    mouse_scale_q8          = 256;
    rotary_scale_q8         = 256;
+   /* #439's tuning statics go back to the identity here too -- iOS cannot
+    * dlclose a core, so anything left set would leak into the next load. */
+   mouse_deadzone[0]       = 0;
+   mouse_deadzone[1]       = 0;
+   mouse_offset[0]         = 0;
+   mouse_offset[1]         = 0;
+   mouse_exponent_q8[0]    = 256;
+   mouse_exponent_q8[1]    = 256;
+   rotary_deadzone         = 0;
+   rotary_offset           = 0;
+   rotary_exponent_q8      = 256;
    headroom_logged         = false;
    video_buffer_alloc_pixels = VIDEO_BUFFER_PIXELS;
    hires_restart_notice_logged = 0;

--- a/libretro.c
+++ b/libretro.c
@@ -326,7 +326,16 @@ static bool inputdev_is_mouse_type(InputDevType t)
  * The two are resolved together, in one function called from both paths,
  * because they are selected by the same fact -- what is plugged into the
  * port -- and a second place that picks between the two devices' ladders is
- * exactly how the bug documented in apply_port_device() came about. */
+ * exactly how the bug documented in apply_port_device() came about.
+ *
+ * IT CAN RUN BEFORE THE OPTIONS HAVE EVER BEEN READ.  The frontend may
+ * call retro_set_controller_port_device() before retro_load_game(), and
+ * that path reaches here without passing through check_variables().  The
+ * statics then still hold their initialisers, which are deliberately the
+ * IDENTITY (and retro_deinit puts them back), so the worst case is a
+ * device that runs untuned until retro_load_game's own check_variables()
+ * resolves it a moment later.  Any future static added here must keep that
+ * property: its initialiser has to be a safe value, not a sentinel. */
 static void apply_port_tuning(int port)
 {
    if (InputDevGetType(port) == INPUTDEV_ROTARY)
@@ -929,6 +938,11 @@ static int32_t read_tune_units(const char *key)
 {
    struct retro_variable var;
 
+   /* NO CLAMP HERE, ON PURPOSE.  AxisTuneSet() owns the bounds for both
+    * the dead zone and the offset; duplicating them here would give the
+    * feature two sets of limits to keep in step.  The exponent reader
+    * below does clamp, but only because it MULTIPLIES before handing the
+    * value on and an unbounded percent would overflow on the way. */
    var.key   = key;
    var.value = NULL;
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -562,6 +562,68 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       },
       "joypad"
    },
+   /* Per-axis rotary tuning (#439).  A rotary is a single wheel, so there
+    * is one axis and no X/Y split; the arithmetic is the same shared layer
+    * the mouse uses (src/jerry/axistune.c).  Defaults are the identity. */
+   {
+      "virtualjaguar_rotary_deadzone",
+      "Rotary Dead Zone",
+      "Rotary Dead Zone",
+      "Discards spinner movement at or below this many host units per poll. A noise gate for a jittery source; movement above the threshold passes at full size.",
+      NULL,
+      "input",
+      {
+         { "0", "Off" },
+         { "1", "1 unit" },
+         { "2", "2 units" },
+         { "3", "3 units" },
+         { "4", "4 units" },
+         { "6", "6 units" },
+         { "8", "8 units" },
+         { NULL, NULL },
+      },
+      "0"
+   },
+   {
+      "virtualjaguar_rotary_offset",
+      "Rotary Offset",
+      "Rotary Offset",
+      "Subtracts a constant from every spinner sample. Cancels a source that reports a small non-zero movement while at rest, which would otherwise spin the knob forever with the controls untouched. Applied in host orientation, before the wheel's direction convention.",
+      NULL,
+      "input",
+      {
+         { "-4", "-4" },
+         { "-3", "-3" },
+         { "-2", "-2" },
+         { "-1", "-1" },
+         { "0",  "Off" },
+         { "1",  "+1" },
+         { "2",  "+2" },
+         { "3",  "+3" },
+         { "4",  "+4" },
+         { NULL, NULL },
+      },
+      "0"
+   },
+   {
+      "virtualjaguar_rotary_exponent",
+      "Rotary Response Curve",
+      "Rotary Response Curve",
+      "Response exponent for the spinner, giving finer control at low speed. The curve is anchored at 64 units per poll: below that an exponent above 1.00 attenuates, at and above it movement passes through unchanged. A higher exponent therefore makes the spinner SLOWER overall -- raise Rotary Sensitivity to get the top speed back.",
+      NULL,
+      "input",
+      {
+         { "100", "Linear (1.00)" },
+         { "125", "1.25" },
+         { "150", "1.50" },
+         { "175", "1.75" },
+         { "200", "2.00" },
+         { "250", "2.50" },
+         { "300", "3.00" },
+         { NULL, NULL },
+      },
+      "100"
+   },
    {
       "virtualjaguar_mouse_sensitivity",
       "Port 2 > Mouse Sensitivity",
@@ -578,6 +640,129 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "200", "200%" },
          { "300", "300%" },
          { "400", "400%" },
+         { NULL, NULL },
+      },
+      "100"
+   },
+   /* Per-axis mouse tuning (#439).  Dead zone and offset are in raw host
+    * units per poll; the exponent is a percentage of 1.0, anchored at 64
+    * units per poll (quadrature.h's saturation point -- see axistune.h).
+    * All defaults are the exact identity, so a user who never opens this
+    * menu gets the pre-#439 path unchanged. */
+   {
+      "virtualjaguar_mouse_deadzone_x",
+      "Port 2 > Mouse Dead Zone (X)",
+      "Mouse Dead Zone (X)",
+      "Discards horizontal mouse movement at or below this many host units per poll. A noise gate for a jittery source (or an analog stick mapped to the mouse); a real mouse reports nothing at rest and needs none. Movement above the threshold passes at full size -- the dead zone drops samples, it does not shrink them.",
+      NULL,
+      "input_p2",
+      {
+         { "0", "Off" },
+         { "1", "1 unit" },
+         { "2", "2 units" },
+         { "3", "3 units" },
+         { "4", "4 units" },
+         { "6", "6 units" },
+         { "8", "8 units" },
+         { NULL, NULL },
+      },
+      "0"
+   },
+   {
+      "virtualjaguar_mouse_deadzone_y",
+      "Port 2 > Mouse Dead Zone (Y)",
+      "Mouse Dead Zone (Y)",
+      "As Mouse Dead Zone (X), for vertical movement.",
+      NULL,
+      "input_p2",
+      {
+         { "0", "Off" },
+         { "1", "1 unit" },
+         { "2", "2 units" },
+         { "3", "3 units" },
+         { "4", "4 units" },
+         { "6", "6 units" },
+         { "8", "8 units" },
+         { NULL, NULL },
+      },
+      "0"
+   },
+   {
+      "virtualjaguar_mouse_offset_x",
+      "Port 2 > Mouse Offset (X)",
+      "Mouse Offset (X)",
+      "Subtracts a constant from every horizontal sample. Cancels a source that reports a small non-zero movement while at rest -- typically an analog stick mapped to the mouse, which otherwise drifts forever. A real mouse reports exactly zero at rest and is unaffected.",
+      NULL,
+      "input_p2",
+      {
+         { "-4", "-4" },
+         { "-3", "-3" },
+         { "-2", "-2" },
+         { "-1", "-1" },
+         { "0",  "Off" },
+         { "1",  "+1" },
+         { "2",  "+2" },
+         { "3",  "+3" },
+         { "4",  "+4" },
+         { NULL, NULL },
+      },
+      "0"
+   },
+   {
+      "virtualjaguar_mouse_offset_y",
+      "Port 2 > Mouse Offset (Y)",
+      "Mouse Offset (Y)",
+      "As Mouse Offset (X), for vertical movement.",
+      NULL,
+      "input_p2",
+      {
+         { "-4", "-4" },
+         { "-3", "-3" },
+         { "-2", "-2" },
+         { "-1", "-1" },
+         { "0",  "Off" },
+         { "1",  "+1" },
+         { "2",  "+2" },
+         { "3",  "+3" },
+         { "4",  "+4" },
+         { NULL, NULL },
+      },
+      "0"
+   },
+   {
+      "virtualjaguar_mouse_exponent_x",
+      "Port 2 > Mouse Response Curve (X)",
+      "Mouse Response Curve (X)",
+      "Response exponent for horizontal movement, giving finer control at low speed. The curve is anchored at 64 units per poll: below that an exponent above 1.00 attenuates, at and above it movement passes through unchanged. Because ordinary movement is well below 64 units, a higher exponent makes the mouse SLOWER overall -- raise Mouse Sensitivity to get the top speed back. These are two different controls.",
+      NULL,
+      "input_p2",
+      {
+         { "100", "Linear (1.00)" },
+         { "125", "1.25" },
+         { "150", "1.50" },
+         { "175", "1.75" },
+         { "200", "2.00" },
+         { "250", "2.50" },
+         { "300", "3.00" },
+         { NULL, NULL },
+      },
+      "100"
+   },
+   {
+      "virtualjaguar_mouse_exponent_y",
+      "Port 2 > Mouse Response Curve (Y)",
+      "Mouse Response Curve (Y)",
+      "As Mouse Response Curve (X), for vertical movement.",
+      NULL,
+      "input_p2",
+      {
+         { "100", "Linear (1.00)" },
+         { "125", "1.25" },
+         { "150", "1.50" },
+         { "175", "1.75" },
+         { "200", "2.00" },
+         { "250", "2.50" },
+         { "300", "3.00" },
          { NULL, NULL },
       },
       "100"

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -564,7 +564,13 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    /* Per-axis rotary tuning (#439).  A rotary is a single wheel, so there
     * is one axis and no X/Y split; the arithmetic is the same shared layer
-    * the mouse uses (src/jerry/axistune.c).  Defaults are the identity. */
+    * the mouse uses (src/jerry/axistune.c).  Defaults are the identity.
+    *
+    * These are SHARED BY BOTH PORTS, exactly as Rotary Sensitivity already
+    * is: two rotaries cannot be tuned independently.  That is a deliberate
+    * carry-forward of the existing shape rather than an omission -- the
+    * rotary options live in the un-prefixed "input" category precisely
+    * because the device is offered on either port. */
    {
       "virtualjaguar_rotary_deadzone",
       "Rotary Dead Zone",

--- a/src/jerry/axistune.c
+++ b/src/jerry/axistune.c
@@ -178,6 +178,20 @@ int32_t AxisTuneApply(const axis_tune *t, int32_t raw, int32_t *gain_q8)
    if (AxisTuneIsIdentity(t))
       return raw;
 
+   /* No sample this poll.  On a RELATIVE axis raw == 0 does not mean "a
+    * reading at the (biased) centre" -- it means the frontend reported no
+    * motion at all, which libretro.c does every single frame for an
+    * attached-but-idle device.  Subtracting the offset here would
+    * manufacture a non-zero delta, clear the (default-zero) dead-zone
+    * gate, and feed QuadFeed forever with the device untouched: exactly
+    * the "spin the knob forever with the controls untouched" failure the
+    * offset option exists to CURE, and a contradiction of its own help
+    * text ("a real mouse reports exactly zero at rest and is
+    * unaffected").  Offset corrects a source that reports movement; it
+    * has nothing to correct when the source reports none. */
+   if (raw == 0)
+      return 0;
+
    v = raw - t->offset;
 
    if (v == 0)

--- a/src/jerry/axistune.c
+++ b/src/jerry/axistune.c
@@ -1,0 +1,231 @@
+/*
+ * src/jerry/axistune.c -- per-axis input tuning (#439).
+ *
+ * See axistune.h for the semantics, for why the dead zone is a gate rather
+ * than a re-base, for where AXISTUNE_REF comes from, and for why the
+ * response curve is reported as a gain instead of folded into the delta.
+ *
+ * WHY THIS IS INTEGER-ONLY AND WHY THAT IS NOT OPTIONAL
+ * ====================================================
+ * The response curve is a fractional power, which is a natural fit for
+ * powf().  It is not used, and libm is not linked into this path, because
+ * the guardrail tests for the input devices are host-independent FNV
+ * digests over a swept input domain (test/tools/joymatrix_identity.c says
+ * so in its own header).  A float pow would make those digests depend on
+ * the host's libm rounding, so the same core would digest differently on
+ * x86-64, arm64 and i686 and the constants would stop meaning anything.
+ *
+ * The curve is therefore evaluated in Q16 fixed point with the classic
+ * identity x^(1/2^k) = k successive square roots, which is exact integer
+ * arithmetic and bit-identical everywhere.
+ */
+
+#include "axistune.h"
+
+/* Q16 multiply of two values in [0, 1.0].
+ *
+ * Both operands are at most 65536 (1.0), so the product is at most 2^32 --
+ * exactly one past what a uint32 holds.  That single case is a multiply by
+ * 1.0, which needs no arithmetic at all, so the guards below are not
+ * micro-optimisation: they are what keeps the product in range. */
+static uint32_t axistune_mul_q16(uint32_t a, uint32_t b)
+{
+   if (a == 65536u)
+      return b;
+   if (b == 65536u)
+      return a;
+   /* Both are now <= 65535, so a * b <= 4294836225 and the rounding
+    * addend cannot carry past uint32. */
+   return (uint32_t)(((a * b) + 32768u) >> 16);
+}
+
+/* Integer square root of a uint32, bit-by-bit (no float, no libm). */
+static uint32_t axistune_isqrt(uint32_t n)
+{
+   uint32_t rem  = 0;
+   uint32_t root = 0;
+   int      i;
+
+   for (i = 0; i < 16; i++)
+   {
+      root <<= 1;
+      rem   = (rem << 2) | (n >> 30);
+      n   <<= 2;
+
+      if (root < rem)
+      {
+         root++;
+         rem -= root;
+         root++;
+      }
+   }
+
+   return root >> 1;
+}
+
+/* Q16 square root of a value in [0, 1.0].  sqrt(x) in Q16 is
+ * isqrt(x << 16); the shift is in range precisely because x < 1.0 here,
+ * and x == 1.0 is answered without shifting. */
+static uint32_t axistune_sqrt_q16(uint32_t x_q16)
+{
+   if (x_q16 >= 65536u)
+      return 65536u;
+   return axistune_isqrt(x_q16 << 16);
+}
+
+/* base^exp in Q16, for base in [0, 1.0] and exp a non-negative Q8.
+ *
+ * Integer part by repeated multiply; fractional part by the successive-root
+ * identity, one root per Q8 fraction bit.  Eight roots is the whole Q8
+ * fraction, so this terminates in a fixed 8 iterations regardless of the
+ * exponent. */
+static uint32_t axistune_pow_q16(uint32_t base_q16, uint32_t exp_q8)
+{
+   uint32_t result = 65536u;
+   uint32_t root   = base_q16;
+   uint32_t ip     = exp_q8 >> 8;
+   uint32_t fp     = exp_q8 & 0xFFu;
+   uint32_t bit;
+
+   if (base_q16 == 0u)
+      return 0u;
+
+   /* base <= 1.0, so each multiply only shrinks the result; eight is far
+    * past the point where it has already underflowed to zero, and the
+    * option ladder never exceeds 3. */
+   if (ip > 8u)
+      ip = 8u;
+
+   while (ip > 0u)
+   {
+      result = axistune_mul_q16(result, base_q16);
+      ip--;
+   }
+
+   for (bit = 0x80u; bit != 0u; bit >>= 1)
+   {
+      root = axistune_sqrt_q16(root);
+      if ((fp & bit) != 0u)
+         result = axistune_mul_q16(result, root);
+   }
+
+   return result;
+}
+
+void AxisTuneReset(axis_tune *t)
+{
+   if (!t)
+      return;
+
+   t->deadzone    = 0;
+   t->offset      = 0;
+   t->exponent_q8 = 256;   /* linear */
+}
+
+void AxisTuneSet(axis_tune *t, int32_t deadzone, int32_t offset,
+                 int32_t exponent_q8)
+{
+   if (!t)
+      return;
+
+   /* A dead zone at or above the curve's reference would gate the entire
+    * range the curve describes, so AXISTUNE_REF is the useful ceiling. */
+   if (deadzone < 0)
+      deadzone = 0;
+   if (deadzone > AXISTUNE_REF)
+      deadzone = AXISTUNE_REF;
+
+   /* An offset larger than the reference is a source so badly mis-centred
+    * that it is saturating the path on its own. */
+   if (offset < -AXISTUNE_REF)
+      offset = -AXISTUNE_REF;
+   if (offset > AXISTUNE_REF)
+      offset = AXISTUNE_REF;
+
+   /* <= 0 is linear by definition (axistune.h, zero-fill identity), and
+    * the top of the ladder is bounded so axistune_pow_q16's integer part
+    * stays inside its own clamp. */
+   if (exponent_q8 <= 0)
+      exponent_q8 = 256;
+   if (exponent_q8 > 2048)
+      exponent_q8 = 2048;
+
+   t->deadzone    = deadzone;
+   t->offset      = offset;
+   t->exponent_q8 = exponent_q8;
+}
+
+int AxisTuneIsIdentity(const axis_tune *t)
+{
+   if (!t)
+      return 1;
+
+   return (t->deadzone <= 0
+           && t->offset == 0
+           && (t->exponent_q8 == 256 || t->exponent_q8 <= 0)) ? 1 : 0;
+}
+
+int32_t AxisTuneApply(const axis_tune *t, int32_t raw, int32_t *gain_q8)
+{
+   int32_t  v, mag, gain;
+   uint32_t n_q16, p_q16;
+
+   if (gain_q8)
+      *gain_q8 = 256;
+
+   /* The identity early-out, before any arithmetic: this is what makes a
+    * defaults-only configuration byte-identical to the pre-#439 path. */
+   if (AxisTuneIsIdentity(t))
+      return raw;
+
+   v = raw - t->offset;
+
+   if (v == 0)
+      return 0;
+
+   mag = (v < 0) ? -v : v;
+
+   /* Gate, not re-base -- see axistune.h.  The sample is dropped whole or
+    * passed whole. */
+   if (mag <= t->deadzone)
+      return 0;
+
+   /* At or above the reference the curve is the identity by construction
+    * (out = REF * (mag/REF)^e is REF at mag == REF for every e), and the
+    * range above it passes through unchanged rather than saturating, so
+    * no fast motion is ever lost to the curve. */
+   if (t->exponent_q8 == 256 || mag >= AXISTUNE_REF)
+      return v;
+
+   /* mag < AXISTUNE_REF here, so the Q16 normalisation cannot reach 1.0
+    * and the shift below cannot overflow. */
+   n_q16 = ((uint32_t)mag << 16) / (uint32_t)AXISTUNE_REF;
+   p_q16 = axistune_pow_q16(n_q16, (uint32_t)t->exponent_q8);
+
+   /* out = REF * (mag/REF)^e, carried in Q8 so the gain division keeps a
+    * fractional result for the small magnitudes that matter most.  The
+    * product peaks at 64 * 65536, well inside int32. */
+   gain = (int32_t)(((uint32_t)AXISTUNE_REF * p_q16) >> 8) / mag;
+
+   /* THE DEAD ZONE IS THE ONLY THING ALLOWED TO DROP A SAMPLE.
+    *
+    * A Q8 gain cannot represent the bottom of a steep curve: at e = 3.0 a
+    * 2-unit sample wants a gain of 0.25/256, which truncates to zero and
+    * the sample vanishes -- so a user who picked a high exponent would see
+    * slow movement not merely attenuated but completely inert, which reads
+    * as a broken device rather than as a curve.  Flooring at 1 keeps such
+    * a sample alive at 1/256 of a state per poll, where QuadFeed's `frac`
+    * carry accumulates it instead of discarding it.  It overstates the
+    * curve only in the region where the curve is asking for very nearly
+    * nothing, and it keeps the two controls' responsibilities disjoint:
+    * the gate decides what is dropped, the curve only decides how fast. */
+   if (gain < 1)
+      gain = 1;
+   if (gain > AXISTUNE_MAX_GAIN)
+      gain = AXISTUNE_MAX_GAIN;
+
+   if (gain_q8)
+      *gain_q8 = gain;
+
+   return v;
+}

--- a/src/jerry/axistune.h
+++ b/src/jerry/axistune.h
@@ -1,0 +1,161 @@
+/*
+ * src/jerry/axistune.h -- per-axis input tuning: dead zone, offset,
+ * response exponent (#439).
+ *
+ * Pure and host-testable, like quadrature.h next door: no dependency on
+ * any emulator header, no Jaguar types, integer arithmetic only.
+ *
+ * ONE LAYER, DERIVED FROM THE TWO SHIPPED CONSUMERS
+ * =================================================
+ * #439 is deliberately last in #428 so the layer is shaped by real
+ * consumers rather than guessed.  The two that exist are:
+ *
+ *   the ST/Amiga mouse (#429)  two RELATIVE axes, host units per poll
+ *   the Tempest rotary (#436)  one RELATIVE axis, host units per poll
+ *
+ * Both reach the machine through exactly one call --
+ * QuadFeed(&q, delta, scale_q8) from InputDevFeed() -- so the tuning has
+ * exactly one insertion point, and #437's analog/driving axes will arrive
+ * at the same one.  There are no per-device copies of this arithmetic and
+ * there must not be.
+ *
+ * BOTH CONSUMERS ARE RELATIVE, AND THAT DECIDES THE SEMANTICS
+ * ==========================================================
+ * DEAD ZONE IS A GATE, NOT A RE-BASE.  On an absolute axis a dead zone is
+ * conventionally re-based (the dead-zone edge is remapped to zero) so the
+ * response has no step at the boundary.  On a RELATIVE axis there is no
+ * centre to re-base toward: the quantity is a speed, and a dead zone is a
+ * noise gate on that speed.  Re-basing would subtract a constant from
+ * every sample, systematically shortening slow motion -- on a device the
+ * game integrates into a position, that is pointer drift versus the hand,
+ * which is worse than the boundary step it would remove.  So the gate is
+ * gate-only: below the threshold the sample is dropped, above it the
+ * sample passes at full magnitude.
+ *
+ * An absolute-axis consumer (#437) will have to answer the re-basing
+ * question for itself.  It is deliberately NOT pre-answered here with an
+ * unused flag: one caller does not justify a mode switch, and the shape of
+ * that answer belongs to the ticket that has a device to test it against.
+ *
+ * OFFSET IS A PER-SAMPLE BIAS, subtracted before the gate.  A real mouse
+ * reports exactly zero at rest and is unaffected by any offset.  The case
+ * this exists for is a frontend that routes something else to the port's
+ * relative axis -- an analog stick mapped to RETRO_DEVICE_MOUSE is the
+ * common one -- where a mis-centred source reports a small constant delta
+ * forever, i.e. pointer drift with the hand off the controls.  Subtracting
+ * the measured bias cancels it exactly.  It runs BEFORE the gate so a
+ * cancelled bias does not eat the gate's budget.
+ *
+ * THE RESPONSE EXPONENT AND WHY ITS REFERENCE IS 64
+ * ================================================
+ * A power curve needs a reference magnitude: `out = REF * (in/REF)^e` is
+ * the only form with a fixed point, and at in == REF the output is REF for
+ * every exponent, so REF is "the speed the curve does not change".  Below
+ * it, e > 1 attenuates (finer control); above it, the input passes through
+ * unchanged.
+ *
+ * REF is NOT a taste constant invented here.  It is QUAD_MAX_BACKLOG,
+ * quadrature.h's own saturation point: that header already establishes 64
+ * Gray states as the most the relative path will ever carry from a single
+ * feed, because a poll-rate-clocked encoder drains one state per poll and
+ * everything past 64 is clamped away.  64 host units per poll at unity
+ * sensitivity is therefore the top of the range this path can express, and
+ * anchoring the curve anywhere else would be the guess.  AXISTUNE_REF is
+ * asserted equal to QUAD_MAX_BACKLOG in test/test_axistune.c so the two
+ * cannot drift apart.
+ *
+ * Consequence worth stating plainly, because a user will hit it: an
+ * exponent above 1.0 makes ordinary movement SLOWER, since ordinary
+ * movement is well below 64 units per poll.  That is what an expo curve
+ * is; the paired sensitivity option is how you get the top speed back.
+ * The two are different controls and the option text says so.
+ *
+ * THE CURVE COMES OUT AS A GAIN, NOT AS A DELTA
+ * =============================================
+ * AxisTuneApply() returns the gated delta in raw units and reports the
+ * curve separately as a Q8 gain, instead of returning a curved delta.
+ * That is not a stylistic choice -- it is the only form that keeps small
+ * movement alive.  A curved delta has to be an integer, and at e = 2.0 a
+ * 4-unit sample curves to 4 * 4/64 = 0.25 units, which truncates to zero:
+ * the whole low end of the curve would quantise away, which on a mouse
+ * reads as a dead device.  Handed back as a gain, the curve multiplies
+ * into the scale QuadFeed() already applies, and QuadFeed's Q8 `frac`
+ * carry -- which exists for exactly this reason, see quadrature.h --
+ * accumulates the fraction across polls instead of discarding it.
+ *
+ * The gain is floored at 1 rather than 0, so the DEAD ZONE IS THE ONLY
+ * THING THAT EVER DROPS A SAMPLE: even the bottom of the steepest curve
+ * leaves a surviving sample moving, just very slowly.  See the comment at
+ * the floor in axistune.c for why that matters at high exponents.
+ *
+ * DEFAULTS ARE THE IDENTITY, AND THAT IS ENFORCED STRUCTURALLY
+ * ===========================================================
+ * A tune whose three fields are all "off" makes AxisTuneApply() return its
+ * argument and a gain of 256, by an early return placed before any
+ * arithmetic.  A user who never opens the menu therefore gets the
+ * pre-#439 path byte for byte; test/test_axistune.c proves it by sweeping
+ * the entire int16 input range.
+ *
+ * A ZERO-FILLED axis_tune IS THAT IDENTITY.  This matters because
+ * InputDevShutdown() memsets its port array (iOS cannot dlclose a core,
+ * so every static has to return to its load-time value), and a zeroed
+ * exponent field would otherwise mean e = 0.0 -- a degenerate curve on
+ * every analog axis after a reload, visible on exactly one platform.
+ * Hence exponent_q8 <= 0 is *defined* as linear here, the same defensive
+ * shape as inputdev.c's existing `if (p->scale_q8 <= 0)` guard, rather
+ * than left to callers to re-establish.
+ */
+
+#ifndef __AXISTUNE_H__
+#define __AXISTUNE_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Reference magnitude for the response curve, in raw host units per poll.
+ * Equal to QUAD_MAX_BACKLOG -- see the header comment above for why that
+ * is the defensible anchor and not a taste constant. */
+#define AXISTUNE_REF 64
+
+/* Ceiling on the reported gain.  Reached only by sub-linear exponents,
+ * whose gain grows without bound as the magnitude approaches zero; 4096
+ * (16x) is InputDevSetScale()'s own ceiling, and the product of the two
+ * is clamped there as well so QuadFeed()'s overflow argument -- written
+ * against a 4096 scale -- still holds. */
+#define AXISTUNE_MAX_GAIN 4096
+
+typedef struct
+{
+   int32_t deadzone;      /* raw units, >= 0; 0 == off                    */
+   int32_t offset;        /* raw units, signed; 0 == off                  */
+   int32_t exponent_q8;   /* Q8; 256 == linear; <= 0 also reads as linear */
+} axis_tune;
+
+/* Identity: dead zone off, offset off, linear response. */
+void AxisTuneReset(axis_tune *t);
+
+/* Store clamped values.  The inputs come from core-option strings, which
+ * a user can hand-edit to anything, so the clamp lives here rather than
+ * at each call site. */
+void AxisTuneSet(axis_tune *t, int32_t deadzone, int32_t offset,
+                 int32_t exponent_q8);
+
+/* Non-zero when this tune cannot change any sample. */
+int AxisTuneIsIdentity(const axis_tune *t);
+
+/* Apply offset and dead zone to `raw`, returning the surviving delta in
+ * raw units (0 when the sample is gated), and write the response curve's
+ * Q8 gain for that magnitude to *gain_q8 (256 == unity).  `gain_q8` may
+ * be NULL.  The caller multiplies the gain into its own Q8 sensitivity;
+ * see "THE CURVE COMES OUT AS A GAIN" above for why it is not folded into
+ * the returned delta. */
+int32_t AxisTuneApply(const axis_tune *t, int32_t raw, int32_t *gain_q8);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __AXISTUNE_H__ */

--- a/src/jerry/inputdev.c
+++ b/src/jerry/inputdev.c
@@ -10,6 +10,7 @@
 
 #include "inputdev.h"
 #include "quadrature.h"
+#include "axistune.h"
 #include "joystick.h"
 #include "state.h"
 
@@ -58,6 +59,8 @@ typedef struct
    quad_axis    x;
    quad_axis    y;
    int32_t      scale_q8;
+   axis_tune    tune_x;      /* option-derived; see InputDevSetTune (#439) */
+   axis_tune    tune_y;
    uint8_t      btn_left;
    uint8_t      btn_right;
    uint8_t      rotary_id;   /* option-derived; see InputDevSetRotaryID */
@@ -102,8 +105,20 @@ void InputDevInit(void)
    unsigned p;
 
    for (p = 0; p < 2; p++)
+   {
       if (inputdev_ports[p].scale_q8 <= 0)
          inputdev_ports[p].scale_q8 = 256;
+
+      /* A zero-filled axis_tune already reads as the identity (see
+       * axistune.h), so this is belt-and-braces rather than load-bearing
+       * -- but it makes the default explicit at exactly the place the
+       * scale's default is, instead of leaving it to a reader to work out
+       * that exponent_q8 == 0 means linear. */
+      if (inputdev_ports[p].tune_x.exponent_q8 <= 0)
+         AxisTuneReset(&inputdev_ports[p].tune_x);
+      if (inputdev_ports[p].tune_y.exponent_q8 <= 0)
+         AxisTuneReset(&inputdev_ports[p].tune_y);
+   }
 
    inputdev_reset_dynamic();
 }
@@ -120,6 +135,10 @@ void InputDevShutdown(void)
    memset(inputdev_ports, 0, sizeof(inputdev_ports));
    inputdev_ports[0].scale_q8 = 256;
    inputdev_ports[1].scale_q8 = 256;
+   AxisTuneReset(&inputdev_ports[0].tune_x);
+   AxisTuneReset(&inputdev_ports[0].tune_y);
+   AxisTuneReset(&inputdev_ports[1].tune_x);
+   AxisTuneReset(&inputdev_ports[1].tune_y);
    inputdev_attach_mask       = 0;
    inputdev_armed             = 0;
 }
@@ -184,11 +203,60 @@ void InputDevSetScale(int port, int32_t scale_q8)
    inputdev_ports[port].scale_q8 = scale_q8;
 }
 
+void InputDevSetTune(int port, int axis, int32_t deadzone, int32_t offset,
+                     int32_t exponent_q8)
+{
+   if (port < 0 || port > 1)
+      return;
+
+   AxisTuneSet(axis == INPUTDEV_AXIS_Y ? &inputdev_ports[port].tune_y
+                                       : &inputdev_ports[port].tune_x,
+               deadzone, offset, exponent_q8);
+}
+
 void InputDevSetRotaryID(int port, int reports_rotary)
 {
    if (port < 0 || port > 1)
       return;
    inputdev_ports[port].rotary_id = reports_rotary ? 1 : 0;
+}
+
+/* The single tuned feed path (#439).  Every analog source funnels through
+ * here, so the tuning has exactly one implementation and cannot drift
+ * between devices.
+ *
+ * `invert` negates the TUNED delta, not the raw one, and the order matters:
+ * the dead zone and the curve are magnitude-symmetric and commute with a
+ * sign flip, but the OFFSET DOES NOT.  An offset cancels a bias measured on
+ * the host axis, so it has to be subtracted in host orientation, before any
+ * device-specific inversion.  Do not "simplify" this by negating `raw` at
+ * the call site.
+ *
+ * The curve arrives as a Q8 gain and multiplies into the port's Q8
+ * sensitivity, which is what lets QuadFeed's existing fractional carry keep
+ * small movement alive -- axistune.h explains why a curved delta could not.
+ * The product is clamped to the same 1..4096 window InputDevSetScale
+ * enforces, because QuadFeed's overflow argument is written against a 4096
+ * ceiling and two multipliers in series would otherwise walk past it. */
+static void inputdev_feed_axis(quad_axis *q, const axis_tune *t,
+                               int32_t raw, int invert, int32_t scale_q8)
+{
+   int32_t gain_q8 = 256;
+   int32_t d       = AxisTuneApply(t, raw, &gain_q8);
+   int32_t eff;
+
+   if (invert)
+      d = -d;
+
+   /* At defaults gain_q8 is exactly 256 and this is exactly scale_q8, so
+    * the call below is bit-for-bit the pre-#439 one. */
+   eff = (scale_q8 * gain_q8) / 256;
+   if (eff < 1)
+      eff = 1;
+   if (eff > 4096)
+      eff = 4096;
+
+   QuadFeed(q, d, eff);
 }
 
 void InputDevFeed(int port, int32_t dx, int32_t dy, uint32_t buttons)
@@ -219,8 +287,10 @@ void InputDevFeed(int port, int32_t dx, int32_t dy, uint32_t buttons)
        * hardware fact: pushing a spinner to the right turns the knob
        * clockwise.  Hence the negation.  There is deliberately no invert
        * option -- an unsourced sign knob is how a real wiring bug gets
-       * papered over instead of found. */
-      QuadFeed(&p->x, -dx, p->scale_q8);
+       * papered over instead of found.  The negation is applied to the
+       * TUNED delta by inputdev_feed_axis -- see the note there on why the
+       * offset must be subtracted in host orientation first. */
+      inputdev_feed_axis(&p->x, &p->tune_x, dx, 1, p->scale_q8);
       (void)dy;
       (void)buttons;
       return;
@@ -234,8 +304,8 @@ void InputDevFeed(int port, int32_t dx, int32_t dy, uint32_t buttons)
     * host "pixel" of motion maps to one decoded count.  Positive dx is
     * right and positive dy is down in libretro, and A-leads-B (increasing
     * phase) is right/down on the wire, so the mapping is direct. */
-   QuadFeed(&p->x, dx, p->scale_q8);
-   QuadFeed(&p->y, dy, p->scale_q8);
+   inputdev_feed_axis(&p->x, &p->tune_x, dx, 0, p->scale_q8);
+   inputdev_feed_axis(&p->y, &p->tune_y, dy, 0, p->scale_q8);
 
    p->btn_left  = (buttons & INPUTDEV_BTN_LEFT)  ? 1 : 0;
    p->btn_right = (buttons & INPUTDEV_BTN_RIGHT) ? 1 : 0;

--- a/src/jerry/inputdev.h
+++ b/src/jerry/inputdev.h
@@ -98,6 +98,34 @@ void InputDevFeed(int port, int32_t dx, int32_t dy, uint32_t buttons);
 /* Sensitivity, Q8 (256 == 1.0), from the core options. */
 void InputDevSetScale(int port, int32_t scale_q8);
 
+/* Per-axis tuning -- dead zone, offset, response exponent (#439).
+ *
+ * ONE LAYER FOR EVERY ANALOG SOURCE.  Both shipped analog devices reach
+ * the machine through InputDevFeed(), so the tuning is applied there and
+ * nowhere else; #437's analog/driving axes will land on the same call.
+ * The semantics, the reference magnitude for the exponent and the reason
+ * the curve arrives as a gain rather than a modified delta are all in
+ * axistune.h -- read that before changing anything here.
+ *
+ * `axis` is INPUTDEV_AXIS_X or INPUTDEV_AXIS_Y.  A rotary is a single
+ * wheel and uses X only; its Y tune is stored but never consulted.
+ *
+ * THE PAD IS NOT TOUCHED BY ANY OF THIS.  A port whose type is
+ * INPUTDEV_PAD never enters InputDevFeed's tuned paths at all -- the
+ * standard digital pad's bits come from joypadNButtons[] via joystick.c
+ * and this file contributes nothing to them.  Pinned by
+ * test/tools/joymatrix_identity's unchanged digests and by
+ * test/tools/tuning_identity.
+ *
+ * Values are clamped in AxisTuneSet(), because they originate in
+ * core-option strings a user can hand-edit.  Defaults (0 / 0 / 256) are
+ * the exact identity, so a user who never opens the menu gets the
+ * pre-#439 behaviour byte for byte. */
+#define INPUTDEV_AXIS_X 0
+#define INPUTDEV_AXIS_Y 1
+void InputDevSetTune(int port, int axis, int32_t deadzone, int32_t offset,
+                     int32_t exponent_q8);
+
 /* Whether a rotary on this port identifies itself to software as a rotary
  * (diode D23 fitted -- TR10 supplemental).  TR10 "Identifying Controller
  * Types": C2 C3 = 1 0 means "Tempest Rotary", 1 1 means "Standard Jaguar
@@ -214,6 +242,12 @@ uint16_t InputDevOverlayF14002(uint16_t data, uint8_t row0, uint8_t row1);
  * The device type and the sensitivity scale are deliberately NOT saved:
  * both are option-derived and constant for a session, and restoring them
  * from a state would let a stale state fight the user's current option.
+ *
+ * The per-axis tuning (#439) is NOT saved either, for the same reason as
+ * the scale: it is option-derived and constant for a session, and it
+ * changes only how host motion is turned into feeds, never any state the
+ * machine can observe.  The chunk does not grow and STATE_VERSION does not
+ * move.
  *
  * The rotary (#436) adds NOTHING here and the chunk does not grow.  It
  * uses the port's existing X axis, so its backlog/carry/phase are already

--- a/test/test_axistune.c
+++ b/test/test_axistune.c
@@ -162,6 +162,50 @@ static void test_offset(void)
          "and a sample that survives both keeps its de-biased magnitude");
 }
 
+/* ---- 4b: an idle device must stay idle ------------------------------- */
+
+static void test_offset_leaves_idle_alone(void)
+{
+   axis_tune t;
+   int32_t   gain = 0;
+   int32_t   off;
+   int       ok = 1;
+
+   printf("a non-zero offset never manufactures motion from an idle device\n");
+
+   /* libretro.c feeds every attached port every frame, passing 0 when the
+    * frontend reports no motion.  On a relative axis that is "no sample",
+    * not "a sample at the biased centre", so the offset must not turn it
+    * into one -- otherwise a configured offset spins the knob forever
+    * with the controls untouched, which is the exact failure the option
+    * exists to cure. */
+   for (off = -64; off <= 64; off++)
+   {
+      AxisTuneSet(&t, 0, off, 256);      /* dead zone 0: nothing else can gate */
+      if (AxisTuneApply(&t, 0, &gain) != 0)
+         ok = 0;
+   }
+   check(ok, "raw 0 stays 0 for every offset in [-64, 64] at dead zone 0");
+
+   /* Same, with a curve in play: the early-out must precede the curve too. */
+   ok = 1;
+   for (off = -64; off <= 64; off++)
+   {
+      AxisTuneSet(&t, 0, off, 512);      /* exponent 2.0 */
+      if (AxisTuneApply(&t, 0, &gain) != 0)
+         ok = 0;
+   }
+   check(ok, "and stays 0 with a non-identity exponent as well");
+
+   /* The offset must still do its job on a real sample -- this is the
+    * guard against "fixing" the above by disabling offset entirely. */
+   AxisTuneSet(&t, 0, 3, 256);
+   check(AxisTuneApply(&t, 3, &gain) == 0,
+         "a device that really reports +3 at rest is still cancelled");
+   check(AxisTuneApply(&t, 10, &gain) == 7,
+         "and real motion is still de-biased");
+}
+
 /* ---- 5 + 6 + 7: the response curve ---------------------------------- */
 
 static void test_curve_reference(void)
@@ -354,6 +398,7 @@ int main(void)
    test_deadzone_is_a_gate();
    printf("\n");
    test_offset();
+   test_offset_leaves_idle_alone();
    printf("\n");
    test_curve_reference();
    printf("\n");

--- a/test/test_axistune.c
+++ b/test/test_axistune.c
@@ -1,0 +1,370 @@
+/*
+ * test/test_axistune.c -- unit test for the per-axis input tuning layer.
+ *
+ * Standalone: compiles src/jerry/axistune.c directly, no core, no dlopen --
+ * the same shape as test/test_quadrature.c next door, and for the same
+ * reason (the module is deliberately pure so its properties can be pinned
+ * without a machine).
+ *
+ * The assertions are #439's contract:
+ *
+ *   1. DEFAULTS ARE THE IDENTITY, proved exhaustively over the whole int16
+ *      input range rather than sampled.  This is the issue's guardrail
+ *      expressed as a number: AxisTuneApply() is the single insertion point
+ *      the tuning has into the analog paths, so "returns its argument
+ *      unchanged, and a unity gain, for every representable input" IS the
+ *      statement that a defaults-only configuration is byte-identical to
+ *      the pre-#439 core.
+ *   2. A ZERO-FILLED axis_tune is that identity.  InputDevShutdown()
+ *      memsets its port array, so if zero were not the identity there would
+ *      be a degenerate curve on every analog axis after an iOS reload --
+ *      a bug reachable on exactly one platform, which is exactly the kind
+ *      that ships.
+ *   3. The dead zone is a GATE, not a re-base: below the threshold the
+ *      sample is dropped whole, above it it passes whole.  A re-basing
+ *      implementation would return 1 where this asserts dz+1.
+ *   4. The offset is subtracted BEFORE the gate, in host orientation.
+ *   5. The curve's fixed point is AXISTUNE_REF: at and above it every
+ *      exponent yields unity gain, so no fast motion is ever lost to the
+ *      curve and no exponent silently rescales the top of the range.
+ *   6. AXISTUNE_REF == QUAD_MAX_BACKLOG.  The reference is quadrature.h's
+ *      saturation point, not a taste constant; this is what stops the two
+ *      drifting apart if either header is edited.
+ *   7. The curve matches hand-computed exact values at the points where
+ *      the fixed-point evaluation must be exact (halves and squares).
+ *   8. THE GATE IS THE ONLY THING THAT DROPS A SAMPLE: across every
+ *      exponent the layer accepts and every magnitude below the reference,
+ *      a sample that passed the gate keeps a non-zero gain.
+ *   9. The effective response mag*gain is monotone non-decreasing in mag,
+ *      for every exponent.  A curve with a fixed-point dip would read as
+ *      the pointer stalling at one speed and is invisible to spot checks.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../src/jerry/axistune.h"
+#include "../src/jerry/quadrature.h"
+
+static int failures;
+
+static void check(int cond, const char *what)
+{
+   if (cond)
+      printf("  ok   %s\n", what);
+   else
+   {
+      printf("  FAIL %s\n", what);
+      failures++;
+   }
+}
+
+/* ---- 1 + 2: the identity ------------------------------------------- */
+
+static void test_defaults_are_identity(void)
+{
+   axis_tune t;
+   axis_tune zeroed;
+   int32_t   raw;
+   int       ok_reset  = 1;
+   int       ok_zeroed = 1;
+
+   printf("defaults are the identity, over the whole int16 range\n");
+
+   AxisTuneReset(&t);
+   memset(&zeroed, 0, sizeof(zeroed));
+
+   check(AxisTuneIsIdentity(&t),      "a reset tune reports itself as the identity");
+   check(AxisTuneIsIdentity(&zeroed), "a ZERO-FILLED tune does too (InputDevShutdown memsets)");
+
+   for (raw = -32768; raw <= 32767; raw++)
+   {
+      int32_t gain = 0;
+
+      if (AxisTuneApply(&t, raw, &gain) != raw || gain != 256)
+      {
+         ok_reset = 0;
+         break;
+      }
+
+      gain = 0;
+      if (AxisTuneApply(&zeroed, raw, &gain) != raw || gain != 256)
+      {
+         ok_zeroed = 0;
+         break;
+      }
+   }
+
+   check(ok_reset,  "reset tune returns every input unchanged at unity gain");
+   check(ok_zeroed, "zero-filled tune does the same -- no iOS-reload curve");
+
+   /* A NULL tune is the identity too: the analog paths must never be able
+    * to lose a sample to a missing configuration. */
+   {
+      int32_t gain = 0;
+      check(AxisTuneApply(NULL, 1234, &gain) == 1234 && gain == 256,
+            "a NULL tune is the identity as well");
+   }
+}
+
+/* ---- 3: the dead zone gates, it does not re-base -------------------- */
+
+static void test_deadzone_is_a_gate(void)
+{
+   axis_tune t;
+   int32_t   gain = 0;
+   int       ok   = 1;
+   int32_t   m;
+
+   printf("dead zone gates whole samples (no re-basing)\n");
+
+   AxisTuneSet(&t, 3, 0, 256);
+
+   check(AxisTuneApply(&t, 3, &gain)  == 0, "at the threshold the sample is dropped");
+   check(AxisTuneApply(&t, -3, &gain) == 0, "and symmetrically in the negative direction");
+
+   /* The discriminating assertion: a re-basing implementation returns 1
+    * here (4 - 3), this one returns 4. */
+   check(AxisTuneApply(&t, 4, &gain)  ==  4, "one unit past it, the FULL sample passes (4, not 1)");
+   check(AxisTuneApply(&t, -4, &gain) == -4, "likewise negative (-4, not -1)");
+
+   for (m = 1; m <= 3; m++)
+      if (AxisTuneApply(&t, m, &gain) != 0 || AxisTuneApply(&t, -m, &gain) != 0)
+         ok = 0;
+   check(ok, "everything at or below the threshold is dropped, both signs");
+
+   /* A dead zone alone must not disturb the response of what survives. */
+   AxisTuneApply(&t, 40, &gain);
+   check(gain == 256, "a dead zone alone leaves the gain at unity");
+}
+
+/* ---- 4: the offset is subtracted before the gate -------------------- */
+
+static void test_offset(void)
+{
+   axis_tune t;
+   int32_t   gain = 0;
+
+   printf("offset is a per-sample bias, subtracted before the gate\n");
+
+   AxisTuneSet(&t, 0, 2, 256);
+   check(AxisTuneApply(&t, 2, &gain)  ==  0, "a sample equal to the offset cancels to zero");
+   check(AxisTuneApply(&t, 5, &gain)  ==  3, "and a larger one is reduced by exactly the offset");
+   check(AxisTuneApply(&t, -5, &gain) == -7, "a sample of the opposite sign moves further out");
+
+   /* Ordering: with offset 2 and dead zone 1, a raw 3 becomes 1, which the
+    * gate then drops.  Gating first would have passed it. */
+   AxisTuneSet(&t, 1, 2, 256);
+   check(AxisTuneApply(&t, 3, &gain) == 0,
+         "the offset runs first -- a cancelled sample can then be gated");
+   check(AxisTuneApply(&t, 5, &gain) == 3,
+         "and a sample that survives both keeps its de-biased magnitude");
+}
+
+/* ---- 5 + 6 + 7: the response curve ---------------------------------- */
+
+static void test_curve_reference(void)
+{
+   axis_tune t;
+   int32_t   gain = 0;
+   int       ok   = 1;
+   int32_t   e;
+
+   printf("the response curve's reference and fixed point\n");
+
+   check(AXISTUNE_REF == QUAD_MAX_BACKLOG,
+         "AXISTUNE_REF is QUAD_MAX_BACKLOG -- the encoder's own saturation point");
+
+   /* At and above the reference every exponent is unity, by construction:
+    * REF * (REF/REF)^e == REF for all e. */
+   for (e = 128; e <= 800; e += 8)
+   {
+      AxisTuneSet(&t, 0, 0, e);
+
+      gain = 0;
+      if (AxisTuneApply(&t, AXISTUNE_REF, &gain) != AXISTUNE_REF || gain != 256)
+         ok = 0;
+
+      gain = 0;
+      if (AxisTuneApply(&t, 4 * AXISTUNE_REF, &gain) != 4 * AXISTUNE_REF
+          || gain != 256)
+         ok = 0;
+   }
+   check(ok, "at and above the reference, every exponent is unity gain");
+}
+
+static void test_curve_exact_points(void)
+{
+   axis_tune t;
+   int32_t   gain;
+
+   printf("the curve matches hand-computed values where it must be exact\n");
+
+   /* e = 2.0.  out = 64 * (m/64)^2 = m^2/64, so gain = 256 * m / 64.  */
+   AxisTuneSet(&t, 0, 0, 512);
+   gain = 0; AxisTuneApply(&t, 32, &gain);
+   check(gain == 128, "e=2.00, mag=32 -> gain 128 (half speed at half the reference)");
+   gain = 0; AxisTuneApply(&t, 16, &gain);
+   check(gain ==  64, "e=2.00, mag=16 -> gain 64");
+   gain = 0; AxisTuneApply(&t,  4, &gain);
+   check(gain ==  16, "e=2.00, mag=4  -> gain 16");
+
+   /* e = 0.5.  out = 64 * sqrt(m/64), so gain = 256 * 64 * sqrt(m/64) / m. */
+   AxisTuneSet(&t, 0, 0, 128);
+   gain = 0; AxisTuneApply(&t, 16, &gain);
+   check(gain == 512, "e=0.50, mag=16 -> gain 512 (sub-linear amplifies below the reference)");
+   gain = 0; AxisTuneApply(&t,  4, &gain);
+   check(gain == 1024, "e=0.50, mag=4  -> gain 1024");
+
+   /* e = 1.5 is the successive-root path with both an integer and a
+    * fractional part: out = 64 * (m/64)^1.5, gain = 256 * (m/64)^0.5. */
+   AxisTuneSet(&t, 0, 0, 384);
+   gain = 0; AxisTuneApply(&t, 16, &gain);
+   check(gain == 128, "e=1.50, mag=16 -> gain 128 (= 256 * sqrt(1/4))");
+   gain = 0; AxisTuneApply(&t,  4, &gain);
+   check(gain ==  64, "e=1.50, mag=4  -> gain 64  (= 256 * sqrt(1/16))");
+
+   /* Linear is a straight pass-through at every magnitude. */
+   AxisTuneSet(&t, 0, 0, 256);
+   gain = 0; AxisTuneApply(&t, 7, &gain);
+   check(gain == 256, "e=1.00 is unity gain everywhere");
+}
+
+/* ---- 8 + 9: the invariants that hold across the whole ladder -------- */
+
+static void test_gate_is_the_only_drop(void)
+{
+   axis_tune t;
+   int32_t   e, m;
+   int       ok_floor = 1;
+   int       ok_ceil  = 1;
+   int32_t   worst_e  = 0;
+   int32_t   worst_m  = 0;
+
+   printf("only the dead zone drops a sample; the curve never zeroes one\n");
+
+   for (e = 1; e <= 2048; e++)
+   {
+      AxisTuneSet(&t, 0, 0, e);
+
+      for (m = 1; m <= AXISTUNE_REF; m++)
+      {
+         int32_t gain = 0;
+         int32_t d    = AxisTuneApply(&t, m, &gain);
+
+         if (d != m)
+            ok_floor = 0;
+         if (gain < 1)
+         {
+            if (ok_floor)
+            {
+               worst_e = e;
+               worst_m = m;
+            }
+            ok_floor = 0;
+         }
+         if (gain > AXISTUNE_MAX_GAIN)
+            ok_ceil = 0;
+      }
+   }
+
+   if (!ok_floor)
+      printf("       first zero gain at exponent_q8=%d magnitude=%d\n",
+             (int)worst_e, (int)worst_m);
+
+   check(ok_floor,
+         "no surviving sample gets a zero gain, at any exponent the layer accepts");
+   check(ok_ceil, "and no gain exceeds AXISTUNE_MAX_GAIN");
+}
+
+static void test_response_is_monotone(void)
+{
+   axis_tune t;
+   int32_t   e, m;
+   int       ok = 1;
+
+   printf("the effective response is monotone in magnitude\n");
+
+   for (e = 100; e <= 800; e++)
+   {
+      int32_t prev = -1;
+
+      AxisTuneSet(&t, 0, 0, e);
+
+      for (m = 1; m <= 200; m++)
+      {
+         int32_t gain = 0;
+         int32_t out;
+
+         AxisTuneApply(&t, m, &gain);
+         out = m * gain;          /* Q8 states before the port sensitivity */
+
+         if (prev >= 0 && out < prev)
+            ok = 0;
+         prev = out;
+      }
+   }
+
+   check(ok, "mag*gain never decreases as magnitude grows, for any exponent");
+}
+
+/* ---- clamping ------------------------------------------------------- */
+
+static void test_set_clamps(void)
+{
+   axis_tune t;
+   int32_t   gain = 0;
+
+   printf("AxisTuneSet clamps hand-edited configuration values\n");
+
+   AxisTuneSet(&t, -5, 0, 256);
+   check(t.deadzone == 0, "a negative dead zone clamps to off");
+
+   AxisTuneSet(&t, 1000000, 0, 256);
+   check(t.deadzone == AXISTUNE_REF, "an absurd dead zone clamps to the reference");
+
+   AxisTuneSet(&t, 0, -1000000, 256);
+   check(t.offset == -AXISTUNE_REF, "an absurd offset clamps to -reference");
+
+   AxisTuneSet(&t, 0, 1000000, 256);
+   check(t.offset == AXISTUNE_REF, "and symmetrically the other way");
+
+   AxisTuneSet(&t, 0, 0, 0);
+   check(t.exponent_q8 == 256, "a zero exponent resolves to linear, not to a degenerate curve");
+
+   AxisTuneSet(&t, 0, 0, -400);
+   check(t.exponent_q8 == 256, "and so does a negative one");
+
+   AxisTuneSet(&t, 0, 0, 999999);
+   check(t.exponent_q8 == 2048, "an absurd exponent clamps to the ceiling");
+
+   /* Clamped-but-extreme values must still behave, not just store. */
+   AxisTuneSet(&t, 0, 0, 2048);
+   check(AxisTuneApply(&t, 1, &gain) == 1 && gain >= 1,
+         "the clamped ceiling exponent still passes a 1-unit sample");
+}
+
+int main(void)
+{
+   printf("=== Per-axis input tuning (axistune) ===\n\n");
+
+   test_defaults_are_identity();
+   printf("\n");
+   test_deadzone_is_a_gate();
+   printf("\n");
+   test_offset();
+   printf("\n");
+   test_curve_reference();
+   printf("\n");
+   test_curve_exact_points();
+   printf("\n");
+   test_gate_is_the_only_drop();
+   printf("\n");
+   test_response_is_monotone();
+   printf("\n");
+   test_set_clamps();
+
+   printf("\n%s\n", failures ? "FAILED" : "All axistune checks passed");
+   return failures ? 1 : 0;
+}

--- a/test/tools/tuning_identity.c
+++ b/test/tools/tuning_identity.c
@@ -1,0 +1,316 @@
+/*
+ * test/tools/tuning_identity.c -- #439's guardrail, measured end to end.
+ *
+ * WHAT THIS PROVES
+ * ================
+ * Per-axis tuning (#439) inserts arithmetic into the path every analog
+ * device's motion takes to the $F14000 matrix.  The issue names two things
+ * that must stay true afterwards, and this file is both of them expressed
+ * as digests over a swept input domain:
+ *
+ *   1. DEFAULTS CHANGE NOTHING.  A user who never opens the menu must get
+ *      the pre-#439 core.  Asserted by running the identical sweep twice --
+ *      once with the tuning API never called at all, once with it called
+ *      using the option defaults -- and requiring the two digests to be
+ *      equal.
+ *
+ *   2. THE DIGITAL PAD IS NOT TOUCHED.  Tuning applies only to analog
+ *      device paths.  Asserted by sweeping with both ports as plain pads,
+ *      driving all 21 button slots on both, with an aggressive non-default
+ *      tuning configured -- and requiring that digest to equal the same
+ *      sweep with tuning at defaults.
+ *
+ * WHY IT SELF-BASELINES INSTEAD OF ASSERTING A CONSTANT
+ * ====================================================
+ * joymatrix_identity.c holds hard-coded digests measured on develop, which
+ * is the right instrument for "nothing about the joystick path moved".  It
+ * is the wrong instrument for this question, because the constant would
+ * have to be re-measured on a build that already contains the change it is
+ * supposed to be judging.  Comparing two runs of the SAME binary against
+ * each other has no such circularity: the only difference between them is
+ * whether the tuning API was called.
+ *
+ * THE NEGATIVE CONTROL IS NOT OPTIONAL
+ * ====================================
+ * A self-baselining equality test passes trivially if the layer is not
+ * wired up at all -- delete the AxisTuneApply() call from InputDevFeed()
+ * and every assertion above still holds.  So a third digest is taken with
+ * a non-default tuning on the ANALOG ports and required to DIFFER.  That
+ * is what makes the equalities mean "defaults are inert" rather than "the
+ * feature does nothing".
+ *
+ * USAGE
+ *   ./test/tools/tuning_identity ./virtualjaguar_libretro.dylib [rom]
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../harness/harness.h"
+
+/* Mirrors InputDevType in src/jerry/inputdev.h.  dlsym'd pointers must
+ * carry the real signature or UBSan -fsanitize=function aborts on a type
+ * mismatch, so the enum is restated rather than passed as int. */
+typedef enum
+{
+   DEV_PAD                 = 0,
+   DEV_MOUSE_ST            = 1,
+   DEV_MOUSE_AMIGA_ADAPTER = 2,
+   DEV_MOUSE_AMIGA_ON_ST   = 3,
+   DEV_ROTARY              = 4
+} InputDevType;
+
+/* Mirrors INPUTDEV_AXIS_* in src/jerry/inputdev.h. */
+#define AXIS_X 0
+#define AXIS_Y 1
+
+#define BUTTON_SLOTS 21
+
+/* Port-1 and port-2 socket-0 row codes, output enable set.  Sweeping both
+ * ports' rows matters: the mouse is row-blind and the rotary is row-0-only,
+ * so a single-row sweep would miss one of the two devices entirely. */
+static const uint16_t row_words[8] = {
+   0x81FE, 0x81FD, 0x81FB, 0x81F7,   /* port 1 rows 0-3 */
+   0x817F, 0x81BF, 0x81DF, 0x81EF    /* port 2 rows 0-3 */
+};
+
+#define FNV1A_OFFSET 0x811C9DC5u
+#define FNV1A_PRIME  0x01000193u
+
+#define SWEEP_SEED  0x5DEECE66u
+#define SWEEP_STEPS 4096
+
+static uint32_t rng_state;
+
+static uint32_t rng_next(void)
+{
+   rng_state = (rng_state * 1103515245u) + 12345u;
+   return rng_state;
+}
+
+static void fold_word(uint32_t *d, uint16_t v)
+{
+   *d = (*d ^ (uint32_t)(v & 0xFFu))       * FNV1A_PRIME;
+   *d = (*d ^ (uint32_t)((v >> 8) & 0xFFu)) * FNV1A_PRIME;
+}
+
+/* ---- core entry points ---------------------------------------------- */
+
+static uint16_t (*p_ReadWord)(uint32_t);
+static void     (*p_WriteWord)(uint32_t, uint16_t);
+static void     (*p_SetType)(int, InputDevType);
+static void     (*p_SetScale)(int, int32_t);
+static void     (*p_SetTune)(int, int, int32_t, int32_t, int32_t);
+static void     (*p_Reset)(void);
+static void     (*p_Feed)(int, int32_t, int32_t, uint32_t);
+static uint8_t  *p_joypad0Buttons;
+static uint8_t  *p_joypad1Buttons;
+
+static int failures;
+
+static void report(int cond, const char *what)
+{
+   if (cond)
+      printf("  ok   %s\n", what);
+   else
+   {
+      printf("  FAIL %s\n", what);
+      failures++;
+   }
+}
+
+/* ---- the sweep ------------------------------------------------------- *
+ *
+ * TUNE MODE:
+ *   0  never call InputDevSetTune at all -- the pre-#439 configuration
+ *   1  call it with the option defaults (0 dead zone, 0 offset, linear)
+ *   2  call it with an aggressive non-default tuning
+ *
+ * The RNG is re-seeded per sweep, so every mode sees the identical motion
+ * stream and the identical button vectors in the identical order.  That is
+ * what makes the digests directly comparable; without it the comparison
+ * would be measuring the RNG. */
+static uint32_t run_sweep(int p0_type, int p1_type, int tune_mode)
+{
+   uint32_t digest = FNV1A_OFFSET;
+   unsigned step, slot, i;
+   int      port;
+
+   p_Reset();
+   p_SetType(0, (InputDevType)p0_type);
+   p_SetType(1, (InputDevType)p1_type);
+   p_SetScale(0, 256);
+   p_SetScale(1, 256);
+
+   for (port = 0; port < 2; port++)
+   {
+      if (tune_mode == 1)
+      {
+         p_SetTune(port, AXIS_X, 0, 0, 256);
+         p_SetTune(port, AXIS_Y, 0, 0, 256);
+      }
+      else if (tune_mode == 2)
+      {
+         /* Deliberately aggressive: a dead zone that swallows the smaller
+          * deltas the stream generates, a non-zero bias, and a steep
+          * curve.  All three have to be inert on a pad. */
+         p_SetTune(port, AXIS_X, 3, 2, 512);
+         p_SetTune(port, AXIS_Y, 2, -1, 384);
+      }
+   }
+
+   rng_state = SWEEP_SEED;
+
+   for (step = 0; step < SWEEP_STEPS; step++)
+   {
+      /* Fill every pad slot on both ports from the stream.  A slot is
+       * filled from a random BIT, not a random byte: a uniform byte would
+       * be non-zero 255 times in 256 and "released" would never be swept.
+       * Same construction as joymatrix_identity.c, for the same reason. */
+      for (slot = 0; slot < BUTTON_SLOTS; slot++)
+      {
+         uint32_t r0 = rng_next();
+         uint32_t r1 = rng_next();
+
+         p_joypad0Buttons[slot] = (r0 & 1u)
+            ? (uint8_t)(1u + ((r0 >> 1) & 0x7Fu)) : (uint8_t)0;
+         p_joypad1Buttons[slot] = (r1 & 1u)
+            ? (uint8_t)(1u + ((r1 >> 1) & 0x7Fu)) : (uint8_t)0;
+      }
+
+      /* Host motion for both ports.  The range straddles the dead zones
+       * and the curve's reference (64) in both directions, so no tuning
+       * knob is swept only in the region where it happens to be inert. */
+      for (port = 0; port < 2; port++)
+      {
+         uint32_t r  = rng_next();
+         int32_t  dx = (int32_t)(r % 161u) - 80;
+         int32_t  dy = (int32_t)((r >> 8) % 161u) - 80;
+
+         p_Feed(port, dx, dy, (r >> 16) & 3u);
+      }
+
+      /* One full eight-row scan per step, folding both register offsets.
+       * The write arms the device layer and the read clocks it, which is
+       * the sequence a real driver's poll produces. */
+      for (i = 0; i < 8; i++)
+      {
+         p_WriteWord(0, row_words[i]);
+         fold_word(&digest, p_ReadWord(0));
+         fold_word(&digest, p_ReadWord(2));
+      }
+   }
+
+   return digest;
+}
+
+int main(int argc, char **argv)
+{
+   harness_config cfg = HARNESS_CONFIG_DEFAULT;
+   harness_result result;
+   char     summary[128];
+   uint32_t pad_untouched, pad_default, pad_tuned;
+   uint32_t analog_untouched, analog_default, analog_tuned;
+
+   cfg.frames = 0;
+   if (!harness_init_from_args(&cfg, argc, argv))
+      return 1;
+
+   if (!cfg.rom_path)
+      cfg.rom_path = "test/roms/yarc.j64";
+   if (!harness_load_rom(&cfg))
+      return 1;
+
+   p_ReadWord  = (uint16_t (*)(uint32_t))harness_dlsym(&cfg, "JoystickReadWord");
+   p_WriteWord = (void (*)(uint32_t, uint16_t))
+                    harness_dlsym(&cfg, "JoystickWriteWord");
+   p_SetType   = (void (*)(int, InputDevType))
+                    harness_dlsym(&cfg, "InputDevSetType");
+   p_SetScale  = (void (*)(int, int32_t))harness_dlsym(&cfg, "InputDevSetScale");
+   p_SetTune   = (void (*)(int, int, int32_t, int32_t, int32_t))
+                    harness_dlsym(&cfg, "InputDevSetTune");
+   p_Reset     = (void (*)(void))harness_dlsym(&cfg, "InputDevReset");
+   p_Feed      = (void (*)(int, int32_t, int32_t, uint32_t))
+                    harness_dlsym(&cfg, "InputDevFeed");
+   p_joypad0Buttons = (uint8_t *)harness_dlsym(&cfg, "joypad0Buttons");
+   p_joypad1Buttons = (uint8_t *)harness_dlsym(&cfg, "joypad1Buttons");
+
+   if (!p_ReadWord || !p_WriteWord || !p_SetType || !p_SetScale
+       || !p_SetTune || !p_Reset || !p_Feed
+       || !p_joypad0Buttons || !p_joypad1Buttons)
+   {
+      fprintf(stderr,
+              "tuning_identity: missing test-ABI symbols.  The wide test "
+              "ABI must export Joystick* / InputDev* / joypad0Buttons / "
+              "joypad1Buttons.  Build with TEST_EXPORTS=1.\n");
+      harness_shutdown(&cfg);
+      return 1;
+   }
+
+   printf("=== Per-axis tuning identity (#439) ===\n\n");
+
+   /* SWEEP ORDER IS LOAD-BEARING, and getting it wrong is a silent
+    * inversion rather than an error.
+    *
+    * A tune is a static in the core: InputDevReset() clears the encoders
+    * but deliberately NOT the option-derived tuning, exactly as it leaves
+    * the sensitivity scale alone (src/jerry/inputdev.h).  So "mode 0" --
+    * the pre-#439 configuration, where the API has never been called -- is
+    * only observable BEFORE the first InputDevSetTune() call in the
+    * process.  Both mode-0 sweeps therefore run first.
+    *
+    * Written the obvious way (all three modes per device configuration,
+    * pads then analog) the analog mode-0 sweep inherits the aggressive
+    * tuning left behind by the pad mode-2 sweep, and the test reports the
+    * exact opposite of the truth: "defaults changed the digest" and "a
+    * non-default tuning did not". */
+   pad_untouched    = run_sweep(DEV_PAD, DEV_PAD, 0);
+   analog_untouched = run_sweep(DEV_ROTARY, DEV_MOUSE_ST, 0);
+
+   pad_default      = run_sweep(DEV_PAD, DEV_PAD, 1);
+   analog_default   = run_sweep(DEV_ROTARY, DEV_MOUSE_ST, 1);
+
+   pad_tuned        = run_sweep(DEV_PAD, DEV_PAD, 2);
+   analog_tuned     = run_sweep(DEV_ROTARY, DEV_MOUSE_ST, 2);
+
+   /* --- the digital pad must be bit-identical, tuned or not ---------- */
+   printf("the standard digital pad is untouched by any tuning\n");
+   printf("       pad digests: untouched 0x%08X  defaults 0x%08X  tuned 0x%08X\n",
+          pad_untouched, pad_default, pad_tuned);
+
+   report(pad_default == pad_untouched,
+          "pad: setting the tuning API to its defaults changes nothing");
+   report(pad_tuned == pad_untouched,
+          "pad: an aggressive tuning changes nothing either -- the guardrail");
+
+   /* --- analog ports: defaults inert, non-defaults live -------------- */
+   printf("\nanalog paths: defaults are inert, non-defaults are not\n");
+   printf("       analog digests: untouched 0x%08X  defaults 0x%08X  tuned 0x%08X\n",
+          analog_untouched, analog_default, analog_tuned);
+
+   report(analog_default == analog_untouched,
+          "rotary on port 1 + mouse on port 2: defaults are byte-identical "
+          "to never calling the API");
+
+   /* The negative control.  Without this the equality above would still
+    * hold on a build where the tuning layer was never wired in. */
+   report(analog_tuned != analog_untouched,
+          "and a non-default tuning DOES move the analog digest (the layer "
+          "is actually connected)");
+
+   /* An analog sweep that digests the same as a pad sweep would mean the
+    * devices contributed nothing and every assertion above is vacuous. */
+   report(analog_untouched != pad_untouched,
+          "the analog sweep is not accidentally a pad sweep");
+
+   sprintf(summary, "%d failure(s)", failures);
+   result.status = failures ? "FAIL" : "PASS";
+   result.name   = "tuning_identity";
+   result.detail = summary;
+   harness_report(&cfg, &result, 1);
+
+   harness_shutdown(&cfg);
+   return failures ? 1 : 0;
+}


### PR DESCRIPTION
Closes #439. Sub-issue of #428.

BigPEmu exposes per-axis dead zone, X/Y offset and a response exponent on its analog device types. This adds the same three controls as **one shared layer**, not per-device copies.

## Why this shape

#439 was deliberately sequenced last in #428 so the layer would be derived from real consumers rather than guessed. Two have shipped — the ST/Amiga mouse (#429, PR #449) and the Tempest rotary (#436, PR #451) — and they decided every design question:

**One insertion point, because both consumers already share one.** Mouse and rotary both reach the machine through a single call, `QuadFeed()` from `InputDevFeed()`. `src/jerry/axistune.c` sits exactly there. #437's analog/driving axes will arrive at the same call, so there is no per-device arithmetic to keep in sync and there must not be.

**Both consumers are relative axes, so the dead zone is a gate, not a re-base.** On an absolute axis a dead zone is conventionally re-based so there is no step at the boundary. On a relative axis there is no centre to re-base toward — the quantity is a *speed*, and a dead zone is a noise gate on it. Re-basing would subtract a constant from every sample, systematically shortening slow motion; on a device the game integrates into a position that is pointer drift versus the hand, which is worse than the step it removes. An absolute-axis consumer (#437) will have to answer the re-basing question for itself. That is deliberately **not** pre-answered here with an unused flag — one caller does not justify a mode switch.

**The offset is subtracted in host orientation, before the gate.** The dead zone and the curve are magnitude-symmetric and commute with a sign flip; the offset does not. The rotary negates its delta as a UX convention, so `inputdev_feed_axis()` negates the *tuned* delta and the code says why, because that is exactly the line a future reader "simplifies".

A real mouse reports zero at rest and is unaffected by any offset. The case it exists for is a frontend routing something else to the port's relative axis — a stick mapped to `RETRO_DEVICE_MOUSE` is the common one — where a mis-centred source drifts forever.

**The exponent's reference is `QUAD_MAX_BACKLOG` (64), not a taste constant.** A power curve needs a reference: `out = REF * (in/REF)^e` is the only form with a fixed point. `quadrature.h` already establishes 64 Gray states as the most a single feed can carry (a poll-rate-clocked encoder drains one state per poll; everything past 64 is clamped away), so 64 host units per poll at unity sensitivity is the top of the range this path can express. Anchoring anywhere else would have been the guess. At and above the reference every exponent is unity gain, so **no fast motion is ever lost to the curve**, and `test_axistune` asserts `AXISTUNE_REF == QUAD_MAX_BACKLOG` so the two headers cannot drift apart.

Worth stating plainly because users will hit it: an exponent above 1.0 makes ordinary movement *slower*, since ordinary movement is well below 64 units per poll. That is what an expo curve is; the paired sensitivity option is how you get top speed back. The option text says so.

**The curve comes out as a gain, not a curved delta.** This is not stylistic — it is the only form that keeps small movement alive. A curved delta has to be an integer, and at e=2.0 a 4-unit sample curves to `4 * 4/64 = 0.25`, which truncates to zero: the whole low end would quantise away and the mouse would read as dead. Handed back as a Q8 gain it multiplies into the scale `QuadFeed()` already applies, and QuadFeed's existing fractional carry — which exists for exactly this reason — accumulates it. The gain is floored at 1 so **the dead zone stays the only thing that ever drops a sample**.

**Integer-only, no libm.** The input-device guardrails are host-independent FNV digests (`joymatrix_identity.c` says so in its own header). A float `pow` would make them depend on the host's libm rounding and the constants would stop meaning anything across x86-64 / arm64 / i686. The fractional power uses the successive-square-root identity in Q16, verified against `libm` to <3% wherever the gain is meaningful and exact at halves and squares.

## Defaults are the identity, structurally

`AxisTuneApply()` returns its argument and a unity gain via an early return placed **before any arithmetic**. A zero-filled `axis_tune` is that identity too — `InputDevShutdown()` memsets its port array (iOS cannot dlclose a core), and a zeroed exponent field would otherwise leave a degenerate curve on every analog axis after a reload, i.e. a bug reachable on exactly one platform.

## Options

All hidden unless the relevant device is attached (existing visibility machinery, extended), all defaulting to the identity.

| Key | Values | Default |
| --- | --- | --- |
| `virtualjaguar_mouse_deadzone_x` | Off, 1, 2, 3, 4, 6, 8 units | `0` (Off) |
| `virtualjaguar_mouse_deadzone_y` | Off, 1, 2, 3, 4, 6, 8 units | `0` (Off) |
| `virtualjaguar_mouse_offset_x` | −4 … +4 | `0` (Off) |
| `virtualjaguar_mouse_offset_y` | −4 … +4 | `0` (Off) |
| `virtualjaguar_mouse_exponent_x` | Linear (1.00), 1.25, 1.50, 1.75, 2.00, 2.50, 3.00 | `100` (Linear) |
| `virtualjaguar_mouse_exponent_y` | Linear (1.00), 1.25, 1.50, 1.75, 2.00, 2.50, 3.00 | `100` (Linear) |
| `virtualjaguar_rotary_deadzone` | Off, 1, 2, 3, 4, 6, 8 units | `0` (Off) |
| `virtualjaguar_rotary_offset` | −4 … +4 | `0` (Off) |
| `virtualjaguar_rotary_exponent` | Linear (1.00), 1.25, 1.50, 1.75, 2.00, 2.50, 3.00 | `100` (Linear) |

A rotary is a single wheel, so it gets one tune and no X/Y split. The rotary options are **shared by both ports** — two rotaries cannot be tuned independently — which is a deliberate carry-forward of how `virtualjaguar_rotary_sensitivity` already behaves, and the reason they sit in the un-prefixed `input` category rather than a per-port one.

Clamping lives in `AxisTuneSet()` alone, so a hand-edited config is bounded in exactly one place regardless of which option it came through.

## Guardrail: the digital pad is untouched

A port whose type is `INPUTDEV_PAD` never enters the tuned paths at all. Proved two ways — the three existing `joymatrix_identity` digests are unmoved, and the new `tuning_identity` sweeps both ports as pads with an aggressive tuning configured and requires the digest to be identical to the untuned sweep.

## Tests

Two new tests, because the feature has two separable claims.

`test/test_axistune.c` — pure unit test, compiles `src/jerry/axistune.c` directly with no core (same shape as `test_quadrature.c`). Asserts the identity **exhaustively over the whole int16 range** rather than sampling it: `AxisTuneApply()` is the single insertion point, so "returns its argument unchanged at unity gain for every representable input" *is* the statement that a defaults-only configuration is byte-identical to the pre-#439 core. Also pins the zero-fill identity, gate-not-re-base (a re-basing implementation returns 1 where this requires 4), offset-before-gate ordering, `AXISTUNE_REF == QUAD_MAX_BACKLOG`, hand-computed curve values, no-zero-gain across every exponent, and monotonicity of `mag*gain`.

`test/tools/tuning_identity.c` — the same feature end to end through `$F14000`. It **self-baselines** (two runs of the same binary, one with the tuning API never called and one with it called at the defaults) instead of asserting a constant, because a constant would have to be measured on a build that already contains the change it is judging.

The third assertion is a **negative control** and is not optional: a non-default tuning must *move* the analog digest. Without it, both equalities would still pass on a build where the layer was never wired into `InputDevFeed()` at all.

Sweep order in that file is load-bearing and documented: a tune is a static that `InputDevReset()` deliberately does not clear (same as the sensitivity scale), so "the API was never called" is only observable before the first `InputDevSetTune()` in the process. Written the obvious way, the analog baseline inherits the pad sweep's tuning and the test reports the exact opposite of the truth — which is how it failed on the first run here.

## Test plan

All run on macOS arm64 with `DEVELOPER_DIR=/Library/Developer/CommandLineTools`.

```
$ make -j8 TEST_EXPORTS=1
  -> clean, no warnings

$ make -j8                      # reverse ABI flip, shipped-slim exports
  -> exit 0, clean

$ bash scripts/c89-lint.sh src/jerry/axistune.c src/jerry/inputdev.c \
                           libretro.c test/test_axistune.c
  -> C89 lint passed

$ ./test/tools/joymatrix_identity ./virtualjaguar_libretro.dylib \
      test/roms/yarc.j64 --quiet
  -> 4 passed, 0 failed
     joymatrix_identity_full             0xC24DDCDE (expected 0xC24DDCDE)
     joymatrix_identity_port1            0xD0CD02E2 (expected 0xD0CD02E2)
     joymatrix_identity_port1_with_mouse 0xD0CD02E2 (expected 0xD0CD02E2)
     joymatrix_identity_full_with_mouse  0x5E1858EA (expected 0x5E1858EA)

$ ./test/tools/mouse_decode_test  ./virtualjaguar_libretro.dylib test/roms/yarc.j64 --quiet
  -> PASS: [mouse_decode]  0 failure(s)

$ ./test/tools/rotary_decode_test ./virtualjaguar_libretro.dylib test/roms/yarc.j64 --quiet
  -> PASS: [rotary_decode] 0 failure(s)

$ ./test/test_axistune
  -> All axistune checks passed (37 checks, 0 failed)

$ ./test/tools/tuning_identity ./virtualjaguar_libretro.dylib test/roms/yarc.j64 --quiet
  -> PASS: [tuning_identity] 0 failure(s)
     pad    digests: untouched 0x4061DDC5  defaults 0x4061DDC5  tuned 0x4061DDC5
     analog digests: untouched 0xED6E4AD9  defaults 0xED6E4AD9  tuned 0x3BEA0665

$ make -j8 TEST_EXPORTS=1 test
  -> EXIT=0
     Core Option Visibility: 5 checks, 0 failed
     16 skipped checks, all "no private ROM/disc" (unchanged from develop)
```

The three digest constants were **not** touched. They are unmoved because the change cannot reach the pad path, which is the point of the exercise.

## Deliberately not done

- **No absolute-axis / re-basing mode.** #437 has no device yet; adding a flag with one caller would be the abstraction the issue's scope warns against. The header states the open question instead.
- **No per-title DB rows.** This is the mechanism, not the data.
- **No savestate change.** The tuning is option-derived and constant for a session and changes only how host motion becomes feeds, never anything the machine can observe — same reasoning `inputdev.h` already gives for the sensitivity scale. `INPUTDEV_STATE_SIZE` and `STATE_VERSION` are unchanged.
- **No invert / sign knob.** Out of scope and, per `inputdev.c`'s existing note, an unsourced sign knob is how a real wiring bug gets papered over instead of found.
- **No hardware verification**, because there is none to do: this layer is entirely host-side pre-processing and touches no emulated register behaviour. The JTRM has nothing to say about how a frontend's mouse deltas are conditioned before they become quadrature pulses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
