### PR TITLE
test(netlink): fail fast when mktemp cannot make the probe log

### DIFF
--- a/test/tools/netlink_latency_test.sh
+++ b/test/tools/netlink_latency_test.sh
@@ -43,7 +43,14 @@ run_case()
 {
     local label="$1" core_port="$2" proxy_port="$3" wait_opt="$4"
     local probe_log rate fps
-    probe_log="$(mktemp "${TMPDIR:-/tmp}/vj_nl_lat_XXXXXX.log")"
+    # Fail fast if mktemp cannot hand us a scratch file.  Without this the
+    # empty $probe_log flows into the redirect, the grep and both seds below
+    # and each reports its own "No such file or directory" before the case
+    # finally errors -- a cascade that buries the actual cause.
+    probe_log="$(mktemp "${TMPDIR:-/tmp}/vj_nl_lat_XXXXXX.log")" || {
+        echo "netlink_latency_test: FAIL ($label: mktemp failed)" >&2
+        return 1
+    }
 
     "$TOOLS/netlink_delay_proxy" --listen "$proxy_port" \
         --connect "127.0.0.1:$core_port" --delay-ms 3 2>/dev/null &


### PR DESCRIPTION
`run_case()` in `test/tools/netlink_latency_test.sh` captured `mktemp`'s output without checking it succeeded. On failure `$probe_log` is empty, and every later use — the `netlink_latency` stdout redirect, the `grep`, both `sed`s and the `rm -f` — then operates on an empty string, each emitting its own `No such file or directory` before the case finally reports `control case errored`:

```
mktemp: mkstemp failed on /var/folders/.../T//vj_nl_lat_XXXXXX.log: File exists
test/tools/netlink_latency_test.sh: line 52: : No such file or directory
grep: : No such file or directory
sed: : No such file or directory
sed: : No such file or directory
netlink_latency_test: FAIL (control case errored)
```

Now one attributable line: `netlink_latency_test: FAIL (<case>: mktemp failed)`.

**Deliberately not addressed:** why `mktemp` failed. It did not reproduce on a solo re-run, and `mktemp` with an `XXXXXX` template is already the concurrency-safe pattern this repo standardises on (per #491) — so the usage is not changed. This is only about the missing failure check.

## Verification

- Guard path: simulated a failing `mktemp`, confirmed a single `FAIL (... mktemp failed)` line and `return 1`, no cascade.
- Normal path unaffected, run against a freshly built core:
  ```
  [control disabled] [probe] 52.4 exchanges/sec ...
  [fixed enabled]    [probe] 87.4 exchanges/sec ...
  netlink_latency_test: PASS (disabled=52.4 quantized <= 60/s, enabled=87.4 beat the frame ceiling)
  ```
  exit 0.
- `bash -n` syntax check clean. Shell script, so `c89-lint` is not applicable.
- One file touched; thresholds and `mktemp` usage unchanged.