### PR TITLE
docs(input): PR #474 review follow-ups (option table, docstring, comment)

### DIFF
--- a/docs/input-devices-user-guide.md
+++ b/docs/input-devices-user-guide.md
@@ -26,14 +26,14 @@ plugged into either port draws on the same five rotary options.
 | *Port 2 > Mouse Sensitivity* (`virtualjaguar_mouse_sensitivity`) | 25% – 400% | 100% |
 | *Port 2 > Mouse Dead Zone (X)* (`virtualjaguar_mouse_deadzone_x`) | Off, 1 – 8 units | Off |
 | *Port 2 > Mouse Dead Zone (Y)* (`virtualjaguar_mouse_deadzone_y`) | Off, 1 – 8 units | Off |
-| *Port 2 > Mouse Offset (X)* (`virtualjaguar_mouse_offset_x`) | -4 – +4 | Off |
-| *Port 2 > Mouse Offset (Y)* (`virtualjaguar_mouse_offset_y`) | -4 – +4 | Off |
+| *Port 2 > Mouse Offset (X)* (`virtualjaguar_mouse_offset_x`) | -4 – -1, Off, +1 – +4 | Off |
+| *Port 2 > Mouse Offset (Y)* (`virtualjaguar_mouse_offset_y`) | -4 – -1, Off, +1 – +4 | Off |
 | *Port 2 > Mouse Response Curve (X)* (`virtualjaguar_mouse_exponent_x`) | Linear (1.00) – 3.00 | Linear (1.00) |
 | *Port 2 > Mouse Response Curve (Y)* (`virtualjaguar_mouse_exponent_y`) | Linear (1.00) – 3.00 | Linear (1.00) |
 | *Rotary Sensitivity* (`virtualjaguar_rotary_sensitivity`) | 25% – 400% | 100% |
 | *Rotary Reports Controller Type* (`virtualjaguar_rotary_id`) | Standard Joypad (no diode), Tempest Rotary (diode fitted) | Standard Joypad |
 | *Rotary Dead Zone* (`virtualjaguar_rotary_deadzone`) | Off, 1 – 8 units | Off |
-| *Rotary Offset* (`virtualjaguar_rotary_offset`) | -4 – +4 | Off |
+| *Rotary Offset* (`virtualjaguar_rotary_offset`) | -4 – -1, Off, +1 – +4 | Off |
 | *Rotary Response Curve* (`virtualjaguar_rotary_exponent`) | Linear (1.00) – 3.00 | Linear (1.00) |
 
 The seven mouse rows (*Mouse Sensitivity* through *Mouse Response Curve (Y)*)

--- a/docs/input-devices-user-guide.md
+++ b/docs/input-devices-user-guide.md
@@ -14,24 +14,53 @@ with a pad.
 
 ## Core options
 
-All three live under **Port 2** in the core options menu.
+Fourteen options together cover device selection and per-axis tuning for both
+ports. The mouse rows live under **Port 2**; the rotary rows are shared by
+**both** ports, exactly like *Rotary Sensitivity* always has been — a rotary
+plugged into either port draws on the same five rotary options.
 
 | Option | Values | Default |
 |---|---|---|
-| *Port 2 > Controller Type* (`virtualjaguar_p2_device`) | Auto (per-title default), Standard Joypad, Atari ST / PS2 Mouse, Amiga Mouse (ST adapter), Amiga Mouse (Amiga adapter) | Auto |
+| *Port 1 > Controller Type* (`virtualjaguar_p1_device`) | Auto (per-title default), Standard Joypad, Rotary (Tempest) | Auto |
+| *Port 2 > Controller Type* (`virtualjaguar_p2_device`) | Auto (per-title default), Standard Joypad, Atari ST / PS2 Mouse, Amiga Mouse (ST adapter), Amiga Mouse (Amiga adapter), Rotary (Tempest) | Auto |
 | *Port 2 > Mouse Sensitivity* (`virtualjaguar_mouse_sensitivity`) | 25% – 400% | 100% |
+| *Port 2 > Mouse Dead Zone (X)* (`virtualjaguar_mouse_deadzone_x`) | Off, 1 – 8 units | Off |
+| *Port 2 > Mouse Dead Zone (Y)* (`virtualjaguar_mouse_deadzone_y`) | Off, 1 – 8 units | Off |
+| *Port 2 > Mouse Offset (X)* (`virtualjaguar_mouse_offset_x`) | -4 – +4 | Off |
+| *Port 2 > Mouse Offset (Y)* (`virtualjaguar_mouse_offset_y`) | -4 – +4 | Off |
+| *Port 2 > Mouse Response Curve (X)* (`virtualjaguar_mouse_exponent_x`) | Linear (1.00) – 3.00 | Linear (1.00) |
+| *Port 2 > Mouse Response Curve (Y)* (`virtualjaguar_mouse_exponent_y`) | Linear (1.00) – 3.00 | Linear (1.00) |
+| *Rotary Sensitivity* (`virtualjaguar_rotary_sensitivity`) | 25% – 400% | 100% |
+| *Rotary Reports Controller Type* (`virtualjaguar_rotary_id`) | Standard Joypad (no diode), Tempest Rotary (diode fitted) | Standard Joypad |
+| *Rotary Dead Zone* (`virtualjaguar_rotary_deadzone`) | Off, 1 – 8 units | Off |
+| *Rotary Offset* (`virtualjaguar_rotary_offset`) | -4 – +4 | Off |
+| *Rotary Response Curve* (`virtualjaguar_rotary_exponent`) | Linear (1.00) – 3.00 | Linear (1.00) |
 
-*Mouse Sensitivity* only appears while a mouse is actually attached to port 2.
+The seven mouse rows (*Mouse Sensitivity* through *Mouse Response Curve (Y)*)
+only appear once a mouse is actually attached to port 2. The five rotary rows
+only appear once a rotary is attached to port 1 or port 2. Both groups are
+gated on the live device, not the option string, so a device your frontend
+assigned directly (see below) reveals them too, exactly as a core-option
+selection would.
+
+The dead zone, offset and response-curve rows are per-axis tuning (#439,
+landed in #474): a noise gate, a centring correction and a low-speed response
+curve, in that order, applied identically to mouse and rotary motion by the
+shared layer in `src/jerry/axistune.c`. Every default is the exact identity,
+so a user who never opens this menu gets the pre-#439 path unchanged — the
+same guarantee the mouse feature itself makes (see above).
 
 **Auto currently means Standard Joypad for every title.** See
 [No per-title auto-select](#no-per-title-auto-select-and-why) below — that is
 a deliberate result, not an unfinished switch.
 
 Your frontend can also select the device directly (RetroArch: *Controls →
-Port 2 → Device Type*), which offers the same four devices. A **mouse** set
-that way outranks the core option. Setting the port back to *Joypad* or *None*
-releases that claim rather than forcing a pad — the core option decides again,
-immediately.
+Port 1/2 → Device Type*), which offers the same devices as each port's
+*Controller Type* option: two on port 1 (Standard Joypad, Rotary), five on
+port 2 (Standard Joypad, the three mice, Rotary) — everything except *Auto*,
+which is not a real device. A device set that way outranks the core option.
+Setting the port back to *Joypad* or *None* releases that claim rather than
+forcing a pad — the core option decides again, immediately.
 
 ### Once a mouse is live, the port-2 RetroPad is disconnected
 
@@ -162,9 +191,9 @@ such at the code sites so nobody "fixes" them later.
 
 ## Not yet implemented
 
-The **Tempest rotary** controller (#436) is a separate device on the same
-track and is not covered here. Lightgun (#437), analog/driving controllers
-(#438) and per-axis tuning (#439) are also open.
+Lightgun support (#438) and analog / driving controllers (#437) are open.
+The **Tempest rotary** (#436) and per-axis tuning (#439) have since shipped —
+see [Core options](#core-options) above.
 
 ## See also
 

--- a/src/jerry/inputdev.c
+++ b/src/jerry/inputdev.c
@@ -82,9 +82,11 @@ static int inputdev_is_mouse(InputDevType t)
 }
 
 /* Dynamic (machine-visible) state only: encoders, button latches and the
- * armed flag.  The device type and the sensitivity scale are owned by the
- * core options and survive a machine reset, exactly as a physical mouse
- * stays plugged in across a console reset. */
+ * armed flag.  The device type, the sensitivity scale, and the per-axis
+ * tuning (tune_x/tune_y, #439 -- dead zone, offset, response exponent) are
+ * all owned by the core options and survive a machine reset, exactly as a
+ * physical mouse stays plugged in across a console reset. Deliberate, and
+ * load-bearing: see test/tools/tuning_identity.c's sweep-order comment. */
 static void inputdev_reset_dynamic(void)
 {
    unsigned p;

--- a/test/test_axistune.c
+++ b/test/test_axistune.c
@@ -36,8 +36,18 @@
  *      exponent the layer accepts and every magnitude below the reference,
  *      a sample that passed the gate keeps a non-zero gain.
  *   9. The effective response mag*gain is monotone non-decreasing in mag,
- *      for every exponent.  A curve with a fixed-point dip would read as
- *      the pointer stalling at one speed and is invisible to spot checks.
+ *      verified for exponent_q8 in [100, 800] -- the exact domain
+ *      test_response_is_monotone() sweeps below. That is not "every
+ *      exponent": the invariant is genuinely FALSE below exponent_q8=100
+ *      (e.g. exponent_q8=1 dips mag 15->16 from mag*gain 16290 to 16288,
+ *      confirmed by direct calculation against AxisTuneApply()). The test
+ *      does not chase that region because nothing in the shipped option
+ *      pipeline can reach it: read_tune_exponent() (libretro.c) only ever
+ *      sees one of the exponent core options' own enumerated values, which
+ *      run 100%-300% (exponent_q8 256-768) -- comfortably inside the
+ *      swept-and-proven [100, 800]. A curve with a fixed-point dip inside
+ *      that reachable range would read as the pointer stalling at one
+ *      speed and is invisible to spot checks.
  */
 
 #include <stdio.h>


### PR DESCRIPTION
## Summary

Three documented-but-non-blocking findings from [PR #474's review](https://github.com/libretro/virtualjaguar-libretro/pull/474#issuecomment-5322384227) (last paragraph). All comment/doc accuracy fixes — **no behavior change**.

- **`docs/input-devices-user-guide.md`**: the options table predated the nine per-axis tuning options (#474/#439) and the rotary device/sensitivity options (#451) — two options documented where fourteen now exist. Rebuilt from `libretro_core_options.h` on develop, grouped by device selection / mouse tuning / rotary tuning, with visibility gating pulled from `update_option_visibility()` in `libretro.c` rather than guessed. Also fixes the "offers the same four devices" line (`retro_controller_info` lists five for port 2 now) — the same count-mismatch class the #450 review flagged for "All three live under Port 2" — and updates "Not yet implemented" now that rotary and per-axis tuning have shipped, correcting an #437/#438 issue-number swap along the way (#437 is analog/driving controllers, #438 is lightgun — verified via `gh issue view`).

  `feat/437-analog-controllers` has **not** merged as of this PR (no open PR for that branch, issue #437 still open), so its options are intentionally not in the table, per the review's instruction not to invent unmerged content.

- **`test/test_axistune.c`**: invariant 9's docstring claimed mag\*gain monotonicity "for every exponent", but `test_response_is_monotone()` only sweeps `exponent_q8` in `[100, 800]`, and the invariant is genuinely false below that (verified independently here, not transcribed: `exponent_q8=1` dips mag 15→16 from mag\*gain 16290→16288). That region is unreachable through the shipped option pipeline — the exponent core options only enumerate 100%-300% (`exponent_q8` 256-768). No assertion or shipped arithmetic changed.

- **`src/jerry/inputdev.c`**: `inputdev_reset_dynamic()`'s enumerating comment named the device type and sensitivity scale as option-derived state that survives a machine reset, but omitted `tune_x`/`tune_y` (#439), which survive by the same rule — `test/tools/tuning_identity.c`'s sweep-order comment documents that survival as load-bearing. Minimal one-block comment edit to keep any merge with the in-flight #437 branch (which also touches this file) trivial.

## Verification

- `bash scripts/c89-lint.sh src/jerry/inputdev.c test/test_axistune.c` — passed.
- `DEVELOPER_DIR=/Library/Developer/CommandLineTools make -j8 TEST_EXPORTS=1 test` — full clean run: 0 failures. Guardrail digests unmoved (per the original PR's own stated values): joymatrix `0xC24DDCDE` / `0xD0CD02E2` / `0xD0CD02E2` / `0x5E1858EA`, `tuning_identity` 0 failures.
- Diff is comment/doc-only: `git diff -U0` on the two `.c` files shows every changed line inside a `/* */` block; the third file is Markdown.
- A later `make test` run hit an unrelated `netlink_latency_test.sh` failure (`mktemp: mkstemp failed ... File exists`) caused by several other concurrent agent worktrees in this environment running `make test` at the same time (confirmed via `ps aux`, not caused by this change); the test passed cleanly on an isolated retry.

## Test plan

- [x] `c89-lint` on both touched `.c` files
- [x] `make TEST_EXPORTS=1 test` exit 0, guardrail digests unmoved
- [x] Diff-is-comment/doc-only assertion made from the actual diff, not memory
- [x] Checked `feat/437-analog-controllers` merge status before finishing (still open, correctly excluded)

No Copilot review requested, per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)