### PR TITLE
feat(jerry): Jaguar Voice Modem emulation — Ultra Vortek netplay over netlink (#481)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -424,7 +424,7 @@ jobs:
           src\cd\cdintf.c src\cd\cdrom.c src\core\crc32.c src\core\event.c ^
           src\jerry\eeprom.c src\core\filedb.c src\jerry\joystick.c src\core\settings.c ^
           src\core\memtrack.c src\core\vjag_memory.c src\core\cheat.c ^
-          src\core\universalhdr.c src\jerry\wavetable.c ^
+          src\core\universalhdr.c src\jerry\wavetable.c src\jerry\voicemodem.c ^
           src\bios\jagbios.c ^
           src\bios\jagbios_m.c ^
           src\bios\jagcdbios.c src\bios\jagdevcdbios.c ^

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ __pycache__/
 /test/tools/menu_step_probe
 /test/tools/present_rate_probe
 test/tools/blitter_static_leak
+test/tools/voicemodem_pair

--- a/Makefile
+++ b/Makefile
@@ -1464,21 +1464,21 @@ test/test_event_queue: test/test_event_queue.c src/core/event.c src/core/event.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_event_queue.c src/core/event.c
 
-test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c
+test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_jlink.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c
+		-o $@ test/test_jlink.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c
 
-test/test_jlink_tcp: test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink.h src/jerry/jlink_tcp.h
+test/test_jlink_tcp: test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c src/jerry/jlink.h src/jerry/jlink_tcp.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c
+		-o $@ test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c
 
 test/test_jlink_netpacket: test/test_jlink_netpacket.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_jlink_netpacket.c -ldl
 
-test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/core/event.c
+test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c src/core/event.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_uart_loopback.c src/jerry/uart.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/core/event.c -lm
+		-o $@ test/test_uart_loopback.c src/jerry/uart.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c src/core/event.c -lm
 
 test/test_uart_core: test/test_uart_core.c test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \

--- a/Makefile
+++ b/Makefile
@@ -982,7 +982,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_chd test/test_chd_unit test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda test/test_cd_synth_subq \
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
-		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/test_pertitle_db \
+		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/voicemodem_pair test/tools/test_pertitle_db \
 		test/tools/test_hook_gate \
 		test/tools/i2s_lag_probe test/tools/joymatrix_identity \
 		test/test_quadrature test/test_axistune test/tools/mouse_decode_test \
@@ -1009,6 +1009,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	./test/test_uart_core ./$(TARGET)
 	./test/test_netlink_host ./$(TARGET)
 	bash test/tools/netlink_pair_test.sh ./$(TARGET)
+	bash test/tools/voicemodem_pair_test.sh ./$(TARGET)
 	bash test/tools/netlink_latency_test.sh ./$(TARGET)
 	@# vjtrace flight-recorder selftest: determinism (field_diff +
 	@# trace_memdiff on two identical runs), watch attribution, and
@@ -1494,6 +1495,10 @@ test/test_netlink_host: test/test_netlink_host.c test/harness/harness.c test/har
 test/tools/netlink_pair: test/tools/netlink_pair.c test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
 		-o $@ test/tools/netlink_pair.c test/harness/harness.c -ldl -lm
+
+test/tools/voicemodem_pair: test/tools/voicemodem_pair.c test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
+		-o $@ test/tools/voicemodem_pair.c test/harness/harness.c -ldl -lm
 
 test/tools/netlink_latency: test/tools/netlink_latency.c test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \

--- a/Makefile.common
+++ b/Makefile.common
@@ -57,6 +57,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/jerry/jlink.c \
 	$(CORE_DIR)/src/jerry/jlink_tcp.c \
 	$(CORE_DIR)/src/jerry/jlink_netpacket.c \
+	$(CORE_DIR)/src/jerry/voicemodem.c \
 	$(CORE_DIR)/src/jerry/uart.c \
 	$(CORE_DIR)/src/tom/op.c \
 	$(CORE_DIR)/src/tom/shadowfb.c \

--- a/docs/voice-modem.md
+++ b/docs/voice-modem.md
@@ -1,0 +1,129 @@
+# Jaguar Voice Modem (JVM) — protocol as spoken by Ultra Vortek
+
+**Status:** derived 2026-08-17 by disassembling the retail Ultra Vortek ROM
+(`Ultra Vortek (1995).jag`, 4 MB, the only JVM title). The game's own modem
+driver is the authoritative spec for what a modem must say; no BigPEmu
+assets were consulted. Emulated by `src/jerry/voicemodem.c` (issue #481).
+
+## Hardware placement
+
+The JVM plugs into the DSP port and talks to JERRY's asynchronous serial
+UART (`$F10030` ASIDATA / `$F10032` ASICTRL+ASISTAT / `$F10034` ASICLK) —
+the same silicon JagLink and CatBox use, so the netlink transport
+(`docs/netlink-design.md`) carries it.
+
+How Ultra Vortek services the port (all addresses are the retail ROM):
+
+- **68K side** (driver at `$80AF96–$80BA19`, runs in ROM): transmits by
+  polling ASISTAT TBE (bit 8) and writing ASIDATA; **never reads RX data
+  registers** outside an init flush.
+- **DSP side**: the audio engine's I2S interrupt handler tail
+  (`$F1B168–$F1B1C2`, loaded to DSP RAM from ROM offset `$E31C`) polls
+  ASISTAT once per I2S sample: on ERROR (bit 15) it writes CLRERR if SERIN
+  is high; on RBF (bit 7) it reads ASIDATA and pushes the byte into a
+  **256-byte ring in main RAM `$6274–$6373`**, write pointer at DSP RAM
+  `$F1BA84`, read pointer at `$F1BA88`. The 68K driver consumes replies
+  from that ring only. There is no RX interrupt use despite RINTEN being
+  set; JINTCTRL bit 4 is enabled but the transfer path is the DSP poll.
+- **UART programming**: ASICTRL = `$0021` (odd parity + RINTEN), wake
+  attempts at ASICLK = `$1C` (~57.6 kbaud) falling back to `$56`
+  (~19.2 kbaud); after wake succeeds the driver issues `$FFFE` (see below)
+  and settles at ASICLK = `$56` — i.e. the DTE rate in use is **19200**.
+
+Menu entry: type **`911` on the numpad while the title logo is on screen**
+("AWESOME" sting → INITIALIZING VOICE MODEM). With no modem answering, the
+game shows MODEM INITIALIZING FAILED / MAKE SURE THE MODEM IS ON.
+
+## Wire format
+
+Console → modem: **16-bit command words, low byte first** (`$8A21` goes out
+as `$21 $8A`). Every command is answered except `$FFFE`.
+
+Modem → console: **3-byte messages: sync `$FF` (`$FE` also accepted), then
+high byte, then low byte**. Reply classes, per the driver's parsers
+(`$80B3B0` transact, `$80B452` data-receive, `$80AFE2` ring scan):
+
+| High byte | Meaning | Driver behavior |
+|-----------|---------|-----------------|
+| echo of command | command acknowledged | compared against what was sent |
+| `$A4` | async status event | `$57F6 &= word` (a bit-clear mask); if the mask goes to zero **and bit 0 of the low byte is set** the driver returns error `$FFF3` ("lost phone connection" class); otherwise consumed silently |
+| `$B1` | async ring indicate | returns status `$FFF4` (RING) to whatever call is in progress |
+| `$F0` | data byte (low byte = payload) | data-phase receive |
+| `$F3` | data frame end; `$F301` = clean end-of-packet | terminates a receive burst |
+| `$86` | connect result for `$8100` (low byte = speed code, shown as MODEM CONNECT SPEED) | proceed with connection |
+| `$80..$8F` (`& $F000 == $8000`) | `$8100` "not yet" | retry (up to 255×) |
+| `$FFFE` (word) | "nothing" reply to `$6800` DTMF poll | poll again |
+
+## Command set (as issued by Ultra Vortek)
+
+| Word | Name (inferred) | Modem must do |
+|------|-----------------|----------------|
+| `$FFFF` (two raw `$FF` bytes) | wake/detect | reply word **`$B800`**; sent at 57.6k, then 19.2k, then 57.6k until answered |
+| `$FFFE` | switch line rate (to 19200) | **no reply** (console switches ASICLK right after) |
+| `$0102` | ident/ping after wake | echo |
+| `$0501` | begin config block | echo |
+| `$000F $B000 $3952 $A021 $F207 $B602 $B504 $B405 $A3FC $A060` | config parameters | echo each |
+| `$2C80` | originate mode (appears in the dial config table, at dial start, and again after handshake) | echo |
+| `$2480` | answer mode (same positions on the answer side) | echo; going off-hook to answer a pending ring |
+| `$8C01` | dial-tone check | echo `$8C01` when line ok (anything else retried ~1000×, then NO DIALTONE) |
+| `$8A2n` | send DTMF digit n (0–15; the dialed number, and the post-connect probe digits) | echo; deliver digit to the far side when connected |
+| `$8C00` | call-progress query | low byte `$1x` = tone/dial still in progress, `$0x` = idle/done |
+| `$6800` | poll for detected DTMF digit | `$68nn` = heard digit nn, word `$FFFE` = nothing yet |
+| `$8000` | go to data mode (pre-connect) | echo |
+| `$8100` | connect/carrier query | `$86xx` = connected at speed xx, `$80xx` = not yet (retried); after `$86xx` the console waits for `$A4` events to clear `$57F6` bits 0+1 (send `$A4FC`) |
+| `$0002`, `$A3FE` | post-connect config | echo |
+| `$9000` | hang up / abort | echo (sent repeatedly until echoed) |
+| `$A040`, `$A0A0` | audio path control (hangup path sends `$9000` then `$A040`) | echo |
+| `$F0xx` | data byte xx to peer (sent raw, no echo consumed) | forward to peer; **do not echo** |
+
+## Connection choreography (both consoles run Ultra Vortek)
+
+Originator: wake → `$FFFE` → `$0102` → `$0501` + config(`$2C80`) →
+`$8C01` dial tone → `$2C80` + `$8A2n` digits of the phone number (`$8C00`
+polled between digits; keypad `$10` = 2 s pause) → poll `$6800` for the
+answerer's probe digits `0,9,8,…,1` → send its own probe digits
+`1,2,…,9,0` as `$8A2n`, polling `$8C00` after each → `$2C80`.
+
+Answerer: wake/config happen when the user enters the modem screen; on
+RING (`$B1xx`) and the user choosing ANSWER PHONE: config(`$2480`) → sends
+probe digits `0,9,8,…,1` → listens via `$6800` for `1,2,…,9,0` → `$2480`.
+
+The mutual DTMF probe is the line-quality check ("TOO MUCH TELEPHONE
+NOISE" when it fails). Speed/carrier negotiation is the `$8000`/`$8100`/
+`$86xx` + `$A4FC` sequence at `$80B278`.
+
+## Data phase (in-game)
+
+- Sender: 4 payload bytes per exchange, each as a raw `$F0xx` word
+  (`$80B570`, from `$579A`), no replies consumed.
+- Receiver: expects 4 × `$F0xx` messages then **`$F301` end-of-packet**
+  (`$80B596` → `$57A0`). The `$F301` is generated by the modem (packet
+  framing), not sent by the far console — the emulation emits it at
+  TX-burst end.
+- Async `$A4` with bit 0 set (e.g. `$A401`) during a call = line drop →
+  LOST PHONE CONNECTION.
+
+## What the emulation does (src/jerry/voicemodem.c)
+
+A virtual modem in front of the jlink transport (`virtualjaguar_uart_device
+= voicemodem`; JagLink stays the default). Dial resolves to the existing
+netlink TCP/netpacket/loopback session; no voice, no DTMF audio, no real
+telephony. Inter-modem wire protocol (2-byte frames over the transport):
+`$01 digit` DTMF, `$02 -` dial, `$03 -` answer, `$04 -` hangup, `$05 xx`
+data byte, `$06 -` end-of-packet. Ring indications are paced ~1/second;
+`$A4FC` is queued after each connected `$86xx` reply so the `$57F6` wait
+can never miss it. ASICLK is ignored — the UART already paces bytes; the
+modem is rate-agnostic. Modem session state is host-side (like jlink's
+sockets) and deliberately not serialized in savestates: loading a state
+mid-call behaves as a pulled phone line.
+
+## Open questions
+
+- The `$86xx` speed code's exact encoding (we reply `$8613`); harmless —
+  the game only displays it.
+- `$B1xx` ring payload (we send `$B100`); the driver only matches the
+  high byte.
+- Config words (`$3952` etc.) are opaque Phylon chipset parameters;
+  echoing satisfies the driver.
+- The retail beta ROM and any voice-mode-specific commands beyond `$A0xx`
+  echoes are unexplored.

--- a/docs/voice-modem.md
+++ b/docs/voice-modem.md
@@ -71,6 +71,12 @@ high byte, then low byte**. Reply classes, per the driver's parsers
 | `$6800` | poll for detected DTMF digit | `$68nn` = heard digit nn, word `$FFFE` = nothing yet |
 | `$8000` | go to data mode (pre-connect) | echo |
 | `$8100` | connect/carrier query | `$86xx` = connected at speed xx, `$80xx` = not yet (retried); after `$86xx` the console waits for `$A4` events to clear `$57F6` bits 0+1 (send `$A4FC`) |
+
+**The `$86xx` speed byte is validated** (RAM `$803C30`, post-connect): the
+game computes `(xx >> 4) - 8`; a negative result is declared TOO MUCH
+TELEPHONE NOISE and the call is torn down. Nibbles `8..E` index a
+displayed-speed table: 9600, 9600, 12000, 14400, 16800, 19200, 57600.
+The emulation replies `$86D0` (19200, matching the programmed UART rate).
 | `$0002`, `$A3FE` | post-connect config | echo |
 | `$9000` | hang up / abort | echo (sent repeatedly until echoed) |
 | `$A040`, `$A0A0` | audio path control (hangup path sends `$9000` then `$A040`) | echo |
@@ -91,6 +97,24 @@ probe digits `0,9,8,…,1` → listens via `$6800` for `1,2,…,9,0` → `$2480`
 The mutual DTMF probe is the line-quality check ("TOO MUCH TELEPHONE
 NOISE" when it fails). Speed/carrier negotiation is the `$8000`/`$8100`/
 `$86xx` + `$A4FC` sequence at `$80B278`.
+
+## Top-level flow (RAM code; RAM address = ROM offset + $43FE)
+
+The whole 68K driver is copied to RAM with the main program and runs
+there (absolute `jsr $11298`-style refs prove it); the `$80Bxxx`
+addresses in this document are the ROM image of RAM `$F394..$FE17`.
+Dial UI path (`$803A50`): dial_seq (`$80B6DC`) -> go_online (`$80B278`)
+-> `$57DB=0` (this console is player 1). Answer path (`$803ABC`):
+answer_seq (`$80B850`) -> go_online -> `$57DB=1`. Both converge at
+`$803C30`: speed-nibble check, then `$57DC=1` — the flag that switches
+the game's input layer to modem-exchanged pad state.
+
+**What UV's netplay actually exchanges:** with `$57DC` set, each frame
+the game packs its local pad longword (plus a coin/meta bit 22) into
+`$579A` and sends it as one 4-byte packet (`$803DDC` -> SendData
+`$80B570`); the far side's packet is received into `$57A0` and the two
+pads are fed to the player slots (`$57E4`/`$57E8`, selected by `$57DB`).
+`$57DD` throttles to one packet per received packet — classic lockstep.
 
 ## Data phase (in-game)
 
@@ -119,8 +143,6 @@ mid-call behaves as a pulled phone line.
 
 ## Open questions
 
-- The `$86xx` speed code's exact encoding (we reply `$8613`); harmless —
-  the game only displays it.
 - `$B1xx` ring payload (we send `$B100`); the driver only matches the
   high byte.
 - Config words (`$3952` etc.) are opaque Phylon chipset parameters;

--- a/exports-test.list
+++ b/exports-test.list
@@ -31,6 +31,7 @@ _gpu_*
 _JERRY*
 _UART*
 _JLink*
+_VM*
 _TOM*
 _OP*
 _tomRam8

--- a/libretro.c
+++ b/libretro.c
@@ -1258,6 +1258,14 @@ static void check_variables(void)
       LOG_INF("[CLOCK] Non-stock clock scales active: M68K %u%%, RISC %u%% (enhancement mode; timing-sensitive bug reports are only valid at 1x)\n",
               (unsigned)m68kClockScalePct, (unsigned)riscClockScalePct);
 
+   var.key = "virtualjaguar_uart_device";
+   var.value = NULL;
+   if (get_variable_pertitle(&var) && var.value
+       && strcmp(var.value, "voicemodem") == 0)
+      JLinkSetDevice(JLINK_DEVICE_VOICEMODEM);
+   else
+      JLinkSetDevice(JLINK_DEVICE_JAGLINK);
+
    var.key = "virtualjaguar_netlink";
    var.value = NULL;
    if (get_variable_pertitle(&var) && var.value)

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -320,6 +320,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "virtualjaguar_uart_device",
+      "Network Link Device",
+      NULL,
+      "What is plugged into the serial port. 'JagLink / CatBox' is the raw cable used by BattleSphere, AirCars and Doom. 'Voice Modem' emulates the Jaguar Voice Modem for Ultra Vortek's phone-line versus mode: type 911 on the numpad at the title screen, then one player dials (any number) and the other answers -- the 'call' is carried over the Network Link transport selected above.",
+      NULL,
+      "network",
+      {
+         { "jaglink",    "JagLink / CatBox (raw cable)" },
+         { "voicemodem", "Voice Modem (Ultra Vortek)" },
+         { NULL, NULL },
+      },
+      "jaglink"
+   },
+   {
       "virtualjaguar_netlink_host",
       "Network Link Host (TCP Client)",
       NULL,

--- a/link-test.T
+++ b/link-test.T
@@ -34,6 +34,7 @@
       JERRY*;
       UART*;
       JLink*;
+      VM*;
       TOM*;
       OP*;
       tomRam8;

--- a/src/jerry/jlink.c
+++ b/src/jerry/jlink.c
@@ -10,6 +10,7 @@
 #include "jlink.h"
 #include "jlink_tcp.h"
 #include "jlink_netpacket.h"
+#include "voicemodem.h"
 #include "state.h"
 
 #define JLINK_RING_SIZE 256
@@ -56,6 +57,7 @@ static void JLinkSleepUsec(int usec)
 #endif
 
 static int jlinkMode = JLINK_MODE_DISABLED;
+static int jlinkDevice = JLINK_DEVICE_JAGLINK;
 static uint8_t jlinkRing[JLINK_RING_SIZE];
 static uint32_t jlinkHead = 0;   /* next byte to pop */
 static uint32_t jlinkCount = 0;
@@ -97,6 +99,8 @@ static long long jlinkReplyEwmaUsec = 0; /* smoothed reply latency */
 #define JLINK_WAIT_MARGIN_USEC  2000
 #define JLINK_SAMPLE_MAX_USEC  50000   /* slower = not a reply, ignore */
 
+static void JLinkVMDrain(void);
+
 static void JLinkRingPush(uint8_t b)
 {
    uint32_t tail;
@@ -128,6 +132,12 @@ static void JLinkRingPush(uint8_t b)
     * and the two counters were never comparable.  (In loopback the same byte
     * legitimately increments both: it really does go out and come back.) */
    jlinkRxTotal++;
+   /* Voice modem: transport bytes are inter-modem frames, parsed as
+    * they arrive; the ring never holds console-visible bytes.  (Bounded
+    * reentrancy through loopback: a parsed frame may send a reply frame,
+    * which lands here again.) */
+   if (jlinkDevice == JLINK_DEVICE_VOICEMODEM)
+      JLinkVMDrain();
 }
 
 void JLinkSetTCPEndpoint(const char *host, int port)
@@ -170,9 +180,17 @@ int JLinkOpen(int mode)
    return 0;
 }
 
+void JLinkTxBurstEnd(void)
+{
+   if (jlinkDevice == JLINK_DEVICE_VOICEMODEM)
+      VMTxBurstEnd();
+   JLinkPump();
+}
+
 void JLinkClose(void)
 {
    JLinkTCPClose();
+   VMReset();
    jlinkMode = JLINK_MODE_DISABLED;
    jlinkHead = 0;
    jlinkCount = 0;
@@ -210,7 +228,58 @@ void JLinkNPDeliver(const uint8_t *buf, size_t len)
       JLinkRingPush(buf[i]);
 }
 
+void JLinkSetDevice(int device)
+{
+   if (device != jlinkDevice)
+   {
+      jlinkDevice = device;
+      VMReset();
+   }
+}
+
+int JLinkDevice(void)
+{
+   return jlinkDevice;
+}
+
+/* Move transport-ring bytes into the voice modem's frame parser.  In
+ * voice-modem mode the ring carries inter-modem frames, never bytes the
+ * console may see directly. */
+static void JLinkVMDrain(void)
+{
+   uint8_t b;
+   while (jlinkCount > 0)
+   {
+      b = jlinkRing[jlinkHead];
+      jlinkHead = (jlinkHead + 1) % JLINK_RING_SIZE;
+      jlinkCount--;
+      VMWireInput(b);
+   }
+}
+
+/* Console-deliverable RX depth for the active device. */
+static int JLinkDeliverable(void)
+{
+   if (jlinkDevice == JLINK_DEVICE_VOICEMODEM)
+      return VMConsoleRxPending();
+   return (int)jlinkCount;
+}
+
 void JLinkSendByte(uint8_t b)
+{
+   if (jlinkMode == JLINK_MODE_DISABLED)
+      return;
+   if (jlinkDevice == JLINK_DEVICE_VOICEMODEM)
+   {
+      /* The modem consumes the console's TX stream; anything bound for
+       * the far side goes out through JLinkWireSendByte. */
+      VMConsoleTx(b);
+      return;
+   }
+   JLinkWireSendByte(b);
+}
+
+void JLinkWireSendByte(uint8_t b)
 {
    if (jlinkMode == JLINK_MODE_DISABLED)
       return;
@@ -278,6 +347,8 @@ void JLinkSetWaitEnabled(int enabled)
 void JLinkFrameTick(void)
 {
    long long budget;
+   if (jlinkDevice == JLINK_DEVICE_VOICEMODEM)
+      VMFrameTick();
    if (!jlinkWaitEnabled)
    {
       jlinkWaitBudgetUsec = 0;
@@ -315,7 +386,8 @@ void JLinkAwaitReply(void)
 {
 #ifdef JLINK_HAVE_WAIT
    long long start, now;
-   if (!jlinkAwaitingReply || jlinkWaitBudgetUsec <= 0 || jlinkCount > 0)
+   if (!jlinkAwaitingReply || jlinkWaitBudgetUsec <= 0
+       || JLinkDeliverable() > 0)
       return;
    if (!JLinkConnected())
       return;
@@ -323,7 +395,7 @@ void JLinkAwaitReply(void)
    for (;;)
    {
       JLinkPump();
-      if (jlinkCount > 0)
+      if (JLinkDeliverable() > 0)
          break;
       if (!JLinkConnected())
          break;             /* peer went away mid-wait */
@@ -356,6 +428,8 @@ void JLinkPump(void)
 
 int JLinkRecvByte(uint8_t *b)
 {
+   if (jlinkDevice == JLINK_DEVICE_VOICEMODEM)
+      return VMConsoleRecv(b);
    if (jlinkCount == 0)
       return 0;
    *b = jlinkRing[jlinkHead];
@@ -366,7 +440,7 @@ int JLinkRecvByte(uint8_t *b)
 
 int JLinkRxPending(void)
 {
-   return (int)jlinkCount;
+   return JLinkDeliverable();
 }
 
 size_t JLinkStateSave(uint8_t *buf)

--- a/src/jerry/jlink.h
+++ b/src/jerry/jlink.h
@@ -20,6 +20,28 @@ enum
    JLINK_MODE_NETPACKET  = 4   /* frontend netplay session (env 78) */
 };
 
+/* What is plugged into the DSP port on the far side of the UART.
+ * JagLink/CatBox are a bare wire (bytes pass through untouched); the
+ * Voice Modem (voicemodem.c) is a command/response device in front of
+ * the same transport. */
+enum
+{
+   JLINK_DEVICE_JAGLINK    = 0,
+   JLINK_DEVICE_VOICEMODEM = 1
+};
+
+void JLinkSetDevice(int device);
+int  JLinkDevice(void);
+
+/* Raw transport send, bypassing the device layer (used by the voice
+ * modem to reach its peer; identical to JLinkSendByte for JagLink). */
+void JLinkWireSendByte(uint8_t b);
+
+/* UART TX burst finished (shift register drained, hold empty): flush
+ * batched transport bytes; the voice modem also emits its end-of-packet
+ * marker here. */
+void JLinkTxBurstEnd(void);
+
 /* Push transport-received bytes into the RX ring (netpacket backend). */
 void JLinkNPDeliver(const uint8_t *buf, size_t len);
 

--- a/src/jerry/uart.c
+++ b/src/jerry/uart.c
@@ -91,8 +91,9 @@ void UARTTXCallback(void)
    {
       /* Burst finished (shift drained, nothing queued): push the
          batched transport bytes out NOW so a mid-frame tic exchange
-         gets sub-millisecond latency as one packet per burst. */
-      JLinkPump();
+         gets sub-millisecond latency as one packet per burst.  The
+         voice modem also emits its end-of-packet marker here. */
+      JLinkTxBurstEnd();
    }
    UARTKickRx();
 }

--- a/src/jerry/voicemodem.c
+++ b/src/jerry/voicemodem.c
@@ -1,0 +1,392 @@
+/* voicemodem.c — Jaguar Voice Modem (JVM) emulation for Ultra Vortek.
+ *
+ * Protocol derived from the retail Ultra Vortek ROM's own 68K modem
+ * driver ($80AF96-$80BA19) and DSP UART service loop; the full derivation
+ * is docs/voice-modem.md.  Summary of the console-facing wire format:
+ *
+ *   console -> modem : 16-bit command words, LOW byte first
+ *   modem  -> console: 3-byte messages: sync $FF, HIGH byte, LOW byte
+ *
+ * Every command word is echoed back unless noted.  Beyond echoes the
+ * modem produces:
+ *   $B800  reply to the $FFFF wake
+ *   $FFFE  reply to a $6800 DTMF poll when no digit is queued
+ *   $68nn  reply to $6800 when digit nn was heard from the far side
+ *   $86xx  reply to $8100 when the call is up ($80xx = not yet)
+ *   $A4FC  async event clearing the driver's $57F6 connect wait bits
+ *   $A401  async "line dropped" (mask clear + bit0 -> driver error $FFF3)
+ *   $B1xx  async ring indicate
+ *   $F0xx  data byte from the far console, $F301 end-of-packet
+ *
+ * The two virtual modems talk to each other over the existing jlink
+ * transport (TCP / netpacket / loopback) with 2-byte frames:
+ *   [VM_FR_* type, value].  "Dial" resolves to the transport session; the
+ * dialed number is consumed and ignored.
+ *
+ * iOS rule: every static is reset in VMReset(), reached from both
+ * retro_init and retro_deinit paths via JLinkClose/UARTDone.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "voicemodem.h"
+#include "jlink.h"
+
+/* ---- inter-modem frame types (ours to define; the real line carried
+ *      tones and a Phylon-proprietary carrier) ---- */
+#define VM_FR_DTMF   0x01
+#define VM_FR_DIAL   0x02
+#define VM_FR_ANSWER 0x03
+#define VM_FR_HANGUP 0x04
+#define VM_FR_DATA   0x05
+#define VM_FR_END    0x06
+
+/* console-facing RX queue (3 bytes per message) */
+#define VM_RXQ_SIZE 1024
+static uint8_t vmRxQ[VM_RXQ_SIZE];
+static uint32_t vmRxHead;
+static uint32_t vmRxCount;
+
+/* heard-DTMF digit queue, popped by $6800 */
+#define VM_DIGQ_SIZE 32
+static uint8_t vmDigQ[VM_DIGQ_SIZE];
+static uint32_t vmDigHead;
+static uint32_t vmDigCount;
+
+/* answer-side probe digits buffered until the call is up */
+#define VM_PENDQ_SIZE 16
+static uint8_t vmPendDig[VM_PENDQ_SIZE];
+static uint32_t vmPendCount;
+
+/* console word assembly (low byte first) */
+static int vmHaveLo;
+static uint8_t vmLoByte;
+
+/* wire frame assembly */
+static int vmWireHaveType;
+static uint8_t vmWireType;
+
+/* call state */
+static int vmAwake;           /* saw $FFFF wake                    */
+static int vmModeAnswer;      /* last mode word: $2480=1, $2C80=0  */
+static int vmConnected;       /* carrier up                        */
+static int vmDialedOut;       /* we sent VM_FR_DIAL                */
+static int vmSawDialDigit;    /* originate-side number in progress */
+static int vmRingPending;     /* far side dialed us                */
+static int vmDataInBurst;     /* DATA sent since last burst end    */
+static unsigned vmRingTimer;  /* frames until next $B1xx           */
+
+static int vmTrace = -1;
+
+static void VMTrace(const char *dir, unsigned v)
+{
+   if (vmTrace < 0)
+   {
+      const char *e = getenv("VJ_VM_TRACE");
+      vmTrace = (e && e[0] == '1') ? 1 : 0;
+   }
+   if (vmTrace)
+      fprintf(stderr, "[vmodem] %s %04X\n", dir, v);
+}
+
+/* ---- console-facing message queue ---- */
+
+static void VMQueueByte(uint8_t b)
+{
+   uint32_t tail;
+   if (vmRxCount >= VM_RXQ_SIZE)
+      return;                     /* full: drop (console will retry) */
+   tail = (vmRxHead + vmRxCount) % VM_RXQ_SIZE;
+   vmRxQ[tail] = b;
+   vmRxCount++;
+}
+
+/* 3-byte message: sync $FF, high byte, low byte */
+static void VMQueueMsg(uint16_t word)
+{
+   if (vmRxCount + 3 > VM_RXQ_SIZE)
+      return;
+   VMTrace("out", word);
+   VMQueueByte(0xFF);
+   VMQueueByte((uint8_t)(word >> 8));
+   VMQueueByte((uint8_t)(word & 0xFF));
+}
+
+int VMConsoleRecv(uint8_t *b)
+{
+   if (vmRxCount == 0)
+      return 0;
+   *b = vmRxQ[vmRxHead];
+   vmRxHead = (vmRxHead + 1) % VM_RXQ_SIZE;
+   vmRxCount--;
+   return 1;
+}
+
+int VMConsoleRxPending(void)
+{
+   return (int)vmRxCount;
+}
+
+/* ---- inter-modem wire ---- */
+
+static void VMWireSend(uint8_t type, uint8_t val)
+{
+   if (!JLinkConnected())
+      return;
+   JLinkWireSendByte(type);
+   JLinkWireSendByte(val);
+}
+
+static void VMHangupLocal(void)
+{
+   if (vmConnected || vmDialedOut)
+      VMWireSend(VM_FR_HANGUP, 0);
+   vmConnected = 0;
+   vmDialedOut = 0;
+   vmSawDialDigit = 0;
+   vmRingPending = 0;
+   vmDataInBurst = 0;
+   vmPendCount = 0;
+   vmDigHead = 0;
+   vmDigCount = 0;
+}
+
+static void VMConnectNow(void)
+{
+   uint32_t i;
+   vmConnected = 1;
+   vmRingPending = 0;
+   /* flush probe digits buffered while the call was still ringing */
+   for (i = 0; i < vmPendCount; i++)
+      VMWireSend(VM_FR_DTMF, vmPendDig[i]);
+   vmPendCount = 0;
+}
+
+/* ---- console command words ---- */
+
+static void VMCommand(uint16_t cmd)
+{
+   VMTrace("cmd", cmd);
+
+   /* wake / detect: also a full call-state reset */
+   if (cmd == 0xFFFF)
+   {
+      vmAwake = 1;
+      VMHangupLocal();
+      VMQueueMsg(0xB800);
+      return;
+   }
+   /* line-rate switch: console changes ASICLK right after and reads no
+    * reply; echoing would desynchronize the next transaction */
+   if (cmd == 0xFFFE)
+      return;
+
+   /* DTMF digit $8A2n */
+   if ((cmd & 0xFFF0) == 0x8A20)
+   {
+      uint8_t digit = (uint8_t)(cmd & 0x0F);
+      VMQueueMsg(cmd);
+      if (vmConnected)
+         VMWireSend(VM_FR_DTMF, digit);
+      else if (vmModeAnswer)
+      {
+         /* answer-side probe digits sent before the carrier settled:
+          * hold them for VMConnectNow */
+         if (vmPendCount < VM_PENDQ_SIZE)
+            vmPendDig[vmPendCount++] = digit;
+      }
+      else
+         vmSawDialDigit = 1;   /* originate: part of the phone number */
+      return;
+   }
+
+   switch (cmd)
+   {
+      case 0x2480:              /* answer mode */
+         vmModeAnswer = 1;
+         VMQueueMsg(cmd);
+         if (vmRingPending && !vmConnected)
+         {
+            VMWireSend(VM_FR_ANSWER, 0);
+            VMConnectNow();
+         }
+         return;
+      case 0x2C80:              /* originate mode */
+         vmModeAnswer = 0;
+         VMQueueMsg(cmd);
+         return;
+      case 0x8C01:              /* dial-tone check */
+         VMQueueMsg(JLinkConnected() ? 0x8C01 : 0x8C00);
+         return;
+      case 0x8C00:              /* call progress: always idle (instant) */
+         VMQueueMsg(0x8C00);
+         return;
+      case 0x6800:              /* poll heard DTMF digit */
+         if (!vmDialedOut && !vmModeAnswer && vmSawDialDigit)
+         {
+            /* first $6800 after the number went in = dialing finished */
+            vmSawDialDigit = 0;
+            vmDialedOut = 1;
+            VMWireSend(VM_FR_DIAL, 0);
+         }
+         if (vmDigCount)
+         {
+            uint8_t d = vmDigQ[vmDigHead];
+            vmDigHead = (vmDigHead + 1) % VM_DIGQ_SIZE;
+            vmDigCount--;
+            VMQueueMsg((uint16_t)(0x6800 | d));
+         }
+         else
+            VMQueueMsg(0xFFFE);
+         return;
+      case 0x8100:              /* carrier / connect-result query */
+         if (vmConnected)
+         {
+            VMQueueMsg(0x8613);   /* $86xx: connected, xx = speed code */
+            VMQueueMsg(0xA4FC);   /* clear the $57F6 connect wait bits */
+         }
+         else
+            VMQueueMsg(0x8000);   /* not yet: driver retries */
+         return;
+      case 0x9000:              /* hang up */
+         VMHangupLocal();
+         VMQueueMsg(cmd);
+         return;
+      default:
+         break;
+   }
+
+   /* data byte to the far console: raw, never echoed */
+   if ((cmd & 0xFF00) == 0xF000)
+   {
+      if (vmConnected)
+      {
+         VMWireSend(VM_FR_DATA, (uint8_t)(cmd & 0xFF));
+         vmDataInBurst = 1;
+      }
+      return;
+   }
+
+   /* everything else ($0102 ident, $0501 + config words, $8000, $0002,
+    * $A0xx audio path, ...) just wants its echo */
+   VMQueueMsg(cmd);
+}
+
+void VMConsoleTx(uint8_t b)
+{
+   if (!vmHaveLo)
+   {
+      vmLoByte = b;
+      vmHaveLo = 1;
+      return;
+   }
+   vmHaveLo = 0;
+   VMCommand((uint16_t)(((uint16_t)b << 8) | vmLoByte));
+}
+
+/* ---- bytes from the far modem ---- */
+
+static void VMWireFrame(uint8_t type, uint8_t val)
+{
+   switch (type)
+   {
+      case VM_FR_DTMF:
+         if (vmDigCount < VM_DIGQ_SIZE)
+         {
+            uint32_t tail = (vmDigHead + vmDigCount) % VM_DIGQ_SIZE;
+            vmDigQ[tail] = (uint8_t)(val & 0x0F);
+            vmDigCount++;
+         }
+         break;
+      case VM_FR_DIAL:
+         if (vmModeAnswer && !vmConnected)
+         {
+            /* already armed to answer: pick up immediately */
+            VMWireSend(VM_FR_ANSWER, 0);
+            VMConnectNow();
+         }
+         else if (!vmConnected)
+         {
+            vmRingPending = 1;
+            vmRingTimer = 0;    /* ring on the next frame tick */
+         }
+         break;
+      case VM_FR_ANSWER:
+         VMConnectNow();
+         break;
+      case VM_FR_HANGUP:
+         if (vmConnected && vmAwake)
+            VMQueueMsg(0xA401);   /* mask clear + bit0: line dropped */
+         vmConnected = 0;
+         vmDialedOut = 0;
+         vmRingPending = 0;
+         vmDigHead = 0;
+         vmDigCount = 0;
+         break;
+      case VM_FR_DATA:
+         VMQueueMsg((uint16_t)(0xF000 | val));
+         break;
+      case VM_FR_END:
+         VMQueueMsg(0xF301);
+         break;
+      default:
+         break;                  /* unknown frame: skip */
+   }
+}
+
+void VMWireInput(uint8_t b)
+{
+   if (!vmWireHaveType)
+   {
+      vmWireType = b;
+      vmWireHaveType = 1;
+      return;
+   }
+   vmWireHaveType = 0;
+   VMWireFrame(vmWireType, b);
+}
+
+void VMTxBurstEnd(void)
+{
+   if (vmDataInBurst)
+   {
+      vmDataInBurst = 0;
+      VMWireSend(VM_FR_END, 0);
+   }
+}
+
+void VMFrameTick(void)
+{
+   if (vmRingPending && !vmConnected && vmAwake)
+   {
+      if (vmRingTimer == 0)
+      {
+         VMQueueMsg(0xB100);     /* RING */
+         vmRingTimer = 60;       /* ~1/second */
+      }
+      else
+         vmRingTimer--;
+   }
+}
+
+void VMReset(void)
+{
+   vmRxHead = 0;
+   vmRxCount = 0;
+   vmDigHead = 0;
+   vmDigCount = 0;
+   vmPendCount = 0;
+   vmHaveLo = 0;
+   vmLoByte = 0;
+   vmWireHaveType = 0;
+   vmWireType = 0;
+   vmAwake = 0;
+   vmModeAnswer = 0;
+   vmConnected = 0;
+   vmDialedOut = 0;
+   vmSawDialDigit = 0;
+   vmRingPending = 0;
+   vmDataInBurst = 0;
+   vmRingTimer = 0;
+   /* vmTrace deliberately kept: env doesn't change mid-process */
+}

--- a/src/jerry/voicemodem.c
+++ b/src/jerry/voicemodem.c
@@ -242,7 +242,12 @@ static void VMCommand(uint16_t cmd)
       case 0x8100:              /* carrier / connect-result query */
          if (vmConnected)
          {
-            VMQueueMsg(0x8613);   /* $86xx: connected, xx = speed code */
+            /* $86xx: connected.  Ultra Vortek requires (xx >> 4) >= 8
+             * and maps nibbles 8..E to a speed display table
+             * (9600,9600,12000,14400,16800,19200,57600); below 8 it
+             * declares TOO MUCH TELEPHONE NOISE and hangs up.  $D =
+             * 19200, the rate the UART is actually programmed to. */
+            VMQueueMsg(0x86D0);
             VMQueueMsg(0xA4FC);   /* clear the $57F6 connect wait bits */
          }
          else

--- a/src/jerry/voicemodem.h
+++ b/src/jerry/voicemodem.h
@@ -1,0 +1,49 @@
+/* voicemodem.h — Jaguar Voice Modem (JVM) emulation for Ultra Vortek.
+ *
+ * A virtual modem state machine sitting between the JERRY UART and the
+ * jlink byte transport (issue #481).  The console-facing protocol is the
+ * one Ultra Vortek's own driver speaks (docs/voice-modem.md); "dial"
+ * resolves to the existing netlink TCP/netpacket/loopback session.  No
+ * voice, no DTMF audio, no real telephony — game data only.
+ *
+ * Consumed by jlink.c only; not a public core API.
+ */
+#ifndef __VOICEMODEM_H__
+#define __VOICEMODEM_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Full reset (power-on / retro_deinit / transport close). */
+void VMReset(void);
+
+/* Byte transmitted by the console over the UART. */
+void VMConsoleTx(uint8_t b);
+
+/* Modem->console byte stream (replies and async messages). */
+int  VMConsoleRecv(uint8_t *b);
+int  VMConsoleRxPending(void);
+
+/* Byte received from the far modem over the jlink transport. */
+void VMWireInput(uint8_t b);
+
+/* UART finished a TX burst (shift register drained, nothing queued). */
+void VMTxBurstEnd(void);
+
+/* Once per video frame: ring-indicate pacing. */
+void VMFrameTick(void);
+
+/* Deliberately no savestate hooks: the whole modem session (call state,
+ * in-flight replies) is host-side, exactly like jlink's sockets.  Loading
+ * a state mid-call behaves as a pulled phone line; Ultra Vortek shows
+ * LOST PHONE CONNECTION and both sides can redial.  See PR #481. */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/tools/uv_modem_game_test.sh
+++ b/test/tools/uv_modem_game_test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# uv_modem_game_test.sh — full-game Ultra Vortek Voice Modem netplay test.
+#
+# Boots two core instances with the retail Ultra Vortek ROM, types the
+# 911 modem code on both title screens, has one side pick ANSWER PHONE
+# and the other DIAL OPPONENT (number "1"), and asserts that both sides
+# get past the whole modem choreography into the in-game lockstep data
+# phase (pad packets as $F0xx words with $F301 framing, visible in the
+# VJ_VM_TRACE log).
+#
+# Usage: uv_modem_game_test.sh <core> [port]
+# Exit codes: 0 pass, 1 fail, 77 = private ROM absent (skip).
+# Runtime: ~95 s (two --realtime instances of 5400 frames).
+set -u
+
+CORE="${1:?usage: uv_modem_game_test.sh <core> [port]}"
+PORT="${2:-$(( 25000 + ($$ % 4000) ))}"
+ROM="test/roms/private/ROMS/Atari Jaguar Rom Collection/ROMS/Ultra Vortek (1995).jag"
+BIN="$(dirname "$0")/netlink_game"
+OUT="${TMPDIR:-/tmp}/uv_modem_game_$$"
+
+if [ ! -f "$ROM" ]; then
+    echo "uv_modem_game_test: SKIP (private ROM absent)" >&2
+    exit 77
+fi
+if [ ! -x "$BIN" ]; then
+    echo "uv_modem_game_test: $BIN not built" >&2
+    exit 1
+fi
+mkdir -p "$OUT"
+
+MAPOPTS=(--option virtualjaguar_uart_device=voicemodem
+  --option virtualjaguar_alt_inputs=enabled
+  --option virtualjaguar_p1_retropad_up=up
+  --option virtualjaguar_p1_retropad_down=down
+  --option virtualjaguar_p1_retropad_left=left
+  --option virtualjaguar_p1_retropad_right=right
+  --option virtualjaguar_p1_retropad_a=btn_a
+  --option virtualjaguar_p1_retropad_b=btn_b
+  --option virtualjaguar_p1_retropad_y=btn_c
+  --option virtualjaguar_p1_retropad_x=num_0
+  --option virtualjaguar_p1_retropad_l1=num_9
+  --option virtualjaguar_p1_retropad_r1=num_1)
+
+export VJ_VM_TRACE=1 VJ_NETLINK_PORT="$PORT"
+
+"$BIN" "$CORE" "$ROM" --role server --frames 5400 --realtime \
+  "${MAPOPTS[@]}" \
+  --press 905:1:6 --press 918:2:6 --press 931:2:6 \
+  --press 1250:up:6 --press 1290:up:6 --press 1360:a:6 \
+  > "$OUT/answer.log" 2>&1 &
+SRV=$!
+sleep 2
+"$BIN" "$CORE" "$ROM" --role client --frames 5400 --realtime \
+  "${MAPOPTS[@]}" \
+  --press 905:1:6 --press 918:2:6 --press 931:2:6 \
+  --press 1250:up:6 --press 1350:a:6 --press 1450:2:6 --press 1530:a:6 \
+  > "$OUT/dial.log" 2>&1 &
+CLI=$!
+wait "$SRV"
+wait "$CLI"
+
+rc=0
+for side in answer dial; do
+    n=$(grep -c "cmd F0" "$OUT/$side.log" || true)
+    if [ "${n:-0}" -lt 10 ]; then
+        echo "uv_modem_game_test: FAIL ($side sent only ${n:-0} data words;" \
+             "log: $OUT/$side.log)" >&2
+        rc=1
+    else
+        echo "uv_modem_game_test: $side side in data phase ($n pad words sent)"
+    fi
+done
+if [ "$rc" -eq 0 ]; then
+    echo "uv_modem_game_test: PASS (port $PORT)"
+    command rm -rf "$OUT"
+fi
+exit "$rc"

--- a/test/tools/uv_modem_game_test.sh
+++ b/test/tools/uv_modem_game_test.sh
@@ -42,16 +42,19 @@ MAPOPTS=(--option virtualjaguar_uart_device=voicemodem
   --option virtualjaguar_p1_retropad_l1=num_9
   --option virtualjaguar_p1_retropad_r1=num_1)
 
-export VJ_VM_TRACE=1 VJ_NETLINK_PORT="$PORT"
+# netlink_game putenv()s VJ_NETLINK_PORT itself from --port (default
+# 42171), overriding any inherited value -- the port MUST go on the
+# command line or concurrent pairs cross-connect on the default.
+export VJ_VM_TRACE=1
 
-"$BIN" "$CORE" "$ROM" --role server --frames 5400 --realtime \
+"$BIN" "$CORE" "$ROM" --role server --port "$PORT" --frames 5400 --realtime \
   "${MAPOPTS[@]}" \
   --press 905:1:6 --press 918:2:6 --press 931:2:6 \
   --press 1250:up:6 --press 1290:up:6 --press 1360:a:6 \
   > "$OUT/answer.log" 2>&1 &
 SRV=$!
 sleep 2
-"$BIN" "$CORE" "$ROM" --role client --frames 5400 --realtime \
+"$BIN" "$CORE" "$ROM" --role client --port "$PORT" --frames 5400 --realtime \
   "${MAPOPTS[@]}" \
   --press 905:1:6 --press 918:2:6 --press 931:2:6 \
   --press 1250:up:6 --press 1350:a:6 --press 1450:2:6 --press 1530:a:6 \

--- a/test/tools/voicemodem_pair.c
+++ b/test/tools/voicemodem_pair.c
@@ -1,0 +1,409 @@
+/* voicemodem_pair.c — one endpoint of the two-process Voice Modem test.
+ *
+ *   voicemodem_pair <core> --role dial|answer [--port N] [--host ADDR]
+ *
+ * Drives the JERRY UART registers with the exact command sequences Ultra
+ * Vortek's modem driver issues (docs/voice-modem.md): wake, ident,
+ * config, dial / answer, the mutual DTMF probe, the $8100 carrier query
+ * with its $A4FC follow-up, and a 4-byte data packet each way ending in
+ * the modem-generated $F301.  Bytes travel the full stack: UART frames
+ * -> voicemodem -> jlink -> TCP -> peer process.  Exit 0 on success.
+ * Driven by test/tools/voicemodem_pair_test.sh.
+ */
+#define _DEFAULT_SOURCE 1
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include "../harness/harness.h"
+#include "jlink.h"
+
+typedef void     (*jerry_ww_t)(uint32_t, uint16_t, uint32_t);
+typedef uint16_t (*jerry_rw_t)(uint32_t, uint32_t);
+typedef int      (*jlink_conn_t)(void);
+typedef void     (*retro_run_t)(void);
+
+#define ROM_SIZE 131072
+#define MAX_WAIT_FRAMES 1200    /* rendezvous budget (~20 s at 60 fps) */
+#define MSG_TIMEOUT 600         /* frames to wait for one 3-byte reply */
+
+static jerry_ww_t jerry_ww;
+static jerry_rw_t jerry_rw;
+static retro_run_t run_frame;
+static const char *g_role = "?";
+
+/* Software RX FIFO.  On real hardware Ultra Vortek's DSP drains RBF at
+ * I2S rate no matter what the 68K is doing; without this, RX bytes
+ * arriving while the test is busy transmitting overrun (OE) and the
+ * 3-byte message stream slips out of sync. */
+#define RXFIFO_SIZE 256
+static uint8_t rxfifo[RXFIFO_SIZE];
+static unsigned rxf_head, rxf_count;
+
+static void drain_rbf(void)
+{
+    while ((jerry_rw(0xF10032, 0) & 0x0080) && rxf_count < RXFIFO_SIZE)
+    {
+        rxfifo[(rxf_head + rxf_count) % RXFIFO_SIZE] =
+            (uint8_t)(jerry_rw(0xF10030, 0) & 0xFF);
+        rxf_count++;
+    }
+}
+
+static void step(void)
+{
+    run_frame();
+    drain_rbf();
+    usleep(2000);   /* headless frames run unthrottled; stay ~wall time */
+}
+
+/* Wait for TBE, then load one byte into the transmitter. */
+static int tx_byte(uint8_t b)
+{
+    int i;
+    for (i = 0; i < MSG_TIMEOUT; i++)
+    {
+        if (jerry_rw(0xF10032, 0) & 0x0100)
+        {
+            jerry_ww(0xF10030, b, 0);
+            return 1;
+        }
+        step();
+    }
+    fprintf(stderr, "[%s] FAIL: TBE never set\n", g_role);
+    return 0;
+}
+
+/* Command word: low byte first (the driver's SendWord). */
+static int send_word(uint16_t w)
+{
+    if (!tx_byte((uint8_t)(w & 0xFF)))
+        return 0;
+    return tx_byte((uint8_t)(w >> 8));
+}
+
+/* Pop one received byte, pumping frames until it arrives. */
+static int rx_byte(uint8_t *b)
+{
+    int i;
+    for (i = 0; i < MSG_TIMEOUT; i++)
+    {
+        drain_rbf();
+        if (rxf_count)
+        {
+            *b = rxfifo[rxf_head];
+            rxf_head = (rxf_head + 1) % RXFIFO_SIZE;
+            rxf_count--;
+            return 1;
+        }
+        step();
+    }
+    return 0;
+}
+
+/* Read one 3-byte modem message ($FF sync, high, low); $B1xx ring
+ * indications repeat and are skipped transparently. */
+static int recv_msg(uint16_t *w)
+{
+    uint8_t sync, hi, lo;
+    for (;;)
+    {
+        if (!rx_byte(&sync))
+            return 0;
+        if (sync != 0xFF && sync != 0xFE)
+        {
+            fprintf(stderr, "[%s] FAIL: bad sync byte %02X\n", g_role, sync);
+            return 0;
+        }
+        if (!rx_byte(&hi) || !rx_byte(&lo))
+            return 0;
+        *w = (uint16_t)(((uint16_t)hi << 8) | lo);
+        if (hi == 0xB1)
+            continue;           /* ring indicate: consume and keep going */
+        return 1;
+    }
+}
+
+static int expect(uint16_t want)
+{
+    uint16_t got;
+    if (!recv_msg(&got))
+    {
+        fprintf(stderr, "[%s] FAIL: timeout waiting for %04X\n",
+                g_role, want);
+        return 0;
+    }
+    if (got != want)
+    {
+        fprintf(stderr, "[%s] FAIL: got %04X, want %04X\n",
+                g_role, got, want);
+        return 0;
+    }
+    return 1;
+}
+
+/* Send a command word and require its echo. */
+static int cmd_echo(uint16_t w)
+{
+    if (!send_word(w))
+        return 0;
+    return expect(w);
+}
+
+/* Poll $6800 until the modem reports a heard digit; require it. */
+static int expect_digit(uint8_t digit, int tries)
+{
+    uint16_t got;
+    int i;
+    for (i = 0; i < tries; i++)
+    {
+        if (!send_word(0x6800))
+            return 0;
+        if (!recv_msg(&got))
+            return 0;
+        if (got == 0xFFFE)
+            continue;           /* nothing heard yet */
+        if (got == (uint16_t)(0x6800 | digit))
+            return 1;
+        fprintf(stderr, "[%s] FAIL: heard %04X, want %04X\n",
+                g_role, got, 0x6800 | digit);
+        return 0;
+    }
+    fprintf(stderr, "[%s] FAIL: digit %u never heard\n", g_role, digit);
+    return 0;
+}
+
+/* Transmit a 4-byte data packet as one continuous burst so the modem's
+ * end-of-packet marker fires once, after the last byte. */
+static int send_packet(const uint8_t *payload)
+{
+    int i;
+    for (i = 0; i < 4; i++)
+    {
+        if (!send_word((uint16_t)(0xF000 | payload[i])))
+            return 0;
+    }
+    return 1;
+}
+
+static int recv_packet(const uint8_t *want)
+{
+    uint16_t got;
+    int i;
+    for (i = 0; i < 4; i++)
+    {
+        if (!recv_msg(&got))
+        {
+            fprintf(stderr, "[%s] FAIL: data byte %d never arrived\n",
+                    g_role, i);
+            return 0;
+        }
+        if (got != (uint16_t)(0xF000 | want[i]))
+        {
+            fprintf(stderr, "[%s] FAIL: data %d: got %04X want %04X\n",
+                    g_role, i, got, 0xF000 | want[i]);
+            return 0;
+        }
+    }
+    return expect(0xF301);      /* modem-generated end-of-packet */
+}
+
+static const char *make_synth_rom(const char *role)
+{
+    static char path[256];
+    static uint8_t rom_buf[ROM_SIZE];
+    FILE *f;
+    const char *tmp = getenv("TMPDIR");
+    snprintf(path, sizeof(path), "%s/vj_vmodem_pair_%s.j64",
+             tmp ? tmp : "/tmp", role);
+    memset(rom_buf, 0, ROM_SIZE);
+    rom_buf[0x404] = 0x00; rom_buf[0x405] = 0x80;
+    rom_buf[0x406] = 0x20; rom_buf[0x407] = 0x00;
+    rom_buf[0x2000] = 0x60; rom_buf[0x2001] = 0xFE;   /* bra.s * */
+    f = fopen(path, "wb");
+    if (!f) return NULL;
+    fwrite(rom_buf, 1, ROM_SIZE, f);
+    fclose(f);
+    return path;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    const char *role = NULL;
+    const char *port = "42171";
+    const char *host = "127.0.0.1";
+    char port_env[64];
+    char host_env[192];
+    jlink_conn_t jlink_connected;
+    jlink_conn_t jlink_mode;
+    int i, dialer = 0, connected = 0, ok = 0;
+    static const uint8_t pkt_dial[4]   = { 0xDE, 0xAD, 0xBE, 0xEF };
+    static const uint8_t pkt_answer[4] = { 0x11, 0x22, 0x33, 0x44 };
+
+    for (i = 1; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "--role") && i + 1 < argc)
+        {
+            role = argv[++i];
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+        else if (!strcmp(argv[i], "--port") && i + 1 < argc)
+        {
+            port = argv[++i];
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+        else if (!strcmp(argv[i], "--host") && i + 1 < argc)
+        {
+            host = argv[++i];
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+    }
+    if (!role || (strcmp(role, "dial") && strcmp(role, "answer")))
+    {
+        fprintf(stderr, "usage: voicemodem_pair <core> --role dial|answer"
+                        " [--port N] [--host ADDR]\n");
+        return 1;
+    }
+    g_role = role;
+    dialer = !strcmp(role, "dial");
+
+    if (snprintf(port_env, sizeof(port_env), "VJ_NETLINK_PORT=%s", port)
+        >= (int)sizeof(port_env))
+        return 1;
+    putenv(port_env);
+    if (snprintf(host_env, sizeof(host_env), "VJ_NETLINK_HOST=%s", host)
+        >= (int)sizeof(host_env))
+        return 1;
+    putenv(host_env);
+
+    cfg.frames = 1;
+    cfg.options[0].key = "virtualjaguar_netlink";
+    cfg.options[0].value = dialer ? "tcp_client" : "tcp_server";
+    cfg.options[1].key = "virtualjaguar_netlink_port";
+    cfg.options[1].value = port;
+    cfg.options[2].key = "virtualjaguar_uart_device";
+    cfg.options[2].value = "voicemodem";
+    cfg.num_options = 3;
+
+    if (!harness_init_from_args(&cfg, argc, argv)) return 1;
+    if (!cfg.rom_path)
+    {
+        cfg.rom_path = make_synth_rom(role);
+        if (!cfg.rom_path) return 1;
+    }
+    if (!harness_load_rom(&cfg)) return 1;
+
+    jerry_ww = (jerry_ww_t)harness_dlsym(&cfg, "JERRYWriteWord");
+    jerry_rw = (jerry_rw_t)harness_dlsym(&cfg, "JERRYReadWord");
+    jlink_connected = (jlink_conn_t)harness_dlsym(&cfg, "JLinkConnected");
+    jlink_mode = (jlink_conn_t)harness_dlsym(&cfg, "JLinkMode");
+    run_frame = (retro_run_t)harness_dlsym(&cfg, "retro_run");
+    if (!jerry_ww || !jerry_rw || !jlink_connected || !run_frame)
+    {
+        fprintf(stderr, "[%s] symbols missing -- build with TEST_EXPORTS=1\n",
+                role);
+        return 1;
+    }
+    if (!dialer && jlink_mode && jlink_mode() == JLINK_MODE_DISABLED)
+    {
+        fprintf(stderr, "[%s] FAIL: netlink server did not open "
+                        "(port %s busy?)\n", role, port);
+        harness_shutdown(&cfg);
+        return 2;
+    }
+
+    /* Slow character pacing (~27 ms/char, one per video frame): this
+     * test reads and refills the UART at frame granularity, and the
+     * 4-byte data packet must stay a single TX burst (TBE is re-armed
+     * every frame, well inside the char time) so the modem's
+     * end-of-packet marker fires exactly once. */
+    jerry_ww(0xF10034, 0x0FFF, 0);
+
+    for (i = 0; i < MAX_WAIT_FRAMES && !connected; i++)
+    {
+        step();
+        if (jlink_connected())
+            connected = 1;
+    }
+    if (!connected)
+    {
+        fprintf(stderr, "[%s] FAIL: transport never connected\n", role);
+        harness_shutdown(&cfg);
+        return 1;
+    }
+    fprintf(stderr, "[%s] transport up\n", role);
+
+    do
+    {
+        /* --- wake / ident (same on both sides) --- */
+        if (!send_word(0xFFFF) || !expect(0xB800)) break;
+        if (!send_word(0xFFFE)) break;              /* no reply */
+        if (!cmd_echo(0x0102)) break;
+        /* --- config block (representative subset; all echo) --- */
+        if (!cmd_echo(0x0501)) break;
+        if (!cmd_echo(0x000F)) break;
+        if (!cmd_echo(0xA3FC)) break;
+
+        if (dialer)
+        {
+            if (!cmd_echo(0x2C80)) break;           /* originate mode */
+            if (!send_word(0x8C01) || !expect(0x8C01)) break; /* tone */
+            if (!cmd_echo(0x8A21)) break;           /* dial digit 1 */
+            if (!send_word(0x8C00) || !expect(0x8C00)) break;
+            /* first $6800 marks end-of-dial; then hear the answerer's
+             * probe digits 0, 9 */
+            if (!expect_digit(0x0, 400)) break;
+            if (!expect_digit(0x9, 400)) break;
+            /* send our probe digits 1, 2 */
+            if (!cmd_echo(0x8A21)) break;
+            if (!cmd_echo(0x8A22)) break;
+        }
+        else
+        {
+            if (!cmd_echo(0x2480)) break;           /* answer mode */
+            /* probe digits 0, 9 (buffered until the call is up) */
+            if (!cmd_echo(0x8A20)) break;
+            if (!cmd_echo(0x8A29)) break;
+            if (!send_word(0x8C00) || !expect(0x8C00)) break;
+            /* hear the dialer's probe digits 1, 2 */
+            if (!expect_digit(0x1, 400)) break;
+            if (!expect_digit(0x2, 400)) break;
+        }
+
+        /* --- carrier query: $86xx then the async $A4FC --- */
+        if (!cmd_echo(0x8000)) break;
+        if (!send_word(0x8100) || !expect(0x8613) || !expect(0xA4FC)) break;
+
+        /* --- data phase: one packet each way --- */
+        if (dialer)
+        {
+            if (!send_packet(pkt_dial)) break;
+            if (!recv_packet(pkt_answer)) break;
+        }
+        else
+        {
+            if (!send_packet(pkt_answer)) break;
+            if (!recv_packet(pkt_dial)) break;
+        }
+
+        ok = 1;
+    } while (0);
+
+    /* Grace period so the peer finishes its paced reads before the
+     * socket goes away under it. */
+    if (ok)
+        for (i = 0; i < 120; i++)
+            step();
+
+    harness_shutdown(&cfg);
+
+    if (!ok)
+    {
+        fprintf(stderr, "[%s] FAIL\n", role);
+        return 1;
+    }
+    fprintf(stderr, "[%s] PASS: modem handshake + data exchange\n", role);
+    return 0;
+}

--- a/test/tools/voicemodem_pair.c
+++ b/test/tools/voicemodem_pair.c
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
 
         /* --- carrier query: $86xx then the async $A4FC --- */
         if (!cmd_echo(0x8000)) break;
-        if (!send_word(0x8100) || !expect(0x8613) || !expect(0xA4FC)) break;
+        if (!send_word(0x8100) || !expect(0x86D0) || !expect(0xA4FC)) break;
 
         /* --- data phase: one packet each way --- */
         if (dialer)

--- a/test/tools/voicemodem_pair_test.sh
+++ b/test/tools/voicemodem_pair_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# voicemodem_pair_test.sh — two-process Voice Modem handshake test driver.
+# Launches an answer-role and a dial-role instance of the core on
+# localhost and requires both to complete the Ultra Vortek modem
+# choreography (see voicemodem_pair.c).
+# Usage: voicemodem_pair_test.sh <core> [port]
+set -u
+
+CORE="${1:?usage: voicemodem_pair_test.sh <core> [port]}"
+# Port default mirrors netlink_pair_test.sh: PID-spread inside
+# 21000-24999, below every CI OS's ephemeral range, and disjoint from
+# netlink_pair_test's 17000-20999 so the two suites never collide.
+PORT="${2:-${VJ_NETLINK_PORT:-$(( 21000 + ($$ % 4000) ))}}"
+BIN="$(dirname "$0")/voicemodem_pair"
+
+if [ ! -x "$BIN" ]; then
+    echo "voicemodem_pair_test: $BIN not built" >&2
+    exit 1
+fi
+
+run_pair() {
+    local port="$1"
+    local answer_rc dial_rc answer_pid
+
+    "$BIN" "$CORE" --role answer --port "$port" &
+    answer_pid=$!
+    sleep 0.3
+    "$BIN" "$CORE" --role dial --port "$port" --host 127.0.0.1
+    dial_rc=$?
+    wait "$answer_pid"
+    answer_rc=$?
+
+    if [ "$answer_rc" -eq 0 ] && [ "$dial_rc" -eq 0 ]; then
+        echo "voicemodem_pair_test: PASS (port $port)"
+        return 0
+    fi
+    if [ "$answer_rc" -eq 2 ]; then
+        return 2
+    fi
+    echo "voicemodem_pair_test: FAIL (answer=$answer_rc dial=$dial_rc)" >&2
+    return 1
+}
+
+port="$PORT"
+for attempt in 1 2 3; do
+    run_pair "$port"
+    rc=$?
+    [ "$rc" -ne 2 ] && exit "$rc"
+    port=$((port + 211))
+    echo "voicemodem_pair_test: port busy, retrying on $port" >&2
+done
+echo "voicemodem_pair_test: FAIL (no bindable port after 3 tries)" >&2
+exit 1


### PR DESCRIPTION
Implements #481: the Jaguar Voice Modem (JVM) is now emulated on JERRY's UART, so **Ultra Vortek's phone-line versus mode works over the existing netlink transport** — two emulator instances, no physical modem.

## What landed

- **`docs/voice-modem.md`** — the JVM protocol, derived by disassembling the retail Ultra Vortek ROM (its own 68K modem driver at `$80AF96-$80BA19` plus the DSP-side UART service loop). Command/response word format, connect choreography, DTMF probe, `$86xx` speed validation, data-phase framing, async event classes, and what UV's netplay actually exchanges (lockstep pad-state packets).
- **`src/jerry/voicemodem.c`** — a virtual modem state machine in front of the jlink transport. "Dial" resolves to the netlink TCP / netpacket / loopback session; DTMF digits, carrier events, and game data ride 2-byte frames between the two modem instances. No voice, no telephony.
- **Core option `virtualjaguar_uart_device`** = `jaglink` (default, behavior unchanged) | `voicemodem`. JagLink/CatBox path untouched apart from the burst-end hook rename (`JLinkTxBurstEnd`), which the modem uses to generate the `$F301` end-of-packet marker the receiving console requires.
- **Tests**: `test/tools/voicemodem_pair` (+`voicemodem_pair_test.sh`, in `make test`) drives the UART registers with UV's exact command sequences across two processes over TCP — wake through carrier-up through a 4-byte data packet each way. `test/tools/uv_modem_game_test.sh` (private-ROM gated, exit 77 skip) runs the full game end-to-end.

## Verified

Two retail Ultra Vortek instances over localhost TCP, fully headless (`--press` scripted): type `911` on both title screens → INITIALIZING VOICE MODEM → one side DIAL OPPONENT (dials "1"), other side ANSWER PHONE → full modem choreography (wake `$FFFF`→`$B800`, config block, dial `$8A2n`, mutual DTMF probe via `$6800`, `$8100`→`$86D0`+`$A4FC` carrier-up) → **both consoles reach the synchronized "VOICE MODEM ONLINE" lobby (TWO PLAYER VS. / OPTIONS / HANG-UP) and exchange lockstep pad packets (~7,000 `$F0xx` words each way per 90 s session)**. Register-level pair test green; `make test` green; `scripts/c89-lint.sh` clean on all touched sources; export lists in sync.

Notable protocol find: UV validates the `$86xx` carrier reply — `(speed_byte >> 4) < 8` is declared "TOO MUCH TELEPHONE NOISE" and torn down; nibbles 8..E index a speed display table (9600..57600). We reply `$86D0` (19200, the programmed UART rate).

## Savestate decision

Modem session state is deliberately **not** serialized, following jlink's socket precedent exactly: the whole call (connection, in-flight replies) is host-side. Loading a state mid-call behaves as a pulled phone line — UV shows LOST PHONE CONNECTION and both sides can redial. The UART/jlink chunks are unchanged, so no STATE_VERSION bump.

## Left out / follow-ups

- Voice and DTMF audio (irrelevant to netplay; the `$A0xx` audio-path commands are echoed).
- `$B1xx` ring payload byte and the exact Phylon config word semantics are unknown (echoes satisfy the driver); documented as open questions in `docs/voice-modem.md`.
- Latency tolerance beyond localhost/LAN is unmeasured (same status as the rest of netlink); the adaptive bounded-reply-wait (PR #250) applies to the modem's wire frames automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
