### PR TITLE
feat(texdump): texture dump mode (issue #369, deliverable 1)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -417,9 +417,9 @@ jobs:
           /I. /Isrc /Isrc\core /Isrc\tom /Isrc\jerry /Isrc\cd /Isrc\bios /Isrc\m68000 /Ilibretro-common\include ^
           /Ideps\libchdr\include /Ideps\libchdr\deps\lzma-25.01\include /Ideps\libchdr\deps\miniz-3.1.1 /Ideps\libchdr\deps\zstd-1.5.7 ^
           /D__LIBRETRO__ /DINLINE="_inline" /DBLITTER_SIMD_SCALAR ^
-          /D_7ZIP_ST /DWANT_RAW_DATA_SECTOR=1 /DWANT_SUBCODE=1 /DVERIFY_BLOCK_CRC=1 ^
+          /D_7ZIP_ST /DMINIZ_DEFLATE_APIS /DWANT_RAW_DATA_SECTOR=1 /DWANT_SUBCODE=1 /DVERIFY_BLOCK_CRC=1 ^
           libretro.c ^
-          src\tom\blitter.c src\tom\blitter_compare.c src\tom\blitter_mmio.c src\jerry\dac.c src\jerry\dsp.c src\core\file.c ^
+          src\tom\blitter.c src\tom\blitter_compare.c src\tom\blitter_mmio.c src\tom\texdump.c src\jerry\dac.c src\jerry\dsp.c src\core\file.c ^
           src\tom\gpu.c src\core\jaguar.c src\jerry\jerry.c src\tom\tom.c src\tom\op.c ^
           src\cd\cdintf.c src\cd\cdrom.c src\core\crc32.c src\core\event.c ^
           src\jerry\eeprom.c src\core\filedb.c src\jerry\joystick.c src\core\settings.c ^

--- a/Makefile
+++ b/Makefile
@@ -893,6 +893,10 @@ endif
 # libchdr is C99; the rest of the core is gnu89. A dedicated rule so
 # the generic %.o: %.c line cannot compile unity.c as C89.  Must sit
 # AFTER `all:` so it is not the default goal.
+#
+# MINIZ_DEFLATE_APIS (texture dump's PNG encoder, issue #369) rides in
+# LIBCHDR_CFLAGS -- see the comment in Makefile.common -- so the
+# theos_ios path, which compiles unity.c without this rule, gets it too.
 $(LIBCHDR_DIR)/unity.o: $(LIBCHDR_DIR)/unity.c
 	$(CC) -c $(OBJOUT)$@ $< $(CFLAGS) $(LIBCHDR_CFLAGS) $(LIBCHDR_WARNFLAGS)
 
@@ -921,7 +925,7 @@ clean:
 		test/tools/test_memory_map test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/tools/test_dsp_audio_diag \
 		test/tools/test_frame_timing test/tools/test_runahead_determinism test/tools/test_pertitle_db \
 		test/test_titledb test/test_titlehook test/tools/test_hook_gate \
-		test/tools/test_wedge_spin test/tools/i2s_lag_probe \
+		test/tools/test_wedge_spin test/tools/test_texdump test/tools/i2s_lag_probe \
 		test/tools/joymatrix_identity test/tools/mouse_decode_test \
 		test/tools/rotary_decode_test \
 		test/test_quadrature \
@@ -971,7 +975,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_blitter_mmio test/test_blitter_cmd test/test_eeprom_lifecycle test/test_eeprom_read_race test/test_tom_visible_window \
 		test/test_framebuffer_integrity test/test_state_compat \
 		test/test_frontend_pacing test/test_jgd \
-		test/tools/test_runahead_determinism test/tools/test_wedge_spin \
+		test/tools/test_runahead_determinism test/tools/test_wedge_spin test/tools/test_texdump \
 		test/test_butch_cd test/test_bios_config test/test_boot_config \
 		test/test_cart_format test/test_cart_needs_bios \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_chd test/test_chd_unit test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda test/test_cd_synth_subq \
@@ -1177,6 +1181,14 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# every STATE_SAVE_BUF; yarc.j64 is in-tree so this never skips, and
 	@# a real music-on title is used when the private corpus is present.
 	./test/tools/test_runahead_determinism ./$(TARGET) test/roms/yarc.j64 --quiet
+	@# Texture dump mode (issue #369): identity-contract freeze vs the
+	@# committed golden list, determinism, fast/accurate engine
+	@# independence, machine inertness (fb hashes + savestate digests
+	@# on vs off), PNG validity, and the bytes-only-identity palette
+	@# check.  yarc.j64 is in-tree so this never skips; the synthetic
+	@# blit battery inside the tool covers every bpp (see the tool
+	@# header for why a ROM run alone is a 2-hash tripwire).
+	./test/tools/test_texdump ./$(TARGET) test/roms/yarc.j64 --quiet
 	@rom=$$(bash scripts/find-rom.sh 'Iron Soldier (1994).jag' 'Iron Soldier (World)*.j64' 'Iron Soldier.jag'); \
 	if [ -n "$$rom" ]; then \
 		./test/tools/test_runahead_determinism ./$(TARGET) "$$rom" --quiet; \
@@ -1699,6 +1711,13 @@ test/tools/test_runahead_determinism: test/tools/test_runahead_determinism.c \
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_runahead_determinism.c \
 		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
+
+test/tools/test_texdump: test/tools/test_texdump.c \
+		test/harness/harness.c test/harness/harness.h src/core/crc32.c
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/test_texdump.c \
+		test/harness/harness.c src/core/crc32.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 
 test/tools/test_wedge_spin: test/tools/test_wedge_spin.c \

--- a/Makefile.common
+++ b/Makefile.common
@@ -20,7 +20,13 @@ INCFLAGS := -I$(CORE_DIR) \
 # (unity.c) with -std=c99; see the unity.o rule in the Makefile.
 # _7ZIP_ST is the LZMA single-thread decode config libchdr expects.
 # -std=c99 / -Wno-* are GCC/Clang only; cl.exe rejects both.
-LIBCHDR_CFLAGS := -D_7ZIP_ST \
+# MINIZ_DEFLATE_APIS restores miniz's compressor (unity.c disables it
+# with MINIZ_NO_DEFLATE_APIS behind an #ifndef guard, precisely so
+# dependents can turn it back on): texture dump (src/tom/texdump.c,
+# issue #369) calls tdefl_write_image_to_png_file_in_memory_ex for its
+# preview PNGs.  Lives here rather than on the unity.o rule alone so the
+# theos_ios path, which compiles unity.c without that rule, gets it too.
+LIBCHDR_CFLAGS := -D_7ZIP_ST -DMINIZ_DEFLATE_APIS \
 	-DWANT_RAW_DATA_SECTOR=1 -DWANT_SUBCODE=1 -DVERIFY_BLOCK_CRC=1
 ifeq (,$(findstring msvc,$(platform)))
 LIBCHDR_CFLAGS += -std=c99
@@ -54,6 +60,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/jerry/uart.c \
 	$(CORE_DIR)/src/tom/op.c \
 	$(CORE_DIR)/src/tom/shadowfb.c \
+	$(CORE_DIR)/src/tom/texdump.c \
 	$(CORE_DIR)/src/tom/tom.c  \
 	$(CORE_DIR)/src/cd/cdintf.c \
 	$(CORE_DIR)/src/cd/cdrom.c \

--- a/docs/texture-dump.md
+++ b/docs/texture-dump.md
@@ -1,0 +1,238 @@
+# Texture dump mode (issue #369, deliverable 1 of 2)
+
+Design spec for `virtualjaguar_texture_dump`: write every unique blit
+source tile a title uses to disk as PNG + manifest, so pack authors have
+something to redraw and developers get a window into what titles
+actually blit. This is the first half of #369; the replacement pipeline
+(second half, v3.5) consumes the contract defined here.
+
+Status: **design approved pending review — not implemented.**
+
+## Goals and non-goals
+
+Goals (v3.4.0):
+
+- Dump each unique blit source exactly once per session as a viewable
+  PNG, plus an append-only manifest row.
+- A **stable identity contract**: the hash a tile dumps under in v3.4.0
+  is the key the v3.5 replacement pipeline looks up, and the filename
+  community authors save redrawn art under. Stable from day one is the
+  target; the manifest carries a `texdump v1` version marker so that if
+  a re-key is ever forced, v2 is visible rather than silent.
+- Pace-neutral and inert by construction: zero work when disabled
+  beyond one branch; when enabled, zero effect on the emulated machine
+  (provable via savestate digests).
+
+Non-goals (v3.4.0):
+
+- No replacement/lookup path (v3.5; >1x replacements ride the Stage 2
+  shadow surface, #367).
+- No capture of OP-only sprites or GPU-computed surfaces (Doom's
+  texture mapper). #369 scopes the HD-pack flow to the blitter; art
+  that never passes through the blitter as a source is invisible here.
+- No pack file-format spec beyond directory layout + hash filename +
+  manifest columns. That minimal surface *is* the seed of the pack
+  format; v3.5 extends it, never rewrites it.
+
+## Capture approach: register-described window at launch
+
+Hook once at the shared blit-launch site (beside `BlitMemoLaunch`,
+before fast/accurate engine dispatch). When the option is on and the
+blit reads source data (`SRCEN`), walk the source rectangle **as
+described by the blit registers** (source channel base, flags, pixel
+size, pitch/width, `B_COUNT`) directly out of emulated memory at launch
+time. Hash it, dedupe, and on first sight render + write the PNG and
+manifest row.
+
+Why register-described rather than tapping the engines' inner loops:
+
+- **Pace-neutral by construction.** All work is host-side at launch;
+  no per-pixel instrumentation in any engine; the bus model never sees
+  a cycle of it.
+- **Engine-independent identity.** Fast and accurate blitters have
+  known read-pattern divergences (e.g. A2_PIXEL writeback). A hash
+  derived from the register description is identical under both
+  engines — a property the test suite asserts, and the reason a
+  day-one stable contract is defensible at all.
+- Exotic blits (scaled, phrase-alignment edge cases) may read slightly
+  different bytes than the described window. For identity that is
+  acceptable: the key must be deterministic and collision-free, not a
+  byte-exact replay of the engine's read stream.
+
+Source-channel selection (whether A1 or A2 is the reader) follows the
+same B_CMD decode the engines themselves use, computed once at launch.
+Implementation must verify the decode against `docs/jtrm-blitter.md`
+(address generators, B_CMD bits) — not against source-code comments.
+
+Skipped (never hashed, never dumped): blits without `SRCEN`
+(pattern/Gouraud fills), described source windows larger than 1 MB
+(garbage-register guard), and blits whose described window falls
+outside populated address space.
+
+## The identity contract (what feeds the hash)
+
+Key = **FNV-1a 64** over a canonical little-endian serialization:
+
+```
+'VJTD' | version=1 | src_bpp | width(px,u16) | height(rows,u16)
+      | source bytes, row-major, packed exactly as stored in memory
+```
+
+- `src_bpp` ∈ {1, 2, 4, 8, 16, 32} from the source channel's pixel-size
+  field.
+- Source bytes are the raw memory contents — index values for ≤8bpp,
+  raw 16/32-bit pixel values otherwise — in stored byte order.
+- Filename: `<hash as 16 lower-case hex digits>.png`.
+
+**The palette is deliberately NOT part of the key.** This diverges from
+SNES/N64 HD-pack precedent (Mesen, Rice hash bytes+palette) for a
+hardware reason: those systems replace at the render-to-screen stage,
+where the palette is in hand. Our replacement happens at **blit time**,
+and the Jaguar blitter never sees a palette — CLUT lookup is an Object
+Processor display-time concept. At replacement time the pipeline has
+only the source bytes; two CLUT variants of one indexed tile are
+*indistinguishable at the swap point*. Keying dumps on bytes+palette
+would therefore mint keys the replacement pipeline can never
+discriminate, stranding every pack drawn against them. Bytes-only keys
+are the honest contract. Palette information is advisory metadata
+(below), never identity.
+
+Collision risk: a title's unique-tile population is thousands to tens
+of thousands; birthday bound at 2^64 is negligible. FNV-1a 64 is
+already this repo's digest idiom (savestate digests, `frame_hash_ab`).
+
+## Rendering (advisory, not identity)
+
+The PNG a hash dumps as is a *preview* for the author's benefit; the
+bytes are the contract.
+
+- **≤8bpp (indexed):** rendered through a snapshot of the relevant TOM
+  CLUT slice taken at first-sight launch. The CLUT CRC is recorded in
+  the manifest. If the same key is later seen under a different CLUT,
+  no new PNG is written (same key, one file); the manifest gains an
+  additional `clut=` sighting row. Authors of palette-animated art get
+  the first palette as their preview and the manifest tells them
+  others exist.
+- **16bpp:** the blitter cannot know whether values are CRY or RGB16 —
+  that is also display-time interpretation. Option
+  `virtualjaguar_texdump_16bpp` = `cry` (default) | `rgb` | `both`
+  chooses the preview rendering; `both` writes `<hash>-cry.png` and
+  `<hash>-rgb.png`. CRY conversion reuses the existing tables in
+  `src/tom/tom.c` — no second implementation.
+- **32bpp:** direct RGB render.
+- PNGs are fully opaque. Transparency on the Jaguar is a *blit*
+  property (`TRANSEN`/`DCOMPEN`), not a tile property; observed flags
+  are recorded per manifest row instead.
+
+## PNG encoder: in-tree miniz, one build define
+
+No new vendored code. miniz 3.1.1 (already vendored for CHD in
+`deps/libchdr`) ships `tdefl_write_image_to_png_file_in_memory_ex()`;
+our unity TU currently disables the compressor with
+`MINIZ_NO_DEFLATE_APIS`, and upstream wrapped every disable in
+`#ifndef` guards precisely so dependents can restore them. Adding
+`-DMINIZ_DEFLATE_APIS` to the existing `unity.o` rule enables the
+encoder on every one of the 30+ targets, MSVC included, because miniz
+already compiles on all of them today. Cost ≈ 10–20 KB on a ~1.9 MB
+dylib. Encode happens at most once per unique hash; the in-memory PNG
+is written through the libretro VFS (`rfopen`/`rfwrite`), same as every
+other file this core touches.
+
+Rejected alternatives: hand-rolled writer (new code to maintain vs one
+define); native platform encoders (ImageIO/WIC/libpng would be a
+per-platform matrix across a 16-target release CI, and
+consoles/Emscripten need the portable path anyway, so both would end up
+shipped).
+
+## On-disk layout
+
+```
+<system_dir>/vj_texdump/<CRC32 8-hex>/
+    manifest.tsv
+    <hash16>.png
+    <hash16>-cry.png / <hash16>-rgb.png     (16bpp 'both' mode only)
+```
+
+- Directory named by cartridge CRC32 only (same identity `titledb`
+  keys on); the human-readable title lives in the manifest header, so
+  no filename sanitization across platforms.
+- `manifest.tsv`, append-only, tab-separated:
+  - header: `# texdump v1 <tab> crc=<CRC32> <tab> title=<name>`
+  - first-sight row per hash:
+    `hash <tab> WxH <tab> bpp <tab> frame=<n> <tab> src=<addr> <tab>
+    clut=<crc|-> <tab> flags=<transen,dcompen|->`
+  - additional-palette sighting: `hash <tab> clut=<crc> <tab> frame=<n>`
+- Counts/statistics are deliberately not tracked (would force manifest
+  rewrites); a summary line goes to the frontend log at unload.
+
+## Runtime behaviour and bounds
+
+- Core options: `virtualjaguar_texture_dump` (disabled default,
+  runtime-toggleable — capture is passive, no restart needed) and
+  `virtualjaguar_texdump_16bpp`, the latter visible only while dump is
+  enabled (same visibility machinery as `virtualjaguar_bios_type`).
+- Dedupe set: open-addressed uint64 table, fixed 2^17 entries (1 MB
+  host RAM, allocated on first enable, freed at `retro_deinit`). On
+  overflow: warn once to the log, stop recording new tiles, keep
+  running.
+- All on the emulation thread; no locks, no queues. Worst realistic
+  first-frames burst (a title blitting hundreds of unique tiles at
+  boot) costs hashing + a few hundred small PNG encodes spread over
+  the frames where each is first seen — a dev-facing feature is
+  allowed a one-time hitch, and dedupe makes steady state near-free.
+- Savestate: **zero fields, no version bump.** All dump state is
+  host-transient; loading a state mid-session merely re-encounters
+  hashes the dedupe set absorbs. (Lesson of #400: enhancement-path
+  state outside the blob is the savestate blind spot — the design
+  answer here is to *have no state the machine can see*.)
+- iOS/static reset: `retro_deinit` frees the set, closes the manifest,
+  resets every static (no dlclose on iOS).
+
+## Test gates (all in `make test`)
+
+1. **Contract freeze (determinism):** `test/roms/yarc.j64` (committed,
+   public), 600 frames, dump on → the set of manifest hashes equals a
+   committed golden list. Two consecutive runs produce identical sets.
+   This is the CI tripwire that makes "stable from day one" real: any
+   change that moves a hash fails loudly and forces a deliberate v2.
+2. **Engine independence:** the same run under
+   `virtualjaguar_blitter=fast` vs accurate yields identical hash
+   sets. This asserts the property that justifies the contract; if it
+   ever fails it is a real divergence finding, not a test to relax.
+3. **Inertness, off:** dump disabled → per-frame framebuffer hashes
+   identical to baseline (existing `frame_hash_ab` pattern).
+4. **Inertness, ON (the strong claim):** dump *enabled* → per-frame
+   framebuffer hashes AND savestate digests at frames 300/600 identical
+   to disabled (`hires_state_digest` pattern: proves the emulated
+   machine cannot observe the feature).
+5. **PNG validity:** parse an emitted file's signature, IHDR, and chunk
+   CRCs in the test harness (chunk CRC-32 verified against
+   `src/core/crc32.c` — no external decoder dependency).
+6. `scripts/c89-lint.sh` on every new file; new sources added to the
+   MSVC compile list in `c-cpp.yml`.
+
+## File plan
+
+- `src/tom/texdump.c` / `.h` — capture, hash, dedupe, CLUT snapshot,
+  render, manifest, miniz PNG write. (~350 lines.)
+- `src/tom/blitter_mmio.c` (or the shared launch site) — one call
+  beside `BlitMemoLaunch`.
+- `libretro.c` / `libretro_core_options.h` — options + visibility.
+- `Makefile.common`, `Makefile` (`-DMINIZ_DEFLATE_APIS` on `unity.o`),
+  `.github/workflows/c-cpp.yml` MSVC list, `exports.list` additions
+  under `TEST_EXPORTS` for the probes.
+- `test/tools/test_texdump.c` + `test/expected/texdump_yarc.txt`.
+- `docs/texture-dump.md` — this document, plus an authoring section
+  (directory layout, what the hash means, palette caveats) written at
+  implementation time.
+
+## Open items carried into implementation
+
+- Verify source-channel B_CMD decode against `docs/jtrm-blitter.md`
+  before trusting the engines' variable naming.
+- Confirm `tdefl_write_image_to_png_file_in_memory_ex` links cleanly
+  from outside the unity TU on MSVC (symbol visibility) — fallback is
+  a tiny TU-local wrapper compiled into unity.
+- Golden-list size for yarc.j64 unknown until first run; if yarc blits
+  too few unique sources to be a meaningful tripwire, add a second
+  committed ROM from `test/roms/`.

--- a/docs/texture-dump.md
+++ b/docs/texture-dump.md
@@ -6,7 +6,10 @@ something to redraw and developers get a window into what titles
 actually blit. This is the first half of #369; the replacement pipeline
 (second half, v3.5) consumes the contract defined here.
 
-Status: **design approved pending review — not implemented.**
+Status: **implemented (v3.4 deliverable 1).** Capture module
+`src/tom/texdump.c`, hook in `src/tom/blitter_mmio.c`, options in
+`libretro.c` / `libretro_core_options.h`, test gates in
+`test/tools/test_texdump.c` + `test/expected/texdump_yarc.txt`.
 
 ## Goals and non-goals
 
@@ -226,13 +229,65 @@ shipped).
   (directory layout, what the hash means, palette caveats) written at
   implementation time.
 
-## Open items carried into implementation
+## Authoring guide (for pack authors)
 
-- Verify source-channel B_CMD decode against `docs/jtrm-blitter.md`
-  before trusting the engines' variable naming.
-- Confirm `tdefl_write_image_to_png_file_in_memory_ex` links cleanly
-  from outside the unity TU on MSVC (symbol visibility) — fallback is
-  a tiny TU-local wrapper compiled into unity.
-- Golden-list size for yarc.j64 unknown until first run; if yarc blits
-  too few unique sources to be a meaningful tripwire, add a second
-  committed ROM from `test/roms/`.
+Turn on **Texture Dump Mode** (Options → Diagnostics) and play. Every
+unique source tile the game pushes through the blitter lands in
+
+```
+<RetroArch system dir>/vj_texdump/<cart CRC32 as 8 hex digits>/
+    manifest.tsv         one row per unique tile (+ palette sightings)
+    <hash16>.png         preview, named by the tile's identity hash
+```
+
+What to know before redrawing:
+
+- **The filename is the contract.** `<hash16>` is the FNV-1a 64 key of
+  the tile's raw bytes (plus bpp and dimensions). The v3.5 replacement
+  pipeline will look art up under exactly this name — never rename the
+  files. If the manifest header ever says something other than
+  `texdump v1`, hashes from a different contract version are not
+  interchangeable.
+- **The PNG is a preview, not the truth.** For indexed (≤8bpp) tiles it
+  was rendered through whatever CLUT the game had loaded the first time
+  the tile was seen; the manifest row records that CLUT's CRC. A tile
+  the game recolours via palette swaps appears ONCE (one hash, one
+  file) with extra `clut=` sighting rows telling you other palettes
+  exist. That is deliberate: the blitter never sees a palette, so two
+  CLUT variants of one tile are indistinguishable at the point where
+  replacement will happen. Draw for the tile, not for one palette.
+- **16bpp tiles** can be CRY or RGB16 — the hardware doesn't say. If a
+  preview looks like noise, switch *Texture Dump: 16bpp Preview* to the
+  other interpretation (or `both`) and reload; the hash (and therefore
+  the filename) does not change.
+- Transparency is a property of each blit, not of the tile; `flags=`
+  in the manifest records the comparator bits seen on first sight.
+  Previews are fully opaque.
+- The manifest is append-only across sessions; play more of the game
+  and new tiles simply append. Dedupe is per-session, so a replayed
+  session may re-append rows for tiles already listed — rows are
+  advisory, files are identity.
+
+## Open items carried into implementation — resolution
+
+- **B_CMD source-channel decode**: verified against
+  `docs/jtrm-blitter.md` — bit 0 SRCEN reads source from **A2**, or
+  from **A1 when DSTA2 (bit 11)** is set. Implemented exactly so in
+  `TexDumpLaunch()`; the engines' variable naming agrees.
+- **miniz linkage**: `tdefl_write_image_to_png_file_in_memory_ex`
+  links cleanly from outside the unity TU (plain extern function, no
+  visibility annotations); the CI MSVC job compiles unity.c with
+  `/DMINIZ_DEFLATE_APIS` to keep cl.exe honest. The fallback wrapper
+  was not needed. The define lives in `LIBCHDR_CFLAGS`
+  (Makefile.common) rather than on the `unity.o` rule alone so the
+  theos_ios path — which compiles unity.c without that rule — gets it
+  too.
+- **Golden-list population**: yarc.j64 blits only its two boot-time
+  code copies through SRCEN (it renders via the OP), and so does
+  jagniccc.j64 — no in-tree public ROM is a meaningful tripwire by
+  itself. Instead of a second ROM, `test/tools/test_texdump.c` drives
+  a **synthetic blit battery** through the real bus/launch path
+  (26 scripted tiles: every bpp, both source channels, plus a
+  palette-change re-blit that must not mint a new hash). The committed
+  golden list (`test/expected/texdump_yarc.txt`, 28 hashes) freezes
+  the ROM tiles and the battery together.

--- a/libretro.c
+++ b/libretro.c
@@ -41,6 +41,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "settings.h"
 #include "shadowfb.h"
 #include "blit_memo.h"
+#include "texdump.h"
 #include "tom.h"
 #include "blitter.h"
 #include "gpu.h"
@@ -202,6 +203,11 @@ static bool show_input_options = true;
 static bool content_loaded         = false;
 static bool show_cd_options        = true;
 static bool show_cart_bios_option  = true;
+/* 16bpp preview interpretation only matters while texture dump is on
+ * (#369).  Defaults visible, like the other show_* gates, so the first
+ * update_option_visibility() sees a change and hides it while the dump
+ * option sits at its disabled default. */
+static bool show_texdump_16bpp     = true;
 static bool enable_alt_inputs = false;
 static uint8_t *joypad_buttons[2] = { joypad0Buttons, joypad1Buttons };
 
@@ -583,6 +589,28 @@ static bool update_option_visibility(void)
       }
    }
 
+   /* The 16bpp preview knob only means anything while texture dump is
+    * enabled (#369) -- same machinery as the mouse/rotary gates above. */
+   {
+      bool show_texdump_prev = show_texdump_16bpp;
+
+      show_texdump_16bpp = false;
+      var.key = "virtualjaguar_texture_dump";
+      var.value = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value
+          && !strcmp(var.value, "enabled"))
+         show_texdump_16bpp = true;
+
+      if (show_texdump_16bpp != show_texdump_prev)
+      {
+         option_display.visible = show_texdump_16bpp;
+         option_display.key     = "virtualjaguar_texdump_16bpp";
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
+                    &option_display);
+         updated = true;
+      }
+   }
+
    return updated;
 }
 
@@ -955,6 +983,29 @@ static void check_variables(void)
        * retro_load_game applies it after ResolveBootConfig instead. */
       if (content_loaded)
          BlitMemoSetMode(blit_memo_requested);
+   }
+
+   /* Texture dump (issue #369): runtime-toggleable, capture is passive
+    * so no restart is needed.  Read raw (not through
+    * get_variable_pertitle()): dumping is a dev-facing choice, never a
+    * per-title default. */
+   var.key = "virtualjaguar_texture_dump";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      TexDumpSetEnabled(strcmp(var.value, "enabled") == 0);
+   else
+      TexDumpSetEnabled(0);
+
+   var.key = "virtualjaguar_texdump_16bpp";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "rgb") == 0)
+         TexDumpSet16bppMode(TEXDUMP_16BPP_RGB);
+      else if (strcmp(var.value, "both") == 0)
+         TexDumpSet16bppMode(TEXDUMP_16BPP_BOTH);
+      else
+         TexDumpSet16bppMode(TEXDUMP_16BPP_CRY);
    }
 
    var.key = "virtualjaguar_crash_detect";
@@ -2473,6 +2524,19 @@ bool retro_load_game(const struct retro_game_info *info)
    else
       TitleDBSetContent(NULL, 0);
 
+   /* Texture dump (#369): dumps land under the system directory, keyed
+    * by the content CRC the DB just latched.  The path is set here once
+    * so a mid-session enable via check_variables() has somewhere to
+    * write without needing environ_cb of its own. */
+   {
+      const char *texdump_sys_dir = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &texdump_sys_dir)
+          && texdump_sys_dir)
+         TexDumpSetBasePath(texdump_sys_dir);
+      else
+         TexDumpSetBasePath(NULL);
+   }
+
    /* Raw gate read (never through get_variable_pertitle()) so the hires
     * read just below -- which runs before check_variables() -- is already
     * gated correctly even on a frontend that hasn't called
@@ -2774,6 +2838,11 @@ void retro_unload_game(void)
    /* Hi-res: N is per-load; drop the shadow surface so the next load
     * re-reads the option from scratch (see shadowfb.h). */
    ShadowHiresShutdown();
+   /* Texture dump (#369): dumps are keyed by content CRC, so a title
+    * boundary closes the manifest and logs the session summary; the
+    * next load's check_variables() re-enables (and re-allocates) if the
+    * option is still on. */
+   TexDumpShutdown();
    video_buffer_alloc_pixels = VIDEO_BUFFER_PIXELS;
    hires_restart_notice_logged = 0;
 
@@ -2966,6 +3035,10 @@ void retro_deinit(void)
    ShadowFBShutdown();
    ShadowHiresShutdown();
    BlitMemoShutdown();
+   /* Texture dump (#369): close the manifest, log the session summary,
+    * free the dedupe set and reset every static. */
+   TexDumpShutdown();
+   show_texdump_16bpp = true;
    /* Non-pad input devices: encoders, phases, attach mask, armed flag and
     * the option-derived type/scale all go back to their load-time values
     * (iOS cannot dlclose a core). */
@@ -3105,6 +3178,10 @@ void retro_run(void)
    /* Blit memo: advance the shadow-restamp dedupe epoch. */
    if (blitMemoMode)
       BlitMemoFrame();
+
+   /* Texture dump (#369): advance the manifest frame number. */
+   if (texDumpEnabled)
+      TexDumpFrame();
 
    /* On the first frame, unpack save data that the frontend loaded
     * into our RETRO_MEMORY_SAVE_RAM buffer after retro_load_game(). */

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -407,6 +407,35 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "k"
    },
    {
+      "virtualjaguar_texture_dump",
+      "Texture Dump Mode",
+      NULL,
+      "Write every unique blitter source tile the title uses to <system dir>/vj_texdump/<cart CRC32>/ as a PNG preview plus a manifest row, for HD texture pack authoring (issue #369). Tiles are identified by a hash of their raw source bytes only -- the palette is advisory metadata, never identity. Takes effect immediately, no restart needed. Developer-facing: leave disabled for normal play.",
+      NULL,
+      "diagnostics",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "virtualjaguar_texdump_16bpp",
+      "Texture Dump: 16bpp Preview",
+      NULL,
+      "How 16-bit source tiles are rendered in their preview PNGs. The blitter cannot know whether 16-bit values are CRY or RGB16 -- that is display-time interpretation -- so this only changes the preview image, never the tile's hash. 'Both' writes a -cry and a -rgb PNG per tile.",
+      NULL,
+      "diagnostics",
+      {
+         { "cry",  "CRY" },
+         { "rgb",  "RGB16" },
+         { "both", "Both" },
+         { NULL, NULL },
+      },
+      "cry"
+   },
+   {
       "virtualjaguar_jgd",
       "Jaguar GameDrive (Restart)",
       NULL,

--- a/src/tom/blitter_mmio.c
+++ b/src/tom/blitter_mmio.c
@@ -1,6 +1,7 @@
 #include "blitter.h"
 #include "blitter_internal.h"
 #include "blit_memo.h"
+#include "texdump.h"
 
 #include <string.h>
 #include "bus_arbiter.h"
@@ -314,6 +315,12 @@ void BlitterWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
       uint32_t busClks = 0;
       if (vjs.blitterTiming)
          busClks = BlitDurationSysclks();
+
+      /* Texture dump (issue #369): capture the register-described
+       * source window BEFORE dispatch, engine-independently.  Read-only
+       * host-side work; the emulated machine cannot observe it. */
+      if (texDumpEnabled)
+         TexDumpLaunch();
 
       if (BlitterCompareIsEnabled())
          BlitterRunComparison();

--- a/src/tom/texdump.c
+++ b/src/tom/texdump.c
@@ -1,0 +1,787 @@
+/*
+ * TEXDUMP.C
+ *
+ * Texture dump mode (issue #369, deliverable 1 of 2).  Design spec:
+ * docs/texture-dump.md -- the spec is authoritative for the identity
+ * contract; this file implements it.
+ *
+ * Capture happens ONCE per blit at the shared launch site (beside
+ * BlitMemoLaunch, before fast/accurate engine dispatch): when the blit
+ * reads source data (SRCEN), the source rectangle is walked exactly as
+ * the blit registers describe it (source channel base, flags, pixel
+ * size, pitch/width, B_COUNT) directly out of emulated memory, hashed,
+ * and deduped.  On first sight a preview PNG and a manifest row are
+ * written.  No per-pixel instrumentation in any engine; the bus model
+ * never sees a cycle of it; the hash is identical under both engines.
+ *
+ * THE IDENTITY CONTRACT (docs/texture-dump.md):
+ *
+ *   key = FNV-1a 64 over
+ *   'VJTD' | version=1 | src_bpp | width(px,u16 LE) | height(rows,u16 LE)
+ *         | source bytes, row-major, packed exactly as stored in memory
+ *
+ * The palette is deliberately NOT part of the key: replacement happens
+ * at blit time and the Jaguar blitter never sees a palette -- CLUT
+ * lookup is an Object Processor display-time concept.  Two CLUT
+ * variants of one indexed tile are indistinguishable at the swap point,
+ * so palette information is advisory manifest metadata, never identity.
+ * Do not "fix" this.
+ *
+ * Source-channel selection follows the B_CMD decode verified against
+ * docs/jtrm-blitter.md ("SRCEN (bit 0): read source data from A2, or A1
+ * if DSTA2 (bit 11)"), NOT source-code comments.  The per-pixel address
+ * formulas below are transliterations of the engines' PIXEL_OFFSET_*
+ * macros (src/tom/blitter.c) with plain integer x/y in place of 16.16.
+ *
+ * Everything here is host-transient: zero savestate fields, and the
+ * capture only READS emulated state (blitter_ram, RAM/ROM, TOM CLUT).
+ */
+
+#include "texdump.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <streams/file_stream.h>
+#include <file/file_path.h>
+
+#include "blitter_internal.h"   /* blitter_ram */
+#include "vjag_memory.h"        /* jaguarMainRAM/ROM, jagMemSpace, GET16 */
+#include "jaggd.h"              /* JGD_BANKING / JGDReadROM8 */
+#include "tom.h"                /* tomRam8 (CLUT at +0x400, VMODE) */
+#include "crc32.h"
+#include "titledb.h"            /* TitleDBContentCRC / TitleDBTitleName */
+#include "log.h"
+
+/* libretro VFS (libretro-common/streams/file_stream_transforms.c) --
+ * same declaration pattern libretro.c uses. */
+RFILE *rfopen(const char *path, const char *mode);
+int rfclose(RFILE *stream);
+int64_t rftell(RFILE *stream);
+int64_t rfwrite(void const *buffer, size_t elem_size, size_t elem_count,
+                RFILE *stream);
+
+/* miniz PNG encoder, compiled into deps/libchdr/unity.o with
+ * -DMINIZ_DEFLATE_APIS (see the unity.o rule in the Makefile).  Local
+ * prototypes rather than miniz.h: the header is C99 and drags in the
+ * whole miniz API surface.  mz_uint == unsigned int, mz_bool == int. */
+void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage,
+      int w, int h, int num_chans, size_t *pLen_out, unsigned int level,
+      int flip);
+void mz_free(void *p);
+
+/* CRY/RGB16 -> XRGB8888 tables (filled by TOMFillLookupTables in
+ * src/tom/tom.c) -- reused for the 16bpp/CLUT previews so there is no
+ * second CRY implementation. */
+extern uint32_t CRY16ToRGB32[0x10000];
+extern uint32_t RGB16ToRGB32[0x10000];
+
+/* ---- constants ------------------------------------------------------ */
+
+#define TD_REG(A) (((uint32_t)blitter_ram[(A)] << 24)      \
+                 | ((uint32_t)blitter_ram[(A) + 1] << 16)  \
+                 | ((uint32_t)blitter_ram[(A) + 2] << 8)   \
+                 |  (uint32_t)blitter_ram[(A) + 3])
+
+#define TD_A1_BASE   0x00
+#define TD_A1_FLAGS  0x04
+#define TD_A1_PIXEL  0x0C
+#define TD_A2_BASE   0x24
+#define TD_A2_FLAGS  0x28
+#define TD_A2_PIXEL  0x30
+#define TD_COMMAND   0x38
+#define TD_COUNT     0x3C
+
+#define TD_FNV_OFFSET 0xCBF29CE484222325ULL
+#define TD_FNV_PRIME  0x00000100000001B3ULL
+
+/* Dedupe set: open-addressed uint64 table, fixed 2^17 entries (1 MB
+ * host RAM).  0 is the empty sentinel; a real hash of 0 is remapped to
+ * a fixed non-zero constant so it stays representable.  Insertion stops
+ * (with a one-time warning) at 3/4 load so probe chains stay bounded. */
+#define TD_SET_BITS    17
+#define TD_SET_SIZE    (1u << TD_SET_BITS)
+#define TD_SET_MASK    (TD_SET_SIZE - 1u)
+#define TD_SET_MAXLOAD ((TD_SET_SIZE / 4u) * 3u)
+#define TD_HASH_ZERO_REMAP 0xD6E8FEB86659FD93ULL
+
+/* Garbage-register guard: described source windows larger than 1 MB are
+ * never hashed (docs/texture-dump.md, "Skipped"). */
+#define TD_MAX_WINDOW_BYTES (1u << 20)
+/* Serialization slack: per row up to a phrase of alignment spill. */
+#define TD_SCRATCH_BYTES (TD_MAX_WINDOW_BYTES + 0x10000)
+
+/* ---- state (ALL host-transient; reset in TexDumpShutdown) ----------- */
+
+int texDumpEnabled = 0;
+
+static int       td_mode16   = TEXDUMP_16BPP_CRY;
+static uint64_t *td_set      = NULL;   /* dedupe table                  */
+static uint32_t  td_entries  = 0;      /* live entries in td_set        */
+static uint8_t  *td_scratch  = NULL;   /* serialized source bytes       */
+static int       td_overflow_warned = 0;
+static int       td_alloc_failed    = 0;
+static int       td_png_warned      = 0;
+static int       td_write_warned    = 0;
+static uint32_t  td_frame    = 0;      /* manifest frame number         */
+static char      td_base[1024];        /* system dir ("" = unset)       */
+static char      td_dir[1200];         /* <base>/vj_texdump/<crc8>      */
+static int       td_dir_ready = 0;
+static RFILE    *td_manifest  = NULL;
+/* Stats for the unload summary line. */
+static uint32_t  td_stat_unique    = 0; /* first-sight tiles dumped     */
+static uint32_t  td_stat_sightings = 0; /* extra-palette sighting rows  */
+static uint32_t  td_stat_captures  = 0; /* SRCEN blits hashed           */
+static uint32_t  td_stat_skipped   = 0; /* windows skipped (guards)     */
+
+/* ---- dedupe set ----------------------------------------------------- */
+
+/* Insert h (non-zero) into the set.  Returns 1 when h was NEW, 0 when
+ * it was already present or the set is full. */
+static int td_set_insert(uint64_t h)
+{
+   uint32_t idx;
+
+   if (h == 0)
+      h = TD_HASH_ZERO_REMAP;
+   idx = (uint32_t)h & TD_SET_MASK;
+   for (;;)
+   {
+      if (td_set[idx] == 0)
+      {
+         if (td_entries >= TD_SET_MAXLOAD)
+         {
+            if (!td_overflow_warned)
+            {
+               td_overflow_warned = 1;
+               LOG_INF("[TEXDUMP] dedupe set full (%u entries); no further "
+                       "new tiles will be recorded this session\n",
+                       (unsigned)td_entries);
+            }
+            return 0;
+         }
+         td_set[idx] = h;
+         td_entries++;
+         return 1;
+      }
+      if (td_set[idx] == h)
+         return 0;
+      idx = (idx + 1) & TD_SET_MASK;
+   }
+}
+
+/* ---- side-effect-free emulated-memory reads ------------------------- */
+
+/* Populated, side-effect-free address space for texture sources: the
+ * main-RAM mirror region, cartridge ROM (GameDrive-banked when active)
+ * and the boot ROM window.  BUTCH/TOM/JERRY and unmapped space are
+ * refused -- reads there can carry side effects, so a window touching
+ * them is skipped entirely (same rule as blitter.c's
+ * shadow_hires_read_src16_a1). */
+static int td_addr_ok(uint32_t a)
+{
+   if (a < 0xDFFF00)
+      return 1;
+   if (a >= 0xE00000 && a < 0xE40000)
+      return 1;
+   return 0;
+}
+
+static uint8_t td_read8(uint32_t a)
+{
+   if (a < 0x800000)
+      return jaguarMainRAM[a & 0x1FFFFF];
+   if (a < 0xDFFF00)
+   {
+      if (JGD_BANKING())
+         return JGDReadROM8(a - 0x800000);
+      return jaguarMainROM[a - 0x800000];
+   }
+   return jagMemSpace[a];   /* boot ROM window (td_addr_ok guarded) */
+}
+
+/* ---- source-window walk --------------------------------------------- */
+
+/* Byte offset of pixel (x, y) inside the channel's window, transliterated
+ * from blitter.c's PIXEL_OFFSET_{1,2,4,8,16,32} macros with integer x/y
+ * (the macros take 16.16 fixed point).  `pitch` is the phrase-gap value
+ * ({0,1,3,2}[FLAGS&3], exactly as the engines decode it); the returned
+ * offset is in BYTES for bpp <= 8 and in PIXELS for 16/32bpp (the caller
+ * scales), matching the macros. */
+static uint32_t td_pixel_offset(uint32_t x, uint32_t y, uint32_t width,
+                                uint32_t pitch, uint32_t psizefield)
+{
+   switch (psizefield)
+   {
+      case 0:  /* 1bpp */
+         return ((y * width / 8) + ((x >> 3) & ~7u)) * (1 + pitch)
+              + ((x >> 3) & 7u);
+      case 1:  /* 2bpp */
+         return ((y * width / 4) + ((x >> 2) & ~7u)) * (1 + pitch)
+              + ((x >> 2) & 7u);
+      case 2:  /* 4bpp */
+         return ((y * (width / 2)) + ((x >> 1) & ~7u)) * (1 + pitch)
+              + ((x >> 1) & 7u);
+      case 3:  /* 8bpp */
+         return ((y * width) + (x & ~7u)) * (1 + pitch) + (x & 7u);
+      case 4:  /* 16bpp (pixel units; byte offset = <<1) */
+         return ((y * width) + (x & ~3u)) * (1 + pitch) + (x & 3u);
+      default: /* 5 = 32bpp (pixel units; byte offset = <<2) */
+         return ((y * width) + (x & ~1u)) * (1 + pitch) + (x & 1u);
+   }
+}
+
+/* Capture description of the current launch, filled by td_describe(). */
+typedef struct
+{
+   uint32_t base;        /* phrase-aligned channel base                */
+   uint32_t flags;       /* channel FLAGS register                     */
+   uint32_t psizefield;  /* (flags >> 3) & 7                           */
+   uint32_t bpp;         /* 1 << psizefield                            */
+   uint32_t pitch;       /* phrase-gap ({0,1,3,2}[flags & 3])          */
+   uint32_t width;       /* window width in pixels (6-bit float)       */
+   uint32_t x0, y0;      /* integer pixel origin                       */
+   uint32_t inner;       /* pixels per row (B_COUNT low)               */
+   uint32_t outer;       /* rows (B_COUNT high)                        */
+   uint32_t src_addr;    /* byte address of pixel (x0, y0)             */
+} td_desc;
+
+/* Serialize the described window into td_scratch, row-major, packed
+ * exactly as stored (each covering byte appended once).  Returns the
+ * byte count, or 0 when any byte falls outside populated address space
+ * or the serialization overruns the scratch buffer. */
+static uint32_t td_serialize(const td_desc *d)
+{
+   uint32_t len = 0;
+   uint32_t r, c, k;
+   uint32_t px, py, off, a, prev;
+
+   for (r = 0; r < d->outer; r++)
+   {
+      py   = (d->y0 + r) & 0xFFFF;
+      prev = 0xFFFFFFFFu;
+      for (c = 0; c < d->inner; c++)
+      {
+         px  = (d->x0 + c) & 0xFFFF;
+         off = td_pixel_offset(px, py, d->width, d->pitch, d->psizefield);
+         if (d->psizefield == 4)
+            off <<= 1;
+         else if (d->psizefield == 5)
+            off <<= 2;
+         if (off == prev && d->bpp < 8)
+            continue;               /* same stored byte as previous pixel */
+         prev = off;
+         k = (d->bpp <= 8) ? 1 : (d->bpp >> 3);
+         if (len + k > TD_SCRATCH_BYTES)
+            return 0;
+         for (; k > 0; k--)
+         {
+            a = (d->base + off) & 0xFFFFFF;
+            if (!td_addr_ok(a))
+               return 0;
+            td_scratch[len++] = td_read8(a);
+            off++;
+         }
+      }
+   }
+   return len;
+}
+
+static uint64_t td_hash(const td_desc *d, uint32_t len)
+{
+   uint64_t h = TD_FNV_OFFSET;
+   uint8_t hdr[10];
+   uint32_t i;
+
+   hdr[0] = 'V';
+   hdr[1] = 'J';
+   hdr[2] = 'T';
+   hdr[3] = 'D';
+   hdr[4] = 1;                              /* contract version        */
+   hdr[5] = (uint8_t)d->bpp;
+   hdr[6] = (uint8_t)(d->inner & 0xFF);     /* width  u16 LE           */
+   hdr[7] = (uint8_t)((d->inner >> 8) & 0xFF);
+   hdr[8] = (uint8_t)(d->outer & 0xFF);     /* height u16 LE           */
+   hdr[9] = (uint8_t)((d->outer >> 8) & 0xFF);
+
+   for (i = 0; i < 10; i++)
+   {
+      h ^= hdr[i];
+      h *= TD_FNV_PRIME;
+   }
+   for (i = 0; i < len; i++)
+   {
+      h ^= td_scratch[i];
+      h *= TD_FNV_PRIME;
+   }
+   return h;
+}
+
+/* ---- output plumbing ------------------------------------------------ */
+
+/* Lazily create <base>/vj_texdump/<crc8>/ and open manifest.tsv for
+ * append (header written when the file is new).  Returns 1 when the
+ * manifest is ready. */
+static int td_ensure_output(void)
+{
+   char path[1400];
+   uint32_t crc;
+   const char *title;
+
+   if (td_manifest)
+      return 1;
+   if (td_dir_ready < 0 || td_base[0] == '\0')
+      return 0;
+
+   crc = TitleDBContentCRC();
+   snprintf(td_dir, sizeof(td_dir), "%s/vj_texdump/%08x", td_base,
+            (unsigned)crc);
+   if (!path_mkdir(td_dir))
+   {
+      if (!td_write_warned)
+      {
+         td_write_warned = 1;
+         LOG_INF("[TEXDUMP] cannot create %s -- dumping disabled\n", td_dir);
+      }
+      td_dir_ready = -1;
+      return 0;
+   }
+   td_dir_ready = 1;
+
+   snprintf(path, sizeof(path), "%s/manifest.tsv", td_dir);
+   td_manifest = rfopen(path, "ab");
+   if (!td_manifest)
+      td_manifest = rfopen(path, "wb");
+   if (!td_manifest)
+   {
+      if (!td_write_warned)
+      {
+         td_write_warned = 1;
+         LOG_INF("[TEXDUMP] cannot open %s -- dumping disabled\n", path);
+      }
+      td_dir_ready = -1;
+      return 0;
+   }
+   if (rftell(td_manifest) == 0)
+   {
+      char hdr[256];
+      int n;
+      title = TitleDBTitleName();
+      n = snprintf(hdr, sizeof(hdr), "# texdump v1\tcrc=%08x\ttitle=%s\n",
+                   (unsigned)crc, title ? title : "unknown");
+      if (n > 0)
+         rfwrite(hdr, 1, (size_t)n, td_manifest);
+   }
+   return 1;
+}
+
+static void td_manifest_write(const char *line, int len)
+{
+   if (len > 0 && td_manifest)
+      rfwrite(line, 1, (size_t)len, td_manifest);
+}
+
+/* Encode an RGB8 buffer as PNG and write it via the VFS. */
+static void td_write_png(const char *path, const uint8_t *rgb,
+                         uint32_t w, uint32_t h)
+{
+   size_t png_len = 0;
+   void *png = tdefl_write_image_to_png_file_in_memory_ex(rgb, (int)w,
+         (int)h, 3, &png_len, 6, 0);
+
+   if (!png)
+   {
+      if (!td_png_warned)
+      {
+         td_png_warned = 1;
+         LOG_INF("[TEXDUMP] PNG encode failed (%ux%u) -- manifest rows "
+                 "continue without previews for such tiles\n",
+                 (unsigned)w, (unsigned)h);
+      }
+      return;
+   }
+   {
+      RFILE *f = rfopen(path, "wb");
+      if (f)
+      {
+         rfwrite(png, 1, png_len, f);
+         rfclose(f);
+      }
+      else if (!td_write_warned)
+      {
+         td_write_warned = 1;
+         LOG_INF("[TEXDUMP] cannot write %s\n", path);
+      }
+   }
+   mz_free(png);
+}
+
+/* ---- preview rendering (advisory, never identity) ------------------- */
+
+/* CLUT snapshot -> XRGB table choice: the CLUT feeds the display in the
+ * current video mode, so RGB16 entries are decoded as RGB when VMODE
+ * says RGB16 and as CRY otherwise.  Advisory only. */
+static uint32_t td_clut_rgb32(uint16_t v)
+{
+   unsigned mode = (GET16(tomRam8, 0x28) >> 1) & 0x03;   /* VMODE */
+   if (mode == 3)
+      return RGB16ToRGB32[v];
+   return CRY16ToRGB32[v];
+}
+
+static void td_store_rgb(uint8_t *dst, uint32_t xrgb)
+{
+   dst[0] = (uint8_t)((xrgb >> 16) & 0xFF);
+   dst[1] = (uint8_t)((xrgb >> 8) & 0xFF);
+   dst[2] = (uint8_t)(xrgb & 0xFF);
+}
+
+/* Extract pixel (c, r) of the described window from emulated memory
+ * (same addressing as td_serialize).  Returns the raw pixel value. */
+static uint32_t td_pixel_value(const td_desc *d, uint32_t c, uint32_t r)
+{
+   uint32_t px  = (d->x0 + c) & 0xFFFF;
+   uint32_t py  = (d->y0 + r) & 0xFFFF;
+   uint32_t off = td_pixel_offset(px, py, d->width, d->pitch, d->psizefield);
+   uint32_t a, b0, b1, b2, b3;
+
+   switch (d->psizefield)
+   {
+      case 0:
+         a = (d->base + off) & 0xFFFFFF;
+         return (td_read8(a) >> ((~px) & 7)) & 0x01;
+      case 1:
+         a = (d->base + off) & 0xFFFFFF;
+         return (td_read8(a) >> (((~px) << 1) & 6)) & 0x03;
+      case 2:
+         a = (d->base + off) & 0xFFFFFF;
+         return (td_read8(a) >> (((~px) << 2) & 4)) & 0x0F;
+      case 3:
+         a = (d->base + off) & 0xFFFFFF;
+         return td_read8(a);
+      case 4:
+         a = (d->base + (off << 1)) & 0xFFFFFF;
+         b0 = td_read8(a);
+         b1 = td_read8((a + 1) & 0xFFFFFF);
+         return (b0 << 8) | b1;
+      default:
+         a = (d->base + (off << 2)) & 0xFFFFFF;
+         b0 = td_read8(a);
+         b1 = td_read8((a + 1) & 0xFFFFFF);
+         b2 = td_read8((a + 2) & 0xFFFFFF);
+         b3 = td_read8((a + 3) & 0xFFFFFF);
+         return (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+   }
+}
+
+/* Render the window as RGB8 rows.  mode16 selects the 16bpp
+ * interpretation (TEXDUMP_16BPP_CRY / _RGB); clut16 is the snapshotted
+ * CLUT (256 x u16, host order) for <=8bpp windows. */
+static uint8_t *td_render(const td_desc *d, int mode16,
+                          const uint16_t *clut16)
+{
+   uint8_t *rgb;
+   uint32_t r, c, v, xrgb;
+
+   rgb = (uint8_t *)malloc((size_t)d->inner * d->outer * 3);
+   if (!rgb)
+      return NULL;
+   for (r = 0; r < d->outer; r++)
+   {
+      uint8_t *row = rgb + (size_t)r * d->inner * 3;
+      for (c = 0; c < d->inner; c++)
+      {
+         v = td_pixel_value(d, c, r);
+         if (d->bpp <= 8)
+            xrgb = td_clut_rgb32(clut16[v & 0xFF]);
+         else if (d->bpp == 16)
+            xrgb = (mode16 == TEXDUMP_16BPP_RGB)
+                 ? RGB16ToRGB32[v & 0xFFFF] : CRY16ToRGB32[v & 0xFFFF];
+         else
+            /* 32bpp: stored phrase bytes are G, R, x, B (the Jaguar's
+             * 24-bit line-buffer order; see tom_render_24bpp_scanline
+             * in src/tom/tom.c). */
+            xrgb = (((v >> 16) & 0xFF) << 16)      /* R (byte 1) */
+                 | (((v >> 24) & 0xFF) << 8)       /* G (byte 0) */
+                 | (v & 0xFF);                     /* B (byte 3) */
+         td_store_rgb(row + (size_t)c * 3, xrgb);
+      }
+   }
+   return rgb;
+}
+
+/* ---- first-sight dump ----------------------------------------------- */
+
+static void td_first_sight(const td_desc *d, uint64_t h, uint32_t cmd,
+                           uint32_t clut_crc, const uint16_t *clut16)
+{
+   char path[1500];
+   char line[256];
+   int n;
+   const char *fl;
+   uint8_t *rgb;
+
+   td_stat_unique++;
+   if (!td_ensure_output())
+      return;
+
+   /* Manifest first-sight row.  flags= records the transparency-
+    * related B_CMD bits observed on the first-seen blit (bit
+    * comparator BCOMPEN, data comparator DCOMPEN -- B_CMD has no
+    * "TRANSEN" bit; docs/jtrm-blitter.md).  Transparency is a blit
+    * property, not a tile property, so it is advisory metadata. */
+   if ((cmd & 0x04000000) && (cmd & 0x08000000))
+      fl = "bcompen,dcompen";
+   else if (cmd & 0x04000000)
+      fl = "bcompen";
+   else if (cmd & 0x08000000)
+      fl = "dcompen";
+   else
+      fl = "-";
+
+   if (d->bpp <= 8)
+      n = snprintf(line, sizeof(line),
+            "%08x%08x\t%ux%u\t%u\tframe=%u\tsrc=%06x\tclut=%08x\tflags=%s\n",
+            (unsigned)(h >> 32), (unsigned)(h & 0xFFFFFFFFu),
+            (unsigned)d->inner, (unsigned)d->outer, (unsigned)d->bpp,
+            (unsigned)td_frame, (unsigned)d->src_addr,
+            (unsigned)clut_crc, fl);
+   else
+      n = snprintf(line, sizeof(line),
+            "%08x%08x\t%ux%u\t%u\tframe=%u\tsrc=%06x\tclut=-\tflags=%s\n",
+            (unsigned)(h >> 32), (unsigned)(h & 0xFFFFFFFFu),
+            (unsigned)d->inner, (unsigned)d->outer, (unsigned)d->bpp,
+            (unsigned)td_frame, (unsigned)d->src_addr, fl);
+   td_manifest_write(line, n);
+
+   /* Preview PNG(s). */
+   if (d->bpp == 16 && td_mode16 == TEXDUMP_16BPP_BOTH)
+   {
+      rgb = td_render(d, TEXDUMP_16BPP_CRY, clut16);
+      if (rgb)
+      {
+         snprintf(path, sizeof(path), "%s/%08x%08x-cry.png", td_dir,
+                  (unsigned)(h >> 32), (unsigned)(h & 0xFFFFFFFFu));
+         td_write_png(path, rgb, d->inner, d->outer);
+         free(rgb);
+      }
+      rgb = td_render(d, TEXDUMP_16BPP_RGB, clut16);
+      if (rgb)
+      {
+         snprintf(path, sizeof(path), "%s/%08x%08x-rgb.png", td_dir,
+                  (unsigned)(h >> 32), (unsigned)(h & 0xFFFFFFFFu));
+         td_write_png(path, rgb, d->inner, d->outer);
+         free(rgb);
+      }
+   }
+   else
+   {
+      rgb = td_render(d, td_mode16 == TEXDUMP_16BPP_RGB
+                         ? TEXDUMP_16BPP_RGB : TEXDUMP_16BPP_CRY, clut16);
+      if (rgb)
+      {
+         snprintf(path, sizeof(path), "%s/%08x%08x.png", td_dir,
+                  (unsigned)(h >> 32), (unsigned)(h & 0xFFFFFFFFu));
+         td_write_png(path, rgb, d->inner, d->outer);
+         free(rgb);
+      }
+   }
+}
+
+/* ---- the launch hook ------------------------------------------------ */
+
+void TexDumpLaunch(void)
+{
+   td_desc d;
+   uint32_t cmd, count, m, e, first_off;
+   uint32_t len;
+   uint64_t h, bytes_est;
+   int src_is_a1;
+   int is_new;
+
+   if (!td_set)
+      return;                       /* enable-time allocation failed */
+
+   cmd = TD_REG(TD_COMMAND);
+   if (!(cmd & 0x00000001))         /* SRCEN: no source read, no tile */
+      return;
+
+   /* JTRM B_CMD bit 0: source data comes from A2, or from A1 when
+    * DSTA2 (bit 11) makes A2 the destination. */
+   src_is_a1 = (cmd & 0x00000800) != 0;
+   if (src_is_a1)
+   {
+      d.base  = TD_REG(TD_A1_BASE) & 0xFFFFFFF8;
+      d.flags = TD_REG(TD_A1_FLAGS);
+      d.x0    = TD_REG(TD_A1_PIXEL) & 0xFFFF;
+      d.y0    = (TD_REG(TD_A1_PIXEL) >> 16) & 0xFFFF;
+   }
+   else
+   {
+      d.base  = TD_REG(TD_A2_BASE) & 0xFFFFFFF8;
+      d.flags = TD_REG(TD_A2_FLAGS);
+      d.x0    = TD_REG(TD_A2_PIXEL) & 0xFFFF;
+      d.y0    = (TD_REG(TD_A2_PIXEL) >> 16) & 0xFFFF;
+   }
+
+   d.psizefield = (d.flags >> 3) & 0x07;
+   if (d.psizefield > 5)            /* garbage pixel-size encoding */
+      return;
+   d.bpp = 1u << d.psizefield;
+   {
+      static const uint32_t pitch_lut[4] = { 0, 1, 3, 2 };
+      d.pitch = pitch_lut[d.flags & 0x03];
+   }
+   m = (d.flags >> 9) & 0x03;
+   e = (d.flags >> 11) & 0x0F;
+   d.width = ((0x04 | m) << e) >> 2;
+
+   count   = TD_REG(TD_COUNT);
+   d.inner = count & 0xFFFF;
+   d.outer = (count >> 16) & 0xFFFF;
+   if (d.inner == 0 || d.outer == 0)
+      return;
+
+   /* Garbage-register guard: > 1 MB described windows are skipped. */
+   bytes_est = ((uint64_t)d.inner * d.outer * d.bpp + 7) / 8;
+   if (bytes_est > TD_MAX_WINDOW_BYTES)
+   {
+      td_stat_skipped++;
+      return;
+   }
+
+   first_off = td_pixel_offset(d.x0, d.y0, d.width, d.pitch, d.psizefield);
+   if (d.psizefield == 4)
+      first_off <<= 1;
+   else if (d.psizefield == 5)
+      first_off <<= 2;
+   d.src_addr = (d.base + first_off) & 0xFFFFFF;
+
+   len = td_serialize(&d);
+   if (len == 0)                    /* outside populated space / overrun */
+   {
+      td_stat_skipped++;
+      return;
+   }
+   td_stat_captures++;
+
+   h = td_hash(&d, len);
+   is_new = td_set_insert(h);
+
+   if (d.bpp <= 8)
+   {
+      /* Palette is advisory metadata: snapshot the CLUT, and dedupe
+       * (key, CLUT CRC) pairs through the same set so a key later seen
+       * under a NEW palette appends one sighting row (never a second
+       * PNG -- same key, one file). */
+      uint16_t clut16[256];
+      uint32_t clut_crc;
+      uint64_t hs;
+      unsigned i;
+      int pair_new;
+
+      for (i = 0; i < 256; i++)
+         clut16[i] = (uint16_t)((tomRam8[0x400 + i * 2] << 8)
+                              | tomRam8[0x400 + i * 2 + 1]);
+      clut_crc = (uint32_t)crc32_calcCheckSum(&tomRam8[0x400], 0x200);
+
+      hs = h;
+      for (i = 0; i < 4; i++)
+      {
+         hs ^= (clut_crc >> (i * 8)) & 0xFF;
+         hs *= TD_FNV_PRIME;
+      }
+      pair_new = td_set_insert(hs);
+
+      if (is_new)
+         td_first_sight(&d, h, cmd, clut_crc, clut16);
+      else if (pair_new && td_ensure_output())
+      {
+         char line[128];
+         int n = snprintf(line, sizeof(line), "%08x%08x\tclut=%08x\tframe=%u\n",
+                          (unsigned)(h >> 32), (unsigned)(h & 0xFFFFFFFFu),
+                          (unsigned)clut_crc, (unsigned)td_frame);
+         td_manifest_write(line, n);
+         td_stat_sightings++;
+      }
+   }
+   else if (is_new)
+      td_first_sight(&d, h, cmd, 0, NULL);
+}
+
+/* ---- option layer --------------------------------------------------- */
+
+void TexDumpSetEnabled(int on)
+{
+   if (on && !td_set && !td_alloc_failed)
+   {
+      td_set = (uint64_t *)calloc(TD_SET_SIZE, sizeof(uint64_t));
+      td_scratch = (uint8_t *)malloc(TD_SCRATCH_BYTES);
+      if (!td_set || !td_scratch)
+      {
+         free(td_set);
+         free(td_scratch);
+         td_set = NULL;
+         td_scratch = NULL;
+         td_alloc_failed = 1;
+         LOG_INF("[TEXDUMP] allocation failed -- texture dump unavailable\n");
+      }
+      else
+         LOG_INF("[TEXDUMP] enabled -- dumping to %s/vj_texdump/\n",
+                 td_base[0] ? td_base : "<system dir unset>");
+   }
+   texDumpEnabled = (on && td_set) ? 1 : 0;
+}
+
+void TexDumpSet16bppMode(int mode)
+{
+   td_mode16 = mode;
+}
+
+void TexDumpSetBasePath(const char *system_dir)
+{
+   if (system_dir && system_dir[0])
+   {
+      strncpy(td_base, system_dir, sizeof(td_base) - 1);
+      td_base[sizeof(td_base) - 1] = '\0';
+   }
+   else
+      td_base[0] = '\0';
+}
+
+void TexDumpFrame(void)
+{
+   td_frame++;
+}
+
+void TexDumpShutdown(void)
+{
+   if (td_stat_captures || td_stat_unique)
+      LOG_INF("[TEXDUMP] session summary: %u unique tiles dumped, "
+              "%u palette sightings, %u source blits hashed, %u skipped\n",
+              (unsigned)td_stat_unique, (unsigned)td_stat_sightings,
+              (unsigned)td_stat_captures, (unsigned)td_stat_skipped);
+   if (td_manifest)
+      rfclose(td_manifest);
+   td_manifest = NULL;
+   free(td_set);
+   free(td_scratch);
+   td_set     = NULL;
+   td_scratch = NULL;
+   td_entries = 0;
+   texDumpEnabled = 0;
+   td_mode16 = TEXDUMP_16BPP_CRY;
+   td_overflow_warned = 0;
+   td_alloc_failed = 0;
+   td_png_warned = 0;
+   td_write_warned = 0;
+   td_frame = 0;
+   td_base[0] = '\0';
+   td_dir[0] = '\0';
+   td_dir_ready = 0;
+   td_stat_unique = 0;
+   td_stat_sightings = 0;
+   td_stat_captures = 0;
+   td_stat_skipped = 0;
+}

--- a/src/tom/texdump.h
+++ b/src/tom/texdump.h
@@ -1,0 +1,70 @@
+/*
+ * TEXDUMP.H
+ *
+ * Texture dump mode (issue #369, deliverable 1 of 2).
+ *
+ * Captures every unique blitter SOURCE window at blit launch, keyed by
+ * an FNV-1a 64 hash over the raw source bytes (the identity contract
+ * the v3.5 replacement pipeline will look up), and writes a preview PNG
+ * plus a manifest row the first time each key is seen.  Design spec:
+ * docs/texture-dump.md.
+ *
+ * Everything here is host-transient: ZERO savestate fields, no effect
+ * on the emulated machine (the capture only READS blitter_ram, main
+ * RAM/cart ROM and TOM's CLUT).  When the option is off the launch site
+ * pays exactly one predictable branch on texDumpEnabled.
+ */
+
+#ifndef __TEXDUMP_H__
+#define __TEXDUMP_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* 16bpp preview interpretation (virtualjaguar_texdump_16bpp).  The
+ * blitter cannot know whether 16-bit values are CRY or RGB16 -- that is
+ * display-time interpretation -- so the option only changes the PNG
+ * preview, never the hash. */
+#define TEXDUMP_16BPP_CRY   0
+#define TEXDUMP_16BPP_RGB   1
+#define TEXDUMP_16BPP_BOTH  2
+
+/* Hot-path gate: the launch site tests this before calling the hook so
+ * the disabled mode costs one predictable branch. */
+extern int texDumpEnabled;
+
+/* Option layer (libretro.c).  Runtime-toggleable: enabling allocates
+ * the dedupe set + capture scratch on FIRST enable; disabling keeps
+ * them (the session's "seen" set survives a toggle) until
+ * TexDumpShutdown() frees everything. */
+void TexDumpSetEnabled(int on);
+void TexDumpSet16bppMode(int mode);
+
+/* Base output directory (the frontend's system dir).  Dumps land in
+ * <base>/vj_texdump/<cart CRC32 as 8 hex>/.  Must be set before the
+ * first capture can write anything; with no base path set, capture
+ * still hashes/dedupes but writes nothing. */
+void TexDumpSetBasePath(const char *system_dir);
+
+/* Once per retro_run: advances the frame number recorded in manifest
+ * rows.  Call guarded:  if (texDumpEnabled) TexDumpFrame(); */
+void TexDumpFrame(void);
+
+/* The launch site (blitter_mmio.c, B_CMD dispatch), BEFORE engine
+ * dispatch.  Reads the register-described source window, hashes it,
+ * and on first sight renders + writes PNG and manifest row.
+ * Call guarded:  if (texDumpEnabled) TexDumpLaunch(); */
+void TexDumpLaunch(void);
+
+/* Close the manifest, log a summary, free the set + scratch and reset
+ * every static (iOS never dlcloses).  Safe to call repeatedly. */
+void TexDumpShutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TEXDUMP_H__ */

--- a/test/expected/texdump_yarc.txt
+++ b/test/expected/texdump_yarc.txt
@@ -1,0 +1,31 @@
+# texdump v1 golden hash list -- see docs/texture-dump.md.
+# Regenerate ONLY for a deliberate contract bump:
+#   ./test/tools/test_texdump <core> <rom> --update-golden
+0e4ae2eb24870790
+0f772bb6bc839bd8
+16e8fa46e9f385ac
+21cf0c079984ecac
+2a5e050ac9b17bd0
+2bde3a05ce2964bc
+421d8b30f71200cc
+61988d68f3fa4c16
+6a7d968113200e58
+7c9d3d7e79ca5e0c
+814cea49cca6aac8
+844b45fe86eb8fd6
+9d9387421c646610
+b1f77f2d3bbfef90
+b88041c0ba7e58d0
+bdec3fb0c6ee6a98
+be036a03e848b290
+c2f123c336896a6c
+c8e69a047a2827e8
+cfae851286a0f848
+d45afa75267ac058
+d646a02c367010d0
+d81ecf4097997450
+d921299d59d81428
+db1330dddf747173
+dcc886748f68a513
+f7d9939f2e53e450
+fbe56a8d86973510

--- a/test/test_blitter_mmio.c
+++ b/test/test_blitter_mmio.c
@@ -28,6 +28,8 @@ void BlitterRunComparison(void) {}
 void blitter_blit(uint32_t cmd) { (void)cmd; }
 void BlitterMidsummer2(void) {}
 int BlitMemoLaunch(void) { return 0; }   /* memo off: dispatch as before */
+int texDumpEnabled = 0;                  /* texture dump off */
+void TexDumpLaunch(void) {}
 
 /* Blitter bus-time model dependencies (vjs.blitterTiming stays 0 in the
  * stub settings above, so the timing path short-circuits; these only

--- a/test/tools/test_option_visibility.c
+++ b/test/tools/test_option_visibility.c
@@ -240,6 +240,9 @@ int main(int argc, char **argv)
    expect("(cart)", "virtualjaguar_cd_trace",      false);
    expect("(cart)", "virtualjaguar_bios",          true);
    expect("(cart)", "virtualjaguar_bios_type",     true);
+   /* Texture dump (#369): the 16bpp preview knob is hidden while the
+    * dump option sits at its disabled default. */
+   expect("(cart)", "virtualjaguar_texdump_16bpp", false);
    p_unload();
 
    /* --- CD: CD options shown, cartridge BIOS option hidden --- */

--- a/test/tools/test_texdump.c
+++ b/test/tools/test_texdump.c
@@ -1,0 +1,1025 @@
+/* test_texdump.c -- Test gates for texture dump mode (issue #369,
+ * deliverable 1).  Spec: docs/texture-dump.md, section "Test gates".
+ *
+ * One binary runs the loaded ROM four times and asserts, in order:
+ *
+ *   1. contract_freeze   dump-on manifest hash set equals the committed
+ *                        golden list (test/expected/texdump_<rom>.txt).
+ *                        The CI tripwire that makes "stable from day
+ *                        one" real: any change that moves a hash fails
+ *                        loudly and forces a deliberate contract v2.
+ *   2. determinism       two consecutive dump-on runs produce identical
+ *                        hash sets.
+ *   3. engine_independence  fast vs accurate blitter yield identical
+ *                        hash sets (the property that justifies the
+ *                        register-described capture).
+ *   4. inertness_on      dump ENABLED leaves per-frame framebuffer
+ *                        hashes AND savestate digests (frames N/2, N)
+ *                        identical to dump-off -- the emulated machine
+ *                        cannot observe the feature.  (This subsumes
+ *                        the weaker "dump off equals baseline" gate:
+ *                        the off run IS the baseline here.)
+ *   5. png_validity      every emitted PNG parses: signature, IHDR
+ *                        dimensions matching the manifest row, and
+ *                        every chunk's CRC-32 (via src/core/crc32.c --
+ *                        no external decoder).
+ *
+ * Also asserts every first-sight manifest row has its PNG on disk, and
+ * reports the unique-tile count (the spec wants >= 20 for a meaningful
+ * tripwire; the golden list committed for yarc.j64 documents the real
+ * number).
+ *
+ * Build (see the Makefile rule):
+ *   cc -O2 -Wall -std=c99 -I./libretro-common/include \
+ *      -o test/tools/test_texdump test/tools/test_texdump.c \
+ *      test/harness/harness.c src/core/crc32.c -ldl -lm
+ *
+ * Usage: ./test/tools/test_texdump <core> [rom] [--frames N]
+ *          [--golden FILE] [--update-golden] [--json] [--quiet]
+ *
+ * --update-golden rewrites the golden list from this run (for the
+ * initial commit and for DELIBERATE contract bumps only -- say so in
+ * the commit message).
+ *
+ * Exit: 0 PASS, 1 FAIL, 2 SKIP (ROM missing).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+
+#include "../harness/harness.h"
+
+/* src/core/crc32.c (compiled into this binary): zlib/PNG CRC-32. */
+int crc32_calcCheckSum(unsigned char *data, unsigned int length);
+
+#define MAX_FRAMES  1200
+#define MAX_HASHES  8192
+#define HASH_CHARS  16
+
+typedef struct {
+    char     hashes[MAX_HASHES][HASH_CHARS + 1];
+    unsigned count;
+    /* width/height per first-sight row, parallel to hashes[] */
+    unsigned w[MAX_HASHES], h[MAX_HASHES];
+} hashset;
+
+typedef struct {
+    uint64_t fb[MAX_FRAMES];
+    unsigned fb_count;
+    uint64_t digest_mid, digest_end;
+    hashset  set;
+    char     dumpdir[1024];   /* <sysdir>/vj_texdump/<crc8> */
+} run_result;
+
+/* ---------- small utils ---------- */
+
+#define FNV_OFFSET 1469598103934665603ULL
+#define FNV_PRIME  1099511628211ULL
+
+static uint64_t fnv1a(uint64_t hh, const void *data, size_t len)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    size_t i;
+    for (i = 0; i < len; i++) {
+        hh ^= p[i];
+        hh *= FNV_PRIME;
+    }
+    return hh;
+}
+
+static int cmp_hash(const void *a, const void *b)
+{
+    return strcmp((const char *)a, (const char *)b);
+}
+
+static void sort_set(hashset *s)
+{
+    /* w/h stay attached to the manifest parse order; only the hash list
+     * itself needs to be order-free for comparison, so sort a copy...
+     * simpler: sort in place and drop w/h association by re-reading the
+     * manifest for the PNG check (see check_pngs).  Here w/h were
+     * already consumed, so in-place is fine. */
+    qsort(s->hashes, s->count, HASH_CHARS + 1, cmp_hash);
+}
+
+static int sets_equal(const hashset *a, const hashset *b)
+{
+    unsigned i;
+    if (a->count != b->count)
+        return 0;
+    for (i = 0; i < a->count; i++)
+        if (strcmp(a->hashes[i], b->hashes[i]) != 0)
+            return 0;
+    return 1;
+}
+
+static uint64_t hash_file(const char *path)
+{
+    FILE *f = fopen(path, "rb");
+    uint8_t buf[65536];
+    size_t n;
+    uint64_t hh = FNV_OFFSET;
+    if (!f)
+        return 0;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
+        hh = fnv1a(hh, buf, n);
+    fclose(f);
+    return hh;
+}
+
+/* ---------- per-frame capture ---------- */
+
+static run_result *g_cur;
+
+static void video_cb(void *ud, const void *data,
+                     unsigned width, unsigned height, size_t pitch)
+{
+    unsigned y;
+    const uint8_t *row = (const uint8_t *)data;
+    uint64_t hh = FNV_OFFSET;
+    (void)ud;
+    if (!g_cur || g_cur->fb_count >= MAX_FRAMES)
+        return;
+    if (!data) {
+        /* Duped frame: carry the previous hash forward (it presents the
+         * previous image), matching the harness's own convention. */
+        g_cur->fb[g_cur->fb_count] =
+            g_cur->fb_count ? g_cur->fb[g_cur->fb_count - 1] : 0;
+        return;
+    }
+    hh = fnv1a(hh, &width, sizeof(width));
+    hh = fnv1a(hh, &height, sizeof(height));
+    for (y = 0; y < height; y++)
+        hh = fnv1a(hh, row + (size_t)y * pitch, (size_t)width * 4);
+    g_cur->fb[g_cur->fb_count] = hh;
+}
+
+/* ---------- manifest / dump dir ---------- */
+
+static int find_dumpdir(const char *sysdir, char *out, size_t out_size)
+{
+    char base[1024];
+    DIR *d;
+    struct dirent *e;
+    int found = 0;
+
+    snprintf(base, sizeof(base), "%s/vj_texdump", sysdir);
+    d = opendir(base);
+    if (!d)
+        return 0;
+    while ((e = readdir(d)) != NULL) {
+        if (e->d_name[0] == '.')
+            continue;
+        snprintf(out, out_size, "%s/%s", base, e->d_name);
+        found = 1;
+        break;
+    }
+    closedir(d);
+    return found;
+}
+
+/* Parse manifest.tsv: collect first-sight rows (those whose second
+ * tab-separated field is WxH).  Returns 0 on open failure. */
+static int read_manifest(const char *dumpdir, hashset *s)
+{
+    char path[1200];
+    char line[512];
+    FILE *f;
+
+    s->count = 0;
+    snprintf(path, sizeof(path), "%s/manifest.tsv", dumpdir);
+    f = fopen(path, "r");
+    if (!f)
+        return 0;
+    while (fgets(line, sizeof(line), f)) {
+        char *tab1, *tab2;
+        unsigned w, h;
+        if (line[0] == '#')
+            continue;
+        tab1 = strchr(line, '\t');
+        if (!tab1 || (size_t)(tab1 - line) != HASH_CHARS)
+            continue;
+        tab2 = strchr(tab1 + 1, '\t');
+        if (!tab2)
+            continue;
+        if (sscanf(tab1 + 1, "%ux%u", &w, &h) != 2)
+            continue;   /* palette-sighting row, not first sight */
+        if (s->count >= MAX_HASHES)
+            break;
+        memcpy(s->hashes[s->count], line, HASH_CHARS);
+        s->hashes[s->count][HASH_CHARS] = '\0';
+        s->w[s->count] = w;
+        s->h[s->count] = h;
+        s->count++;
+    }
+    fclose(f);
+    return 1;
+}
+
+/* ---------- PNG validation ---------- */
+
+static uint32_t be32(const uint8_t *p)
+{
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16)
+         | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+
+/* Full structural parse: signature, IHDR first with expected dims,
+ * every chunk CRC verified, ends with IEND.  Returns NULL on success or
+ * a static error string. */
+static const char *check_png(const char *path, unsigned exp_w, unsigned exp_h)
+{
+    static const uint8_t sig[8] = { 137, 80, 78, 71, 13, 10, 26, 10 };
+    static char err[256];
+    FILE *f = fopen(path, "rb");
+    uint8_t *buf;
+    long len;
+    size_t pos;
+    int first = 1, saw_iend = 0;
+
+    if (!f) {
+        snprintf(err, sizeof(err), "missing file %s", path);
+        return err;
+    }
+    fseek(f, 0, SEEK_END);
+    len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (len < 8 + 25) {
+        fclose(f);
+        snprintf(err, sizeof(err), "%s: too short (%ld bytes)", path, len);
+        return err;
+    }
+    buf = (uint8_t *)malloc((size_t)len);
+    if (!buf || fread(buf, 1, (size_t)len, f) != (size_t)len) {
+        free(buf);
+        fclose(f);
+        snprintf(err, sizeof(err), "%s: read failed", path);
+        return err;
+    }
+    fclose(f);
+
+    if (memcmp(buf, sig, 8) != 0) {
+        free(buf);
+        snprintf(err, sizeof(err), "%s: bad PNG signature", path);
+        return err;
+    }
+    pos = 8;
+    while (pos + 12 <= (size_t)len) {
+        uint32_t clen = be32(buf + pos);
+        uint32_t crc_stored, crc_calc;
+        if (pos + 12 + clen > (size_t)len) {
+            free(buf);
+            snprintf(err, sizeof(err), "%s: chunk overruns file", path);
+            return err;
+        }
+        crc_stored = be32(buf + pos + 8 + clen);
+        crc_calc = (uint32_t)crc32_calcCheckSum(buf + pos + 4, clen + 4);
+        if (crc_stored != crc_calc) {
+            free(buf);
+            snprintf(err, sizeof(err), "%s: chunk CRC mismatch "
+                     "(%08x != %08x)", path, crc_stored, crc_calc);
+            return err;
+        }
+        if (first) {
+            uint32_t w, h;
+            if (memcmp(buf + pos + 4, "IHDR", 4) != 0) {
+                free(buf);
+                snprintf(err, sizeof(err), "%s: first chunk not IHDR", path);
+                return err;
+            }
+            w = be32(buf + pos + 8);
+            h = be32(buf + pos + 12);
+            if (w != exp_w || h != exp_h) {
+                free(buf);
+                snprintf(err, sizeof(err), "%s: IHDR %ux%u != manifest %ux%u",
+                         path, w, h, exp_w, exp_h);
+                return err;
+            }
+            first = 0;
+        }
+        if (memcmp(buf + pos + 4, "IEND", 4) == 0)
+            saw_iend = 1;
+        pos += 12 + clen;
+    }
+    free(buf);
+    if (!saw_iend) {
+        snprintf(err, sizeof(err), "%s: no IEND chunk", path);
+        return err;
+    }
+    return NULL;
+}
+
+/* Every first-sight row must have its PNG, and every PNG must parse. */
+static const char *check_pngs(const run_result *r)
+{
+    static char err[300];
+    unsigned i;
+    for (i = 0; i < r->set.count; i++) {
+        char path[1300];
+        const char *e;
+        snprintf(path, sizeof(path), "%s/%s.png", r->dumpdir,
+                 r->set.hashes[i]);
+        if (access(path, R_OK) != 0) {
+            /* 16bpp 'both' mode would use -cry/-rgb suffixes, but this
+             * test runs the default cry mode, so plain <hash>.png is
+             * the contract. */
+            snprintf(err, sizeof(err), "no PNG for manifest row %s",
+                     r->set.hashes[i]);
+            return err;
+        }
+        e = check_png(path, r->set.w[i], r->set.h[i]);
+        if (e)
+            return e;
+    }
+    return NULL;
+}
+
+/* ---------- synthetic blit battery ----------
+ *
+ * Neither in-tree public ROM blits more than its two boot-time code
+ * copies through the blitter with SRCEN (yarc and jagniccc render via
+ * the OP / pattern fills), so a ROM run alone is a 2-hash tripwire.
+ * This battery drives real B_CMD launches through the core's own bus
+ * (JaguarWriteLong -> TOM -> BlitterWriteWord -> TexDumpLaunch) over
+ * tile bytes this test wrote into emulated RAM: every bpp, both source
+ * channels (A2 and DSTA2's A1), and a palette-change re-blit that must
+ * NOT mint a new hash (bytes-only identity) but must append a clut
+ * sighting row.  Needs the TEST_EXPORTS wide ABI for JaguarWriteLong /
+ * jaguarMainRAM. */
+
+typedef void (*jw32_fn)(uint32_t, uint32_t, uint32_t);
+typedef void (*jw16_fn)(uint32_t, uint16_t, uint32_t);
+
+typedef struct {
+    jw16_fn  ww;
+    jw32_fn  wl;
+    uint8_t *ram;
+} synth_ctx;
+
+#define SYNTH_SRC  0x180000u   /* tile bytes (well above yarc's use)  */
+#define SYNTH_DST  0x1A0000u   /* blit destination scratch            */
+
+/* A1/A2 FLAGS for a pixel-mode window: width 2^e pixels, pitch 0. */
+static uint32_t synth_flags(unsigned log2_width, unsigned psize)
+{
+    return 0x10000u                       /* XADDCTL = add pixel size */
+         | ((uint32_t)log2_width << 11)   /* width float: m=0, e      */
+         | ((uint32_t)psize << 3);
+}
+
+/* Launch one W x H copy blit with source at src_addr.  psize is the
+ * FLAGS pixel-size field (0..5); log2w must satisfy W <= 2^log2w.
+ * dsta2 flips the channels (A1 becomes the source). */
+static void synth_blit(const synth_ctx *sc, uint32_t src_addr,
+                       unsigned w, unsigned h, unsigned log2w,
+                       unsigned psize, int dsta2)
+{
+    uint32_t sflags = synth_flags(log2w, psize);
+    uint32_t dflags = synth_flags(log2w, psize);
+    uint32_t step   = ((uint32_t)1 << 16) | ((uint32_t)(-(int)w) & 0xFFFF);
+    uint32_t cmd    = 0x00600000u   /* LFU = source (REPLACE)  */
+                    | 0x00000001u   /* SRCEN                   */
+                    | 0x00000200u   /* UPDA1                   */
+                    | 0x00000400u;  /* UPDA2                   */
+    uint32_t sbase = src_addr, dbase = SYNTH_DST;
+    uint32_t a1base, a2base, a1flags, a2flags;
+
+    if (dsta2) {
+        cmd |= 0x00000800u;         /* DSTA2: A1 reads, A2 writes */
+        a1base = sbase; a1flags = sflags;
+        a2base = dbase; a2flags = dflags;
+    } else {
+        a1base = dbase; a1flags = dflags;
+        a2base = sbase; a2flags = sflags;
+    }
+
+    sc->wl(0xF02200u, a1base, 0);   /* A1_BASE  */
+    sc->wl(0xF02204u, a1flags, 0);  /* A1_FLAGS */
+    sc->wl(0xF0220Cu, 0, 0);        /* A1_PIXEL */
+    sc->wl(0xF02210u, step, 0);     /* A1_STEP  */
+    sc->wl(0xF02218u, 0, 0);        /* A1_FPIXEL*/
+    sc->wl(0xF02224u, a2base, 0);   /* A2_BASE  */
+    sc->wl(0xF02228u, a2flags, 0);  /* A2_FLAGS */
+    sc->wl(0xF02230u, 0, 0);        /* A2_PIXEL */
+    sc->wl(0xF02234u, step, 0);     /* A2_STEP  */
+    sc->wl(0xF0223Cu, ((uint32_t)h << 16) | w, 0);  /* B_COUNT */
+    sc->wl(0xF02238u, cmd, 0);      /* B_CMD -> launch */
+}
+
+static void synth_set_clut(const synth_ctx *sc, unsigned seed)
+{
+    unsigned i;
+    for (i = 0; i < 256; i++)
+        sc->ww(0xF00400u + i * 2, (uint16_t)(i * 257u ^ seed), 0);
+}
+
+/* Fill a source tile with deterministic bytes.  Returns bytes used. */
+static uint32_t synth_fill(const synth_ctx *sc, uint32_t addr,
+                           uint32_t nbytes, unsigned seed)
+{
+    uint32_t i;
+    for (i = 0; i < nbytes; i++)
+        sc->ram[(addr + i) & 0x1FFFFF] =
+            (uint8_t)((i * 31u + seed * 97u + (i >> 5)) & 0xFF);
+    return nbytes;
+}
+
+/* Expected battery population (keep in sync with the loops below):
+ * 8 x 8bpp + 4 x 4bpp + 4 x 16bpp + 4 x 32bpp + 2 x 1bpp + 2 x 2bpp
+ * + 2 x DSTA2 8bpp = 26 unique tiles; 1 palette sighting (re-blit of
+ * an already-seen tile under a different CLUT). */
+#define SYNTH_EXPECTED_UNIQUE 26
+
+static int synth_battery(harness_config *cfg)
+{
+    synth_ctx sc;
+    void *sym;
+    unsigned k;
+    uint32_t src = SYNTH_SRC;
+
+    sc.wl = (jw32_fn)harness_dlsym(cfg, "JaguarWriteLong");
+    sc.ww = (jw16_fn)harness_dlsym(cfg, "JaguarWriteWord");
+    sym   = harness_dlsym(cfg, "jaguarMainRAM");
+    if (!sc.wl || !sc.ww || !sym)
+        return 0;                    /* slim ABI: battery unavailable */
+    sc.ram = *(uint8_t **)sym;
+    if (!sc.ram)
+        return 0;
+
+    synth_set_clut(&sc, 0x0000);
+
+    /* 8 x 8bpp 16x16 */
+    for (k = 0; k < 8; k++) {
+        synth_fill(&sc, src, 16 * 16, 0x10 + k);
+        synth_blit(&sc, src, 16, 16, 4, 3, 0);
+        src += 0x200;
+    }
+    /* 4 x 4bpp 16x8 */
+    for (k = 0; k < 4; k++) {
+        synth_fill(&sc, src, 16 * 8 / 2, 0x20 + k);
+        synth_blit(&sc, src, 16, 8, 4, 2, 0);
+        src += 0x100;
+    }
+    /* 4 x 16bpp 8x8 */
+    for (k = 0; k < 4; k++) {
+        synth_fill(&sc, src, 8 * 8 * 2, 0x30 + k);
+        synth_blit(&sc, src, 8, 8, 3, 4, 0);
+        src += 0x100;
+    }
+    /* 4 x 32bpp 4x4 */
+    for (k = 0; k < 4; k++) {
+        synth_fill(&sc, src, 4 * 4 * 4, 0x40 + k);
+        synth_blit(&sc, src, 4, 4, 2, 5, 0);
+        src += 0x100;
+    }
+    /* 2 x 1bpp 32x8 */
+    for (k = 0; k < 2; k++) {
+        synth_fill(&sc, src, 32 * 8 / 8, 0x50 + k);
+        synth_blit(&sc, src, 32, 8, 5, 0, 0);
+        src += 0x100;
+    }
+    /* 2 x 2bpp 16x8 */
+    for (k = 0; k < 2; k++) {
+        synth_fill(&sc, src, 16 * 8 / 4, 0x60 + k);
+        synth_blit(&sc, src, 16, 8, 4, 1, 0);
+        src += 0x100;
+    }
+    /* 2 x DSTA2 (A1 as source) 8bpp 16x16 */
+    for (k = 0; k < 2; k++) {
+        synth_fill(&sc, src, 16 * 16, 0x70 + k);
+        synth_blit(&sc, src, 16, 16, 4, 3, 1);
+        src += 0x200;
+    }
+
+    /* Palette-change re-blit: same bytes as tile #1, new CLUT.  Must
+     * NOT create a new hash (palette is never identity) -- it appends a
+     * clut= sighting row instead. */
+    synth_set_clut(&sc, 0x5A5A);
+    synth_fill(&sc, SYNTH_SRC, 16 * 16, 0x10);
+    synth_blit(&sc, SYNTH_SRC, 16, 16, 4, 3, 0);
+
+    return 1;
+}
+
+/* Count palette-sighting rows (hash TAB clut= ...) in the manifest. */
+static unsigned count_sightings(const char *dumpdir)
+{
+    char path[1200];
+    char line[512];
+    FILE *f;
+    unsigned n = 0;
+
+    snprintf(path, sizeof(path), "%s/manifest.tsv", dumpdir);
+    f = fopen(path, "r");
+    if (!f)
+        return 0;
+    while (fgets(line, sizeof(line), f)) {
+        char *tab1 = strchr(line, '\t');
+        if (line[0] == '#' || !tab1)
+            continue;
+        if (!strncmp(tab1 + 1, "clut=", 5))
+            n++;
+    }
+    fclose(f);
+    return n;
+}
+
+/* ---------- one emulation run ---------- */
+
+static int do_run(const char *core, const char *rom, unsigned frames,
+                  int dump_on, int fast_blitter, int synth,
+                  const char *sysdir, run_result *out, int quiet)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    unsigned i;
+    char state_path[256];
+
+    memset(out, 0, sizeof(*out));
+    cfg.core_path  = core;
+    cfg.rom_path   = rom;
+    cfg.frames     = frames;
+    cfg.quiet      = 1;
+    cfg.system_dir = sysdir;
+    cfg.options[cfg.num_options].key   = "virtualjaguar_texture_dump";
+    cfg.options[cfg.num_options].value = dump_on ? "enabled" : "disabled";
+    cfg.num_options++;
+    cfg.options[cfg.num_options].key   = "virtualjaguar_usefastblitter";
+    cfg.options[cfg.num_options].value = fast_blitter ? "enabled" : "disabled";
+    cfg.num_options++;
+    cfg.options[cfg.num_options].key   = "virtualjaguar_texdump_16bpp";
+    cfg.options[cfg.num_options].value = "cry";
+    cfg.num_options++;
+    cfg.video_callback = video_cb;
+
+    if (!harness_load_core(&cfg))
+        return 0;
+    if (!harness_load_rom(&cfg)) {
+        harness_shutdown(&cfg);
+        return 0;
+    }
+
+    snprintf(state_path, sizeof(state_path), "%s/texdump_probe.state", sysdir);
+    g_cur = out;
+    for (i = 0; i < frames; i++) {
+        harness_step(&cfg);
+        out->fb_count++;
+        if (i + 1 == frames / 2) {
+            if (harness_save_state(&cfg, state_path))
+                out->digest_mid = hash_file(state_path);
+        }
+        if (i + 1 == frames) {
+            if (harness_save_state(&cfg, state_path))
+                out->digest_end = hash_file(state_path);
+        }
+    }
+    g_cur = NULL;
+    if (getenv("TEXDUMP_DEBUG"))
+        fprintf(stderr, "DBG run dump=%d fast=%d mid=%016llx end=%016llx\n",
+                dump_on, fast_blitter,
+                (unsigned long long)out->digest_mid,
+                (unsigned long long)out->digest_end);
+    if (synth && !synth_battery(&cfg)) {
+        fprintf(stderr, "texdump: synthetic battery needs the TEST_EXPORTS "
+                "wide ABI (JaguarWriteLong/jaguarMainRAM not exported)\n");
+        harness_shutdown(&cfg);
+        return 0;
+    }
+    /* Unload BEFORE reading the manifest: retro_unload_game closes it
+     * (and logs the session summary). */
+    harness_shutdown(&cfg);
+    unlink(state_path);
+
+    if (dump_on) {
+        if (!find_dumpdir(sysdir, out->dumpdir, sizeof(out->dumpdir))) {
+            if (!quiet)
+                fprintf(stderr, "texdump: no dump directory under %s\n", sysdir);
+            return 0;
+        }
+        if (!read_manifest(out->dumpdir, &out->set)) {
+            if (!quiet)
+                fprintf(stderr, "texdump: no manifest in %s\n", out->dumpdir);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* ---------- golden list ---------- */
+
+static int read_golden(const char *path, hashset *s)
+{
+    FILE *f = fopen(path, "r");
+    char line[64];
+    s->count = 0;
+    if (!f)
+        return 0;
+    while (fgets(line, sizeof(line), f)) {
+        size_t n = strspn(line, "0123456789abcdef");
+        if (n != HASH_CHARS)
+            continue;
+        if (s->count >= MAX_HASHES)
+            break;
+        memcpy(s->hashes[s->count], line, HASH_CHARS);
+        s->hashes[s->count][HASH_CHARS] = '\0';
+        s->count++;
+    }
+    fclose(f);
+    return 1;
+}
+
+static int write_golden(const char *path, const hashset *s)
+{
+    FILE *f = fopen(path, "w");
+    unsigned i;
+    if (!f)
+        return 0;
+    fprintf(f, "# texdump v1 golden hash list -- see docs/texture-dump.md.\n");
+    fprintf(f, "# Regenerate ONLY for a deliberate contract bump:\n");
+    fprintf(f, "#   ./test/tools/test_texdump <core> <rom> --update-golden\n");
+    for (i = 0; i < s->count; i++)
+        fprintf(f, "%s\n", s->hashes[i]);
+    fclose(f);
+    return 1;
+}
+
+/* ---------- scratch dirs ---------- */
+
+static void rm_rf_dump(const char *sysdir)
+{
+    /* Remove <sysdir>/vj_texdump/<crc>/ contents + dirs + sysdir.  Only
+     * files this test created; no recursion beyond the known layout. */
+    char base[1100], sub[1200], fp[2400];
+    DIR *d, *d2;
+    struct dirent *e, *e2;
+
+    snprintf(base, sizeof(base), "%s/vj_texdump", sysdir);
+    d = opendir(base);
+    if (d) {
+        while ((e = readdir(d)) != NULL) {
+            if (e->d_name[0] == '.')
+                continue;
+            snprintf(sub, sizeof(sub), "%s/%s", base, e->d_name);
+            d2 = opendir(sub);
+            if (d2) {
+                while ((e2 = readdir(d2)) != NULL) {
+                    if (e2->d_name[0] == '.')
+                        continue;
+                    snprintf(fp, sizeof(fp), "%s/%s", sub, e2->d_name);
+                    unlink(fp);
+                }
+                closedir(d2);
+            }
+            rmdir(sub);
+        }
+        closedir(d);
+    }
+    rmdir(base);
+    rmdir(sysdir);
+}
+
+/* ---------- main ---------- */
+
+int main(int argc, char **argv)
+{
+    harness_config argcfg = HARNESS_CONFIG_DEFAULT;
+    const char *golden_path = "test/expected/texdump_yarc.txt";
+    int update_golden = 0;
+    int json = 0, quiet = 0;
+    unsigned frames;
+    int i;
+    run_result *ra, *rb, *rc, *rd, *re;
+    hashset golden;
+    char dir_a[64], dir_b[64], dir_c[64], dir_d[64], dir_e[64];
+    harness_result results[12];
+    unsigned nres = 0;
+    int failed = 0;
+    static char d_freeze[256], d_det[128], d_eng[128], d_inert[192],
+                d_png[320], d_count[160], d_synth[320], d_spng[320],
+                d_sight[160];
+
+    /* Pre-parse this tool's own flags and REMOVE them from the argv the
+     * harness sees: its parser skips unknown flags but would read
+     * --golden's value as a positional ROM path. */
+    {
+        char **fargv = (char **)malloc(sizeof(char *) * (size_t)argc);
+        int fargc = 0;
+        if (!fargv)
+            return 1;
+        fargv[fargc++] = argv[0];
+        for (i = 1; i < argc; i++) {
+            if (!strcmp(argv[i], "--golden") && i + 1 < argc)
+                golden_path = argv[++i];
+            else if (!strcmp(argv[i], "--update-golden"))
+                update_golden = 1;
+            else {
+                if (!strcmp(argv[i], "--json"))
+                    json = 1;
+                else if (!strcmp(argv[i], "--quiet"))
+                    quiet = 1;
+                fargv[fargc++] = argv[i];
+            }
+        }
+        argc = fargc;
+        argv = fargv;
+    }
+
+    argcfg.frames = 600;
+    if (!harness_init_from_args(&argcfg, argc, argv)) {
+        fprintf(stderr, "usage: %s <core> [rom] [--frames N] [--golden F] "
+                "[--update-golden] [--json] [--quiet]\n", argv[0]);
+        return 1;
+    }
+    if (!argcfg.rom_path)
+        argcfg.rom_path = "test/roms/yarc.j64";
+    if (access(argcfg.rom_path, R_OK) != 0) {
+        printf("SKIP: ROM not available (%s)\n", argcfg.rom_path);
+        return 2;
+    }
+    frames = argcfg.frames;
+    if (frames > MAX_FRAMES)
+        frames = MAX_FRAMES;
+
+    ra = (run_result *)calloc(1, sizeof(run_result));
+    rb = (run_result *)calloc(1, sizeof(run_result));
+    rc = (run_result *)calloc(1, sizeof(run_result));
+    rd = (run_result *)calloc(1, sizeof(run_result));
+    re = (run_result *)calloc(1, sizeof(run_result));
+    if (!ra || !rb || !rc || !rd || !re) {
+        fprintf(stderr, "FAIL: out of memory\n");
+        return 1;
+    }
+
+    snprintf(dir_a, sizeof(dir_a), "/tmp/vj_texdump_test_a_%d", (int)getpid());
+    snprintf(dir_b, sizeof(dir_b), "/tmp/vj_texdump_test_b_%d", (int)getpid());
+    snprintf(dir_c, sizeof(dir_c), "/tmp/vj_texdump_test_c_%d", (int)getpid());
+    snprintf(dir_d, sizeof(dir_d), "/tmp/vj_texdump_test_d_%d", (int)getpid());
+    snprintf(dir_e, sizeof(dir_e), "/tmp/vj_texdump_test_e_%d", (int)getpid());
+    mkdir(dir_a, 0777);
+    mkdir(dir_b, 0777);
+    mkdir(dir_c, 0777);
+    mkdir(dir_d, 0777);
+    mkdir(dir_e, 0777);
+
+    /* Run order note: the fast-blitter run goes LAST.  These runs share
+     * one process, and harness_init_from_args() itself holds a dlopen
+     * reference, so core statics stay resident across runs (the iOS
+     * no-dlclose regime).  A fast->accurate engine flip leaves a
+     * residue that moves the NEXT run's savestate digest -- reproduced
+     * with texture dump never enabled at all, so it is a pre-existing
+     * cross-load leak, not a texdump effect.  With the off-baseline (D)
+     * before the fast run (C), every comparison below is between runs
+     * whose predecessors used the same engine. */
+
+    /* Run A: dump on, accurate blitter (the reference run). */
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 0, 0, dir_a, ra, quiet))
+        goto run_fail;
+    /* Run B: identical -> determinism. */
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 0, 0, dir_b, rb, quiet))
+        goto run_fail;
+    /* Run D: dump off, accurate -> the inertness baseline. */
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 0, 0, 0, dir_d, rd, quiet))
+        goto run_fail;
+    /* Run E: synthetic blit battery (a few boot frames, then driven
+     * B_CMD launches over test-authored tile bytes -- every bpp, both
+     * source channels, palette-change re-blit). */
+    if (!do_run(argcfg.core_path, argcfg.rom_path, 10, 1, 0, 1, dir_e, re, quiet))
+        goto run_fail;
+    /* Run C: fast blitter -> engine independence of the hash set. */
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 1, 0, dir_c, rc, quiet))
+        goto run_fail;
+
+    /* PNG check needs w/h in manifest order; run before sorting. */
+    {
+        const char *e = check_pngs(ra);
+        snprintf(d_png, sizeof(d_png), "%s",
+                 e ? e : "all PNGs parse (signature, IHDR dims, chunk CRCs)");
+        results[nres].status = e ? "FAIL" : "PASS";
+        results[nres].name   = "png_validity";
+        results[nres].detail = d_png;
+        if (e) failed = 1;
+        nres++;
+    }
+
+    sort_set(&ra->set);
+    sort_set(&rb->set);
+    sort_set(&rc->set);
+
+    /* Gate: determinism (two identical runs, identical sets). */
+    {
+        int ok = sets_equal(&ra->set, &rb->set);
+        snprintf(d_det, sizeof(d_det), "run A %u vs run B %u hashes",
+                 ra->set.count, rb->set.count);
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "determinism";
+        results[nres].detail = d_det;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    /* Gate: engine independence. */
+    {
+        int ok = sets_equal(&ra->set, &rc->set);
+        snprintf(d_eng, sizeof(d_eng), "accurate %u vs fast %u hashes",
+                 ra->set.count, rc->set.count);
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "engine_independence";
+        results[nres].detail = d_eng;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    /* Gate: dump-on inertness (fb hashes + savestate digests vs off). */
+    {
+        int first_diff = -1;
+        unsigned f;
+        int ok;
+        for (f = 0; f < frames; f++) {
+            if (ra->fb[f] != rd->fb[f]) {
+                first_diff = (int)f;
+                break;
+            }
+        }
+        ok = (first_diff < 0)
+          && ra->digest_mid && ra->digest_end
+          && ra->digest_mid == rd->digest_mid
+          && ra->digest_end == rd->digest_end;
+        if (first_diff >= 0)
+            snprintf(d_inert, sizeof(d_inert),
+                     "framebuffer diverges at frame %d", first_diff + 1);
+        else if (!ra->digest_mid || !ra->digest_end)
+            snprintf(d_inert, sizeof(d_inert), "savestate capture failed");
+        else if (ok)
+            snprintf(d_inert, sizeof(d_inert),
+                     "%u frames + savestate digests @%u/%u identical on/off",
+                     frames, frames / 2, frames);
+        else
+            snprintf(d_inert, sizeof(d_inert),
+                     "savestate digest differs (@%u: %d, @%u: %d)",
+                     frames / 2, ra->digest_mid != rd->digest_mid,
+                     frames, ra->digest_end != rd->digest_end);
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "inertness_on";
+        results[nres].detail = d_inert;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    /* Synthetic battery gates: PNG validity across every bpp, unique
+     * count exactly as scripted (ROM boot tiles + battery), and exactly
+     * one palette-sighting row -- the bytes-only identity claim made
+     * falsifiable: a CLUT change must NOT mint a new hash. */
+    {
+        const char *e = check_pngs(re);
+        snprintf(d_spng, sizeof(d_spng), "%s",
+                 e ? e : "battery PNGs parse across 1/2/4/8/16/32bpp");
+        results[nres].status = e ? "FAIL" : "PASS";
+        results[nres].name   = "synth_png_validity";
+        results[nres].detail = d_spng;
+        if (e) failed = 1;
+        nres++;
+    }
+    {
+        unsigned expect = ra->set.count + SYNTH_EXPECTED_UNIQUE;
+        int ok = (re->set.count == expect);
+        snprintf(d_synth, sizeof(d_synth),
+                 "battery dumped %u unique tiles (expected %u: %u ROM boot "
+                 "+ %u scripted)", re->set.count, expect, ra->set.count,
+                 (unsigned)SYNTH_EXPECTED_UNIQUE);
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "synth_population";
+        results[nres].detail = d_synth;
+        if (!ok) failed = 1;
+        nres++;
+    }
+    {
+        unsigned s = count_sightings(re->dumpdir);
+        int ok = (s == 1);
+        snprintf(d_sight, sizeof(d_sight),
+                 "%u palette sighting row(s) (expected 1: CLUT change never "
+                 "mints a new hash)", s);
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "palette_not_identity";
+        results[nres].detail = d_sight;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    /* Tile population sanity: the golden list is only a meaningful
+     * tripwire with a real population behind it.  No in-tree public ROM
+     * blits more than its two boot copies, so the battery run supplies
+     * the population (docs/texture-dump.md open item 3). */
+    {
+        int ok = re->set.count >= 20;
+        snprintf(d_count, sizeof(d_count), "%u unique tiles in the battery "
+                 "manifest (tripwire needs >= 20)", re->set.count);
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "tile_population";
+        results[nres].detail = d_count;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    sort_set(&re->set);
+
+    /* Gate: contract freeze vs the committed golden list.  The frozen
+     * set is the UNION of the ROM run (run A) and the battery run (run
+     * E), so the identity contract is pinned across every bpp and both
+     * source channels, not just what the ROM happens to blit. */
+    {
+        static hashset combined;
+        unsigned ia = 0, ie = 0;
+        combined.count = 0;
+        while ((ia < ra->set.count || ie < re->set.count)
+               && combined.count < MAX_HASHES) {
+            int c;
+            if (ia >= ra->set.count) c = 1;
+            else if (ie >= re->set.count) c = -1;
+            else c = strcmp(ra->set.hashes[ia], re->set.hashes[ie]);
+            if (c < 0)
+                strcpy(combined.hashes[combined.count++], ra->set.hashes[ia++]);
+            else if (c > 0)
+                strcpy(combined.hashes[combined.count++], re->set.hashes[ie++]);
+            else {
+                strcpy(combined.hashes[combined.count++], ra->set.hashes[ia++]);
+                ie++;
+            }
+        }
+
+        if (update_golden) {
+            int ok = write_golden(golden_path, &combined);
+            snprintf(d_freeze, sizeof(d_freeze), "golden list %s: %u hashes %s",
+                     golden_path, combined.count, ok ? "written" : "WRITE FAILED");
+            results[nres].status = ok ? "INFO" : "FAIL";
+            results[nres].name   = "contract_freeze";
+            results[nres].detail = d_freeze;
+            if (!ok) failed = 1;
+            nres++;
+        } else {
+            int ok = 0;
+            if (!read_golden(golden_path, &golden)) {
+                snprintf(d_freeze, sizeof(d_freeze),
+                         "golden list missing: %s (run with --update-golden "
+                         "for a DELIBERATE contract (re)freeze)", golden_path);
+            } else {
+                ok = sets_equal(&combined, &golden);
+                if (ok)
+                    snprintf(d_freeze, sizeof(d_freeze),
+                             "%u hashes match %s", combined.count, golden_path);
+                else {
+                    unsigned ic = 0, ig = 0, miss = 0, add = 0;
+                    while (ic < combined.count || ig < golden.count) {
+                        int c;
+                        if (ic >= combined.count) c = 1;
+                        else if (ig >= golden.count) c = -1;
+                        else c = strcmp(combined.hashes[ic], golden.hashes[ig]);
+                        if (c == 0) { ic++; ig++; }
+                        else if (c < 0) { add++; ic++; }
+                        else { miss++; ig++; }
+                    }
+                    snprintf(d_freeze, sizeof(d_freeze),
+                             "IDENTITY CONTRACT MOVED: %u new / %u missing vs "
+                             "%s (%u run, %u golden) -- an intentional change "
+                             "needs --update-golden AND a contract-version bump "
+                             "rationale in the commit", add, miss, golden_path,
+                             combined.count, golden.count);
+                }
+            }
+            results[nres].status = ok ? "PASS" : "FAIL";
+            results[nres].name   = "contract_freeze";
+            results[nres].detail = d_freeze;
+            if (!ok) failed = 1;
+            nres++;
+        }
+    }
+
+    /* Report through the shared harness formatting (json aware). */
+    {
+        harness_config rcfg = HARNESS_CONFIG_DEFAULT;
+        rcfg.json_output = json;
+        rcfg.quiet = quiet;
+        harness_report(&rcfg, results, nres);
+    }
+
+    rm_rf_dump(dir_a);
+    rm_rf_dump(dir_b);
+    rm_rf_dump(dir_c);
+    rm_rf_dump(dir_d);
+    rm_rf_dump(dir_e);
+    free(ra); free(rb); free(rc); free(rd); free(re);
+    return failed ? 1 : 0;
+
+run_fail:
+    fprintf(stderr, "FAIL: emulation run did not complete\n");
+    rm_rf_dump(dir_a);
+    rm_rf_dump(dir_b);
+    rm_rf_dump(dir_c);
+    rm_rf_dump(dir_d);
+    rm_rf_dump(dir_e);
+    free(ra); free(rb); free(rc); free(rd); free(re);
+    return 1;
+}

--- a/test/tools/test_texdump.c
+++ b/test/tools/test_texdump.c
@@ -732,8 +732,13 @@ int main(int argc, char **argv)
     if (!harness_init_from_args(&argcfg, argc, argv)) {
         fprintf(stderr, "usage: %s <core> [rom] [--frames N] [--golden F] "
                 "[--update-golden] [--json] [--quiet]\n", argv[0]);
+        free(argv);
         return 1;
     }
+    /* argv now points at the fargv scratch array built above; it is not
+     * read again past this point, so free it here rather than leaving it
+     * for process exit (LeakSanitizer flags the latter). */
+    free(argv);
     if (!argcfg.rom_path)
         argcfg.rom_path = "test/roms/yarc.j64";
     if (access(argcfg.rom_path, R_OK) != 0) {


### PR DESCRIPTION
Implements texture dump mode per the approved design spec (`docs/texture-dump.md`, first commit on this branch): every unique blit **source** tile a title pushes through the blitter is written once per session to `<system_dir>/vj_texdump/<cart CRC32>/` as a preview PNG plus an append-only `manifest.tsv` row, for HD-pack authoring and title inspection.

## What's here

- **`src/tom/texdump.c`/`.h`** — capture at the shared blit-launch site (beside `BlitMemoLaunch`, before engine dispatch): SRCEN-gated, register-described source walk, FNV-1a 64 key, open-addressed 2^17 dedupe set (allocated on first enable, freed + statics reset in `retro_deinit`/`retro_unload_game` — iOS never dlcloses), first-sight PNG render + manifest row. Windows >1 MB or touching non-populated address space are skipped.
- **Source-channel decode verified against `docs/jtrm-blitter.md`**, not source comments: B_CMD bit 0 (SRCEN) reads from **A2**, or from **A1 when DSTA2 (bit 11)** is set. Per-pixel addressing transliterates the engines' `PIXEL_OFFSET_*` formulas (width 6-bit float, pitch phrase-gap `{0,1,3,2}`, per-bpp packing).
- **PNG encoder** — in-tree miniz 3.1.1 (`tdefl_write_image_to_png_file_in_memory_ex`), enabled by defining `MINIZ_DEFLATE_APIS` for the libchdr unity TU; writes go through the libretro VFS (`rfopen`/`rfwrite`). No new vendored code.
- **Options** — `virtualjaguar_texture_dump` (disabled default, runtime-toggleable, no restart) and `virtualjaguar_texdump_16bpp` (cry|rgb|both), the latter visible only while the dump is enabled (same visibility machinery as the existing gates). Inserted as one contiguous block after `virtualjaguar_bios_type` to keep merge conflicts with the concurrent BIOS-loader branch minimal.
- **Zero savestate fields, no STATE_VERSION bump.** All state is host-transient.

## Identity contract

The key is **FNV-1a 64 over `'VJTD' | ver=1 | src_bpp | w:u16 | h:u16 | raw source bytes, row-major, packed as stored`** (little-endian serialization). **The palette is deliberately NOT part of the key**: replacement happens at blit time and the Jaguar blitter never sees a palette — CLUT lookup is an Object Processor display-time concept, so two CLUT variants of one indexed tile are indistinguishable at the swap point. Palette information is advisory manifest metadata (`clut=` CRC on first sight, extra sighting rows for later palettes), never identity. The manifest header carries `texdump v1` so a forced re-key is visible, never silent.

## Test plan

All gates run inside `make test` via `test/tools/test_texdump.c` (in-tree `test/roms/yarc.j64`; never skips):

```
DEVELOPER_DIR=/Library/Developer/CommandLineTools make -j8 TEST_EXPORTS=1 test   # exit 0
DEVELOPER_DIR=/Library/Developer/CommandLineTools make -j8                        # reverse ABI flip links clean
bash scripts/c89-lint.sh src/tom/texdump.c        # C89 lint passed (ditto texdump.h, blitter_mmio.c, libretro.c)
./test/tools/test_texdump ./virtualjaguar_libretro.dylib test/roms/yarc.j64 --frames 600
```

Result (9/9):

- `contract_freeze` — 28 hashes match the committed golden list `test/expected/texdump_yarc.txt`
- `determinism` — two consecutive dump-on runs, identical hash sets
- `engine_independence` — fast vs accurate blitter, identical hash sets
- `inertness_on` — 600 per-frame framebuffer hashes AND savestate digests at frames 300/600 identical dump-on vs dump-off (the machine cannot see the feature)
- `png_validity` / `synth_png_validity` — every emitted PNG parsed structurally: signature, IHDR dims vs manifest, every chunk CRC-32 via `src/core/crc32.c` (no external decoder)
- `synth_population` / `tile_population` — 28 unique tiles (2 ROM boot + 26 scripted)
- `palette_not_identity` — a CLUT-change re-blit of known bytes mints NO new hash and appends exactly one sighting row

## Deviations from spec

1. **Golden-list population**: yarc.j64 blits only its two boot-time code copies through SRCEN (it renders via the OP) — and so does `jagniccc.j64`, the only other in-tree public ROM (measured at 600 and 900 frames). Instead of the spec's "add a second committed ROM" fallback (there is no adequate one), the test drives a **synthetic blit battery** through the core's real bus/launch path (`JaguarWriteLong` → TOM → `BlitterWriteWord` → `TexDumpLaunch`, TEST_EXPORTS ABI): 26 scripted tiles covering 1/2/4/8/16/32 bpp, both source channels (A2 and DSTA2's A1), and the palette re-blit check. The committed golden list freezes ROM + battery together — a stronger tripwire than any in-tree ROM run.
2. **`MINIZ_DEFLATE_APIS` lives in `LIBCHDR_CFLAGS`** (Makefile.common) rather than on the `unity.o` rule alone: the theos_ios path compiles `unity.c` through theos' own rules, bypassing `unity.o`, and would otherwise ship without the encoder. The effect is identical everywhere else (the flag reaches only unity.c and the standalone CHD tools). The CI MSVC job also compiles unity.c with `/DMINIZ_DEFLATE_APIS`, confirming the deflate code under cl.exe; the spec's fallback wrapper was not needed (plain extern linkage suffices).
3. **`flags=` manifest tokens are `bcompen`/`dcompen`**, not the spec's `transen`: B_CMD has no TRANSEN bit (verified against `docs/jtrm-blitter.md`) — bit-comparator (26) and data-comparator (27) transparency are what the hardware actually has.
4. Palette-sighting dedupe reuses the main hash set (key ⊕ CLUT CRC inserted alongside the primary key) instead of a parallel per-entry structure — same behavior as specified (one sighting row per new palette per tile), no extra allocation.

Also fixed in passing: `test/test_blitter_mmio.c` gained the texdump stubs its standalone link now needs, and `test/tools/test_option_visibility.c` asserts the 16bpp knob is hidden while the dump option is at its default.

**Found while testing (pre-existing, not addressed here):** a fast→accurate engine flip leaves static residue that changes the next session's savestate bytes when the core stays resident (iOS no-dlclose regime) — reproduced with texture dump never enabled. The test sequences its runs to sidestep it; see the "Run order note" in `test/tools/test_texdump.c`.

Part 1 of #369; replacement pipeline is deliverable 2 (v3.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
