### PR TITLE
fix(blitter): clear the B_CMD decode statics on reset (#479)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ __pycache__/
 /test/tools/m68k_pc_histogram
 /test/tools/menu_step_probe
 /test/tools/present_rate_probe
+test/tools/blitter_static_leak

--- a/Makefile
+++ b/Makefile
@@ -928,6 +928,7 @@ clean:
 		test/tools/test_wedge_spin test/tools/test_texdump test/tools/i2s_lag_probe \
 		test/tools/joymatrix_identity test/tools/mouse_decode_test \
 		test/tools/rotary_decode_test test/tools/tuning_identity \
+		test/tools/blitter_static_leak \
 		test/test_quadrature test/test_axistune \
 		test/.skipped-checks
 
@@ -986,6 +987,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/tools/i2s_lag_probe test/tools/joymatrix_identity \
 		test/test_quadrature test/test_axistune test/tools/mouse_decode_test \
 		test/tools/rotary_decode_test test/tools/tuning_identity \
+		test/tools/blitter_static_leak \
 		tools/jagcd/jagcd-chd-check
 	@# Skip ledger: truncate FIRST so a previous run's rows cannot resurface
 	@# as fresh skips (the stale-row failure mode documented for
@@ -1257,6 +1259,12 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# an FNV digest measured on develop.  Committed before any device code
 	@# so later PRs are measured against a number that predates them.
 	./test/tools/joymatrix_identity ./$(TARGET) test/roms/yarc.j64 --quiet
+	@# Cross-load static leak (#479): a fast-blitter session must not
+	@# contaminate the savestate of the accurate session that follows it
+	@# while the core stays resident (iOS cannot dlclose).  The run1-vs-run2
+	@# control inside the tool means a failure here is attributable, not
+	@# just "the harness is not reproducible".
+	./test/tools/blitter_static_leak ./$(TARGET) test/roms/yarc.j64
 	@# Quadrature encoder unit test (no core): the Gray sequence in both
 	@# directions, the one-state-per-advance rate policy, the backlog
 	@# clamp and the Q8 carry.
@@ -1636,6 +1644,18 @@ test/tools/joymatrix_identity: test/tools/joymatrix_identity.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/joymatrix_identity.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+
+# Cross-load static-state leak gate (#479).  Pins the core with an extra
+# dlopen ref (the iOS no-dlclose regime) and proves an accurate-blitter
+# session run AFTER a fast-blitter session serialises byte-identical
+# state.  Catches BlitterStateSave()/BlitterResetDecodeState() drifting
+# apart: a newly-serialised field that nobody clears fails here.
+test/tools/blitter_static_leak: test/tools/blitter_static_leak.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/blitter_static_leak.c \
 		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
 

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -4373,6 +4373,51 @@ pipe-lining the comparator inputs where appropriate.
 
 /* Save state serialization for Blitter */
 
+/* Clear every decoded field that BlitterStateSave() serialises (issue
+ * #479).
+ *
+ * These statics are the B_CMD decode: the FAST engine (blitter_blit)
+ * writes them, the accurate engine (BlitterMidsummer2) does not, and
+ * most of them feed nothing but the savestate.  BlitterReset() used to
+ * clear only blitter_ram, so once the fast engine had run, every field
+ * below survived retro_unload_game + retro_deinit and was serialised
+ * into the NEXT session's state blob.
+ *
+ * A fresh dlopen zeroes them as BSS, which is why this is invisible on
+ * desktop -- and why it is live on iOS, where dlclose is impossible and
+ * the core stays resident for the life of the app.
+ *
+ * KEEP THIS LIST IN THE SAME ORDER AS BlitterStateSave() BELOW.  If a
+ * field is serialised it must be cleared here; test/tools/blitter_static_leak
+ * is the regression gate that catches the two lists drifting apart.
+ * blitter_ram itself is not cleared here -- BlitterReset() owns it. */
+void BlitterResetDecodeState(void)
+{
+   src = dst = misc = a1ctl = mode = ity = zop = op = ctrl = 0;
+   a1_addr = a2_addr = 0;
+   a1_zoffs = a2_zoffs = 0;
+   xadd_a1_control = xadd_a2_control = 0;
+   a1_pitch = a2_pitch = 0;
+   n_pixels = n_lines = 0;
+   a1_x = a1_y = a1_width = 0;
+   a2_x = a2_y = a2_width = 0;
+   a2_mask_x = a2_mask_y = 0;
+   a1_xadd = a1_yadd = a2_xadd = a2_yadd = 0;
+   a1_phrase_mode = a2_phrase_mode = 0;
+   a1_step_x = a1_step_y = a2_step_x = a2_step_y = 0;
+   outer_loop = inner_loop = 0;
+   a2_psize = a1_psize = 0;
+   gouraud_add = 0;
+   memset(gd_i, 0, sizeof(gd_i));
+   memset(gd_c, 0, sizeof(gd_c));
+   gd_ia = gd_ca = 0;
+   colour_index = 0;
+   zadd = 0;
+   memset(z_i, 0, sizeof(z_i));
+   a1_clip_x = a1_clip_y = 0;
+}
+
+
 size_t BlitterStateSave(uint8_t *buf)
 {
    uint8_t *start = buf;

--- a/src/tom/blitter.h
+++ b/src/tom/blitter.h
@@ -17,6 +17,9 @@ void BlitterTimingTick(uint32_t sysclks);
 uint32_t BlitterTimingGetBusy(void);
 void BlitterTimingSetBusy(uint32_t clks);
 void BlitterReset(void);
+/* Zero the B_CMD decode statics that BlitterStateSave() serialises.
+ * Called by BlitterReset()/BlitterDone(); see blitter.c for why (#479). */
+void BlitterResetDecodeState(void);
 void BlitterDone(void);
 
 uint8_t BlitterReadByte(uint32_t, uint32_t who);

--- a/src/tom/blitter_mmio.c
+++ b/src/tom/blitter_mmio.c
@@ -184,11 +184,18 @@ void BlitterInit(void)
 void BlitterReset(void)
 {
    memset(blitter_ram, 0x00, 0xA0);
+   /* The register file is not the whole of the blitter's serialised
+    * state: the B_CMD decode statics live in blitter.c and used to
+    * survive teardown into the next session's savestate (#479). */
+   BlitterResetDecodeState();
 }
 
 
 void BlitterDone(void)
 {
+   /* iOS cannot dlclose the core, so nothing re-zeroes statics between
+    * sessions -- teardown has to do it explicitly (see CLAUDE.md). */
+   BlitterReset();
 }
 
 

--- a/test/test_blitter_mmio.c
+++ b/test/test_blitter_mmio.c
@@ -27,6 +27,10 @@ int BlitterCompareIsEnabled(void) { return 0; }
 void BlitterRunComparison(void) {}
 void blitter_blit(uint32_t cmd) { (void)cmd; }
 void BlitterMidsummer2(void) {}
+/* The B_CMD decode statics live in blitter.c, which this test
+ * deliberately does not link; the real one is exercised by
+ * test/tools/blitter_static_leak (#479). */
+void BlitterResetDecodeState(void) {}
 int BlitMemoLaunch(void) { return 0; }   /* memo off: dispatch as before */
 int texDumpEnabled = 0;                  /* texture dump off */
 void TexDumpLaunch(void) {}

--- a/test/tools/blitter_static_leak.c
+++ b/test/tools/blitter_static_leak.c
@@ -1,0 +1,286 @@
+/*
+ * test/tools/blitter_static_leak.c -- cross-load static-state leak probe
+ * (issue #479).
+ *
+ * WHAT THIS CATCHES
+ *
+ * A static that the FAST blitter engine mutates and that survives
+ * retro_unload_game + retro_deinit, so it lands in the NEXT session's
+ * savestate blob.  On desktop a fresh dlopen re-zeroes the library's
+ * statics and hides this entirely; on iOS dlclose is impossible, the
+ * core stays resident for the life of the app, and the residue is
+ * live.  CLAUDE.md's rule is that every static is reset in
+ * retro_deinit -- this probe is the enforcement.
+ *
+ * THE SHAPE OF THE TEST
+ *
+ * One process, four full sessions against the same ROM, with an extra
+ * dlopen reference held across all of them so the image is never
+ * unloaded (mirroring iOS):
+ *
+ *   run 1  accurate            -> reference
+ *   run 2  accurate            -> proves the probe itself is stable
+ *   run 3  fast                -> the contaminating run
+ *   run 4  accurate            -> must equal runs 1 and 2
+ *
+ * Run 2 is not redundant.  Without it a failure in run 4 cannot be
+ * distinguished from "this harness simply is not reproducible across
+ * loads", which would make the whole result meaningless.
+ *
+ * Savestate blobs are captured mid-run (frame 300) and at the end
+ * (frame 600).  Framebuffer hashes are collected alongside them
+ * because the two disagree in the interesting way: the leak moves
+ * SAVESTATE bytes while leaving the PICTURE identical, so a test that
+ * only compared frames would report all-clear.
+ *
+ * Exit status: 0 = clean, 1 = leak detected, 2 = harness/setup error.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+#include "../harness/harness.h"
+
+#define RUN_COUNT      4
+#define SNAP_A         300
+#define SNAP_B         600
+#define TOTAL_FRAMES   600
+
+typedef struct {
+    const char *label;
+    const char *fastblitter;      /* "enabled" / "disabled" */
+    uint8_t    *snap[2];          /* blobs at SNAP_A, SNAP_B */
+    size_t      snap_len[2];
+    uint32_t    fb_hash[2];
+} run_result;
+
+/* Serialize hooks resolved from the resident image, so this probe does
+ * not depend on the harness growing an in-memory serialize accessor. */
+static size_t (*p_serialize_size)(void);
+static bool   (*p_serialize)(void *, size_t);
+
+static run_result g_runs[RUN_COUNT];
+static run_result *g_active;
+static harness_config *g_cfg;
+
+/* Called after every emulated frame.  Grabs a blob at the two snapshot
+ * points.  Kept deliberately dumb: no comparison here, only capture. */
+static bool frame_hook(void *user, unsigned frame)
+{
+    unsigned slot;
+    size_t   size;
+
+    (void)user;
+
+    if (frame == SNAP_A)
+        slot = 0;
+    else if (frame == SNAP_B)
+        slot = 1;
+    else
+        return true;
+
+    if (!g_active || !g_cfg || !p_serialize || !p_serialize_size)
+        return true;
+
+    size = p_serialize_size();
+    if (size == 0)
+        return true;
+
+    g_active->snap[slot] = (uint8_t *)malloc(size);
+    if (!g_active->snap[slot])
+        return true;
+
+    if (!p_serialize(g_active->snap[slot], size)) {
+        free(g_active->snap[slot]);
+        g_active->snap[slot] = NULL;
+        return true;
+    }
+    g_active->snap_len[slot] = size;
+    g_active->fb_hash[slot]  = g_cfg->last_fb_hash;
+    return true;
+}
+
+/* One complete session: load core, load ROM, run, snapshot, tear down. */
+static bool do_run(run_result *r, const char *core, const char *rom)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+
+    cfg.core_path            = core;
+    cfg.rom_path             = rom;
+    cfg.frames               = TOTAL_FRAMES;
+    cfg.quiet                = true;
+    cfg.want_fb_hash         = true;
+    cfg.frame_callback       = frame_hook;
+    cfg.frame_callback_data  = NULL;
+
+    cfg.options[0].key   = "virtualjaguar_usefastblitter";
+    cfg.options[0].value = r->fastblitter;
+    cfg.num_options      = 1;
+
+    g_active = r;
+    g_cfg    = &cfg;
+
+    if (!harness_load_core(&cfg)) {
+        fprintf(stderr, "[%s] harness_load_core failed\n", r->label);
+        return false;
+    }
+
+    p_serialize_size = (size_t (*)(void))
+        harness_dlsym(&cfg, "retro_serialize_size");
+    p_serialize = (bool (*)(void *, size_t))
+        harness_dlsym(&cfg, "retro_serialize");
+    if (!p_serialize || !p_serialize_size) {
+        fprintf(stderr, "[%s] core lacks retro_serialize\n", r->label);
+        harness_shutdown(&cfg);
+        return false;
+    }
+
+    if (!harness_load_rom(&cfg)) {
+        fprintf(stderr, "[%s] harness_load_rom failed\n", r->label);
+        harness_shutdown(&cfg);
+        return false;
+    }
+
+    harness_run(&cfg);
+    harness_shutdown(&cfg);     /* retro_unload_game + retro_deinit + dlclose */
+    g_active = NULL;
+    g_cfg    = NULL;
+
+    if (!r->snap[0] || !r->snap[1]) {
+        fprintf(stderr, "[%s] missing snapshot(s)\n", r->label);
+        return false;
+    }
+    return true;
+}
+
+/* Byte-diff two blobs; report the first differing offset and a count. */
+static size_t blob_diff(const uint8_t *a, size_t alen,
+                        const uint8_t *b, size_t blen,
+                        size_t *first_off)
+{
+    size_t i, n, diff = 0;
+
+    *first_off = (size_t)-1;
+    if (alen != blen) {
+        *first_off = 0;
+        return (alen > blen) ? alen : blen;
+    }
+    n = alen;
+    for (i = 0; i < n; i++) {
+        if (a[i] != b[i]) {
+            if (*first_off == (size_t)-1)
+                *first_off = i;
+            diff++;
+        }
+    }
+    return diff;
+}
+
+static void report_pair(const run_result *x, const run_result *y,
+                        unsigned slot, int *failures)
+{
+    size_t first, diff;
+
+    diff = blob_diff(x->snap[slot], x->snap_len[slot],
+                     y->snap[slot], y->snap_len[slot], &first);
+
+    printf("  %-28s frame %3u : ", "", (slot == 0) ? SNAP_A : SNAP_B);
+    printf("%s vs %s -> ", x->label, y->label);
+    if (diff == 0) {
+        printf("identical (%u bytes)\n", (unsigned)x->snap_len[slot]);
+    } else {
+        printf("DIFFER: %u byte(s), first at offset %u (0x%X)\n",
+               (unsigned)diff, (unsigned)first, (unsigned)first);
+        {
+            size_t k, shown = 0;
+            for (k = 0; k < x->snap_len[slot] && shown < 64; k++) {
+                if (x->snap[slot][k] != y->snap[slot][k]) {
+                    printf("      0x%06X: %02X -> %02X\n", (unsigned)k,
+                           x->snap[slot][k], y->snap[slot][k]);
+                    shown++;
+                }
+            }
+        }
+        (*failures)++;
+    }
+    printf("  %-28s            fb_hash %08X vs %08X %s\n", "",
+           x->fb_hash[slot], y->fb_hash[slot],
+           (x->fb_hash[slot] == y->fb_hash[slot]) ? "(same picture)"
+                                                  : "(PICTURE ALSO MOVED)");
+}
+
+int main(int argc, char **argv)
+{
+    const char *core = "./virtualjaguar_libretro.dylib";
+    const char *rom  = "test/roms/yarc.j64";
+    void       *pin;
+    unsigned    i;
+    int         failures = 0;
+    int         rc;
+
+    if (argc > 1) core = argv[1];
+    if (argc > 2) rom  = argv[2];
+
+    /* Pin the image for the whole test.  harness_shutdown() dlcloses its
+     * own handle after every run; this extra reference keeps the library
+     * mapped and its statics alive, which is the iOS regime the bug
+     * lives in.  Without this the test cannot fail, because each run
+     * gets freshly-zeroed statics. */
+    pin = dlopen(core, RTLD_LAZY | RTLD_LOCAL);
+    if (!pin) {
+        fprintf(stderr, "cannot pin core '%s': %s\n", core, dlerror());
+        return 2;
+    }
+
+    memset(g_runs, 0, sizeof(g_runs));
+    g_runs[0].label = "run1-accurate";  g_runs[0].fastblitter = "disabled";
+    g_runs[1].label = "run2-accurate";  g_runs[1].fastblitter = "disabled";
+    g_runs[2].label = "run3-FAST";      g_runs[2].fastblitter = "enabled";
+    g_runs[3].label = "run4-accurate";  g_runs[3].fastblitter = "disabled";
+
+    printf("=== Blitter cross-load static leak (#479) ===\n");
+    printf("core: %s\nrom:  %s\n", core, rom);
+    printf("image pinned (extra dlopen ref) -- statics persist across runs\n\n");
+
+    for (i = 0; i < RUN_COUNT; i++) {
+        printf("running %s (usefastblitter=%s)...\n",
+               g_runs[i].label, g_runs[i].fastblitter);
+        if (!do_run(&g_runs[i], core, rom)) {
+            dlclose(pin);
+            return 2;
+        }
+    }
+
+    printf("\n--- control: run1 vs run2 (both accurate, no fast run between) ---\n");
+    {
+        int control_fail = 0;
+        report_pair(&g_runs[0], &g_runs[1], 0, &control_fail);
+        report_pair(&g_runs[0], &g_runs[1], 1, &control_fail);
+        if (control_fail) {
+            printf("\nCONTROL FAILED: two identical back-to-back sessions already\n"
+                   "differ, so this probe cannot attribute anything to the fast\n"
+                   "engine.  Fix the probe before trusting a run4 result.\n");
+            dlclose(pin);
+            return 2;
+        }
+        printf("  control OK: repeated sessions are byte-identical\n");
+    }
+
+    printf("\n--- subject: run1 vs run4 (accurate, after a FAST run) ---\n");
+    report_pair(&g_runs[0], &g_runs[3], 0, &failures);
+    report_pair(&g_runs[0], &g_runs[3], 1, &failures);
+
+    printf("\n=== %s ===\n",
+           failures ? "LEAK DETECTED" : "clean: no cross-load residue");
+
+    rc = failures ? 1 : 0;
+
+    for (i = 0; i < RUN_COUNT; i++) {
+        free(g_runs[i].snap[0]);
+        free(g_runs[i].snap[1]);
+    }
+    dlclose(pin);
+    return rc;
+}


### PR DESCRIPTION
Closes #479.

## The bug

`BlitterReset()` cleared `blitter_ram` and nothing else. The ~50 B_CMD decode statics in `blitter.c` that `BlitterStateSave()` serialises — `src`, `dst`, `misc`, `a1ctl`, `mode`, `ity`, `zop`, `op`, `ctrl`, the A1/A2 address generators, the Gouraud/Z arrays, `colour_index`, `a1_clip_x/y` — were never reset, and `BlitterDone()` was empty.

Only the **fast** engine (`blitter_blit`) writes them; the accurate engine (`BlitterMidsummer2`) does not. A fresh accurate session therefore leaves them all zero, because a fresh `dlopen` zeroes them as BSS — which is exactly why this is invisible on desktop and **live on iOS**, where `dlclose` is impossible and the core stays resident for the life of the app. Run the fast engine once and every field above survives `retro_unload_game` + `retro_deinit` into the *next* session's state blob.

## Evidence

`yarc.j64`, 600 frames, core pinned with an extra `dlopen` ref:

| comparison | frame 300 | frame 600 |
|---|---|---|
| run1 vs run2 (both accurate) — control | identical | identical |
| run1 vs run4 (accurate, after a fast run) | **56 bytes differ** | **56 bytes differ** |

Same 56 bytes at both snapshots — a region that never updates during a run, the signature of carried-over data — while the framebuffer hashes stay byte-identical (`F4C30EA3` / `EB70F7DE`), so a picture-only check reports all-clear.

The first differing offset is **`$217500`, precisely `blitter_chunk_base + $100`**: the first byte *after* `blitter_ram`, i.e. `src`. That pins the decode block and exonerates the register file.

## What this closes

Savestates written after an engine flip did not reproduce bit-identically against a core that reached the same point without one — the property run-ahead and netplay determinism both rely on (cf. #400, where the hi-res epoch sitting outside the blob broke the same thing). Any single-process blitter A/B also inherited residue across arms.

## The fix

`BlitterResetDecodeState()` in `blitter.c`, where the statics live, listed in `BlitterStateSave()`'s exact field order so the two can be diffed by eye. Called from `BlitterReset()` (so `TOMReset` → `JaguarReset` clears at every game load) and from `BlitterDone()` (so teardown clears too, per CLAUDE.md's iOS static-reset rule).

**Safe by construction:** zeroing at reset reproduces exactly the state a fresh `dlopen` produces, so it cannot change behaviour that already worked.

## Regression gate

`test/tools/blitter_static_leak`, wired into `make test`. Pins the image with an extra `dlopen` ref and runs four sessions — accurate, accurate, fast, accurate — asserting run 4 matches run 1. **Run 2 is not redundant:** without it a run-4 failure cannot be told apart from "this harness is not reproducible across loads". It doubles as drift protection — a field added to `BlitterStateSave()` but not to the reset fails here.

`test/test_blitter_mmio` links `blitter_mmio.c` in isolation, so it gets a `BlitterResetDecodeState()` stub alongside the `blitter_blit` / `BlitterMidsummer2` stubs it already carries.

## Test plan
- [x] Probe fails before the fix (56 bytes), passes after — same probe binary, sequential runs
- [x] `make -j8 TEST_EXPORTS=1 test` → **exit 0**, zero failing sections, 1 expected skip (CUE→CHD, no CHSE-capable chdman on PATH)
- [x] New gate in-suite: `control OK` + `clean: no cross-load residue`
- [x] `scripts/c89-lint.sh` on all touched files → passed
- [x] `test/test_blitter_mmio` (isolated link) passes