### PR TITLE
feat(texreplace): texture replacement pipeline, tier 1 (#369 deliverable 2)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -419,7 +419,7 @@ jobs:
           /D__LIBRETRO__ /DINLINE="_inline" /DBLITTER_SIMD_SCALAR ^
           /D_7ZIP_ST /DMINIZ_DEFLATE_APIS /DWANT_RAW_DATA_SECTOR=1 /DWANT_SUBCODE=1 /DVERIFY_BLOCK_CRC=1 ^
           libretro.c ^
-          src\tom\blitter.c src\tom\blitter_compare.c src\tom\blitter_mmio.c src\tom\texdump.c src\jerry\dac.c src\jerry\dsp.c src\core\file.c ^
+          src\tom\blitter.c src\tom\blitter_compare.c src\tom\blitter_mmio.c src\tom\texdump.c src\tom\texreplace.c src\jerry\dac.c src\jerry\dsp.c src\core\file.c ^
           src\tom\gpu.c src\core\jaguar.c src\jerry\jerry.c src\tom\tom.c src\tom\op.c ^
           src\cd\cdintf.c src\cd\cdrom.c src\core\crc32.c src\core\biosdb.c src\core\event.c ^
           src\jerry\eeprom.c src\core\filedb.c src\jerry\joystick.c src\core\settings.c ^

--- a/Makefile
+++ b/Makefile
@@ -926,7 +926,7 @@ clean:
 		test/tools/test_frame_timing test/tools/test_runahead_determinism test/tools/test_pertitle_db \
 		test/test_biosdb test/test_cart_bios_loader \
 		test/test_titledb test/test_titlehook test/tools/test_hook_gate \
-		test/tools/test_wedge_spin test/tools/test_texdump test/tools/i2s_lag_probe \
+		test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace test/tools/i2s_lag_probe \
 		test/tools/joymatrix_identity test/tools/mouse_decode_test \
 		test/tools/rotary_decode_test test/tools/tuning_identity \
 		test/tools/blitter_static_leak \
@@ -977,7 +977,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_blitter_mmio test/test_blitter_cmd test/test_eeprom_lifecycle test/test_eeprom_read_race test/test_tom_visible_window \
 		test/test_framebuffer_integrity test/test_state_compat \
 		test/test_frontend_pacing test/test_jgd \
-		test/tools/test_runahead_determinism test/tools/test_wedge_spin test/tools/test_texdump \
+		test/tools/test_runahead_determinism test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace \
 		test/test_butch_cd test/test_bios_config test/test_boot_config \
 		test/test_cart_format test/test_cart_needs_bios test/test_cart_bios_loader \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_chd test/test_chd_unit test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda test/test_cd_synth_subq \
@@ -1194,6 +1194,11 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# blit battery inside the tool covers every bpp (see the tool
 	@# header for why a ROM run alone is a 2-hash tripwire).
 	./test/tools/test_texdump ./$(TARGET) test/roms/yarc.j64 --quiet
+	@# Texture replacement gates (#369 deliverable 2): no-pack and
+	@# with-pack machine inertness (fb hashes + savestate digests +
+	@# battery destination RAM), shadow-framebuffer presentation of a
+	@# first-principles synthetic pack, and determinism.
+	./test/tools/test_texreplace ./$(TARGET) test/roms/yarc.j64 --quiet
 	@rom=$$(bash scripts/find-rom.sh 'Iron Soldier (1994).jag' 'Iron Soldier (World)*.j64' 'Iron Soldier.jag'); \
 	if [ -n "$$rom" ]; then \
 		./test/tools/test_runahead_determinism ./$(TARGET) "$$rom" --quiet; \
@@ -1783,6 +1788,13 @@ test/tools/test_texdump: test/tools/test_texdump.c \
 		test/harness/harness.c test/harness/harness.h src/core/crc32.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_texdump.c \
+		test/harness/harness.c src/core/crc32.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
+
+test/tools/test_texreplace: test/tools/test_texreplace.c \
+		test/harness/harness.c test/harness/harness.h src/core/crc32.c
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/test_texreplace.c \
 		test/harness/harness.c src/core/crc32.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,6 +61,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/tom/op.c \
 	$(CORE_DIR)/src/tom/shadowfb.c \
 	$(CORE_DIR)/src/tom/texdump.c \
+	$(CORE_DIR)/src/tom/texreplace.c \
 	$(CORE_DIR)/src/tom/tom.c  \
 	$(CORE_DIR)/src/cd/cdintf.c \
 	$(CORE_DIR)/src/cd/cdrom.c \

--- a/docs/texture-dump.md
+++ b/docs/texture-dump.md
@@ -1,15 +1,18 @@
-# Texture dump mode (issue #369, deliverable 1 of 2)
+# Texture dump + replacement (issue #369)
 
-Design spec for `virtualjaguar_texture_dump`: write every unique blit
-source tile a title uses to disk as PNG + manifest, so pack authors have
-something to redraw and developers get a window into what titles
-actually blit. This is the first half of #369; the replacement pipeline
-(second half, v3.5) consumes the contract defined here.
+Design spec for `virtualjaguar_texture_dump` (deliverable 1: write
+every unique blit source tile a title uses to disk as PNG + manifest,
+so pack authors have something to redraw) and
+`virtualjaguar_texture_replace` (deliverable 2: present pack art in
+place of those tiles).  The replacement pipeline consumes exactly the
+identity contract dump mode freezes — see "Replacement pipeline" below.
 
-Status: **implemented (v3.4 deliverable 1).** Capture module
-`src/tom/texdump.c`, hook in `src/tom/blitter_mmio.c`, options in
-`libretro.c` / `libretro_core_options.h`, test gates in
-`test/tools/test_texdump.c` + `test/expected/texdump_yarc.txt`.
+Status: **both implemented.**  Dump: capture module `src/tom/texdump.c`,
+hook in `src/tom/blitter_mmio.c`, options in `libretro.c` /
+`libretro_core_options.h`, test gates in `test/tools/test_texdump.c` +
+`test/expected/texdump_yarc.txt`.  Replacement: `src/tom/texreplace.c`
+(+ `ShadowFBStoreRGB` in `src/tom/shadowfb.c`), gates in
+`test/tools/test_texreplace.c`.
 
 ## Goals and non-goals
 
@@ -267,6 +270,143 @@ What to know before redrawing:
   and new tiles simply append. Dedupe is per-session, so a replayed
   session may re-append rows for tiles already listed — rows are
   advisory, files are identity.
+
+## Replacement pipeline (deliverable 2 of 2)
+
+`virtualjaguar_texture_replace` presents pack art in place of dumped
+tiles.  Module: `src/tom/texreplace.c`; hooks around the engine
+dispatch in `src/tom/blitter_mmio.c`; presentation via
+`ShadowFBStoreRGB` in `src/tom/shadowfb.c`.
+
+### Pack layout
+
+```
+<system_dir>/vj_texpacks/<CRC32 8-hex>/<hash16>.png
+```
+
+Mirrors the dump layout, so an author's workflow is: dump, redraw,
+move one directory over.  Only files named exactly `<16 hex>.png` are
+read; anything else in the directory (manifest copies, notes, PSDs) is
+ignored.  Accepted PNGs: 8-bit depth, non-interlaced, color types
+0/2/3/4/6 (gray, RGB, indexed, gray+alpha, RGBA).  The whole pack is
+decoded ONCE into a host-side hash→pixels map — at content load, or on
+first enable — never at blit time.
+
+### Architecture: host-only, presentation-riding
+
+The pipeline never touches the emulated machine.  Not "restores it
+afterwards" — never touches it:
+
+1. At blit launch (pre-dispatch) the SOURCE window is hashed with the
+   same shared helpers dump mode uses (`TexDumpDescribe` /
+   `TexDumpSerialize` / `TexDumpHashKey` — one implementation, frozen
+   contract).  A map hit with matching dimensions arms the launch, and
+   the DESTINATION window is described before the engines write back
+   the pointer registers.
+2. The blit dispatches completely stock.
+3. Post-dispatch, the destination window is walked host-side: every
+   pixel whose RAM word now equals the source pixel captured
+   pre-dispatch (the **per-pixel straight-copy witness**) gets its pack
+   RGB888 stored into the true-color shadow framebuffer, tagged with
+   that RAM value.  The OP's existing shadow presentation path
+   (`ShadowFBLineFromRAM` → the CRY scanline renderer) then presents
+   the pack art; the value-check makes every entry self-invalidating
+   when RAM moves on.
+
+The witness makes wrong models harmless: transparent (BCOMPEN /
+DCOMPEN) pixels, shaded or Gouraud outputs, exotic step patterns —
+anything whose destination value is not the source value — simply
+never stores, and the stock pixel presents.
+
+Consequences, all load-bearing:
+
+- **Zero savestate fields, zero RAM writes, zero bus-model time.**
+  Savestates, rewind, run-ahead and netplay see a bit-identical
+  machine with or without a pack; only the presented frame differs.
+  `test/tools/test_texreplace.c` asserts framebuffer hashes, savestate
+  digests AND battery destination RAM are identical to
+  replacement-off, while the shadow surface provably carries the pack
+  art.
+- **Packs are true-color.**  Replacement RGB is presented through the
+  shadow surface, so there is no RGB→CRY quantization anywhere in the
+  pipeline.  Alpha < 128 in a pack pixel means "keep the stock pixel"
+  (transparency at blit time is still the game's business).
+- **The shadow surface is forced on** while a pack is active, but the
+  Gouraud-precision stores (the True Color feature proper) stay gated
+  on `virtualjaguar_true_color` via the separate `shadowFBPrecision`
+  flag — a replacement-only activation leaves every non-replaced pixel
+  bit-identical to stock.
+- The option is **visible only when a pack directory exists** for the
+  loaded content (same `SET_CORE_OPTIONS_DISPLAY` machinery as the
+  16bpp-preview knob), and defaults to disabled.
+
+### Tier status and limits
+
+- **Tier 1 (shipped): 16bpp source tiles, 1x, straight-copy blits** —
+  the sprite/UI blit class dump mode was built for.  Presentation
+  requires the CRY 16bpp OP path (the dominant framebuffer case);
+  RGB16-mode displays and GPU-computed surfaces (Doom's texture
+  mapper) are out of scope, same as dump mode.
+- **Known coherence limit:** a replacement entry's RGB is pack art,
+  not a function of the tagged value.  A later non-blit write of the
+  *same* 16-bit value to a replaced address keeps presenting pack RGB
+  until the next store to that word.  Stock true-color has the same
+  tag scheme but is immune by construction (its RGB is derived from
+  the value); for replacement this is a documented cosmetic edge.
+- **Interaction with internal resolution:** at Nx the hi-res shadow
+  surface wins wherever its entries hit, so replaced tiles may present
+  stock there.  >1x replacements riding the Stage 2 surface are the
+  planned fix (tier 3, design notes on #369).
+- **Indexed (≤8bpp) sources (tier 2, not yet shipped):** the pipeline
+  cannot inject RGB into an indexed blit — the destination holds
+  palette indices and the CLUT is applied per-object at OP render
+  time.  The planned design (notes on #369) keeps the host-only
+  architecture: a byte-granular index shadow filled at the same
+  post-blit witness point, resolved at the OP's indexed line-buffer
+  write sites through the object's own palette base, presenting via
+  the same shadow line buffer.  Authors will supply index-map PNGs
+  (gray or indexed color type; the sample value IS the Jaguar palette
+  index), which keeps palette-swapped sprites faithful.  Until it
+  ships, indexed pack entries load but never present (counted in the
+  session summary).
+
+### Test gates (all in `make test`)
+
+`test/tools/test_texreplace.c`, on `test/roms/yarc.j64` plus a
+scripted 9-tile blit battery (16bpp A2- and A1-sourced, a 16×16, a
+dimension-mismatched entry, an RGBA entry with alpha holes, an 8bpp
+and a 32bpp tier-skip entry):
+
+1. `nopack_inert` — enabled with no pack ≡ disabled (framebuffer,
+   savestate digests, battery destination RAM, gate off).
+2. `pack_machine_inert` — enabled WITH a pack: the machine is still
+   bit-identical to disabled.
+3. `pack_presents` — every replaced destination word resolves
+   (value-tagged) to the pack pixel's RGB; mismatched/holed/other-tier
+   entries produce exactly no stores.
+4. `presentation_path` — `ShadowFBLineFromRAM` lands pack RGB in the
+   line buffer the scanline renderer reads.
+5. `determinism` — two identical pack runs agree on everything.
+
+The synthetic pack is built from FIRST PRINCIPLES: the test computes
+each tile's hash from the documented contract and writes the PNGs
+itself, so a lookup hit also cross-checks the frozen contract against
+an independent implementation.  (It caught a real test bug on first
+run: an LFU nibble of 3 is a NOT-copy, and the per-pixel witness
+correctly refused to store a single pixel.)
+
+### Authoring guide (replacement)
+
+1. Turn on **Texture Dump Mode** and play; collect
+   `<system dir>/vj_texdump/<CRC32>/`.
+2. Redraw any tile you like.  Keep the dumped pixel dimensions — a
+   resized PNG is skipped (one log line names the first offender).
+   Draw in full RGB; alpha means "keep the original game pixel here".
+3. Save under the SAME filename into
+   `<system dir>/vj_texpacks/<CRC32>/`.
+4. Enable **Texture Replacement** (Options → Video; it appears once
+   the pack directory exists).  No restart needed.  The log reports
+   `pack ...: N/M PNGs loaded` at load and a session summary at exit.
 
 ## Open items carried into implementation — resolution
 

--- a/exports-test.list
+++ b/exports-test.list
@@ -80,6 +80,15 @@ _shadowHiresN
 _shadowFBActive
 _blitMemo*
 _TitleDB*
+# Texture dump/replacement (#369) probes + the shadow-framebuffer
+# presentation functions the replacement tests drive directly.
+_TexDump*
+_TexReplace*
+_texDumpEnabled
+_texReplaceEnabled
+_ShadowFB*
+_shadowLineRGB
+_shadowLineTag
 # _TitleHook* is NOT covered by _TitleDB* -- the applier lives in its own
 # translation unit and its own name prefix.
 _TitleHook*

--- a/libretro.c
+++ b/libretro.c
@@ -43,6 +43,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "shadowfb.h"
 #include "blit_memo.h"
 #include "texdump.h"
+#include "texreplace.h"
 #include "tom.h"
 #include "blitter.h"
 #include "gpu.h"
@@ -209,6 +210,9 @@ static bool show_cart_bios_option  = true;
  * update_option_visibility() sees a change and hides it while the dump
  * option sits at its disabled default. */
 static bool show_texdump_16bpp     = true;
+/* Texture replacement (#369 deliverable 2) only means anything when a
+ * pack directory exists for the loaded content; hidden otherwise. */
+static bool show_texture_replace   = true;
 static bool enable_alt_inputs = false;
 static uint8_t *joypad_buttons[2] = { joypad0Buttons, joypad1Buttons };
 
@@ -685,6 +689,23 @@ static bool update_option_visibility(void)
       }
    }
 
+   /* Texture replacement (#369 deliverable 2): only shown when a pack
+    * directory exists for the loaded content -- an option that can
+    * never do anything is noise. */
+   {
+      bool show_replace_prev = show_texture_replace;
+
+      show_texture_replace = TexReplacePackAvailable() ? true : false;
+      if (show_texture_replace != show_replace_prev)
+      {
+         option_display.visible = show_texture_replace;
+         option_display.key     = "virtualjaguar_texture_replace";
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
+                    &option_display);
+         updated = true;
+      }
+   }
+
    return updated;
 }
 
@@ -1035,12 +1056,31 @@ static void check_variables(void)
     * memo whenever the engine identity flips. */
    BlitMemoNotifyEngine(vjs.useFastBlitter ? 1 : 0);
 
+   /* Texture replacement (#369 deliverable 2): raw read (never a
+    * per-title default).  Enabling triggers the one-off pack load once
+    * the system dir + content CRC are known (retro_load_game). */
+   var.key = "virtualjaguar_texture_replace";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      TexReplaceSetEnabled(strcmp(var.value, "enabled") == 0);
+   else
+      TexReplaceSetEnabled(0);
+
    var.key = "virtualjaguar_true_color";
    var.value = NULL;
-   if (get_variable_pertitle(&var) && var.value)
-      ShadowFBSetEnabled(strcmp(var.value, "enabled") == 0);
-   else
-      ShadowFBSetEnabled(0);
+   {
+      bool tc_on = false;
+      if (get_variable_pertitle(&var) && var.value)
+         tc_on = strcmp(var.value, "enabled") == 0;
+      /* An active texture-replacement pack presents through the shadow
+       * framebuffer, so it forces the SURFACE on even with True Color
+       * disabled -- but the Gouraud precision stores (the True Color
+       * feature proper) follow the option alone, so a replacement-only
+       * activation leaves every non-replaced pixel bit-identical
+       * (docs/texture-dump.md, "Replacement pipeline"). */
+      ShadowFBSetEnabled((tc_on || texReplaceEnabled) ? 1 : 0);
+      ShadowFBSetPrecision(tc_on ? 1 : 0);
+   }
 
    /* Internal resolution is applied ONCE at content load (retro_load_game)
     * because the libretro geometry maximum cannot grow mid-session.  Here
@@ -2783,6 +2823,15 @@ bool retro_load_game(const struct retro_game_info *info)
          TexDumpSetBasePath(texdump_sys_dir);
       else
          TexDumpSetBasePath(NULL);
+      /* Texture replacement (#369 deliverable 2): same base, packs read
+       * from <system dir>/vj_texpacks/<CRC32>/.  ContentLoaded probes
+       * availability (option visibility) and performs the one-off pack
+       * load if the option was already on; a loaded pack then forces
+       * the shadow framebuffer it presents through. */
+      TexReplaceSetBasePath(texdump_sys_dir);
+      TexReplaceContentLoaded();
+      if (texReplaceEnabled)
+         ShadowFBSetEnabled(1);
    }
 
    /* Raw gate read (never through get_variable_pertitle()) so the hires
@@ -3091,6 +3140,10 @@ void retro_unload_game(void)
     * next load's check_variables() re-enables (and re-allocates) if the
     * option is still on. */
    TexDumpShutdown();
+   /* Texture replacement (#369): packs are per-CRC too -- free the map
+    * and log the session summary; the next load's check_variables() +
+    * TexReplaceContentLoaded() reload if the option is still on. */
+   TexReplaceShutdown();
    video_buffer_alloc_pixels = VIDEO_BUFFER_PIXELS;
    hires_restart_notice_logged = 0;
 
@@ -3287,6 +3340,9 @@ void retro_deinit(void)
     * free the dedupe set and reset every static. */
    TexDumpShutdown();
    show_texdump_16bpp = true;
+   /* Texture replacement (#369): free the pack map, reset every static. */
+   TexReplaceShutdown();
+   show_texture_replace = true;
    /* Non-pad input devices: encoders, phases, attach mask, armed flag and
     * the option-derived type/scale all go back to their load-time values
     * (iOS cannot dlclose a core). */

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -437,6 +437,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "cry"
    },
    {
+      "virtualjaguar_texture_replace",
+      "Texture Replacement",
+      NULL,
+      "Present community texture-pack art in place of the title's own blitter tiles (issue #369). Packs live in <system dir>/vj_texpacks/<cart CRC32>/, named by the same hashes Texture Dump Mode writes. Presentation-only: the emulated machine, savestates and netplay are bit-identical with or without a pack. Shown only when a pack directory exists for the loaded title.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "virtualjaguar_jgd",
       "Jaguar GameDrive (Restart)",
       NULL,

--- a/link-test.T
+++ b/link-test.T
@@ -83,6 +83,15 @@
       shadowFBActive;
       blitMemo*;
       TitleDB*;
+      /* Texture dump/replacement (#369) probes + the shadow-framebuffer
+       * presentation functions the replacement tests drive directly. */
+      TexDump*;
+      TexReplace*;
+      texDumpEnabled;
+      texReplaceEnabled;
+      ShadowFB*;
+      shadowLineRGB;
+      shadowLineTag;
       /* TitleHook* is NOT covered by TitleDB* -- the applier lives in its
        * own translation unit and its own name prefix. */
       TitleHook*;

--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -795,7 +795,7 @@ void blitter_generic(uint32_t cmd)
                            sfb_frac = (uint16_t)(sfb_i24 & 0xFFFF);
                      }
                   }
-                  if (shadowFBActive && !inhibit && (GOURD || SRCSHADE))
+                  if (shadowFBPrecision && !inhibit && (GOURD || SRCSHADE))
                      ShadowFBStoreCry(a1_addr + (PIXEL_OFFSET_16(a1) << 1),
                            (uint16_t)writedata, sfb_frac);
                   if (shadowHiresActive)
@@ -964,7 +964,7 @@ void blitter_generic(uint32_t cmd)
                            sfb_frac = (uint16_t)(sfb_i24 & 0xFFFF);
                      }
                   }
-                  if (shadowFBActive && !inhibit && (GOURD || SRCSHADE))
+                  if (shadowFBPrecision && !inhibit && (GOURD || SRCSHADE))
                      ShadowFBStoreCry(a2_addr + (PIXEL_OFFSET_16(a2) << 1),
                            (uint16_t)writedata, sfb_frac);
                   if (shadowHiresActive)
@@ -3681,7 +3681,7 @@ A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
                    * just gouraud, also refreshes the Nx shadow block by
                    * box replication (see shadowfb.h). */
                   if (pixsize == 4
-                        && (shadowHiresActive || (shadowFBActive && gourd)))
+                        && (shadowHiresActive || (shadowFBPrecision && gourd)))
                   {
                      if (phrase_mode)
                      {
@@ -3692,7 +3692,7 @@ A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
                            sfb_v = (uint16_t)(wdata >> ((3 - sfb_k) << 4));
                            sfb_f = gourd
                               ? (uint16_t)(srcd1 >> ((3 - sfb_k) << 4)) : 0;
-                           if (shadowFBActive && gourd)
+                           if (shadowFBPrecision && gourd)
                               ShadowFBStoreCry(address + ((uint32_t)sfb_k << 1),
                                     sfb_v, sfb_f);
                            if (shadowHiresActive)
@@ -3703,7 +3703,7 @@ A1_outside	:= OR6 (a1_outside, a1_x{15}, a1xgr, a1xeq, a1_y{15}, a1ygr, a1yeq);
                      else
                      {
                         uint16_t sfb_f = gourd ? (uint16_t)srcd1 : 0;
-                        if (shadowFBActive && gourd)
+                        if (shadowFBPrecision && gourd)
                            ShadowFBStoreCry(address, (uint16_t)wdata, sfb_f);
                         if (shadowHiresActive)
                         {

--- a/src/tom/blitter_mmio.c
+++ b/src/tom/blitter_mmio.c
@@ -2,6 +2,7 @@
 #include "blitter_internal.h"
 #include "blit_memo.h"
 #include "texdump.h"
+#include "texreplace.h"
 
 #include <string.h>
 #include "bus_arbiter.h"
@@ -320,6 +321,7 @@ void BlitterWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
       /* Compute the bus time BEFORE dispatch: the engines update their
        * shadow registers as they run. */
       uint32_t busClks = 0;
+      int trBlit = 0;
       if (vjs.blitterTiming)
          busClks = BlitDurationSysclks();
 
@@ -328,6 +330,15 @@ void BlitterWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
        * host-side work; the emulated machine cannot observe it. */
       if (texDumpEnabled)
          TexDumpLaunch();
+
+      /* Texture replacement (issue #369 deliverable 2): hash the source
+       * window pre-dispatch (dump mode above captures the ORIGINAL
+       * tile, so dump+replace compose for authors).  On a pack hit the
+       * post-dispatch hook records pack RGB into the shadow
+       * framebuffer -- host-side presentation only, the emulated
+       * machine cannot observe it either. */
+      if (texReplaceEnabled)
+         trBlit = TexReplacePreBlit();
 
       if (BlitterCompareIsEnabled())
          BlitterRunComparison();
@@ -339,6 +350,9 @@ void BlitterWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
          else
             BlitterMidsummer2();
       }
+
+      if (trBlit)
+         TexReplacePostBlit();
 
       /* The blit's results are complete (memory is final, as before);
        * only the TIME is owed.  The window is paid by the next

--- a/src/tom/shadowfb.c
+++ b/src/tom/shadowfb.c
@@ -26,6 +26,14 @@ extern uint32_t CRY16ToRGB32[0x10000];
 
 int shadowFBActive = 0;
 
+/* Gouraud/SRCSHADE precision stores in the blitter engines are gated
+ * separately from the surface (issue #369 deliverable 2): the texture
+ * replacement pipeline needs the surface + presentation path WITHOUT
+ * changing any non-replaced pixel, while the True Color option wants
+ * both.  Effective = option wanted AND surface active. */
+int shadowFBPrecision = 0;
+static int shadowFBPrecisionWant = 0;
+
 uint32_t shadowLineRGB[SHADOWFB_LINE_PIXELS];
 uint32_t shadowLineTag[SHADOWFB_LINE_PIXELS];
 
@@ -55,6 +63,26 @@ void ShadowFBStoreCry(uint32_t addr, uint16_t value16, uint16_t frac16)
       return;
    idx = (addr & 0x1FFFFE) >> 1;
    shadowRGB[idx] = ShadowFBCryRGB(value16, frac16);
+   shadowTag[idx] = (uint32_t)value16 | SHADOWFB_TAG_VALID;
+}
+
+/* Texture-replacement store (issue #369 deliverable 2): record an
+ * ARBITRARY RGB888 for a main-RAM word, tagged against the 16-bit value
+ * the RAM actually holds.  Unlike ShadowFBStoreCry the RGB is not a
+ * function of the value -- it is pack art -- so this is only called
+ * from the replacement pipeline's post-blit walk, which re-runs on
+ * every launch (memo skips included); it is deliberately NOT logged to
+ * the blit memo's shadow-store replay. */
+void ShadowFBStoreRGB(uint32_t addr, uint16_t value16, uint32_t rgb888)
+{
+   uint32_t idx;
+   if (!shadowFBActive)
+      return;
+   addr &= 0xFFFFFF;
+   if (addr >= 0x800000)
+      return;
+   idx = (addr & 0x1FFFFE) >> 1;
+   shadowRGB[idx] = rgb888 & 0x00FFFFFF;
    shadowTag[idx] = (uint32_t)value16 | SHADOWFB_TAG_VALID;
 }
 
@@ -109,9 +137,16 @@ void ShadowFBSetEnabled(int enable)
       }
       ShadowFBInvalidate();
       shadowFBActive = 1;
+      shadowFBPrecision = shadowFBPrecisionWant;
    }
    else
       ShadowFBShutdown();
+}
+
+void ShadowFBSetPrecision(int on)
+{
+   shadowFBPrecisionWant = on ? 1 : 0;
+   shadowFBPrecision = (shadowFBPrecisionWant && shadowFBActive) ? 1 : 0;
 }
 
 void ShadowFBShutdown(void)
@@ -123,6 +158,8 @@ void ShadowFBShutdown(void)
    shadowRGB = NULL;
    shadowTag = NULL;
    shadowFBActive = 0;
+   shadowFBPrecision = 0;
+   shadowFBPrecisionWant = 0;
    memset(shadowLineRGB, 0, sizeof(shadowLineRGB));
    memset(shadowLineTag, 0, sizeof(shadowLineTag));
 }

--- a/src/tom/shadowfb.h
+++ b/src/tom/shadowfb.h
@@ -36,9 +36,21 @@ extern "C" {
 #define SHADOWFB_LINE_PIXELS 720
 #define SHADOWFB_TAG_VALID   0x10000
 
-/* Nonzero when the core option is on AND the buffers are allocated.
- * Hot paths gate on this before doing any shadow work. */
+/* Nonzero when the surface is on AND the buffers are allocated.  Hot
+ * paths gate on this before doing any shadow work.  The surface can be
+ * active for two reasons: the True Color option, or an active texture
+ * replacement pack (#369 deliverable 2) presenting through it. */
 extern int shadowFBActive;
+
+/* Nonzero when the blitter engines should make Gouraud/SRCSHADE
+ * precision stores (the True Color feature proper).  Always implies
+ * shadowFBActive.  A replacement-only activation leaves this OFF so
+ * every non-replaced pixel presents bit-identically to stock. */
+extern int shadowFBPrecision;
+
+/* Set by the True Color option (independent of surface allocation
+ * order; the effective flag is recomputed on enable). */
+void ShadowFBSetPrecision(int on);
 
 /* Shadow line buffer, parallel to tomRam8[0x1800..], one entry per
  * 16-bit line-buffer pixel.  Tag = value16 | SHADOWFB_TAG_VALID. */
@@ -64,6 +76,12 @@ uint32_t ShadowFBCryRGB(uint16_t value16, uint16_t frac16);
 /* Record a full-precision pixel for a main-RAM word address (blit time).
  * Addresses outside the bottom-8MB RAM mirror window are ignored. */
 void ShadowFBStoreCry(uint32_t addr, uint16_t value16, uint16_t frac16);
+
+/* Texture-replacement store (issue #369 deliverable 2): record an
+ * ARBITRARY RGB888 for a main-RAM word address, tagged against value16.
+ * Only the replacement pipeline calls this (see texreplace.c); it is
+ * not part of the blit memo's shadow-store replay. */
+void ShadowFBStoreRGB(uint32_t addr, uint16_t value16, uint32_t rgb888);
 
 /* Value-checked lookup: returns nonzero and fills *rgb888 only when the
  * entry's tag matches current16 (the value just read from RAM). */

--- a/src/tom/texdump.c
+++ b/src/tom/texdump.c
@@ -96,6 +96,10 @@ extern uint32_t RGB16ToRGB32[0x10000];
 #define TD_FNV_OFFSET 0xCBF29CE484222325ULL
 #define TD_FNV_PRIME  0x00000100000001B3ULL
 
+/* Local aliases for the shared window-size constants (texdump.h). */
+#define TD_MAX_WINDOW_BYTES TEXDUMP_MAX_WINDOW_BYTES
+#define TD_SCRATCH_BYTES    TEXDUMP_SCRATCH_BYTES
+
 /* Dedupe set: open-addressed uint64 table, fixed 2^17 entries (1 MB
  * host RAM).  0 is the empty sentinel; a real hash of 0 is remapped to
  * a fixed non-zero constant so it stays representable.  Insertion stops
@@ -105,12 +109,6 @@ extern uint32_t RGB16ToRGB32[0x10000];
 #define TD_SET_MASK    (TD_SET_SIZE - 1u)
 #define TD_SET_MAXLOAD ((TD_SET_SIZE / 4u) * 3u)
 #define TD_HASH_ZERO_REMAP 0xD6E8FEB86659FD93ULL
-
-/* Garbage-register guard: described source windows larger than 1 MB are
- * never hashed (docs/texture-dump.md, "Skipped"). */
-#define TD_MAX_WINDOW_BYTES (1u << 20)
-/* Serialization slack: per row up to a phrase of alignment spill. */
-#define TD_SCRATCH_BYTES (TD_MAX_WINDOW_BYTES + 0x10000)
 
 /* ---- state (ALL host-transient; reset in TexDumpShutdown) ----------- */
 
@@ -178,8 +176,8 @@ static int td_set_insert(uint64_t h)
  * and the boot ROM window.  BUTCH/TOM/JERRY and unmapped space are
  * refused -- reads there can carry side effects, so a window touching
  * them is skipped entirely (same rule as blitter.c's
- * shadow_hires_read_src16_a1). */
-static int td_addr_ok(uint32_t a)
+ * shadow_hires_read_src16_a1).  Shared with texreplace.c (texdump.h). */
+int TexDumpAddrOK(uint32_t a)
 {
    if (a < 0xDFFF00)
       return 1;
@@ -188,7 +186,7 @@ static int td_addr_ok(uint32_t a)
    return 0;
 }
 
-static uint8_t td_read8(uint32_t a)
+uint8_t TexDumpRead8(uint32_t a)
 {
    if (a < 0x800000)
       return jaguarMainRAM[a & 0x1FFFFF];
@@ -198,7 +196,7 @@ static uint8_t td_read8(uint32_t a)
          return JGDReadROM8(a - 0x800000);
       return jaguarMainROM[a - 0x800000];
    }
-   return jagMemSpace[a];   /* boot ROM window (td_addr_ok guarded) */
+   return jagMemSpace[a];   /* boot ROM window (TexDumpAddrOK guarded) */
 }
 
 /* ---- source-window walk --------------------------------------------- */
@@ -232,26 +230,29 @@ static uint32_t td_pixel_offset(uint32_t x, uint32_t y, uint32_t width,
    }
 }
 
-/* Capture description of the current launch, filled by td_describe(). */
-typedef struct
+/* Byte offset of pixel (c, r) inside the described window, scaled to
+ * bytes for every bpp (texdump.h; used by the replacement pipeline's
+ * destination-window walk). */
+uint32_t TexDumpPixelByteOffset(const TexDumpDesc *d, uint32_t c,
+                                uint32_t r)
 {
-   uint32_t base;        /* phrase-aligned channel base                */
-   uint32_t flags;       /* channel FLAGS register                     */
-   uint32_t psizefield;  /* (flags >> 3) & 7                           */
-   uint32_t bpp;         /* 1 << psizefield                            */
-   uint32_t pitch;       /* phrase-gap ({0,1,3,2}[flags & 3])          */
-   uint32_t width;       /* window width in pixels (6-bit float)       */
-   uint32_t x0, y0;      /* integer pixel origin                       */
-   uint32_t inner;       /* pixels per row (B_COUNT low)               */
-   uint32_t outer;       /* rows (B_COUNT high)                        */
-   uint32_t src_addr;    /* byte address of pixel (x0, y0)             */
-} td_desc;
+   uint32_t px  = (d->x0 + c) & 0xFFFF;
+   uint32_t py  = (d->y0 + r) & 0xFFFF;
+   uint32_t off = td_pixel_offset(px, py, d->width, d->pitch,
+                                  d->psizefield);
+   if (d->psizefield == 4)
+      off <<= 1;
+   else if (d->psizefield == 5)
+      off <<= 2;
+   return off;
+}
 
-/* Serialize the described window into td_scratch, row-major, packed
- * exactly as stored (each covering byte appended once).  Returns the
- * byte count, or 0 when any byte falls outside populated address space
- * or the serialization overruns the scratch buffer. */
-static uint32_t td_serialize(const td_desc *d)
+/* Serialize the described window into buf, row-major, packed exactly
+ * as stored (each covering byte appended once).  Returns the byte
+ * count, or 0 when any byte falls outside populated address space or
+ * the serialization overruns cap.  Shared with texreplace.c: this IS
+ * the identity contract's byte stream -- do not change the walk. */
+uint32_t TexDumpSerialize(const TexDumpDesc *d, uint8_t *buf, uint32_t cap)
 {
    uint32_t len = 0;
    uint32_t r, c, k;
@@ -273,14 +274,14 @@ static uint32_t td_serialize(const td_desc *d)
             continue;               /* same stored byte as previous pixel */
          prev = off;
          k = (d->bpp <= 8) ? 1 : (d->bpp >> 3);
-         if (len + k > TD_SCRATCH_BYTES)
+         if (len + k > cap)
             return 0;
          for (; k > 0; k--)
          {
             a = (d->base + off) & 0xFFFFFF;
-            if (!td_addr_ok(a))
+            if (!TexDumpAddrOK(a))
                return 0;
-            td_scratch[len++] = td_read8(a);
+            buf[len++] = TexDumpRead8(a);
             off++;
          }
       }
@@ -288,7 +289,8 @@ static uint32_t td_serialize(const td_desc *d)
    return len;
 }
 
-static uint64_t td_hash(const td_desc *d, uint32_t len)
+uint64_t TexDumpHashKey(const TexDumpDesc *d, const uint8_t *bytes,
+                        uint32_t len)
 {
    uint64_t h = TD_FNV_OFFSET;
    uint8_t hdr[10];
@@ -312,10 +314,85 @@ static uint64_t td_hash(const td_desc *d, uint32_t len)
    }
    for (i = 0; i < len; i++)
    {
-      h ^= td_scratch[i];
+      h ^= bytes[i];
       h *= TD_FNV_PRIME;
    }
    return h;
+}
+
+/* Decode ONE address channel into *d with the given counts (texdump.h;
+ * the replacement pipeline models a launch's destination window with
+ * this).  Returns 0 on a garbage pixel-size encoding. */
+int TexDumpDescribeChannel(TexDumpDesc *d, int use_a1,
+                           uint32_t inner, uint32_t outer)
+{
+   uint32_t m, e;
+
+   if (use_a1)
+   {
+      d->base  = TD_REG(TD_A1_BASE) & 0xFFFFFFF8;
+      d->flags = TD_REG(TD_A1_FLAGS);
+      d->x0    = TD_REG(TD_A1_PIXEL) & 0xFFFF;
+      d->y0    = (TD_REG(TD_A1_PIXEL) >> 16) & 0xFFFF;
+   }
+   else
+   {
+      d->base  = TD_REG(TD_A2_BASE) & 0xFFFFFFF8;
+      d->flags = TD_REG(TD_A2_FLAGS);
+      d->x0    = TD_REG(TD_A2_PIXEL) & 0xFFFF;
+      d->y0    = (TD_REG(TD_A2_PIXEL) >> 16) & 0xFFFF;
+   }
+
+   d->psizefield = (d->flags >> 3) & 0x07;
+   if (d->psizefield > 5)            /* garbage pixel-size encoding */
+      return 0;
+   d->bpp = 1u << d->psizefield;
+   {
+      static const uint32_t pitch_lut[4] = { 0, 1, 3, 2 };
+      d->pitch = pitch_lut[d->flags & 0x03];
+   }
+   m = (d->flags >> 9) & 0x03;
+   e = (d->flags >> 11) & 0x0F;
+   d->width = ((0x04 | m) << e) >> 2;
+
+   d->inner = inner;
+   d->outer = outer;
+   d->src_addr = (d->base + TexDumpPixelByteOffset(d, 0, 0)) & 0xFFFFFF;
+   return 1;
+}
+
+/* Decode the current launch's SOURCE window (texdump.h).  Returns 1
+ * when this is a sane SRCEN blit worth hashing, 0 for no-source /
+ * garbage-register launches, and -1 for a sane-looking window larger
+ * than the 1 MB guard (counted as a skip by dump mode). */
+int TexDumpDescribe(TexDumpDesc *d, uint32_t *cmd_out)
+{
+   uint32_t cmd, count;
+   uint64_t bytes_est;
+   int src_is_a1;
+
+   cmd = TD_REG(TD_COMMAND);
+   if (cmd_out)
+      *cmd_out = cmd;
+   if (!(cmd & 0x00000001))         /* SRCEN: no source read, no tile */
+      return 0;
+
+   /* JTRM B_CMD bit 0: source data comes from A2, or from A1 when
+    * DSTA2 (bit 11) makes A2 the destination. */
+   src_is_a1 = (cmd & 0x00000800) != 0;
+
+   count = TD_REG(TD_COUNT);
+   if ((count & 0xFFFF) == 0 || (count >> 16) == 0)
+      return 0;
+   if (!TexDumpDescribeChannel(d, src_is_a1, count & 0xFFFF,
+                               (count >> 16) & 0xFFFF))
+      return 0;
+
+   /* Garbage-register guard: > 1 MB described windows are skipped. */
+   bytes_est = ((uint64_t)d->inner * d->outer * d->bpp + 7) / 8;
+   if (bytes_est > TD_MAX_WINDOW_BYTES)
+      return -1;
+   return 1;
 }
 
 /* ---- output plumbing ------------------------------------------------ */
@@ -439,7 +516,7 @@ static void td_store_rgb(uint8_t *dst, uint32_t xrgb)
 
 /* Extract pixel (c, r) of the described window from emulated memory
  * (same addressing as td_serialize).  Returns the raw pixel value. */
-static uint32_t td_pixel_value(const td_desc *d, uint32_t c, uint32_t r)
+static uint32_t td_pixel_value(const TexDumpDesc *d, uint32_t c, uint32_t r)
 {
    uint32_t px  = (d->x0 + c) & 0xFFFF;
    uint32_t py  = (d->y0 + r) & 0xFFFF;
@@ -450,27 +527,27 @@ static uint32_t td_pixel_value(const td_desc *d, uint32_t c, uint32_t r)
    {
       case 0:
          a = (d->base + off) & 0xFFFFFF;
-         return (td_read8(a) >> ((~px) & 7)) & 0x01;
+         return (TexDumpRead8(a) >> ((~px) & 7)) & 0x01;
       case 1:
          a = (d->base + off) & 0xFFFFFF;
-         return (td_read8(a) >> (((~px) << 1) & 6)) & 0x03;
+         return (TexDumpRead8(a) >> (((~px) << 1) & 6)) & 0x03;
       case 2:
          a = (d->base + off) & 0xFFFFFF;
-         return (td_read8(a) >> (((~px) << 2) & 4)) & 0x0F;
+         return (TexDumpRead8(a) >> (((~px) << 2) & 4)) & 0x0F;
       case 3:
          a = (d->base + off) & 0xFFFFFF;
-         return td_read8(a);
+         return TexDumpRead8(a);
       case 4:
          a = (d->base + (off << 1)) & 0xFFFFFF;
-         b0 = td_read8(a);
-         b1 = td_read8((a + 1) & 0xFFFFFF);
+         b0 = TexDumpRead8(a);
+         b1 = TexDumpRead8((a + 1) & 0xFFFFFF);
          return (b0 << 8) | b1;
       default:
          a = (d->base + (off << 2)) & 0xFFFFFF;
-         b0 = td_read8(a);
-         b1 = td_read8((a + 1) & 0xFFFFFF);
-         b2 = td_read8((a + 2) & 0xFFFFFF);
-         b3 = td_read8((a + 3) & 0xFFFFFF);
+         b0 = TexDumpRead8(a);
+         b1 = TexDumpRead8((a + 1) & 0xFFFFFF);
+         b2 = TexDumpRead8((a + 2) & 0xFFFFFF);
+         b3 = TexDumpRead8((a + 3) & 0xFFFFFF);
          return (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
    }
 }
@@ -478,7 +555,7 @@ static uint32_t td_pixel_value(const td_desc *d, uint32_t c, uint32_t r)
 /* Render the window as RGB8 rows.  mode16 selects the 16bpp
  * interpretation (TEXDUMP_16BPP_CRY / _RGB); clut16 is the snapshotted
  * CLUT (256 x u16, host order) for <=8bpp windows. */
-static uint8_t *td_render(const td_desc *d, int mode16,
+static uint8_t *td_render(const TexDumpDesc *d, int mode16,
                           const uint16_t *clut16)
 {
    uint8_t *rgb;
@@ -513,7 +590,7 @@ static uint8_t *td_render(const td_desc *d, int mode16,
 
 /* ---- first-sight dump ----------------------------------------------- */
 
-static void td_first_sight(const td_desc *d, uint64_t h, uint32_t cmd,
+static void td_first_sight(const TexDumpDesc *d, uint64_t h, uint32_t cmd,
                            uint32_t clut_crc, const uint16_t *clut16)
 {
    char path[1500];
@@ -593,72 +670,26 @@ static void td_first_sight(const td_desc *d, uint64_t h, uint32_t cmd,
 
 void TexDumpLaunch(void)
 {
-   td_desc d;
-   uint32_t cmd, count, m, e, first_off;
+   TexDumpDesc d;
+   uint32_t cmd;
    uint32_t len;
-   uint64_t h, bytes_est;
-   int src_is_a1;
+   uint64_t h;
+   int rc;
    int is_new;
 
    if (!td_set)
       return;                       /* enable-time allocation failed */
 
-   cmd = TD_REG(TD_COMMAND);
-   if (!(cmd & 0x00000001))         /* SRCEN: no source read, no tile */
+   rc = TexDumpDescribe(&d, &cmd);
+   if (rc == 0)
       return;
-
-   /* JTRM B_CMD bit 0: source data comes from A2, or from A1 when
-    * DSTA2 (bit 11) makes A2 the destination. */
-   src_is_a1 = (cmd & 0x00000800) != 0;
-   if (src_is_a1)
-   {
-      d.base  = TD_REG(TD_A1_BASE) & 0xFFFFFFF8;
-      d.flags = TD_REG(TD_A1_FLAGS);
-      d.x0    = TD_REG(TD_A1_PIXEL) & 0xFFFF;
-      d.y0    = (TD_REG(TD_A1_PIXEL) >> 16) & 0xFFFF;
-   }
-   else
-   {
-      d.base  = TD_REG(TD_A2_BASE) & 0xFFFFFFF8;
-      d.flags = TD_REG(TD_A2_FLAGS);
-      d.x0    = TD_REG(TD_A2_PIXEL) & 0xFFFF;
-      d.y0    = (TD_REG(TD_A2_PIXEL) >> 16) & 0xFFFF;
-   }
-
-   d.psizefield = (d.flags >> 3) & 0x07;
-   if (d.psizefield > 5)            /* garbage pixel-size encoding */
-      return;
-   d.bpp = 1u << d.psizefield;
-   {
-      static const uint32_t pitch_lut[4] = { 0, 1, 3, 2 };
-      d.pitch = pitch_lut[d.flags & 0x03];
-   }
-   m = (d.flags >> 9) & 0x03;
-   e = (d.flags >> 11) & 0x0F;
-   d.width = ((0x04 | m) << e) >> 2;
-
-   count   = TD_REG(TD_COUNT);
-   d.inner = count & 0xFFFF;
-   d.outer = (count >> 16) & 0xFFFF;
-   if (d.inner == 0 || d.outer == 0)
-      return;
-
-   /* Garbage-register guard: > 1 MB described windows are skipped. */
-   bytes_est = ((uint64_t)d.inner * d.outer * d.bpp + 7) / 8;
-   if (bytes_est > TD_MAX_WINDOW_BYTES)
+   if (rc < 0)                      /* > 1 MB described window */
    {
       td_stat_skipped++;
       return;
    }
 
-   first_off = td_pixel_offset(d.x0, d.y0, d.width, d.pitch, d.psizefield);
-   if (d.psizefield == 4)
-      first_off <<= 1;
-   else if (d.psizefield == 5)
-      first_off <<= 2;
-   d.src_addr = (d.base + first_off) & 0xFFFFFF;
-
-   len = td_serialize(&d);
+   len = TexDumpSerialize(&d, td_scratch, TD_SCRATCH_BYTES);
    if (len == 0)                    /* outside populated space / overrun */
    {
       td_stat_skipped++;
@@ -666,7 +697,7 @@ void TexDumpLaunch(void)
    }
    td_stat_captures++;
 
-   h = td_hash(&d, len);
+   h = TexDumpHashKey(&d, td_scratch, len);
    is_new = td_set_insert(h);
 
    if (d.bpp <= 8)

--- a/src/tom/texdump.h
+++ b/src/tom/texdump.h
@@ -36,6 +36,70 @@ extern "C" {
  * the disabled mode costs one predictable branch. */
 extern int texDumpEnabled;
 
+/* ---- shared identity-contract machinery (deliverable 2 consumer) ----
+ *
+ * The replacement pipeline (texreplace.c, deliverable 2 of #369) must
+ * compute EXACTLY the key a tile dumped under, so the decode / walk /
+ * hash helpers below are the single implementation both modules use.
+ * They are pure reads of blitter_ram + emulated memory: no dump state,
+ * no allocation, callable whether or not dump mode is enabled. */
+
+/* Register-described blit window (docs/texture-dump.md).  Filled by
+ * TexDumpDescribe / TexDumpDescribeChannel. */
+typedef struct
+{
+   uint32_t base;        /* phrase-aligned channel base                */
+   uint32_t flags;       /* channel FLAGS register                     */
+   uint32_t psizefield;  /* (flags >> 3) & 7                           */
+   uint32_t bpp;         /* 1 << psizefield                            */
+   uint32_t pitch;       /* phrase-gap ({0,1,3,2}[flags & 3])          */
+   uint32_t width;       /* window width in pixels (6-bit float)       */
+   uint32_t x0, y0;      /* integer pixel origin                       */
+   uint32_t inner;       /* pixels per row (B_COUNT low)               */
+   uint32_t outer;       /* rows (B_COUNT high)                        */
+   uint32_t src_addr;    /* byte address of pixel (x0, y0)             */
+} TexDumpDesc;
+
+/* Garbage-register guard: described windows larger than 1 MB are never
+ * hashed; the serialization buffer adds a phrase of per-row slack. */
+#define TEXDUMP_MAX_WINDOW_BYTES (1u << 20)
+#define TEXDUMP_SCRATCH_BYTES    (TEXDUMP_MAX_WINDOW_BYTES + 0x10000)
+
+/* Decode the current launch's SOURCE window from blitter_ram.  Returns
+ * 1 when this is a sane SRCEN blit (cmd stored to *cmd_out when non-
+ * NULL); 0 for no-source / garbage-register launches; -1 for a sane
+ * window larger than the 1 MB guard. */
+int TexDumpDescribe(TexDumpDesc *d, uint32_t *cmd_out);
+
+/* Decode ONE address channel (nonzero use_a1 = A1) with the given
+ * inner/outer counts -- the replacement pipeline uses this to model the
+ * DESTINATION window of a launch.  Returns 1 unless the channel's
+ * pixel-size encoding is garbage. */
+int TexDumpDescribeChannel(TexDumpDesc *d, int use_a1,
+                           uint32_t inner, uint32_t outer);
+
+/* Serialize the described window into buf (row-major covering bytes,
+ * the identity contract's byte stream).  Returns the byte count, or 0
+ * when the window leaves populated address space or overruns cap. */
+uint32_t TexDumpSerialize(const TexDumpDesc *d, uint8_t *buf, uint32_t cap);
+
+/* FNV-1a 64 over the frozen header + the serialized bytes. */
+uint64_t TexDumpHashKey(const TexDumpDesc *d, const uint8_t *bytes,
+                        uint32_t len);
+
+/* BYTE offset of pixel (c, r) inside the described window (already
+ * scaled for 16/32bpp).  Add d->base and mask to 24 bits for the
+ * address; sub-byte pixel position for bpp < 8 follows the stored
+ * big-endian packing (pixel x sits (~x & mask) sub-positions up). */
+uint32_t TexDumpPixelByteOffset(const TexDumpDesc *d, uint32_t c,
+                                uint32_t r);
+
+/* Side-effect-free emulated-memory read used by the walkers (main RAM
+ * mirror, cart ROM incl. GameDrive banking, boot ROM).  TexDumpAddrOK
+ * bounds the populated, side-effect-free space. */
+int     TexDumpAddrOK(uint32_t a);
+uint8_t TexDumpRead8(uint32_t a);
+
 /* Option layer (libretro.c).  Runtime-toggleable: enabling allocates
  * the dedupe set + capture scratch on FIRST enable; disabling keeps
  * them (the session's "seen" set survives a toggle) until

--- a/src/tom/texreplace.c
+++ b/src/tom/texreplace.c
@@ -1,0 +1,773 @@
+/*
+ * TEXREPLACE.C
+ *
+ * Texture replacement pipeline (issue #369, deliverable 2 of 2).
+ * Design + authoring guide: docs/texture-dump.md ("Replacement
+ * pipeline") -- the identity contract there is authoritative; this file
+ * consumes it through the shared helpers in texdump.c (TexDumpDescribe /
+ * TexDumpSerialize / TexDumpHashKey), never a copy of them.
+ *
+ * ARCHITECTURE: entirely host-side, presentation-riding.
+ *
+ *   1. At game load (or first enable), every
+ *      <system_dir>/vj_texpacks/<CRC32>/<hash16>.png is decoded into a
+ *      host hash->pixels map.  One-off file I/O; never at blit time.
+ *   2. At blit launch (PreBlit, before engine dispatch) the SOURCE
+ *      window is hashed exactly as dump mode hashes it.  A map hit
+ *      with matching dimensions arms the launch.
+ *   3. After dispatch (PostBlit) the DESTINATION window is walked; for
+ *      every pixel whose RAM word now equals the source pixel captured
+ *      pre-dispatch (the per-pixel straight-copy witness), the pack
+ *      pixel's RGB888 is stored into the true-color shadow
+ *      framebuffer, tagged with that RAM value.  The OP's existing
+ *      shadow presentation path (op.c -> ShadowFBLineFromRAM -> the
+ *      CRY scanline renderer) then presents the pack art.
+ *
+ * The per-pixel witness makes wrong models harmless: transparent
+ * (BCOMPEN/DCOMPEN) pixels, shaded/Gouraud outputs, non-rectangular
+ * step patterns -- anything whose destination value is not the source
+ * value -- simply never stores, and the stock pixel presents.
+ *
+ * The emulated machine cannot observe any of this: no RAM writes, no
+ * register writes, no bus-model time, ZERO savestate fields.  With the
+ * option off (or no pack present) the launch site pays one predictable
+ * branch and the output is bit-identical to stock.
+ *
+ * Known limits (documented in docs/texture-dump.md): presentation
+ * requires the CRY 16bpp OP path (the dominant framebuffer case); the
+ * shadow tag is value-checked, so a later NON-blit write of the same
+ * 16-bit value to a replaced address keeps presenting pack RGB until
+ * the next store to that word; indexed (<=8bpp) and >1x replacements
+ * are future tiers.
+ */
+
+#include "texreplace.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <boolean.h>
+#include <streams/file_stream.h>
+#include <file/file_path.h>
+#include <vfs/vfs_implementation.h>
+
+#include "texdump.h"    /* shared identity-contract helpers */
+#include "shadowfb.h"   /* ShadowFBStoreRGB / shadowFBActive */
+#include "titledb.h"    /* TitleDBContentCRC */
+#include "log.h"
+
+/* libretro VFS (libretro-common/streams/file_stream_transforms.c) --
+ * same declaration pattern texdump.c uses. */
+RFILE *rfopen(const char *path, const char *mode);
+int rfclose(RFILE *stream);
+int64_t rftell(RFILE *stream);
+int64_t rfseek(RFILE *stream, int64_t offset, int origin);
+int64_t rfread(void *buffer, size_t elem_size, size_t elem_count,
+               RFILE *stream);
+
+/* miniz inflate, compiled into deps/libchdr/unity.o (the decompression
+ * APIs are never disabled there).  Local prototypes rather than
+ * miniz.h, same as texdump.c's encoder declarations. */
+void *tinfl_decompress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len,
+                                   size_t *pOut_len, int flags);
+void mz_free(void *p);
+#define TR_TINFL_PARSE_ZLIB_HEADER 1
+
+/* ---- pack map ------------------------------------------------------- */
+
+/* PNG color types we accept (8-bit depth, non-interlaced only). */
+#define TR_CT_GRAY       0
+#define TR_CT_RGB        2
+#define TR_CT_PAL        3
+#define TR_CT_GRAY_ALPHA 4
+#define TR_CT_RGBA       6
+
+/* conv[] pixel: low 24 bits RGB888; bit 31 = "skip" (author alpha).  */
+#define TR_CONV_SKIP 0x80000000u
+
+typedef struct
+{
+   uint64_t key;         /* identity-contract hash (the filename)      */
+   uint16_t w, h;        /* PNG dimensions                             */
+   uint8_t  ctype;       /* PNG color type (TR_CT_*)                   */
+   uint8_t  channels;    /* bytes per pixel in raw[]                   */
+   uint8_t *raw;         /* unfiltered scanlines, w*h*channels bytes   */
+   uint8_t *pal;         /* 768-byte PLTE copy (TR_CT_PAL only)        */
+   uint32_t *conv;       /* lazy RGB888(+skip) cache, w*h entries      */
+} tr_entry;
+
+#define TR_TAB_BITS  14
+#define TR_TAB_SIZE  (1u << TR_TAB_BITS)
+#define TR_TAB_MASK  (TR_TAB_SIZE - 1u)
+#define TR_TAB_MAXLOAD ((TR_TAB_SIZE / 4u) * 3u)
+#define TR_KEY_ZERO_REMAP 0xD6E8FEB86659FD93ULL
+
+/* Per-PNG sanity caps: tiles are dump-window sized. */
+#define TR_MAX_PNG_BYTES  (8u << 20)
+#define TR_MAX_PIXELS     (1u << 20)
+
+/* ---- state (ALL host-transient; reset in TexReplaceShutdown) -------- */
+
+int texReplaceEnabled = 0;
+
+static int        tr_want       = 0;   /* option state                  */
+static int        tr_loaded     = 0;   /* pack load attempted           */
+static int        tr_pack_avail = 0;   /* pack dir exists for content   */
+static char       tr_base[1024];       /* system dir ("" = unset)       */
+static tr_entry **tr_tab        = NULL;
+static uint32_t   tr_count      = 0;
+static uint8_t   *tr_scratch    = NULL; /* serialized source bytes      */
+static int        tr_alloc_failed = 0;
+static int        tr_dim_warned = 0;
+
+/* Armed launch (PreBlit -> PostBlit).  Both windows are described
+ * PRE-dispatch: the engines write back the pointer registers as they
+ * run (UPDA1/UPDA2), so a post-dispatch register read would describe
+ * the END of the blit, not its origin. */
+static TexDumpDesc tr_desc;
+static TexDumpDesc tr_dst;
+static uint32_t    tr_cmd = 0;
+static uint32_t    tr_len = 0;
+static tr_entry   *tr_hit = NULL;
+
+/* Stats for the unload summary line. */
+static uint32_t tr_stat_hits       = 0; /* armed launches               */
+static uint32_t tr_stat_stores     = 0; /* pixels stored to the shadow  */
+static uint32_t tr_stat_skip_dims  = 0; /* pack PNG dims != window dims */
+static uint32_t tr_stat_skip_tier  = 0; /* non-16bpp window hits        */
+
+/* ---- pack map ------------------------------------------------------- */
+
+static tr_entry *tr_find(uint64_t key)
+{
+   uint32_t idx;
+   if (!tr_tab)
+      return NULL;
+   if (key == 0)
+      key = TR_KEY_ZERO_REMAP;
+   idx = (uint32_t)key & TR_TAB_MASK;
+   for (;;)
+   {
+      tr_entry *e = tr_tab[idx];
+      if (!e)
+         return NULL;
+      if (e->key == key)
+         return e;
+      idx = (idx + 1) & TR_TAB_MASK;
+   }
+}
+
+static int tr_insert(tr_entry *e)
+{
+   uint32_t idx;
+   if (tr_count >= TR_TAB_MAXLOAD)
+      return 0;
+   if (e->key == 0)
+      e->key = TR_KEY_ZERO_REMAP;
+   idx = (uint32_t)e->key & TR_TAB_MASK;
+   for (;;)
+   {
+      if (!tr_tab[idx])
+      {
+         tr_tab[idx] = e;
+         tr_count++;
+         return 1;
+      }
+      if (tr_tab[idx]->key == e->key)
+         return 0;                     /* duplicate hash: keep first */
+      idx = (idx + 1) & TR_TAB_MASK;
+   }
+}
+
+static void tr_free_entry(tr_entry *e)
+{
+   if (!e)
+      return;
+   free(e->raw);
+   free(e->pal);
+   free(e->conv);
+   free(e);
+}
+
+/* ---- PNG decode (chunk walk + miniz inflate + unfilter) ------------- */
+
+static uint32_t tr_be32(const uint8_t *p)
+{
+   return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16)
+        | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+
+static int tr_paeth(int a, int b, int c)
+{
+   int p  = a + b - c;
+   int pa = p > a ? p - a : a - p;
+   int pb = p > b ? p - b : b - p;
+   int pc = p > c ? p - c : c - p;
+   if (pa <= pb && pa <= pc)
+      return a;
+   if (pb <= pc)
+      return b;
+   return c;
+}
+
+/* Decode an 8-bit-depth, non-interlaced PNG into a fresh tr_entry
+ * (without key).  Returns the entry or NULL (with a reason for the
+ * one-line load log). */
+static tr_entry *tr_png_decode(const uint8_t *buf, size_t n,
+                               const char **why)
+{
+   static const uint8_t sig[8] = { 137, 80, 78, 71, 13, 10, 26, 10 };
+   static const uint8_t chan_for_ct[7] = { 1, 0, 3, 1, 2, 0, 4 };
+   uint32_t w = 0, h = 0;
+   uint8_t ctype = 0xFF;
+   uint8_t *pal = NULL;
+   uint8_t *idat = NULL;
+   size_t idat_len = 0;
+   uint8_t *inflated = NULL;
+   size_t inflated_len = 0;
+   tr_entry *e = NULL;
+   size_t pos;
+   uint32_t channels, stride;
+   uint32_t r, i;
+
+   *why = "corrupt";
+   if (n < 8 + 25 || memcmp(buf, sig, 8) != 0)
+      return NULL;
+
+   /* Chunk walk: IHDR first, concatenate IDAT, stop at IEND.  Chunk
+    * CRCs are not verified -- a corrupt stream fails the inflate/size
+    * checks below instead. */
+   pos = 8;
+   while (pos + 12 <= n)
+   {
+      uint32_t clen = tr_be32(buf + pos);
+      const uint8_t *tag  = buf + pos + 4;
+      const uint8_t *body = buf + pos + 8;
+      if (clen > n || pos + 12 + clen > n)
+         goto fail;
+      if (pos == 8)
+      {
+         if (memcmp(tag, "IHDR", 4) != 0 || clen != 13)
+            goto fail;
+         w     = tr_be32(body);
+         h     = tr_be32(body + 4);
+         ctype = body[9];
+         if (body[8] != 8)
+         {
+            *why = "bit depth != 8";
+            goto fail;
+         }
+         if (body[12] != 0)
+         {
+            *why = "interlaced";
+            goto fail;
+         }
+         if (ctype > 6 || chan_for_ct[ctype] == 0)
+         {
+            *why = "unsupported color type";
+            goto fail;
+         }
+         if (w == 0 || h == 0 || w > 0xFFFF || h > 0xFFFF
+             || (uint64_t)w * h > TR_MAX_PIXELS)
+         {
+            *why = "bad dimensions";
+            goto fail;
+         }
+      }
+      else if (!memcmp(tag, "PLTE", 4))
+      {
+         if (clen > 768 || (clen % 3) != 0)
+            goto fail;
+         if (!pal)
+         {
+            pal = (uint8_t *)calloc(1, 768);
+            if (!pal)
+               goto fail;
+            memcpy(pal, body, clen);
+         }
+      }
+      else if (!memcmp(tag, "IDAT", 4))
+      {
+         uint8_t *grown = (uint8_t *)realloc(idat, idat_len + clen);
+         if (!grown)
+            goto fail;
+         idat = grown;
+         memcpy(idat + idat_len, body, clen);
+         idat_len += clen;
+      }
+      else if (!memcmp(tag, "IEND", 4))
+         break;
+      pos += 12 + (size_t)clen;
+   }
+   if (ctype == 0xFF || !idat)
+      goto fail;
+   if (ctype == TR_CT_PAL && !pal)
+      goto fail;
+
+   channels = chan_for_ct[ctype];
+   stride   = w * channels;
+
+   inflated = (uint8_t *)tinfl_decompress_mem_to_heap(idat, idat_len,
+                  &inflated_len, TR_TINFL_PARSE_ZLIB_HEADER);
+   if (!inflated || inflated_len != (size_t)h * (stride + 1))
+      goto fail;
+
+   e = (tr_entry *)calloc(1, sizeof(tr_entry));
+   if (!e)
+      goto fail;
+   e->raw = (uint8_t *)malloc((size_t)h * stride);
+   if (!e->raw)
+      goto fail;
+   e->w = (uint16_t)w;
+   e->h = (uint16_t)h;
+   e->ctype = ctype;
+   e->channels = (uint8_t)channels;
+   e->pal = pal;
+   pal = NULL;                        /* owned by e now */
+
+   /* Unfilter (PNG filters 0-4; bpp for filtering = channels). */
+   for (r = 0; r < h; r++)
+   {
+      const uint8_t *src = inflated + (size_t)r * (stride + 1);
+      uint8_t *dst  = e->raw + (size_t)r * stride;
+      const uint8_t *up = r ? dst - stride : NULL;
+      uint8_t filter = src[0];
+      src++;
+      switch (filter)
+      {
+         case 0:
+            memcpy(dst, src, stride);
+            break;
+         case 1:
+            for (i = 0; i < stride; i++)
+               dst[i] = (uint8_t)(src[i]
+                      + (i >= channels ? dst[i - channels] : 0));
+            break;
+         case 2:
+            for (i = 0; i < stride; i++)
+               dst[i] = (uint8_t)(src[i] + (up ? up[i] : 0));
+            break;
+         case 3:
+            for (i = 0; i < stride; i++)
+            {
+               unsigned a = i >= channels ? dst[i - channels] : 0;
+               unsigned b = up ? up[i] : 0;
+               dst[i] = (uint8_t)(src[i] + ((a + b) >> 1));
+            }
+            break;
+         case 4:
+            for (i = 0; i < stride; i++)
+            {
+               int a = i >= channels ? dst[i - channels] : 0;
+               int b = up ? up[i] : 0;
+               int c = (up && i >= channels) ? up[i - channels] : 0;
+               dst[i] = (uint8_t)(src[i] + tr_paeth(a, b, c));
+            }
+            break;
+         default:
+            goto fail;
+      }
+   }
+
+   mz_free(inflated);
+   free(idat);
+   *why = NULL;
+   return e;
+
+fail:
+   if (inflated)
+      mz_free(inflated);
+   free(idat);
+   free(pal);
+   tr_free_entry(e);
+   return NULL;
+}
+
+/* ---- pack loading --------------------------------------------------- */
+
+static int tr_hex16(const char *s, uint64_t *out)
+{
+   uint64_t v = 0;
+   int i;
+   for (i = 0; i < 16; i++)
+   {
+      char c = s[i];
+      v <<= 4;
+      if (c >= '0' && c <= '9')
+         v |= (uint64_t)(c - '0');
+      else if (c >= 'a' && c <= 'f')
+         v |= (uint64_t)(c - 'a' + 10);
+      else if (c >= 'A' && c <= 'F')
+         v |= (uint64_t)(c - 'A' + 10);
+      else
+         return 0;
+   }
+   *out = v;
+   return 1;
+}
+
+static void tr_pack_dir(char *out, size_t out_size)
+{
+   snprintf(out, out_size, "%s/vj_texpacks/%08x", tr_base,
+            (unsigned)TitleDBContentCRC());
+}
+
+/* Read one pack PNG and insert it.  Returns 1 on success. */
+static int tr_load_file(const char *dir, const char *name, uint64_t key)
+{
+   char path[1400];
+   RFILE *f;
+   int64_t sz;
+   uint8_t *buf;
+   tr_entry *e;
+   const char *why = NULL;
+
+   snprintf(path, sizeof(path), "%s/%s", dir, name);
+   f = rfopen(path, "rb");
+   if (!f)
+      return 0;
+   rfseek(f, 0, SEEK_END);
+   sz = rftell(f);
+   rfseek(f, 0, SEEK_SET);
+   if (sz <= 0 || sz > (int64_t)TR_MAX_PNG_BYTES)
+   {
+      rfclose(f);
+      LOG_INF("[TEXREPLACE] %s: skipped (bad size %lld)\n", name,
+              (long long)sz);
+      return 0;
+   }
+   buf = (uint8_t *)malloc((size_t)sz);
+   if (!buf)
+   {
+      rfclose(f);
+      return 0;
+   }
+   if (rfread(buf, 1, (size_t)sz, f) != sz)
+   {
+      free(buf);
+      rfclose(f);
+      return 0;
+   }
+   rfclose(f);
+
+   e = tr_png_decode(buf, (size_t)sz, &why);
+   free(buf);
+   if (!e)
+   {
+      LOG_INF("[TEXREPLACE] %s: skipped (%s)\n", name, why);
+      return 0;
+   }
+   e->key = key;
+   if (!tr_insert(e))
+   {
+      tr_free_entry(e);
+      return 0;
+   }
+   return 1;
+}
+
+static void tr_load_pack(void)
+{
+   char dir[1200];
+   libretro_vfs_implementation_dir *d;
+   unsigned scanned = 0;
+
+   tr_loaded = 1;
+   if (tr_base[0] == '\0')
+      return;
+
+   tr_pack_dir(dir, sizeof(dir));
+   d = retro_vfs_opendir_impl(dir, false);
+   if (!d)
+      return;
+
+   if (!tr_tab)
+      tr_tab = (tr_entry **)calloc(TR_TAB_SIZE, sizeof(tr_entry *));
+   if (!tr_scratch)
+      tr_scratch = (uint8_t *)malloc(TEXDUMP_SCRATCH_BYTES);
+   if (!tr_tab || !tr_scratch)
+   {
+      free(tr_tab);
+      free(tr_scratch);
+      tr_tab = NULL;
+      tr_scratch = NULL;
+      tr_alloc_failed = 1;
+      retro_vfs_closedir_impl(d);
+      LOG_INF("[TEXREPLACE] allocation failed -- replacement unavailable\n");
+      return;
+   }
+
+   while (retro_vfs_readdir_impl(d))
+   {
+      const char *name = retro_vfs_dirent_get_name_impl(d);
+      uint64_t key;
+      if (!name)
+         continue;
+      /* Exactly <16 hex>.png -- anything else in the directory is the
+       * author's business (manifest copies, notes, PSDs). */
+      if (strlen(name) != 20 || strcmp(name + 16, ".png") != 0)
+         continue;
+      if (!tr_hex16(name, &key))
+         continue;
+      scanned++;
+      tr_load_file(dir, name, key);
+   }
+   retro_vfs_closedir_impl(d);
+
+   LOG_INF("[TEXREPLACE] pack %s: %u/%u PNGs loaded\n", dir,
+           (unsigned)tr_count, scanned);
+}
+
+/* ---- conversion (lazy, once per entry) ------------------------------ */
+
+/* Build the RGB888(+skip) cache from the decoded PNG.  Pack art is
+ * presented in true color through the shadow framebuffer, so there is
+ * deliberately NO RGB->CRY quantization anywhere in this pipeline. */
+static int tr_convert(tr_entry *e)
+{
+   uint32_t npix = (uint32_t)e->w * e->h;
+   uint32_t i;
+
+   if (e->conv)
+      return 1;
+   e->conv = (uint32_t *)malloc((size_t)npix * 4);
+   if (!e->conv)
+      return 0;
+   for (i = 0; i < npix; i++)
+   {
+      const uint8_t *p = e->raw + (size_t)i * e->channels;
+      uint32_t v;
+      switch (e->ctype)
+      {
+         case TR_CT_GRAY:
+            v = ((uint32_t)p[0] << 16) | ((uint32_t)p[0] << 8) | p[0];
+            break;
+         case TR_CT_GRAY_ALPHA:
+            v = ((uint32_t)p[0] << 16) | ((uint32_t)p[0] << 8) | p[0];
+            if (p[1] < 0x80)
+               v |= TR_CONV_SKIP;
+            break;
+         case TR_CT_PAL:
+            v = ((uint32_t)e->pal[p[0] * 3] << 16)
+              | ((uint32_t)e->pal[p[0] * 3 + 1] << 8)
+              |  (uint32_t)e->pal[p[0] * 3 + 2];
+            break;
+         case TR_CT_RGBA:
+            v = ((uint32_t)p[0] << 16) | ((uint32_t)p[1] << 8) | p[2];
+            if (p[3] < 0x80)
+               v |= TR_CONV_SKIP;
+            break;
+         default:  /* TR_CT_RGB */
+            v = ((uint32_t)p[0] << 16) | ((uint32_t)p[1] << 8) | p[2];
+            break;
+      }
+      e->conv[i] = v;
+   }
+   return 1;
+}
+
+/* ---- launch hooks --------------------------------------------------- */
+
+int TexReplacePreBlit(void)
+{
+   uint64_t h;
+   tr_entry *e;
+
+   tr_hit = NULL;
+   if (!tr_tab || !tr_scratch || tr_count == 0)
+      return 0;
+   if (TexDumpDescribe(&tr_desc, &tr_cmd) != 1)
+      return 0;
+   tr_len = TexDumpSerialize(&tr_desc, tr_scratch, TEXDUMP_SCRATCH_BYTES);
+   if (tr_len == 0)
+      return 0;
+   h = TexDumpHashKey(&tr_desc, tr_scratch, tr_len);
+   e = tr_find(h);
+   if (!e)
+      return 0;
+
+   /* Tier 1: 16bpp source windows.  Indexed (<=8bpp) and 32bpp tiers
+    * are future work (docs/texture-dump.md). */
+   if (tr_desc.bpp != 16)
+   {
+      tr_stat_skip_tier++;
+      return 0;
+   }
+   /* 1x contract: the pack PNG must match the dumped dimensions. */
+   if (e->w != tr_desc.inner || e->h != tr_desc.outer)
+   {
+      tr_stat_skip_dims++;
+      if (!tr_dim_warned)
+      {
+         tr_dim_warned = 1;
+         LOG_INF("[TEXREPLACE] %016llx.png is %ux%u but the tile is "
+                 "%ux%u -- 1x replacements must keep the dumped size "
+                 "(further mismatches not logged)\n",
+                 (unsigned long long)e->key, (unsigned)e->w, (unsigned)e->h,
+                 (unsigned)tr_desc.inner, (unsigned)tr_desc.outer);
+      }
+      return 0;
+   }
+   if (!tr_convert(e))
+      return 0;
+
+   /* Describe the DESTINATION window now, before the engines write the
+    * pointer registers back.  The destination is the channel the source
+    * is not: A1 normally, A2 under DSTA2 (JTRM B_CMD bit 11). */
+   if (!TexDumpDescribeChannel(&tr_dst, (tr_cmd & 0x00000800) == 0,
+                               tr_desc.inner, tr_desc.outer))
+      return 0;
+   if (tr_dst.psizefield != 4)     /* 16bpp destinations only (tier 1) */
+   {
+      tr_stat_skip_tier++;
+      return 0;
+   }
+
+   tr_hit = e;
+   tr_stat_hits++;
+   return 1;
+}
+
+void TexReplacePostBlit(void)
+{
+   const TexDumpDesc *dd = &tr_dst;
+   tr_entry *e = tr_hit;
+   uint32_t r, c;
+
+   tr_hit = NULL;
+   if (!e || !shadowFBActive)
+      return;
+
+   for (r = 0; r < dd->outer; r++)
+   {
+      /* Source pixel words sit in tr_scratch exactly 2 bytes per pixel,
+       * row-major (the 16bpp serialization appends each pixel's two
+       * covering bytes; the sub-byte dedupe only applies below 8bpp). */
+      const uint8_t *srow = tr_scratch + (size_t)r * dd->inner * 2;
+      const uint32_t *crow = e->conv + (size_t)r * e->w;
+      for (c = 0; c < dd->inner; c++)
+      {
+         uint32_t daddr, conv;
+         uint16_t src16, cur16;
+         conv = crow[c];
+         if (conv & TR_CONV_SKIP)
+            continue;              /* author alpha: keep the stock pixel */
+         src16 = (uint16_t)(((uint16_t)srow[c * 2] << 8) | srow[c * 2 + 1]);
+         daddr = (dd->base + TexDumpPixelByteOffset(dd, c, r)) & 0xFFFFFF;
+         if (daddr >= 0x7FFFFE)
+            continue;              /* shadow covers main RAM words only */
+         cur16 = (uint16_t)(((uint16_t)TexDumpRead8(daddr) << 8)
+                          | TexDumpRead8(daddr + 1));
+         if (cur16 != src16)
+            continue;              /* not a straight-copied pixel */
+         ShadowFBStoreRGB(daddr, cur16, conv);
+         tr_stat_stores++;
+      }
+   }
+}
+
+/* ---- option layer --------------------------------------------------- */
+
+static void tr_update_gate(void)
+{
+   texReplaceEnabled = (tr_want && tr_tab && tr_scratch && tr_count > 0)
+                     ? 1 : 0;
+}
+
+void TexReplaceSetEnabled(int on)
+{
+   tr_want = on ? 1 : 0;
+   if (tr_want && !tr_loaded && !tr_alloc_failed)
+   {
+      /* Re-probe on enable: the author may have created the pack
+       * directory after the content was loaded. */
+      if (!tr_pack_avail && tr_base[0] != '\0')
+      {
+         char dir[1200];
+         tr_pack_dir(dir, sizeof(dir));
+         tr_pack_avail = path_is_directory(dir) ? 1 : 0;
+      }
+      if (tr_pack_avail)
+         tr_load_pack();
+   }
+   tr_update_gate();
+}
+
+void TexReplaceSetBasePath(const char *system_dir)
+{
+   if (system_dir && system_dir[0])
+   {
+      strncpy(tr_base, system_dir, sizeof(tr_base) - 1);
+      tr_base[sizeof(tr_base) - 1] = '\0';
+   }
+   else
+      tr_base[0] = '\0';
+}
+
+void TexReplaceContentLoaded(void)
+{
+   char dir[1200];
+
+   tr_pack_avail = 0;
+   if (tr_base[0] != '\0')
+   {
+      tr_pack_dir(dir, sizeof(dir));
+      tr_pack_avail = path_is_directory(dir) ? 1 : 0;
+   }
+   if (tr_want && !tr_loaded && !tr_alloc_failed && tr_pack_avail)
+      tr_load_pack();
+   tr_update_gate();
+}
+
+int TexReplacePackAvailable(void)
+{
+   return tr_pack_avail;
+}
+
+int TexReplaceHasEntries(void)
+{
+   return tr_count > 0;
+}
+
+void TexReplaceShutdown(void)
+{
+   if (tr_stat_hits || tr_stat_skip_dims || tr_stat_skip_tier)
+      LOG_INF("[TEXREPLACE] session summary: %u armed launches, %u pixels "
+              "stored, %u dimension mismatches, %u non-16bpp hits\n",
+              (unsigned)tr_stat_hits, (unsigned)tr_stat_stores,
+              (unsigned)tr_stat_skip_dims, (unsigned)tr_stat_skip_tier);
+   if (tr_tab)
+   {
+      uint32_t i;
+      for (i = 0; i < TR_TAB_SIZE; i++)
+         tr_free_entry(tr_tab[i]);
+      free(tr_tab);
+      /* The pack's value-tagged RGB entries must not outlive the pack:
+       * if the surface stays allocated across a title boundary, a
+       * same-value coincidence in the next title would present orphaned
+       * pack pixels.  (No-op when the surface is already down.) */
+      if (tr_stat_stores)
+         ShadowFBInvalidate();
+   }
+   free(tr_scratch);
+   tr_tab     = NULL;
+   tr_scratch = NULL;
+   tr_count   = 0;
+   texReplaceEnabled = 0;
+   tr_want       = 0;
+   tr_loaded     = 0;
+   tr_pack_avail = 0;
+   tr_alloc_failed = 0;
+   tr_dim_warned = 0;
+   tr_base[0]  = '\0';
+   tr_cmd = 0;
+   tr_len = 0;
+   tr_hit = NULL;
+   memset(&tr_desc, 0, sizeof(tr_desc));
+   memset(&tr_dst, 0, sizeof(tr_dst));
+   tr_stat_hits      = 0;
+   tr_stat_stores    = 0;
+   tr_stat_skip_dims = 0;
+   tr_stat_skip_tier = 0;
+}

--- a/src/tom/texreplace.h
+++ b/src/tom/texreplace.h
@@ -1,0 +1,76 @@
+/*
+ * TEXREPLACE.H
+ *
+ * Texture replacement pipeline (issue #369, deliverable 2 of 2).
+ *
+ * Consumes the identity contract dump mode (texdump.c) freezes: at blit
+ * launch the SOURCE window is hashed with the shared texdump helpers,
+ * looked up in a host-side pack map preloaded from
+ * <system_dir>/vj_texpacks/<cart CRC32>/<hash16>.png, and on a hit the
+ * launch's DESTINATION pixels are recorded into the true-color shadow
+ * framebuffer (shadowfb.c) as value-tagged pack RGB.  The OP's existing
+ * shadow presentation path then shows the pack art.
+ *
+ * The emulated machine is NEVER touched: no RAM/register writes, zero
+ * savestate fields, no bus-model time.  Savestates, rewind, runahead
+ * and netplay see a bit-identical machine whether or not a pack is
+ * active; only the presented frame differs.  Design + authoring guide:
+ * docs/texture-dump.md ("Replacement pipeline").
+ */
+
+#ifndef __TEXREPLACE_H__
+#define __TEXREPLACE_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Hot-path gate: option enabled AND the loaded pack has entries.  The
+ * launch site tests this before calling the hooks so the disabled mode
+ * costs one predictable branch. */
+extern int texReplaceEnabled;
+
+/* Option layer (libretro.c).  Runtime-toggleable; enabling triggers the
+ * pack load (one-off host file I/O) if the base path and content CRC
+ * are already known, otherwise the load happens when they arrive via
+ * TexReplaceContentLoaded(). */
+void TexReplaceSetEnabled(int on);
+
+/* Base directory (the frontend's system dir).  Packs are read from
+ * <base>/vj_texpacks/<cart CRC32 as 8 hex>/. */
+void TexReplaceSetBasePath(const char *system_dir);
+
+/* Content is loaded and TitleDBSetContent() has latched the CRC: probe
+ * pack availability (for option visibility) and load the pack now if
+ * the option is already on. */
+void TexReplaceContentLoaded(void);
+
+/* Nonzero when a pack directory exists for the loaded content
+ * (regardless of the option state) -- gates option visibility. */
+int TexReplacePackAvailable(void);
+
+/* Nonzero when the loaded pack has at least one entry -- the libretro
+ * layer uses this to force the shadow framebuffer on. */
+int TexReplaceHasEntries(void);
+
+/* Launch-site hooks (blitter_mmio.c, around engine dispatch).
+ * PreBlit hashes the source window and arms a hit; PostBlit walks the
+ * destination window and records value-tagged pack RGB into the shadow
+ * framebuffer.  Call guarded:
+ *    trBlit = texReplaceEnabled ? TexReplacePreBlit() : 0;
+ *    ... dispatch ...
+ *    if (trBlit) TexReplacePostBlit();  */
+int  TexReplacePreBlit(void);
+void TexReplacePostBlit(void);
+
+/* Free the pack, reset every static (iOS never dlcloses).  Safe to
+ * call repeatedly. */
+void TexReplaceShutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TEXREPLACE_H__ */

--- a/test/test_blitter_mmio.c
+++ b/test/test_blitter_mmio.c
@@ -34,6 +34,9 @@ void BlitterResetDecodeState(void) {}
 int BlitMemoLaunch(void) { return 0; }   /* memo off: dispatch as before */
 int texDumpEnabled = 0;                  /* texture dump off */
 void TexDumpLaunch(void) {}
+int texReplaceEnabled = 0;               /* texture replacement off */
+int TexReplacePreBlit(void) { return 0; }
+void TexReplacePostBlit(void) {}
 
 /* Blitter bus-time model dependencies (vjs.blitterTiming stays 0 in the
  * stub settings above, so the timing path short-circuits; these only

--- a/test/tools/test_texreplace.c
+++ b/test/tools/test_texreplace.c
@@ -1,0 +1,867 @@
+/* test_texreplace.c -- Test gates for the texture replacement pipeline
+ * (issue #369, deliverable 2).  Spec: docs/texture-dump.md,
+ * "Replacement pipeline".
+ *
+ * One binary runs the loaded ROM four times and asserts, in order:
+ *
+ *   1. nopack_inert      replacement ENABLED with no pack present is
+ *                        bit-identical to disabled: per-frame
+ *                        framebuffer hashes, savestate digests
+ *                        (frames N/2, N) and every battery blit's
+ *                        destination RAM bytes -- and the hot gate
+ *                        (texReplaceEnabled) stays off.
+ *   2. pack_machine_inert  replacement ENABLED with a synthetic pack:
+ *                        the EMULATED MACHINE is still bit-identical
+ *                        to disabled (framebuffer hashes, savestate
+ *                        digests, battery destination RAM).  The
+ *                        pipeline is host-side presentation only.
+ *   3. pack_presents     the same run's shadow framebuffer carries the
+ *                        pack art: for every replaced tile, every
+ *                        destination word resolves (value-tagged) to
+ *                        the pack pixel's RGB.  Dimension-mismatched,
+ *                        alpha-holed and non-16bpp pack entries
+ *                        produce exactly no stores.
+ *   4. presentation_path the function the OP calls per 16bpp pixel
+ *                        (ShadowFBLineFromRAM) lands pack RGB in the
+ *                        shadow line buffer the scanline renderer
+ *                        reads.
+ *   5. determinism       two identical pack runs agree on everything.
+ *
+ * The synthetic pack is built from FIRST PRINCIPLES: the test computes
+ * each battery tile's identity hash from the documented contract
+ * (FNV-1a 64 over 'VJTD'|ver|bpp|w|h|bytes) and writes
+ * <hash16>.png itself (stored-deflate PNG, no external encoder).  A
+ * lookup hit therefore also cross-checks the frozen contract against
+ * an independent implementation.
+ *
+ * Build (see the Makefile rule):
+ *   cc -O2 -Wall -std=c99 -I./libretro-common/include \
+ *      -o test/tools/test_texreplace test/tools/test_texreplace.c \
+ *      test/harness/harness.c src/core/crc32.c -ldl -lm
+ *
+ * Usage: ./test/tools/test_texreplace <core> [rom] [--frames N]
+ *          [--json] [--quiet]
+ *
+ * Exit: 0 PASS, 1 FAIL, 2 SKIP (ROM missing).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+
+#include "../harness/harness.h"
+
+/* src/core/crc32.c (compiled into this binary): zlib/PNG CRC-32. */
+int crc32_calcCheckSum(unsigned char *data, unsigned int length);
+
+#define MAX_FRAMES 1200
+
+#define FNV_OFFSET 0xCBF29CE484222325ULL
+#define FNV_PRIME  0x00000100000001B3ULL
+
+/* ---------- battery layout ---------- */
+
+#define BAT_SRC  0x180000u
+#define BAT_DST  0x1C0000u
+#define BAT_DST_STRIDE 0x1000u
+
+/* pack_kind */
+#define PK_RGB   0   /* correct RGB pack PNG -> full replacement      */
+#define PK_DIMS  1   /* wrong-dimension PNG  -> zero stores           */
+#define PK_RGBA  2   /* RGBA with alpha holes -> partial replacement  */
+#define PK_GRAY  3   /* gray PNG for an 8bpp tile -> tier skip        */
+#define PK_RGB32 4   /* RGB PNG for a 32bpp tile -> tier skip         */
+
+typedef struct {
+    unsigned w, h;
+    unsigned psize;      /* FLAGS pixel-size field                    */
+    unsigned log2w;
+    int      dsta2;      /* A1 is the source                          */
+    int      pack_kind;
+    unsigned expect_hits; /* pixels that must resolve to pack RGB     */
+} bat_tile;
+
+static const bat_tile tiles[] = {
+    {  8,  8, 4, 3, 0, PK_RGB,   64 },
+    {  8,  8, 4, 3, 0, PK_RGB,   64 },
+    {  8,  8, 4, 3, 0, PK_RGB,   64 },
+    {  8,  8, 4, 3, 1, PK_RGB,   64 },   /* DSTA2: A1 reads, A2 writes */
+    { 16, 16, 4, 4, 0, PK_RGB,  256 },
+    {  8,  8, 4, 3, 0, PK_DIMS,   0 },
+    {  8,  8, 4, 3, 0, PK_RGBA,  62 },   /* 2 alpha holes              */
+    { 16, 16, 3, 4, 0, PK_GRAY,   0 },   /* 8bpp source: future tier   */
+    {  4,  4, 5, 2, 0, PK_RGB32,  0 },   /* 32bpp source: future tier  */
+};
+#define N_TILES ((unsigned)(sizeof(tiles) / sizeof(tiles[0])))
+
+static unsigned tile_bpp(const bat_tile *t)
+{
+    return 1u << t->psize;
+}
+
+static unsigned tile_bytes(const bat_tile *t)
+{
+    return t->w * t->h * tile_bpp(t) / 8;
+}
+
+/* Deterministic source fill, shared between the RAM write and the
+ * from-first-principles hash. */
+static uint8_t fill_byte(unsigned tile, unsigned i)
+{
+    return (uint8_t)((i * 31u + (0x10u + tile) * 97u + (i >> 5)) & 0xFF);
+}
+
+/* Expected pack art, shared between PNG generation and assertion. */
+static void pack_rgb(unsigned tile, unsigned x, unsigned y, uint8_t *rgb)
+{
+    rgb[0] = (uint8_t)((x * 37u + y * 11u + tile * 71u) & 0xFF);
+    rgb[1] = (uint8_t)((x * 5u + y * 29u + 153u) & 0xFF);
+    rgb[2] = (uint8_t)((x * 13u + y * 3u + tile) & 0xFF);
+}
+
+static int pack_alpha_hole(const bat_tile *t, unsigned x, unsigned y)
+{
+    return (x == 0 && y == 0) || (x == t->w - 1 && y == t->h - 1);
+}
+
+/* Identity-contract hash, implemented independently of the core.  For
+ * every battery tile the window is pixel-mode, pitch 0, origin (0,0)
+ * with width == row length, so the serialized byte stream is exactly
+ * the fill bytes in order. */
+static uint64_t tile_hash(unsigned tile)
+{
+    const bat_tile *t = &tiles[tile];
+    uint64_t h = FNV_OFFSET;
+    uint8_t hdr[10];
+    unsigned i, n = tile_bytes(t);
+
+    hdr[0] = 'V'; hdr[1] = 'J'; hdr[2] = 'T'; hdr[3] = 'D';
+    hdr[4] = 1;
+    hdr[5] = (uint8_t)tile_bpp(t);
+    hdr[6] = (uint8_t)(t->w & 0xFF);
+    hdr[7] = (uint8_t)((t->w >> 8) & 0xFF);
+    hdr[8] = (uint8_t)(t->h & 0xFF);
+    hdr[9] = (uint8_t)((t->h >> 8) & 0xFF);
+    for (i = 0; i < 10; i++) {
+        h ^= hdr[i];
+        h *= FNV_PRIME;
+    }
+    for (i = 0; i < n; i++) {
+        h ^= fill_byte(tile, i);
+        h *= FNV_PRIME;
+    }
+    return h;
+}
+
+static uint32_t tile_dst(unsigned tile)
+{
+    return BAT_DST + tile * BAT_DST_STRIDE;
+}
+
+/* ---------- minimal PNG writer (stored deflate) ---------- */
+
+static uint32_t adler32(const uint8_t *p, size_t n)
+{
+    uint32_t a = 1, b = 0;
+    size_t i;
+    for (i = 0; i < n; i++) {
+        a = (a + p[i]) % 65521u;
+        b = (b + a) % 65521u;
+    }
+    return (b << 16) | a;
+}
+
+static void put_be32(uint8_t *p, uint32_t v)
+{
+    p[0] = (uint8_t)(v >> 24);
+    p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);
+    p[3] = (uint8_t)v;
+}
+
+static void png_chunk(FILE *f, const char *tag, const uint8_t *data,
+                      uint32_t len)
+{
+    uint8_t hdr[8], crcb[4];
+    uint8_t *tmp = (uint8_t *)malloc(len + 4);
+    uint32_t crc;
+
+    put_be32(hdr, len);
+    memcpy(hdr + 4, tag, 4);
+    fwrite(hdr, 1, 8, f);
+    if (len)
+        fwrite(data, 1, len, f);
+    memcpy(tmp, tag, 4);
+    if (len)
+        memcpy(tmp + 4, data, len);
+    crc = (uint32_t)crc32_calcCheckSum(tmp, len + 4);
+    put_be32(crcb, crc);
+    fwrite(crcb, 1, 4, f);
+    free(tmp);
+}
+
+/* Write an 8-bit PNG.  ctype 0 = gray (1ch), 2 = RGB (3ch),
+ * 6 = RGBA (4ch).  raw = w*h*ch bytes. */
+static int write_png(const char *path, unsigned w, unsigned h,
+                     unsigned ctype, const uint8_t *raw)
+{
+    static const uint8_t sig[8] = { 137, 80, 78, 71, 13, 10, 26, 10 };
+    unsigned ch = (ctype == 0) ? 1 : (ctype == 2) ? 3 : 4;
+    unsigned stride = w * ch;
+    size_t rawlen = (size_t)h * (stride + 1);
+    uint8_t *scan = (uint8_t *)malloc(rawlen);
+    size_t zmax = rawlen + 6 + 5 * (rawlen / 65535 + 1);
+    uint8_t *z = (uint8_t *)malloc(zmax);
+    size_t zlen = 0, off = 0;
+    unsigned r;
+    uint8_t ihdr[13];
+    FILE *f;
+
+    if (!scan || !z) {
+        free(scan);
+        free(z);
+        return 0;
+    }
+    for (r = 0; r < h; r++) {
+        scan[(size_t)r * (stride + 1)] = 0;   /* filter: None */
+        memcpy(scan + (size_t)r * (stride + 1) + 1, raw + (size_t)r * stride,
+               stride);
+    }
+
+    /* zlib wrapper + stored deflate blocks. */
+    z[zlen++] = 0x78;
+    z[zlen++] = 0x01;
+    while (off < rawlen) {
+        size_t blk = rawlen - off;
+        int last;
+        if (blk > 65535)
+            blk = 65535;
+        last = (off + blk == rawlen);
+        z[zlen++] = (uint8_t)(last ? 1 : 0);
+        z[zlen++] = (uint8_t)(blk & 0xFF);
+        z[zlen++] = (uint8_t)(blk >> 8);
+        z[zlen++] = (uint8_t)(~blk & 0xFF);
+        z[zlen++] = (uint8_t)((~blk >> 8) & 0xFF);
+        memcpy(z + zlen, scan + off, blk);
+        zlen += blk;
+        off += blk;
+    }
+    {
+        uint32_t ad = adler32(scan, rawlen);
+        z[zlen++] = (uint8_t)(ad >> 24);
+        z[zlen++] = (uint8_t)(ad >> 16);
+        z[zlen++] = (uint8_t)(ad >> 8);
+        z[zlen++] = (uint8_t)ad;
+    }
+
+    f = fopen(path, "wb");
+    if (!f) {
+        free(scan);
+        free(z);
+        return 0;
+    }
+    fwrite(sig, 1, 8, f);
+    put_be32(ihdr, w);
+    put_be32(ihdr + 4, h);
+    ihdr[8]  = 8;                /* bit depth  */
+    ihdr[9]  = (uint8_t)ctype;
+    ihdr[10] = 0;
+    ihdr[11] = 0;
+    ihdr[12] = 0;                /* non-interlaced */
+    png_chunk(f, "IHDR", ihdr, 13);
+    png_chunk(f, "IDAT", z, (uint32_t)zlen);
+    png_chunk(f, "IEND", NULL, 0);
+    fclose(f);
+    free(scan);
+    free(z);
+    return 1;
+}
+
+/* Build the synthetic pack under <sysdir>/vj_texpacks/<crc8>/. */
+static int build_pack(const char *sysdir, uint32_t crc)
+{
+    char dir[1200], path[1400];
+    unsigned tile;
+
+    snprintf(dir, sizeof(dir), "%s/vj_texpacks", sysdir);
+    mkdir(dir, 0777);
+    snprintf(dir, sizeof(dir), "%s/vj_texpacks/%08x", sysdir, (unsigned)crc);
+    mkdir(dir, 0777);
+
+    for (tile = 0; tile < N_TILES; tile++) {
+        const bat_tile *t = &tiles[tile];
+        uint64_t key = tile_hash(tile);
+        unsigned pw = t->w, ph = t->h, ctype = 2, ch;
+        uint8_t *raw;
+        unsigned x, y;
+        int ok;
+
+        switch (t->pack_kind) {
+            case PK_DIMS:
+                pw = t->w * 2;    /* deliberately wrong */
+                ph = t->h * 2;
+                break;
+            case PK_RGBA:
+                ctype = 6;
+                break;
+            case PK_GRAY:
+                ctype = 0;
+                break;
+            default:
+                break;
+        }
+        ch = (ctype == 0) ? 1 : (ctype == 2) ? 3 : 4;
+        raw = (uint8_t *)malloc((size_t)pw * ph * ch);
+        if (!raw)
+            return 0;
+        for (y = 0; y < ph; y++)
+            for (x = 0; x < pw; x++) {
+                uint8_t *p = raw + ((size_t)y * pw + x) * ch;
+                uint8_t rgb[3];
+                pack_rgb(tile, x, y, rgb);
+                if (ctype == 0)
+                    p[0] = rgb[0];
+                else {
+                    p[0] = rgb[0];
+                    p[1] = rgb[1];
+                    p[2] = rgb[2];
+                    if (ctype == 6)
+                        p[3] = pack_alpha_hole(t, x, y) ? 0x00 : 0xFF;
+                }
+            }
+        snprintf(path, sizeof(path), "%s/%08x%08x.png", dir,
+                 (unsigned)(key >> 32), (unsigned)(key & 0xFFFFFFFFu));
+        ok = write_png(path, pw, ph, ctype, raw);
+        free(raw);
+        if (!ok)
+            return 0;
+    }
+    return 1;
+}
+
+static void rm_rf_pack(const char *sysdir)
+{
+    char base[1100], sub[1300], fp[2600];
+    DIR *d, *d2;
+    struct dirent *e, *e2;
+
+    snprintf(base, sizeof(base), "%s/vj_texpacks", sysdir);
+    d = opendir(base);
+    if (d) {
+        while ((e = readdir(d)) != NULL) {
+            if (e->d_name[0] == '.')
+                continue;
+            snprintf(sub, sizeof(sub), "%s/%s", base, e->d_name);
+            d2 = opendir(sub);
+            if (d2) {
+                while ((e2 = readdir(d2)) != NULL) {
+                    if (e2->d_name[0] == '.')
+                        continue;
+                    snprintf(fp, sizeof(fp), "%s/%s", sub, e2->d_name);
+                    unlink(fp);
+                }
+                closedir(d2);
+            }
+            rmdir(sub);
+        }
+        closedir(d);
+    }
+    rmdir(base);
+    rmdir(sysdir);
+}
+
+/* ---------- per-frame capture ---------- */
+
+static uint64_t fnv1a(uint64_t hh, const void *data, size_t len)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    size_t i;
+    for (i = 0; i < len; i++) {
+        hh ^= p[i];
+        hh *= FNV_PRIME;
+    }
+    return hh;
+}
+
+typedef struct {
+    uint64_t fb[MAX_FRAMES];
+    unsigned fb_count;
+    uint64_t digest_mid, digest_end;
+    uint64_t dest_hash[N_TILES];   /* battery destination RAM, per blit */
+    uint32_t crc;                  /* TitleDBContentCRC()               */
+    int      gate;                 /* texReplaceEnabled after battery   */
+    int      shadow_active;        /* shadowFBActive after battery      */
+    unsigned hits[N_TILES];        /* dest words resolving to pack RGB  */
+    unsigned wrong_rgb[N_TILES];   /* resolved but with the WRONG RGB   */
+    unsigned line_rgb_ok;          /* presentation_path sample result   */
+} run_result;
+
+static run_result *g_cur;
+
+static void video_cb(void *ud, const void *data,
+                     unsigned width, unsigned height, size_t pitch)
+{
+    unsigned y;
+    const uint8_t *row = (const uint8_t *)data;
+    uint64_t hh = FNV_OFFSET;
+    (void)ud;
+    if (!g_cur || g_cur->fb_count >= MAX_FRAMES)
+        return;
+    if (!data) {
+        g_cur->fb[g_cur->fb_count] =
+            g_cur->fb_count ? g_cur->fb[g_cur->fb_count - 1] : 0;
+        return;
+    }
+    hh = fnv1a(hh, &width, sizeof(width));
+    hh = fnv1a(hh, &height, sizeof(height));
+    for (y = 0; y < height; y++)
+        hh = fnv1a(hh, row + (size_t)y * pitch, (size_t)width * 4);
+    g_cur->fb[g_cur->fb_count] = hh;
+}
+
+static uint64_t hash_file(const char *path)
+{
+    FILE *f = fopen(path, "rb");
+    uint8_t buf[65536];
+    size_t n;
+    uint64_t hh = FNV_OFFSET;
+    if (!f)
+        return 0;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
+        hh = fnv1a(hh, buf, n);
+    fclose(f);
+    return hh;
+}
+
+/* ---------- battery driver (same bus path as test_texdump's) ---------- */
+
+typedef void (*jw32_fn)(uint32_t, uint32_t, uint32_t);
+typedef uint32_t (*crc_fn)(void);
+typedef int (*sfb_lookup_fn)(uint32_t, uint16_t, uint32_t *);
+typedef void (*sfb_line_fn)(int, uint32_t, uint16_t);
+
+typedef struct {
+    jw32_fn  wl;
+    uint8_t *ram;
+} bat_ctx;
+
+static uint32_t bat_flags(unsigned log2w, unsigned psize)
+{
+    return 0x10000u | ((uint32_t)log2w << 11) | ((uint32_t)psize << 3);
+}
+
+static void bat_blit(const bat_ctx *bc, unsigned tile)
+{
+    const bat_tile *t = &tiles[tile];
+    uint32_t sflags = bat_flags(t->log2w, t->psize);
+    uint32_t dflags = bat_flags(t->log2w, t->psize);
+    uint32_t step   = ((uint32_t)1 << 16) | ((uint32_t)(-(int)t->w) & 0xFFFF);
+    uint32_t cmd    = 0x01800000u    /* LFU = source (REPLACE: LFU2|LFU3) */
+                    | 0x00000001u    /* SRCEN                  */
+                    | 0x00000200u    /* UPDA1                  */
+                    | 0x00000400u;   /* UPDA2                  */
+    uint32_t sbase = BAT_SRC, dbase = tile_dst(tile);
+    uint32_t a1base, a2base, a1flags, a2flags;
+
+    if (t->dsta2) {
+        cmd |= 0x00000800u;          /* DSTA2: A1 reads, A2 writes */
+        a1base = sbase; a1flags = sflags;
+        a2base = dbase; a2flags = dflags;
+    } else {
+        a1base = dbase; a1flags = dflags;
+        a2base = sbase; a2flags = sflags;
+    }
+
+    bc->wl(0xF02200u, a1base, 0);
+    bc->wl(0xF02204u, a1flags, 0);
+    bc->wl(0xF0220Cu, 0, 0);
+    bc->wl(0xF02210u, step, 0);
+    bc->wl(0xF02218u, 0, 0);
+    bc->wl(0xF02224u, a2base, 0);
+    bc->wl(0xF02228u, a2flags, 0);
+    bc->wl(0xF02230u, 0, 0);
+    bc->wl(0xF02234u, step, 0);
+    bc->wl(0xF0223Cu, ((uint32_t)t->h << 16) | t->w, 0);
+    bc->wl(0xF02238u, cmd, 0);       /* B_CMD -> launch */
+}
+
+static int run_battery(harness_config *cfg, run_result *out)
+{
+    bat_ctx bc;
+    void *sym;
+    unsigned tile, i;
+
+    bc.wl = (jw32_fn)harness_dlsym(cfg, "JaguarWriteLong");
+    sym   = harness_dlsym(cfg, "jaguarMainRAM");
+    if (!bc.wl || !sym)
+        return 0;
+    bc.ram = *(uint8_t **)sym;
+    if (!bc.ram)
+        return 0;
+
+    for (tile = 0; tile < N_TILES; tile++) {
+        unsigned n = tile_bytes(&tiles[tile]);
+        for (i = 0; i < n; i++)
+            bc.ram[(BAT_SRC + i) & 0x1FFFFF] = fill_byte(tile, i);
+        bat_blit(&bc, tile);
+        out->dest_hash[tile] = fnv1a(FNV_OFFSET,
+                                     bc.ram + (tile_dst(tile) & 0x1FFFFF), n);
+    }
+    return 1;
+}
+
+/* Probe the shadow framebuffer against the expected pack art.  Runs in
+ * every run (in off / no-pack runs everything must miss). */
+static void probe_shadow(harness_config *cfg, run_result *out)
+{
+    sfb_lookup_fn lookup =
+        (sfb_lookup_fn)harness_dlsym(cfg, "ShadowFBLookup");
+    sfb_line_fn line_fn =
+        (sfb_line_fn)harness_dlsym(cfg, "ShadowFBLineFromRAM");
+    uint32_t *line_rgb = (uint32_t *)harness_dlsym(cfg, "shadowLineRGB");
+    int *gate = (int *)harness_dlsym(cfg, "texReplaceEnabled");
+    int *sfb  = (int *)harness_dlsym(cfg, "shadowFBActive");
+    void *ram_sym = harness_dlsym(cfg, "jaguarMainRAM");
+    uint8_t *ram;
+    unsigned tile, x, y;
+
+    if (!lookup || !line_fn || !line_rgb || !gate || !sfb || !ram_sym)
+        return;
+    ram = *(uint8_t **)ram_sym;
+    out->gate = *gate;
+    out->shadow_active = *sfb;
+
+    for (tile = 0; tile < N_TILES; tile++) {
+        const bat_tile *t = &tiles[tile];
+        if (t->psize != 4)
+            continue;                /* shadow words are 16bpp only */
+        for (y = 0; y < t->h; y++)
+            for (x = 0; x < t->w; x++) {
+                uint32_t daddr = tile_dst(tile) + (y * t->w + x) * 2;
+                uint16_t cur16 =
+                    (uint16_t)(((uint16_t)ram[daddr & 0x1FFFFF] << 8)
+                             | ram[(daddr + 1) & 0x1FFFFF]);
+                uint32_t rgb = 0;
+                uint8_t exp[3];
+                if (!lookup(daddr, cur16, &rgb))
+                    continue;
+                pack_rgb(tile, x, y, exp);
+                if (rgb == (((uint32_t)exp[0] << 16)
+                          | ((uint32_t)exp[1] << 8) | exp[2]))
+                    out->hits[tile]++;
+                else
+                    out->wrong_rgb[tile]++;
+            }
+    }
+
+    /* presentation_path: drive the exact per-pixel function the OP's
+     * 16bpp renderer calls and read the line-buffer RGB the scanline
+     * renderer would present.  Sample: tile 0, pixel (2, 3). */
+    {
+        uint32_t daddr = tile_dst(0) + (3 * tiles[0].w + 2) * 2;
+        uint16_t cur16 = (uint16_t)(((uint16_t)ram[daddr & 0x1FFFFF] << 8)
+                                  | ram[(daddr + 1) & 0x1FFFFF]);
+        uint8_t exp[3];
+        line_fn(7, daddr, cur16);
+        pack_rgb(0, 2, 3, exp);
+        out->line_rgb_ok = (line_rgb[7] == (((uint32_t)exp[0] << 16)
+                                          | ((uint32_t)exp[1] << 8)
+                                          | exp[2])) ? 1 : 0;
+    }
+}
+
+/* ---------- one emulation run ---------- */
+
+static int do_run(const char *core, const char *rom, unsigned frames,
+                  int replace_on, const char *sysdir, run_result *out)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    unsigned i;
+    char state_path[1200];
+    crc_fn crc_get;
+
+    memset(out, 0, sizeof(*out));
+    cfg.core_path  = core;
+    cfg.rom_path   = rom;
+    cfg.frames     = frames;
+    cfg.quiet      = 1;
+    cfg.system_dir = sysdir;
+    cfg.options[cfg.num_options].key   = "virtualjaguar_texture_replace";
+    cfg.options[cfg.num_options].value = replace_on ? "enabled" : "disabled";
+    cfg.num_options++;
+    /* True Color stays OFF: the pipeline must force the shadow surface
+     * it presents through all by itself. */
+    cfg.options[cfg.num_options].key   = "virtualjaguar_true_color";
+    cfg.options[cfg.num_options].value = "disabled";
+    cfg.num_options++;
+    cfg.options[cfg.num_options].key   = "virtualjaguar_texture_dump";
+    cfg.options[cfg.num_options].value = "disabled";
+    cfg.num_options++;
+    cfg.video_callback = video_cb;
+
+    if (!harness_load_core(&cfg))
+        return 0;
+    if (!harness_load_rom(&cfg)) {
+        harness_shutdown(&cfg);
+        return 0;
+    }
+
+    {
+        crc_get = (crc_fn)harness_dlsym(&cfg, "TitleDBContentCRC");
+        if (crc_get)
+            out->crc = crc_get();
+    }
+
+    snprintf(state_path, sizeof(state_path), "%s/texreplace_probe.state",
+             sysdir);
+    g_cur = out;
+    for (i = 0; i < frames; i++) {
+        harness_step(&cfg);
+        out->fb_count++;
+        if (i + 1 == frames / 2) {
+            if (harness_save_state(&cfg, state_path))
+                out->digest_mid = hash_file(state_path);
+        }
+        if (i + 1 == frames) {
+            if (harness_save_state(&cfg, state_path))
+                out->digest_end = hash_file(state_path);
+        }
+    }
+    g_cur = NULL;
+
+    if (!run_battery(&cfg, out)) {
+        fprintf(stderr, "texreplace: battery needs the TEST_EXPORTS wide "
+                "ABI (JaguarWriteLong/jaguarMainRAM not exported)\n");
+        harness_shutdown(&cfg);
+        return 0;
+    }
+    probe_shadow(&cfg, out);
+
+    harness_shutdown(&cfg);
+    unlink(state_path);
+    return 1;
+}
+
+/* ---------- comparisons ---------- */
+
+static int machine_equal(const run_result *a, const run_result *b,
+                         unsigned frames, char *why, size_t why_size)
+{
+    unsigned f, t;
+    for (f = 0; f < frames; f++)
+        if (a->fb[f] != b->fb[f]) {
+            snprintf(why, why_size, "framebuffer diverges at frame %u", f + 1);
+            return 0;
+        }
+    if (!a->digest_mid || !a->digest_end) {
+        snprintf(why, why_size, "savestate capture failed");
+        return 0;
+    }
+    if (a->digest_mid != b->digest_mid || a->digest_end != b->digest_end) {
+        snprintf(why, why_size, "savestate digest differs (@mid: %d, @end: %d)",
+                 a->digest_mid != b->digest_mid, a->digest_end != b->digest_end);
+        return 0;
+    }
+    for (t = 0; t < N_TILES; t++)
+        if (a->dest_hash[t] != b->dest_hash[t]) {
+            snprintf(why, why_size, "battery tile %u destination RAM differs", t);
+            return 0;
+        }
+    snprintf(why, why_size, "%u frames + digests + %u battery destinations "
+             "identical", frames, (unsigned)N_TILES);
+    return 1;
+}
+
+/* ---------- main ---------- */
+
+int main(int argc, char **argv)
+{
+    harness_config argcfg = HARNESS_CONFIG_DEFAULT;
+    int json = 0, quiet = 0;
+    unsigned frames;
+    int i;
+    run_result *ro, *rn, *rp, *rq;
+    char dir_o[64], dir_n[64], dir_p[64];
+    harness_result results[8];
+    unsigned nres = 0;
+    int failed = 0;
+    static char d_nopack[224], d_inert[224], d_pres[320], d_line[128],
+                d_det[224];
+
+    for (i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--json"))
+            json = 1;
+        else if (!strcmp(argv[i], "--quiet"))
+            quiet = 1;
+    }
+
+    argcfg.frames = 600;
+    if (!harness_init_from_args(&argcfg, argc, argv)) {
+        fprintf(stderr, "usage: %s <core> [rom] [--frames N] [--json] "
+                "[--quiet]\n", argv[0]);
+        return 1;
+    }
+    if (!argcfg.rom_path)
+        argcfg.rom_path = "test/roms/yarc.j64";
+    if (access(argcfg.rom_path, R_OK) != 0) {
+        printf("SKIP: ROM not available (%s)\n", argcfg.rom_path);
+        return 2;
+    }
+    frames = argcfg.frames;
+    if (frames > MAX_FRAMES)
+        frames = MAX_FRAMES;
+
+    ro = (run_result *)calloc(1, sizeof(run_result));
+    rn = (run_result *)calloc(1, sizeof(run_result));
+    rp = (run_result *)calloc(1, sizeof(run_result));
+    rq = (run_result *)calloc(1, sizeof(run_result));
+    if (!ro || !rn || !rp || !rq) {
+        fprintf(stderr, "FAIL: out of memory\n");
+        return 1;
+    }
+
+    snprintf(dir_o, sizeof(dir_o), "/tmp/vj_texrep_o_%d", (int)getpid());
+    snprintf(dir_n, sizeof(dir_n), "/tmp/vj_texrep_n_%d", (int)getpid());
+    snprintf(dir_p, sizeof(dir_p), "/tmp/vj_texrep_p_%d", (int)getpid());
+    mkdir(dir_o, 0777);
+    mkdir(dir_n, 0777);
+    mkdir(dir_p, 0777);
+
+    /* Run O: replacement disabled (the machine baseline). */
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 0, dir_o, ro))
+        goto run_fail;
+    /* Run N: enabled, but no pack directory exists in this sysdir. */
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, dir_n, rn))
+        goto run_fail;
+    /* Build the synthetic pack from first principles, then run P
+     * (enabled, pack present) twice for determinism. */
+    if (!build_pack(dir_p, ro->crc)) {
+        fprintf(stderr, "FAIL: could not build the synthetic pack\n");
+        goto run_fail;
+    }
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, dir_p, rp))
+        goto run_fail;
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, dir_p, rq))
+        goto run_fail;
+
+    /* Gate 1: no pack -> bit-identical machine AND gate off. */
+    {
+        char why[192];
+        int ok = machine_equal(ro, rn, frames, why, sizeof(why));
+        if (ok && rn->gate != 0) {
+            ok = 0;
+            snprintf(why, sizeof(why),
+                     "texReplaceEnabled=%d with no pack (want 0)", rn->gate);
+        }
+        if (ok && rn->shadow_active != 0) {
+            ok = 0;
+            snprintf(why, sizeof(why),
+                     "shadowFBActive=%d with no pack and True Color off "
+                     "(want 0)", rn->shadow_active);
+        }
+        snprintf(d_nopack, sizeof(d_nopack), "%s", why);
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "nopack_inert";
+        results[nres].detail = d_nopack;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    /* Gate 2: pack present -> the machine is STILL bit-identical. */
+    {
+        char why[192];
+        int ok = machine_equal(ro, rp, frames, why, sizeof(why));
+        snprintf(d_inert, sizeof(d_inert), "%s", why);
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "pack_machine_inert";
+        results[nres].detail = d_inert;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    /* Gate 3: pack present -> the shadow framebuffer presents it. */
+    {
+        int ok = (rp->gate == 1) && (rp->shadow_active == 1);
+        unsigned t;
+        char frag[64];
+        snprintf(d_pres, sizeof(d_pres), "gate=%d shadow=%d hits:",
+                 rp->gate, rp->shadow_active);
+        for (t = 0; t < N_TILES; t++) {
+            if (rp->hits[t] != tiles[t].expect_hits || rp->wrong_rgb[t])
+                ok = 0;
+            snprintf(frag, sizeof(frag), " t%u=%u/%u", t, rp->hits[t],
+                     tiles[t].expect_hits);
+            strncat(d_pres, frag, sizeof(d_pres) - strlen(d_pres) - 1);
+            if (rp->wrong_rgb[t]) {
+                snprintf(frag, sizeof(frag), "(%u wrong)", rp->wrong_rgb[t]);
+                strncat(d_pres, frag, sizeof(d_pres) - strlen(d_pres) - 1);
+            }
+        }
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "pack_presents";
+        results[nres].detail = d_pres;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    /* Gate 4: the OP's per-pixel presentation function shows pack RGB. */
+    {
+        int ok = rp->line_rgb_ok == 1;
+        snprintf(d_line, sizeof(d_line), "ShadowFBLineFromRAM -> "
+                 "shadowLineRGB %s pack art",
+                 ok ? "carries" : "DOES NOT carry");
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "presentation_path";
+        results[nres].detail = d_line;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    /* Gate 5: two identical pack runs agree on everything. */
+    {
+        char why[192];
+        int ok = machine_equal(rp, rq, frames, why, sizeof(why));
+        unsigned t;
+        for (t = 0; t < N_TILES && ok; t++)
+            if (rp->hits[t] != rq->hits[t]
+                || rp->wrong_rgb[t] != rq->wrong_rgb[t]) {
+                ok = 0;
+                snprintf(why, sizeof(why), "shadow hits differ on tile %u", t);
+            }
+        if (ok && rp->line_rgb_ok != rq->line_rgb_ok) {
+            ok = 0;
+            snprintf(why, sizeof(why), "presentation sample differs");
+        }
+        snprintf(d_det, sizeof(d_det), "%s", why);
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "determinism";
+        results[nres].detail = d_det;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    {
+        harness_config rcfg = HARNESS_CONFIG_DEFAULT;
+        rcfg.json_output = json;
+        rcfg.quiet = quiet;
+        harness_report(&rcfg, results, nres);
+    }
+
+    rm_rf_pack(dir_o);
+    rm_rf_pack(dir_n);
+    rm_rf_pack(dir_p);
+    free(ro); free(rn); free(rp); free(rq);
+    return failed ? 1 : 0;
+
+run_fail:
+    fprintf(stderr, "FAIL: emulation run did not complete\n");
+    rm_rf_pack(dir_o);
+    rm_rf_pack(dir_n);
+    rm_rf_pack(dir_p);
+    free(ro); free(rn); free(rp); free(rq);
+    return 1;
+}


### PR DESCRIPTION
Part 2 of #369 — the texture REPLACEMENT pipeline, consuming the identity contract PR #478's dump mode froze. Tier 1 lands: **16bpp source tiles, 1x, straight-copy blits** (the sprite/UI blit class dump mode was built for), fully gated in `make test` and verified on a real title. Tier 2 (indexed) and tier 3 (>1x on the Stage 2 surface) are designed in notes on #369.

## Architecture: host-only, presentation-riding

The pipeline **never touches the emulated machine** — not "restores it afterwards"; never writes it at all:

1. At blit launch the SOURCE window is hashed with the *shared* texdump helpers (`TexDumpDescribe` / `TexDumpSerialize` / `TexDumpHashKey` — exported from `texdump.c`, not copied), and the DESTINATION window is described pre-dispatch (the engines write back the pointer registers as they run).
2. The blit dispatches completely stock.
3. Post-dispatch, every destination word that now equals its captured source word (the **per-pixel straight-copy witness**) gets its pack pixel's RGB888 stored into the true-color shadow framebuffer via the new `ShadowFBStoreRGB`, value-tagged. The OP's existing shadow presentation path (`ShadowFBLineFromRAM` → CRY scanline renderer) presents the art.

The witness makes wrong models harmless: transparent (BCOMPEN/DCOMPEN), shaded, or exotic pixels never store, and the stock pixel presents. It caught a real bug in this PR's own test battery on first run — an LFU nibble of 3 is a NOT-copy, and the witness refused to store a single pixel.

Consequences, all asserted by the new gates:

- **Savestates, rewind, run-ahead, netplay: bit-identical** with or without a pack. Zero savestate fields, zero RAM writes, zero bus-model time (pace-neutral by construction — same as dump mode).
- **Packs are true color.** No RGB→CRY quantization exists anywhere in the pipeline. Pack alpha < 128 = "keep the stock pixel".
- The Gouraud-precision engine stores were split onto a new `shadowFBPrecision` flag, so a replacement pack forcing the shadow *surface* on does NOT drag in the True Color feature — every non-replaced pixel stays bit-identical, and `virtualjaguar_true_color` behaves exactly as before.

## Pack layout & option

```
<system_dir>/vj_texpacks/<CRC32>/<hash16>.png
```

Mirrors the dump layout — authoring is "dump, redraw, move one directory over". PNGs (8-bit, non-interlaced, gray/RGB/indexed/gray+alpha/RGBA) are decoded once at load into a host hash map (chunk walk + miniz `tinfl` inflate + unfilter, ~150 lines C89 — no new vendored code); **never any file I/O at blit time**. `virtualjaguar_texture_replace`: default disabled, runtime-toggleable, visible only when a pack directory exists for the loaded title.

## Tests (all in `make test`)

`test/tools/test_texreplace.c` runs yarc.j64 + a scripted 9-tile battery (A2- and A1-sourced 16bpp, a 16×16, a dimension-mismatched entry, RGBA with alpha holes, 8bpp/32bpp tier-skip entries):

| gate | claim |
|---|---|
| `nopack_inert` | enabled + no pack ≡ disabled (fb hashes, savestate digests, battery dest RAM, gate off) |
| `pack_machine_inert` | enabled + pack: the machine is STILL bit-identical to disabled |
| `pack_presents` | every replaced dest word resolves value-tagged to the exact pack RGB; mismatched/holed/other-tier entries store exactly nothing |
| `presentation_path` | the OP's per-pixel function lands pack RGB in the shadow line buffer |
| `determinism` | two identical pack runs agree on everything |

The synthetic pack is built **from first principles** — the test computes each tile's hash from the documented contract and writes the PNGs itself — so every lookup hit also cross-checks the frozen contract against an independent implementation. All 9 texdump gates (incl. `contract_freeze`, 28 golden hashes) pass unchanged across the helper extraction.

**Real-game verification** (local, private ROM): a solid-magenta pack generated over Tempest 2000's 395 dumped 16bpp tiles presents magenta in **894/900 headless frames** (peak 43k pixels/frame); the replacement-off run shows zero. Same pack machinery on AvP loads 361/361 and stores per the witness, but AvP's display path isn't a 16bpp CRY OP bitmap over those words — exactly the tier-1 boundary the docs state.

Full `make TEST_EXPORTS=1 test` exits 0; `scripts/c89-lint.sh` clean on every touched file; export lists in sync; MSVC list updated.

## Files

- `src/tom/texreplace.c/.h` — the pipeline
- `src/tom/texdump.c/.h` — mechanical helper extraction (contract frozen, golden test proves it)
- `src/tom/shadowfb.c/.h`, `src/tom/blitter.c` — `ShadowFBStoreRGB` + precision/surface split
- `src/tom/blitter_mmio.c` — pre/post hooks around dispatch
- `libretro.c`, `libretro_core_options.h` — option, visibility gate, shadow coupling, teardown
- `test/tools/test_texreplace.c`, `test/test_blitter_mmio.c`, `Makefile`, `Makefile.common`, `c-cpp.yml`, export lists
- `docs/texture-dump.md` — extended (one doc for both deliverables, per the spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
