### PR TITLE
test: make scratch paths per-process to survive concurrent suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -968,6 +968,16 @@ else
 # rev (+ -dirty) against this before running -- a stale dylib fails loudly
 # instead of silently testing the wrong code (see scripts/build-id.sh).
 test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
+# Per-process EEPROM fixture scratch: two concurrent `make test` runs
+# (different worktrees/sessions sharing /tmp) would otherwise recompile
+# and overwrite the same generator binary and regenerate/truncate the
+# same fixture ROM out from under each other mid-suite.  $(shell echo
+# $$PPID) is evaluated once, at parse time, in a subshell whose parent
+# is this `make` process -- so every recipe line below sees the same
+# value for the life of one `make test` invocation, and two concurrent
+# invocations get different values.
+test: EEPROM_GEN_TOOL := /tmp/vj_gen_eeprom_test_rom_$(shell echo $$PPID)
+test: EEPROM_FIXTURE := /tmp/vj_eeprom_lifecycle_$(shell echo $$PPID).j64
 test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_netpacket test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 test/test_titledb test/test_titlehook test/test_biosdb \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
@@ -1373,12 +1383,16 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		--max-fastest-frame-fraction 100 \
 		--option virtualjaguar_m68k_clock_scale=0.5x
 	@# EEPROM lifecycle test: generates a test ROM, then exercises load/unload/reload.
-	@$(CC) -O2 -Wall -o /tmp/gen_eeprom_test_rom test/tools/gen_eeprom_test_rom.c && \
-		/tmp/gen_eeprom_test_rom /tmp/eeprom_lifecycle_test.j64 && \
-		./test/test_eeprom_lifecycle ./$(TARGET) /tmp/eeprom_lifecycle_test.j64
+	@# EEPROM_GEN_TOOL / EEPROM_FIXTURE are per-process (see the `test:`
+	@# target-specific variable above) so two concurrent `make test` runs
+	@# don't recompile/overwrite each other's generator binary or fixture.
+	@$(CC) -O2 -Wall -o $(EEPROM_GEN_TOOL) test/tools/gen_eeprom_test_rom.c && \
+		$(EEPROM_GEN_TOOL) $(EEPROM_FIXTURE) && \
+		./test/test_eeprom_lifecycle ./$(TARGET) $(EEPROM_FIXTURE)
 	@# EEPROM read-race test: joystick polls must not steal EEPROM DO bits
 	@# (Raiden background-music death regression).
-	./test/test_eeprom_read_race ./$(TARGET) /tmp/eeprom_lifecycle_test.j64
+	./test/test_eeprom_read_race ./$(TARGET) $(EEPROM_FIXTURE)
+	@rm -f $(EEPROM_GEN_TOOL) $(EEPROM_FIXTURE)
 	@# Per-title enhancement defaults DB E2E (#368): apply / disable /
 	@# user-override contract, driven through the real dlopen'd core.
 	@# shadowHiresN is fixed for the whole session at retro_load_game

--- a/test/test_cart_needs_bios.c
+++ b/test/test_cart_needs_bios.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <dlfcn.h>
+#include <unistd.h>
 
 #include "harness/harness.h"
 
@@ -278,6 +279,18 @@ int main(int argc, char **argv)
    uint32_t size = 0;
    int fail = 0;
    const char *core;
+   char ff_path[64];
+   char rayman_path[64];
+   char addq_path[64];
+
+   /* Per-process scratch paths: two concurrent `make test` suites would
+    * otherwise write/read the same fixture ROMs. */
+   snprintf(ff_path, sizeof(ff_path), "/tmp/vj_needs_bios_ff_%ld.j64",
+            (long)getpid());
+   snprintf(rayman_path, sizeof(rayman_path),
+            "/tmp/vj_needs_bios_rayman_%ld.j64", (long)getpid());
+   snprintf(addq_path, sizeof(addq_path), "/tmp/vj_needs_bios_addq_%ld.j64",
+            (long)getpid());
 
    core = (argc > 1 && argv[1] && argv[1][0] != '-') ? argv[1]
          : default_core_path();
@@ -304,7 +317,7 @@ int main(int argc, char **argv)
    fprintf(stderr, "=== default-HLE autodetect ===\n");
 
    if (!build_ff_pad_bootintro(&buf, &size) ||
-         !write_rom("/tmp/vj_needs_bios_ff.j64", buf, size))
+         !write_rom(ff_path, buf, size))
    {
       fprintf(stderr, "FAIL: write ff pad rom\n");
       free(buf);
@@ -312,12 +325,13 @@ int main(int argc, char **argv)
    }
    free(buf);
    buf = NULL;
-   if (run_autodetect_arm(argc, argv, "/tmp/vj_needs_bios_ff.j64", 1,
+   if (run_autodetect_arm(argc, argv, ff_path, 1,
          "autodetect_ff_pad"))
       fail++;
+   remove(ff_path);
 
    if (!build_rayman_demo_shape(&buf, &size) ||
-         !write_rom("/tmp/vj_needs_bios_rayman.j64", buf, size))
+         !write_rom(rayman_path, buf, size))
    {
       fprintf(stderr, "FAIL: write rayman-shape rom\n");
       free(buf);
@@ -325,21 +339,23 @@ int main(int argc, char **argv)
    }
    free(buf);
    buf = NULL;
-   if (run_autodetect_arm(argc, argv, "/tmp/vj_needs_bios_rayman.j64", 0,
+   if (run_autodetect_arm(argc, argv, rayman_path, 0,
          "autodetect_rayman_demo_shape"))
       fail++;
+   remove(rayman_path);
 
    if (!build_addq_fence(&buf, &size) ||
-         !write_rom("/tmp/vj_needs_bios_addq.j64", buf, size))
+         !write_rom(addq_path, buf, size))
    {
       fprintf(stderr, "FAIL: write addq rom\n");
       free(buf);
       return 1;
    }
    free(buf);
-   if (run_autodetect_arm(argc, argv, "/tmp/vj_needs_bios_addq.j64", 0,
+   if (run_autodetect_arm(argc, argv, addq_path, 0,
          "autodetect_addq_fence"))
       fail++;
+   remove(addq_path);
 
    if (fail)
    {

--- a/test/test_fountain_crash.c
+++ b/test/test_fountain_crash.c
@@ -31,7 +31,6 @@
 #include "harness/harness.h"
 
 #define FOUNTAIN_ROM_DEFAULT "/tmp/fountain_vj.j64"
-#define DUMMY_CART_PATH      "/tmp/vj_dummy_cart_469.j64"
 #define DUMMY_CART_SIZE      131072u
 #define BIOS_ROM_PARK_PC     0x00E005DCu
 #define MAX_PRESENT_WIDTH    652u
@@ -147,6 +146,15 @@ int main(int argc, char **argv)
     char dummy_detail[80];
     char m_detail[80];
     char live_detail[160];
+    char dummy_cart_path[64];
+
+    /* Per-process scratch path: two concurrent `make test` suites would
+     * otherwise write/read the same dummy cart file. FOUNTAIN_ROM_DEFAULT
+     * stays fixed -- it names a well-known spot for a manually-placed,
+     * read-only optional ROM, and the Makefile checks that literal path
+     * too. */
+    snprintf(dummy_cart_path, sizeof(dummy_cart_path),
+             "/tmp/vj_dummy_cart_469_%ld.j64", (long)getpid());
 
     cfg.frames = 180;
     cfg.use_bios = 1;
@@ -162,12 +170,12 @@ int main(int argc, char **argv)
     dummy_ok = 0;
     live_ok = 1;
 
-    if (!write_dummy_cart(DUMMY_CART_PATH)) {
-        fprintf(stderr, "FAIL: cannot write dummy cart %s\n", DUMMY_CART_PATH);
+    if (!write_dummy_cart(dummy_cart_path)) {
+        fprintf(stderr, "FAIL: cannot write dummy cart %s\n", dummy_cart_path);
         harness_shutdown(&cfg);
         return 1;
     }
-    cfg.rom_path = DUMMY_CART_PATH;
+    cfg.rom_path = dummy_cart_path;
     if (!harness_load_rom(&cfg)) {
         harness_shutdown(&cfg);
         return 1;
@@ -188,7 +196,7 @@ int main(int argc, char **argv)
     if (!harness_init_from_args(&cfg, argc, argv))
         return 1;
     cfg.use_bios = 1;
-    cfg.rom_path = DUMMY_CART_PATH;
+    cfg.rom_path = dummy_cart_path;
     harness_set_option(&cfg, "virtualjaguar_bios_type", "m");
     if (!harness_load_rom(&cfg)) {
         harness_shutdown(&cfg);
@@ -202,6 +210,7 @@ int main(int argc, char **argv)
     results[nres].detail = m_detail;
     nres++;
     harness_shutdown(&cfg);
+    remove(dummy_cart_path);
 
     if (!dummy_ok)
         return 1;

--- a/test/tools/flicker_detect.c
+++ b/test/tools/flicker_detect.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <math.h>
 #include <dlfcn.h>
+#include <unistd.h>
 #include "libretro-common/include/libretro.h"
 
 #define WIN 16
@@ -22,6 +23,10 @@
 
 static unsigned cur_frame = 0;
 static unsigned total_frames = 600;
+/* Per-process default prefix, set in main() before argv parsing so a
+ * default (unspecified --prefix) run doesn't collide with a concurrent
+ * invocation in /tmp; explicit --prefix still overrides it. */
+static char default_prefix[64];
 static const char *out_prefix = "/tmp/flicker";
 static const char *label = "rom";
 static int use_bios = 0;
@@ -262,6 +267,9 @@ int main(int argc, char **argv) {
       return 1;
    }
    int i;
+   snprintf(default_prefix, sizeof(default_prefix), "/tmp/flicker_%ld",
+            (long)getpid());
+   out_prefix = default_prefix;
    for (i = 3; i < argc; i++) {
       if (!strcmp(argv[i], "--frames") && i + 1 < argc) total_frames = atoi(argv[++i]);
       else if (!strcmp(argv[i], "--prefix") && i + 1 < argc) out_prefix = argv[++i];

--- a/test/tools/test_hook_gate.c
+++ b/test/tools/test_hook_gate.c
@@ -162,7 +162,12 @@ int main(int argc, char **argv)
     harness_result results[8];
     uint8_t *jagmem;
     void (*set_hooks)(const TitleDBHook *, int);
-    const char *statefile = "/tmp/vj_hook_gate_state.raw";
+    char statefile[64];
+
+    /* Per-process path: a fixed name collides when two `make test`
+     * suites run concurrently in different worktrees/sessions. */
+    snprintf(statefile, sizeof(statefile), "/tmp/vj_hook_gate_state_%ld.raw",
+              (long)getpid());
 
     for (i = 1; i < argc; i++)
         if (strcmp(argv[i], "--case") == 0 && i + 1 < argc)

--- a/test/tools/test_runahead_determinism.c
+++ b/test/tools/test_runahead_determinism.c
@@ -336,14 +336,26 @@ int main(int argc, char **argv)
     unsigned       pass2_audio_entries = 0;
     int            audio_measurable;
     int            ring_full_any = 0;
-    char           state_a[] = "/tmp/vj_runahead_a.state";
-    char           state_b[] = "/tmp/vj_runahead_b.state";
-    char           state_c[] = "/tmp/vj_runahead_c.state";
+    char           state_a[64];
+    char           state_b[64];
+    char           state_c[64];
     uint8_t       *blob_b = NULL, *blob_c = NULL;
     size_t         len_b = 0, len_c = 0;
     int            state_stable = 0;
     char           detail_v[256], detail_a[256], detail_s[256], detail_r[256];
     int            failed = 0;
+
+    /* Per-process paths: two concurrent `make test` suites (different
+     * worktrees/sessions) sharing /tmp must not race on the same
+     * savestate file -- one run deleting/overwriting the other's state
+     * mid-test produces a spurious "retro_unserialize failed" that
+     * looks exactly like a real determinism regression. */
+    snprintf(state_a, sizeof(state_a), "/tmp/vj_runahead_a_%ld.state",
+             (long)getpid());
+    snprintf(state_b, sizeof(state_b), "/tmp/vj_runahead_b_%ld.state",
+             (long)getpid());
+    snprintf(state_c, sizeof(state_c), "/tmp/vj_runahead_c_%ld.state",
+             (long)getpid());
 
     for (i = 1; i < (unsigned)argc; i++) {
         if (!strcmp(argv[i], "--warmup") && i + 1 < (unsigned)argc)

--- a/test/tools/test_screenshot.c
+++ b/test/tools/test_screenshot.c
@@ -12,6 +12,7 @@
 #include <dlfcn.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <unistd.h>
 
 #include "../../libretro-common/include/libretro.h"
 #include "../../src/m68000/m68kinterface.h"
@@ -227,11 +228,18 @@ int main(int argc, char **argv)
 {
    void *handle;
    const char *core_path, *rom_path, *state_path;
-   const char *out_path = "/tmp/jaguar_screenshot.ppm";
+   const char *out_path;
+   char default_out_path[64];
    struct retro_game_info info;
    size_t fsize, state_size;
    void *rom_data, *state_data;
    int i, num_frames = 3;
+
+   /* Per-process default: two concurrent invocations without --out
+    * would otherwise clobber each other's screenshot. */
+   snprintf(default_out_path, sizeof(default_out_path),
+            "/tmp/jaguar_screenshot_%ld.ppm", (long)getpid());
+   out_path = default_out_path;
 
    if (argc < 4)
    {


### PR DESCRIPTION
Fixes a spurious-failure class observed 2026-08-18 while several agent sessions ran `make test` concurrently.

`test/tools/test_runahead_determinism.c` wrote savestates to the fixed path `/tmp/vj_runahead_a.state`. Two suites raced; one deleted the other's file mid-test and the victim failed with `harness: cannot open save state` / `FAIL: retro_unserialize failed`. That reads exactly like a real determinism regression, which is the worst way for a flake to present.

Scratch paths are now per-process (`getpid()`-keyed), matching the pattern the CD tests and `test_texdump`/`test_texreplace` already use. Paths that were already race-safe were left alone: the five CD tests that already key on `getpid()`, and every `mkstemp`/`XXXXXX` template (race-safe by construction — `netlink_latency_test.sh` was investigated during an earlier flake and cleared).

Verification is deferred to CI and to the v3.4.0 release branch: this repo currently has several agent sessions building concurrently, so a local full-suite run is exactly the condition this PR fixes and would not be a trustworthy signal either way.