### PR TITLE
feat(netlink): auto link mode, LAN host discovery, and OSD narration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,7 @@ coverage.xml
 test/tools/netlink_latency
 test/tools/netlink_delay_proxy
 test/tools/netlink_discover_probe
+test/tools/netlink_rebuild_witness
 
 # Skip ledger written by `make test` (scripts/test-skip.sh)
 test/.skipped-checks

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ test/tools/__pycache__/
 coverage.xml
 test/tools/netlink_latency
 test/tools/netlink_delay_proxy
+test/tools/netlink_discover_probe
 
 # Skip ledger written by `make test` (scripts/test-skip.sh)
 test/.skipped-checks

--- a/Makefile
+++ b/Makefile
@@ -994,7 +994,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_chd test/test_chd_unit test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda test/test_cd_synth_subq \
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
-		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/voicemodem_pair test/tools/netlink_game test/tools/test_pertitle_db \
+		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/netlink_discover_probe test/tools/voicemodem_pair test/tools/netlink_game test/tools/test_pertitle_db \
 		test/tools/test_hook_gate \
 		test/tools/i2s_lag_probe test/tools/joymatrix_identity \
 		test/test_quadrature test/test_axistune test/tools/mouse_decode_test \
@@ -1023,6 +1023,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	./test/test_uart_core ./$(TARGET)
 	./test/test_netlink_host ./$(TARGET)
 	bash test/tools/netlink_pair_test.sh ./$(TARGET)
+	bash test/tools/netlink_discover_pair.sh ./$(TARGET)
 	bash test/tools/voicemodem_pair_test.sh ./$(TARGET)
 	bash test/tools/netlink_latency_test.sh ./$(TARGET)
 	@# Ultra Vortek Voice Modem (#481) end to end, the only retail JVM
@@ -1546,13 +1547,13 @@ test/test_event_queue: test/test_event_queue.c src/core/event.c src/core/event.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_event_queue.c src/core/event.c
 
-test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c
+test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_jlink.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c
+		-o $@ test/test_jlink.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c
 
-test/test_jlink_tcp: test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c src/jerry/jlink.h src/jerry/jlink_tcp.h
+test/test_jlink_tcp: test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/jlink.h src/jerry/jlink_tcp.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c
+		-o $@ test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c
 
 test/test_jlink_discover: test/test_jlink_discover.c src/jerry/jlink_discover.c src/jerry/jlink_discover.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
@@ -1562,9 +1563,9 @@ test/test_jlink_netpacket: test/test_jlink_netpacket.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_jlink_netpacket.c -ldl
 
-test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c src/core/event.c
+test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/core/event.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_uart_loopback.c src/jerry/uart.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c src/core/event.c -lm
+		-o $@ test/test_uart_loopback.c src/jerry/uart.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/core/event.c -lm
 
 test/test_uart_core: test/test_uart_core.c test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
@@ -1592,6 +1593,10 @@ test/tools/netlink_latency: test/tools/netlink_latency.c test/harness/harness.c 
 
 test/tools/netlink_delay_proxy: test/tools/netlink_delay_proxy.c
 	$(CC) -O2 -Wall -o $@ test/tools/netlink_delay_proxy.c
+
+test/tools/netlink_discover_probe: test/tools/netlink_discover_probe.c src/jerry/jlink_discover.c
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
+		-o $@ test/tools/netlink_discover_probe.c src/jerry/jlink_discover.c
 
 test/test_dram_timing: test/test_dram_timing.c src/core/bus_arbiter.c src/core/bus_arbiter.h
 	$(CC) -O2 -Wall -std=c99 -o $@ test/test_dram_timing.c src/core/bus_arbiter.c

--- a/Makefile
+++ b/Makefile
@@ -994,7 +994,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_chd test/test_chd_unit test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda test/test_cd_synth_subq \
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
-		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/netlink_discover_probe test/tools/voicemodem_pair test/tools/netlink_game test/tools/test_pertitle_db \
+		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/netlink_discover_probe test/tools/netlink_rebuild_witness test/tools/voicemodem_pair test/tools/netlink_game test/tools/test_pertitle_db \
 		test/tools/test_hook_gate \
 		test/tools/i2s_lag_probe test/tools/joymatrix_identity \
 		test/test_quadrature test/test_axistune test/tools/mouse_decode_test \
@@ -1026,6 +1026,16 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	bash test/tools/netlink_discover_pair.sh ./$(TARGET)
 	bash test/tools/voicemodem_pair_test.sh ./$(TARGET)
 	bash test/tools/netlink_latency_test.sh ./$(TARGET)
+	@# Review-round-1 finding (task 4, #467): no other test runs a core in
+	@# a discovery-active mode long enough in REAL wall-clock time (not
+	@# frame count) for netlink_rebuild_host_options()'s 2s rate-limit
+	@# gate to open, so its SET_CORE_OPTIONS_V2 push -- the feature's
+	@# actual deliverable -- had never executed anywhere. Single process:
+	@# injects one real UDP beacon over the core's own discovery socket,
+	@# paces retro_run() past the 2s gate, and asserts the rebuild's own
+	@# log line fires and three independently-hidden option rows (host,
+	@# CD-only, mouse tuning) are still hidden afterward.
+	./test/tools/netlink_rebuild_witness ./$(TARGET)
 	@# Ultra Vortek Voice Modem (#481) end to end, the only retail JVM
 	@# title: two core instances drive the real ROM through 911 -> the
 	@# ANSWER/DIAL choreography -> the in-game lockstep data phase, gating
@@ -1597,6 +1607,15 @@ test/tools/netlink_delay_proxy: test/tools/netlink_delay_proxy.c
 test/tools/netlink_discover_probe: test/tools/netlink_discover_probe.c src/jerry/jlink_discover.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
 		-o $@ test/tools/netlink_discover_probe.c src/jerry/jlink_discover.c
+
+# Deliberately NOT linked against test/harness/harness.c -- this test needs
+# SET_CORE_OPTIONS_DISPLAY recording and an interceptable log callback,
+# neither of which the shared harness's environment callback provides (see
+# the file header comment for why). Standalone dlopen loader instead, same
+# shape as test/tools/test_option_visibility.c.
+test/tools/netlink_rebuild_witness: test/tools/netlink_rebuild_witness.c
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/netlink_rebuild_witness.c -ldl
 
 test/test_dram_timing: test/test_dram_timing.c src/core/bus_arbiter.c src/core/bus_arbiter.h
 	$(CC) -O2 -Wall -std=c99 -o $@ test/test_dram_timing.c src/core/bus_arbiter.c

--- a/Makefile
+++ b/Makefile
@@ -979,7 +979,7 @@ test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
 # invocations get different values.
 test: EEPROM_GEN_TOOL := /tmp/vj_gen_eeprom_test_rom_$(shell echo $$PPID)
 test: EEPROM_FIXTURE := /tmp/vj_eeprom_lifecycle_$(shell echo $$PPID).j64
-test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_netpacket test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 test/test_titledb test/test_titlehook test/test_biosdb \
+test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_discover test/test_jlink_netpacket test/test_uart_loopback test/test_blitter_simd test/test_dsp_mac40 test/test_titledb test/test_titlehook test/test_biosdb \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
@@ -1017,6 +1017,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	./test/test_event_queue
 	./test/test_jlink
 	./test/test_jlink_tcp
+	./test/test_jlink_discover
 	./test/test_jlink_netpacket ./$(TARGET)
 	./test/test_uart_loopback
 	./test/test_uart_core ./$(TARGET)
@@ -1552,6 +1553,10 @@ test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h src/jerry
 test/test_jlink_tcp: test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c src/jerry/jlink.h src/jerry/jlink_tcp.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/voicemodem.c
+
+test/test_jlink_discover: test/test_jlink_discover.c src/jerry/jlink_discover.c src/jerry/jlink_discover.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
+		-o $@ test/test_jlink_discover.c src/jerry/jlink_discover.c
 
 test/test_jlink_netpacket: test/test_jlink_netpacket.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile.common
+++ b/Makefile.common
@@ -56,6 +56,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/jerry/jerry.c \
 	$(CORE_DIR)/src/jerry/jlink.c \
 	$(CORE_DIR)/src/jerry/jlink_tcp.c \
+	$(CORE_DIR)/src/jerry/jlink_discover.c \
 	$(CORE_DIR)/src/jerry/jlink_netpacket.c \
 	$(CORE_DIR)/src/jerry/voicemodem.c \
 	$(CORE_DIR)/src/jerry/uart.c \

--- a/docs/netlink-design.md
+++ b/docs/netlink-design.md
@@ -134,9 +134,11 @@ Backends selected by core option:
 
 ### 3. Core options (`libretro_core_options.h`)
 
-- `virtualjaguar_netlink`: `disabled` (default; UART still emulated —
-  registers behave, SERIN reads idle, nothing connects) | `loopback` |
-  `tcp_server` | `tcp_client` | `netpacket` (phase 3).
+- `virtualjaguar_netlink`: `disabled` | `loopback` | `tcp_server` |
+  `tcp_client` | `netpacket` (phase 3) | `auto` (added #467, now the
+  default — see "Transport selection" below; UART is still emulated in
+  every mode: registers behave, SERIN reads idle, nothing connects while
+  the resolved mode has no live peer).
 - `virtualjaguar_netlink_port`: enum of a few ports (default 42171).
 - Host for `tcp_client`: `virtualjaguar_netlink_host` option. Stock
   RetroArch options cannot take free text, so the option ships preset
@@ -145,7 +147,70 @@ Backends selected by core option:
   frontend returns — frontends with free-text option UIs (Provenance)
   supply arbitrary addresses directly. Resolution order: env
   `VJ_NETLINK_HOST`, then the option (sentinel defers to the file), then
-  `<system_dir>/vj_netlink.txt`, then `127.0.0.1`.
+  `<system_dir>/vj_netlink.txt`, then `127.0.0.1`. Since #467 the value
+  list is also rebuilt at runtime with LAN-discovered hosts spliced in
+  ahead of the `jaghub.local`/`vj_netlink.txt` presets — see "Transport
+  selection" below. The `vj_netlink.txt` file itself is **one line, the
+  host address only, no port, trailing newline optional** — `fgets` reads
+  the first line and strips trailing CR/LF/space. The port always comes
+  from `virtualjaguar_netlink_port`, never from the file.
+
+### 3a. Transport selection & LAN discovery (2026-08-18 addendum, #467)
+
+Full design rationale, wire format, and the iOS Local-Network permission
+testing trap live in [`docs/netlink-ux-design.md`](netlink-ux-design.md);
+this is the short version for readers of the base design.
+
+`virtualjaguar_netlink` resolves to exactly one of three transport
+families at any given time:
+
+| Family | Modes | Selection |
+|---|---|---|
+| Frontend netplay | `netpacket` | Automatic whenever a RetroArch ≥ 1.16 netplay session is live (env 78, already unconditional); `auto` resolves here first. |
+| Direct TCP | `tcp_server`, `tcp_client` | Explicit user choice. `tcp_client` additionally needs a host, resolved per the order above. |
+| Idle | `disabled`, `loopback`, or `auto` with no netplay session | No transport (`disabled`), local TX→RX echo only (`loopback`), or genuinely nothing yet (`auto` idle — the OSD says so; see below). |
+
+`auto` (default since #467) is netplay-when-live-else-idle **only** — it
+does not restore a previously chosen direct mode (there is nowhere to
+read a prior choice from with a single option key) and it never
+auto-connects to a discovered peer. A "call" the Voice Modem places
+without the player asking for it is exactly the surprise this design
+avoids.
+
+**LAN discovery beacon.** `tcp_server` (and `tcp_client`, listen-only) run
+a UDP broadcast beacon/listener on port **42170** — deliberately outside
+the `virtualjaguar_netlink_port` range (42171–42174) so the two can never
+collide. Fixed 40-byte packet: 4-byte magic `VJAG`, 1-byte protocol
+version, 1-byte device (0 = JagLink/CatBox, 1 = Voice Modem), 2-byte
+big-endian TCP port, 32-byte NUL-padded hostname. A host also beacons
+(so peers can see it) while listening (so it can see other peers too); a
+client only listens — neither dials out on its own. Peers expire after
+10 s; the peer table caps at 8 entries and drives a rebuilt
+`virtualjaguar_netlink_host` value list, rate-limited to at most one
+`SET_CORE_OPTIONS_V2` re-send per 2 s. Discovery deliberately does **not**
+run in `auto` or `disabled` — starting a UDP listener on every load for
+every user, most of whom never touch networking, would trip the OS Local
+Network permission prompt unconditionally.
+
+Because the beacon carries device type, a Voice Modem host discovered by
+a JagLink client (or the reverse) is flagged both in the host picker's
+label and with an on-screen warning — the two products share the wire
+protocol's transport but never interoperate at the device layer, and
+today that failure is otherwise silent.
+
+**iOS/tvOS Bonjour constraint.** mDNS is not used for discovery, on any
+platform, and this is a hard platform constraint rather than a stylistic
+choice: RetroArch's iOS/tvOS `Info.plist` declares only `_ra-bless._tcp`
+and `_ra_netplay._tcp` under `NSBonjourServices`; iOS permits only
+enumerated service types, so a core advertising `_vjaglink._tcp` is
+silently blocked with no error the core could detect or work around.
+UDP broadcast has no such allowlist — iOS/tvOS both carry the
+`com.apple.developer.networking.multicast` entitlement (covers broadcast)
+and declare `NSLocalNetworkUsageDescription` — so broadcast discovery
+works on exactly the platform where mDNS cannot, making it the primary
+mechanism rather than a fallback. Unblocking Bonjour needs an upstream
+RetroArch `Info.plist` change and is tracked as a separate follow-up, not
+part of this core.
 
 ### 4. Testing
 

--- a/docs/netlink-ux-design.md
+++ b/docs/netlink-ux-design.md
@@ -1,0 +1,223 @@
+# Network link setup: usable configuration for JagLink, CatBox and the Voice Modem
+
+**Date:** 2026-08-18
+**Status:** design approved, not yet implemented
+**Branch:** `feat/netlink-ux`, stacked on `release/v3.4.0`
+**Issues:** follows #481 (voice modem), #494 (netpacket untested)
+
+## Problem
+
+The core supports three Jaguar networking products over two transports, and
+the configuration UI does not explain any of it. Three concrete failures, all
+observed:
+
+1. **The netplay path is invisible.** The core already registers the netpacket
+   interface unconditionally (`libretro.c`, `retro_set_environment`) and
+   `JLinkNPStart()` takes the link over for the duration of a frontend netplay
+   session, restoring the previous mode on stop. This means "link over
+   RetroArch netplay, zero IP configuration" **already works**. Nothing in the
+   UI says so; it is mentioned only inside a 60-word blurb attached to the
+   *TCP client host* option, which a user only reads once they are already
+   committed to manual IP entry.
+
+2. **The host address cannot be typed.** libretro core options are strictly
+   enumerated. RetroArch stores a value *index* into a `string_list`
+   (`struct core_option.vals` / `core_option_manager_set_val(opt, idx,
+   val_idx, ...)`) and there is no keyboard path in any core-option menu
+   callback. The libretro header agrees: `default_value` "must equal one of
+   the value members in the `values` array, or else this option will be
+   ignored." Free-text host entry is therefore impossible for **any** core, on
+   any platform. Today's workarounds — a `.local` preset, `vj_netlink.txt`, or
+   localhost — are all poor, and on iOS they are the only choices.
+
+3. **`vj_netlink.txt` is undocumented and over-explained.** The option
+   description is long, yet never states the file format.
+
+Underneath all three: until this release the entire link stack logged nothing,
+so a link that never came up was indistinguishable from one that was never
+configured. `[NETLINK]` logging landed in d3e5caa / 2e03bac and is the
+foundation this design builds on.
+
+## Constraints discovered
+
+These are verified facts, not assumptions. They drove the design.
+
+- **Free-text options are impossible.** See above. Discovery replacing text
+  entry is not a nicety; it is the only route to "pick a host" on a touch
+  device.
+- **Dynamic option values are supported in RetroArch.** A second
+  `SET_CORE_OPTIONS_V2` tears down and rebuilds the option manager
+  (`runloop.c`), flushing current values to disk first. Feasible, but a full
+  teardown — so re-send only on real change, never on a timer.
+- **Bonjour from a core is blocked on iOS/tvOS.** RetroArch's `Info.plist`
+  declares exactly `_ra-bless._tcp` and `_ra_netplay._tcp` under
+  `NSBonjourServices`; iOS permits only enumerated service types. A core
+  advertising `_vjaglink._tcp` is silently blocked. Unblocking needs an
+  upstream RetroArch plist change.
+- **UDP broadcast is permitted on iOS.** RetroArch's iOS entitlements carry
+  `com.apple.developer.networking.multicast` (which covers broadcast) and both
+  iOS and tvOS declare `NSLocalNetworkUsageDescription`. A UDP beacon from
+  inside the core works on the platform where Bonjour does not.
+  *Caveat:* that entitlement is in official builds; a self-signed RetroArch
+  lacking it will not broadcast.
+
+Consequence: **UDP is the primary discovery mechanism, not the fallback.**
+mDNS is deferred to a follow-up ticket, blocked upstream on iOS/tvOS.
+
+## Design
+
+### 1. Option model
+
+Every existing key is retained and values are **added**, never renamed, so no
+existing `.opt` file breaks and no migration code is needed.
+
+| Key | Change |
+|---|---|
+| `virtualjaguar_netlink` | label → **"Network Link"**. New `auto` value, becomes the default. `disabled` / `loopback` / `tcp_server` / `tcp_client` all still parse. |
+| `virtualjaguar_uart_device` | unchanged. **"What is plugged in"**: JagLink/CatBox, or Voice Modem. CatBox and JagLink are the same wire protocol and stay one entry. |
+| `virtualjaguar_netlink_host` | becomes the **discovered-host picker**. Values rebuilt at runtime: `127.0.0.1`, one row per live beacon, then `vj_netlink.txt` and the `.local` preset as fallbacks. |
+| `virtualjaguar_netlink_port` | unchanged; moves to an Advanced category. |
+| `virtualjaguar_netlink_wait` | unchanged; moves to Advanced. |
+
+`auto` resolution order, evaluated at load and whenever netplay starts/stops:
+
+1. frontend netplay session live → netpacket (already automatic today)
+2. else an explicit direct mode previously chosen → use it
+3. else idle
+
+**`auto` never auto-connects to a discovered peer.** Discovery populates the
+host list; choosing a host stays a deliberate user action. Silently dialling
+whoever answered a broadcast is a surprising thing for an emulator to do, and
+with the Voice Modem it would place a "call" the user did not initiate. In
+`auto` with no netplay and no prior direct mode, the link stays idle and the
+OSD says so.
+
+Fresh installs therefore default to "works over netplay, no configuration".
+Existing installs keep whatever value their `.opt` already holds.
+
+Row visibility is driven by the `SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK` the
+core already registers:
+
+| Mode | Rows shown |
+|---|---|
+| `auto`, `disabled`, `loopback` | none beyond device |
+| `tcp_server` | port |
+| `tcp_client` | host, port |
+
+### 2. Discovery protocol
+
+New file `src/jerry/jlink_discover.c` / `.h`. No dependencies; plain BSD
+sockets, guarded the same way `jlink_tcp.c` guards its platform support.
+
+**Beacon.** A host in `tcp_server` (or `auto` having resolved to a direct
+host) broadcasts once per second to `255.255.255.255:42170`:
+
+```
+offset  size  field
+0       4     magic 'V','J','A','G'
+4       1     protocol version (1)
+5       1     device: 0 = jaglink/catbox, 1 = voice modem
+6       2     TCP port, big-endian
+8       32    display name, NUL-padded UTF-8
+```
+
+40 bytes fixed. Port **42170** is deliberately outside the
+`virtualjaguar_netlink_port` option range (42171–42174) so discovery can never
+collide with a link port.
+
+The display name is the system hostname (`gethostname`, `GetComputerNameA` on
+Windows), truncated to 31 chars + NUL. No new option: a name the user must
+type is the problem this feature exists to remove.
+
+**Listener.** Any core in `tcp_client` or `auto` binds 42170 and keeps a peer
+table: source IP, name, device, port, last-seen timestamp. Entries expire
+after 10 s. The listener runs from the existing per-frame `JLinkPoll()` path —
+no thread.
+
+The listener socket **must** set `SO_REUSEADDR` (and `SO_REUSEPORT` where it
+exists) before binding. Two cores on one machine is the normal development and
+test configuration — it is exactly what `netlink_pair_test.sh` and
+`uv_modem_game_test.sh` do — and without it the second instance fails to bind
+and discovery silently does nothing on the very setup used to test it. A host
+also ignores its own beacons, matched on the magic+name+port tuple rather than
+source IP, since loopback and LAN addresses differ for the same machine.
+
+**Option refresh.** When the peer set changes (an add, or an expiry — not on
+every beacon), the core rebuilds `virtualjaguar_netlink_host`'s values and
+re-sends `SET_CORE_OPTIONS_V2`. Cap at 8 discovered peers. Rate-limit rebuilds
+to at most one per 2 s so a flapping peer cannot thrash the menu.
+
+**Device mismatch.** The beacon carries device type, so a Voice Modem host
+seen by a JagLink client (or the reverse) is flagged in the host label and in
+an OSD warning. These two will never interoperate and today fail silently.
+
+### 3. OSD narration
+
+`SET_MESSAGE_EXT`, on state transitions only, mirroring the `[NETLINK]` log
+lines so screen and log agree:
+
+| Trigger | Message |
+|---|---|
+| link resolved at load | `Network Link: netplay session (Voice Modem)` / `…: direct client -> 192.168.1.42` |
+| link up | `Jaguar link connected (Voice Modem)` |
+| link down | `Jaguar link lost` |
+| peer set changed | `Found 2 Jaguar hosts on the LAN` |
+| device mismatch | `Host is running JagLink, you are set to Voice Modem` |
+| device set, link idle | `Voice Modem selected but link is idle -- start netplay or pick a host` |
+
+The last one is the exact failure that motivated this work.
+
+### 4. Documentation
+
+- `virtualjaguar_netlink_host` description shortened, and the
+  `vj_netlink.txt` format finally stated: **one line, the host address only,
+  no port, trailing newline optional.** (Port comes from
+  `virtualjaguar_netlink_port`.) The existing parser already behaves this way
+  — it `fgets` the first line and strips trailing CR/LF/space — so this is
+  documenting reality, not changing it.
+- `docs/netlink-design.md` gains a transport-selection section.
+- `docs/voice-modem.md` troubleshooting section updated for `auto`.
+
+### 5. What is deliberately not in scope
+
+- mDNS/Bonjour (blocked upstream on iOS/tvOS; separate ticket)
+- WAN/internet discovery — netplay's own lobby already solves that
+- changing the netpacket takeover semantics, which work correctly today
+- any change to the modem protocol or the JagLink wire format
+
+## Testing
+
+Discovery state is host-side, like jlink's sockets, and is **not** serialized
+into savestates — consistent with the existing rule for modem session state.
+
+| Test | Gate |
+|---|---|
+| `test/test_jlink_discover` (new, no core) | beacon encode/decode round-trip; truncated and wrong-magic packets rejected; peer expiry at 10 s; table caps at 8 |
+| `test/tools/netlink_discover_pair.sh` (new) | two cores on loopback: host beacons, client's peer table populates, then expires after the host exits |
+| existing `netlink_pair_test.sh`, `voicemodem_pair_test.sh`, `uv_modem_game_test.sh` | must stay green — `auto` must not change explicit-mode behaviour |
+| `test/tools/test_option_visibility` | extended: per-mode row visibility matrix |
+| manual, two RetroArch instances | OSD text correct on iOS and macOS |
+
+C89 strict throughout (`scripts/c89-lint.sh`), per CLAUDE.md.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `SET_CORE_OPTIONS_V2` re-send disrupts a user sitting in the options menu | rebuild only on real peer-set change, rate-limited to 1 per 2 s |
+| Non-RetroArch frontends handle re-send poorly | discovery degrades to "no extra host rows"; every existing manual path still works |
+| Self-signed RetroArch lacks the multicast entitlement | documented; manual host selection remains |
+| UDP broadcast blocked by AP client isolation | documented; `vj_netlink.txt` and `.local` remain |
+| `auto` changes default behaviour for fresh installs | existing `.opt` files keep their value; only new installs see `auto` |
+
+## Landing
+
+This is a feature, and CLAUDE.md says release branches carry bug fixes only.
+Three options, for the maintainer to choose:
+
+1. **Stack on the release branch** (chosen): `feat/netlink-ux` is cut from
+   `release/v3.4.0`; PR it into the release branch, so v3.4.0 ships with it.
+   Delays v3.4.0 by the size of this work.
+2. Ship v3.4.0 as-is; retarget this at `develop` as the v3.5.0 headline.
+3. Split: the documentation and OSD parts are arguably fixes for the
+   diagnosability defect and could ride v3.4.0; discovery and `auto` wait.

--- a/docs/netlink-ux-design.md
+++ b/docs/netlink-ux-design.md
@@ -1,7 +1,7 @@
 # Network link setup: usable configuration for JagLink, CatBox and the Voice Modem
 
 **Date:** 2026-08-18
-**Status:** design approved, not yet implemented
+**Status:** implemented (see `libretro.c`, `src/jerry/jlink.c`, `src/jerry/jlink_discover.c`)
 **Branch:** `feat/netlink-ux`, stacked on `release/v3.4.0`
 **Issues:** follows #481 (voice modem), #494 (netpacket untested)
 
@@ -104,8 +104,8 @@ existing `.opt` file breaks and no migration code is needed.
 | `virtualjaguar_netlink` | label → **"Network Link"**. New `auto` value, becomes the default. `disabled` / `loopback` / `tcp_server` / `tcp_client` all still parse. |
 | `virtualjaguar_uart_device` | unchanged. **"What is plugged in"**: JagLink/CatBox, or Voice Modem. CatBox and JagLink are the same wire protocol and stay one entry. |
 | `virtualjaguar_netlink_host` | becomes the **discovered-host picker**. Values rebuilt at runtime: `127.0.0.1`, one row per live beacon, then `vj_netlink.txt` and the `.local` preset as fallbacks. |
-| `virtualjaguar_netlink_port` | unchanged; moves to an Advanced category. |
-| `virtualjaguar_netlink_wait` | unchanged; moves to Advanced. |
+| `virtualjaguar_netlink_port` | unchanged. (This design originally proposed moving it to an "Advanced" category; that category was never implemented and there is no plan to add it -- the option stays in its existing top-level position.) |
+| `virtualjaguar_netlink_wait` | unchanged. (Same "Advanced" category that was never implemented -- see above.) |
 
 `auto` resolution order, evaluated at load and whenever netplay starts/stops:
 
@@ -144,8 +144,10 @@ core already registers:
 New file `src/jerry/jlink_discover.c` / `.h`. No dependencies; plain BSD
 sockets, guarded the same way `jlink_tcp.c` guards its platform support.
 
-**Beacon.** A host in `tcp_server` (or `auto` having resolved to a direct
-host) broadcasts once per second to `255.255.255.255:42170`:
+**Beacon.** A host in `tcp_server` broadcasts once per second to
+`255.255.255.255:42170`. (As shipped, `auto` never resolves to a direct
+host -- see the "amended during pre-flight review" note above -- so this is
+`tcp_server` only, not `tcp_server` or `auto`.)
 
 ```
 offset  size  field
@@ -164,10 +166,24 @@ The display name is the system hostname (`gethostname`, `GetComputerNameA` on
 Windows), truncated to 31 chars + NUL. No new option: a name the user must
 type is the problem this feature exists to remove.
 
-**Listener.** Any core in `tcp_client` or `auto` binds 42170 and keeps a peer
-table: source IP, name, device, port, last-seen timestamp. Entries expire
-after 10 s. The listener runs from the existing per-frame `JLinkPoll()` path —
-no thread.
+**Listener.** A core in `tcp_client` (listen-only) or `tcp_server` (beacon +
+listen) binds 42170 and keeps a peer table: source IP, name, device, port,
+last-seen timestamp. Entries expire after 10 s. **`auto` never binds the
+socket at all** -- discovery is deliberately not started for `auto` (see the
+`JLinkDiscStart()` call site in `libretro.c`'s `netlink_apply()`), because
+`auto` is the option's default: opening a UDP listener on port 42170 for
+every user on every load would trip the OS's Local Network permission
+prompt for players who never touched the networking options. Do not "fix"
+this back to matching an earlier draft of this doc that said otherwise.
+
+The listener runs from `JLinkFrameTick()` (`src/jerry/jlink.c`), not from
+`JLinkPoll()`. `JLinkPoll()` is also reached via `JLinkPump()`, which games
+call thousands of times per frame while spinning on a reply, so a
+`recvfrom()` drain loop there would be wasteful and, unlike TCP polling, has
+no mode gate to keep it rare. `JLinkFrameTick()` runs once per video frame
+regardless of `jlinkMode`, which matches the 1 Hz beacon / 10 s expiry
+cadence this module works on (see `JLinkFrameTick()`'s declaration comment
+in `jlink.c` for the full rationale).
 
 The listener socket **must** set `SO_REUSEADDR` (and `SO_REUSEPORT` where it
 exists) before binding. Two cores on one machine is the normal development and
@@ -228,7 +244,7 @@ into savestates — consistent with the existing rule for modem session state.
 | Test | Gate |
 |---|---|
 | `test/test_jlink_discover` (new, no core) | beacon encode/decode round-trip; truncated and wrong-magic packets rejected; peer expiry at 10 s; table caps at 8 |
-| `test/tools/netlink_discover_pair.sh` (new) | two cores on loopback: host beacons, client's peer table populates, then expires after the host exits |
+| `test/tools/netlink_discover_pair.sh` (new) | two cores on loopback: host beacons, client's peer table populates. As shipped this asserts population only -- it kills the beacon process but never re-checks the listener afterward, so it does NOT cover expiry after the host exits. (Expiry-at-10s logic is covered separately, beacon-free, by `test/test_jlink_discover` above.) |
 | existing `netlink_pair_test.sh`, `voicemodem_pair_test.sh`, `uv_modem_game_test.sh` | must stay green — `auto` must not change explicit-mode behaviour |
 | `test/tools/test_option_visibility` | extended: per-mode row visibility matrix |
 | manual, two RetroArch instances | OSD text correct on iOS and macOS |

--- a/docs/netlink-ux-design.md
+++ b/docs/netlink-ux-design.md
@@ -64,6 +64,34 @@ These are verified facts, not assumptions. They drove the design.
 Consequence: **UDP is the primary discovery mechanism, not the fallback.**
 mDNS is deferred to a follow-up ticket, blocked upstream on iOS/tvOS.
 
+### Testing trap: Local Network permission is per binary
+
+On macOS (and iOS), Local Network access is approved **per executable**, not
+per user or per machine. A freshly built test binary is a new subject and
+raises its own prompt; an unanswered prompt fails closed, silently.
+
+This cost a full misdiagnosis during implementation. A run of
+`netlink_discover_pair.sh` failed, and three independent from-scratch
+reproductions "confirmed" that local UDP broadcast did not loop back on the
+host at all — so the failure was attributed to the machine's network stack.
+It was not. Every reproduction ran under an interpreter that already held
+the permission, while the newly compiled probe did not, and its prompt had
+timed out. A direct three-destination measurement on the same machine showed
+`255.255.255.255` and `127.0.0.1` both delivering normally, and the real pair
+test passed on the next run once the prompt was settled.
+
+When a discovery test fails on macOS, check the permission before suspecting
+the code:
+
+- answer the Local Network prompt (it may appear behind the terminal window)
+- System Settings → Privacy & Security → Local Network, confirm the terminal
+  or test binary is listed and enabled
+- a rebuild can re-prompt, so a test that passed yesterday can fail today for
+  this reason alone
+
+A timed-out prompt and a broken network stack are indistinguishable from
+inside the process: `sendto` succeeds either way and nothing arrives.
+
 ## Design
 
 ### 1. Option model

--- a/docs/netlink-ux-design.md
+++ b/docs/netlink-ux-design.md
@@ -82,8 +82,15 @@ existing `.opt` file breaks and no migration code is needed.
 `auto` resolution order, evaluated at load and whenever netplay starts/stops:
 
 1. frontend netplay session live → netpacket (already automatic today)
-2. else an explicit direct mode previously chosen → use it
-3. else idle
+2. else idle
+
+> **Amended during pre-flight review.** This originally read "else an
+> explicit direct mode previously chosen → use it". Dropped: with a single
+> option key there is nowhere to read a previous choice from — selecting
+> `auto` overwrites it — so honouring it would require hidden persisted
+> state whose behaviour the user can neither see nor predict across
+> restarts. Users wanting a direct link select `tcp_host`/`tcp_client`
+> explicitly, and the OSD says so when the link is idle.
 
 **`auto` never auto-connects to a discovered peer.** Discovery populates the
 host list; choosing a host stays a deliberate user action. Silently dialling

--- a/docs/netlink-ux-plan.md
+++ b/docs/netlink-ux-plan.md
@@ -1,0 +1,993 @@
+# Network Link UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make JagLink/CatBox/Voice Modem setup comprehensible and near-zero-config: an `auto` link mode that uses netplay when a session is live, LAN host discovery that replaces impossible text entry, and OSD narration of link state.
+
+**Architecture:** A new dependency-free UDP beacon module (`src/jerry/jlink_discover.c`) splits cleanly into pure codec + peer-table logic (unit-testable with no sockets) and a thin socket layer driven from the existing per-frame `JLinkPoll()`. `libretro.c` gains an `auto` mode resolver, per-mode option visibility through the already-registered update-display callback, a discovered-host option list rebuilt via `SET_CORE_OPTIONS_V2`, and `SET_MESSAGE_EXT` narration.
+
+**Tech Stack:** C89 (GNU89), BSD sockets, libretro core options v2.
+
+**Spec:** [`docs/netlink-ux-design.md`](netlink-ux-design.md)
+
+## Global Constraints
+
+- **C89/GNU89 strict.** All declarations at top of block, before any statement. No `for (int i…)`, no compound literals, no designated initializers, no VLAs. Verify each touched C file with `bash scripts/c89-lint.sh <file>`.
+- **Build:** `DEVELOPER_DIR=/Library/Developer/CommandLineTools make -j$(getconf _NPROCESSORS_ONLN) TEST_EXPORTS=1`
+- **Never `rm`/`cp`/`mv` bare** — the user's shell aliases them to `-i` and they hang with no TTY. Use `command rm -f`, `command cp -f`, or `trash`.
+- **New exported symbols must be added to BOTH `exports-test.list` (Mach-O) and `link-test.T` (GNU ld).** A symbol in only one is silently NULL from `harness_dlsym` on the other platform. `scripts/check-export-lists.py` runs inside `make test` and will fail the build.
+- **New test binaries** must be added to the `test:` prerequisite list in the Makefile (around line 997) *and* invoked in the recipe.
+- **Discovery port is 42170**, deliberately outside the `virtualjaguar_netlink_port` option range (42171–42174).
+- **Discovery state is host-side and never serialized into savestates**, matching the existing rule for jlink sockets and modem session state.
+- Commit messages use conventional commits: `feat(netlink):`, `fix(netlink):`, `test(netlink):`, `docs:`.
+
+---
+
+### Task 1: Beacon codec and peer table (pure logic, no sockets)
+
+Splitting the wire format and peer bookkeeping away from sockets means the
+tricky parts — truncation, bad magic, expiry, dedupe, capacity — are testable
+with no network at all, and the socket layer in Task 2 becomes trivial.
+
+**Files:**
+- Create: `src/jerry/jlink_discover.h`
+- Create: `src/jerry/jlink_discover.c`
+- Create: `test/test_jlink_discover.c`
+- Modify: `Makefile` (add build rule + test list entry)
+- Modify: `Makefile.common` (add `jlink_discover.o` to sources)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `size_t JLinkDiscEncode(uint8_t *buf, size_t cap, int device, int port, const char *name)` → bytes written (40) or 0 on failure
+  - `int JLinkDiscDecode(const uint8_t *buf, size_t len, int *device, int *port, char *name, size_t name_cap)` → 1 on valid packet, 0 otherwise
+  - `void JLinkDiscPeersReset(void)`
+  - `int JLinkDiscPeerSeen(const char *addr, const char *name, int device, int port, uint32_t now_ms)` → 1 if the peer set changed
+  - `int JLinkDiscPeerExpire(uint32_t now_ms)` → 1 if any peer expired
+  - `int JLinkDiscPeerCount(void)`
+  - `const JLinkPeer *JLinkDiscPeerAt(int i)` → NULL when out of range
+  - constants `JLINK_DISC_PORT` (42170), `JLINK_DISC_PKT_LEN` (40), `JLINK_DISC_MAX_PEERS` (8), `JLINK_DISC_EXPIRE_MS` (10000), `JLINK_DISC_DEV_JAGLINK` (0), `JLINK_DISC_DEV_VOICEMODEM` (1)
+
+- [ ] **Step 1: Write the header**
+
+```c
+/* jlink_discover.h -- LAN discovery beacon for the Jaguar network link.
+   Split in two halves on purpose: the codec + peer table below are pure
+   logic with no sockets, so every awkward case (truncated packet, wrong
+   magic, expiry, capacity) is unit-testable without a network.  The
+   socket layer lives in the same .c file behind JLINK_DISC_HAVE_NET. */
+#ifndef __JLINK_DISCOVER_H__
+#define __JLINK_DISCOVER_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Outside the virtualjaguar_netlink_port option range (42171-42174) so a
+   discovery socket can never collide with a link socket. */
+#define JLINK_DISC_PORT        42170
+#define JLINK_DISC_VERSION     1
+#define JLINK_DISC_PKT_LEN     40
+#define JLINK_DISC_NAME_MAX    32   /* 31 chars + NUL */
+#define JLINK_DISC_ADDR_MAX    46   /* INET6_ADDRSTRLEN */
+#define JLINK_DISC_MAX_PEERS   8
+#define JLINK_DISC_EXPIRE_MS   10000
+
+#define JLINK_DISC_DEV_JAGLINK    0
+#define JLINK_DISC_DEV_VOICEMODEM 1
+
+typedef struct
+{
+   char     name[JLINK_DISC_NAME_MAX];
+   char     addr[JLINK_DISC_ADDR_MAX];
+   int      device;
+   int      port;
+   uint32_t last_seen_ms;
+} JLinkPeer;
+
+size_t JLinkDiscEncode(uint8_t *buf, size_t cap, int device, int port,
+                       const char *name);
+int    JLinkDiscDecode(const uint8_t *buf, size_t len, int *device,
+                       int *port, char *name, size_t name_cap);
+
+void   JLinkDiscPeersReset(void);
+int    JLinkDiscPeerSeen(const char *addr, const char *name, int device,
+                         int port, uint32_t now_ms);
+int    JLinkDiscPeerExpire(uint32_t now_ms);
+int    JLinkDiscPeerCount(void);
+const JLinkPeer *JLinkDiscPeerAt(int i);
+
+#endif
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `test/test_jlink_discover.c`:
+
+```c
+#include <stdio.h>
+#include <string.h>
+#include "jlink_discover.h"
+
+static int failures = 0;
+
+static void check(int cond, const char *what)
+{
+   if (!cond) { printf("FAIL: %s\n", what); failures++; }
+   else        printf("  ok: %s\n", what);
+}
+
+static void test_roundtrip(void)
+{
+   uint8_t buf[64];
+   int dev = -1, port = -1;
+   char name[JLINK_DISC_NAME_MAX];
+   size_t n;
+
+   n = JLinkDiscEncode(buf, sizeof(buf), JLINK_DISC_DEV_VOICEMODEM,
+                       42171, "jaghub");
+   check(n == JLINK_DISC_PKT_LEN, "encode writes exactly 40 bytes");
+   check(JLinkDiscDecode(buf, n, &dev, &port, name, sizeof(name)) == 1,
+         "decode accepts its own packet");
+   check(dev == JLINK_DISC_DEV_VOICEMODEM, "device survives round-trip");
+   check(port == 42171, "port survives round-trip");
+   check(strcmp(name, "jaghub") == 0, "name survives round-trip");
+}
+
+static void test_rejects_bad(void)
+{
+   uint8_t buf[64];
+   int dev, port;
+   char name[JLINK_DISC_NAME_MAX];
+
+   JLinkDiscEncode(buf, sizeof(buf), JLINK_DISC_DEV_JAGLINK, 42171, "x");
+
+   check(JLinkDiscDecode(buf, JLINK_DISC_PKT_LEN - 1, &dev, &port,
+                         name, sizeof(name)) == 0,
+         "truncated packet rejected");
+   buf[0] = 'X';
+   check(JLinkDiscDecode(buf, JLINK_DISC_PKT_LEN, &dev, &port,
+                         name, sizeof(name)) == 0,
+         "wrong magic rejected");
+   buf[0] = 'V'; buf[4] = 99;
+   check(JLinkDiscDecode(buf, JLINK_DISC_PKT_LEN, &dev, &port,
+                         name, sizeof(name)) == 0,
+         "wrong version rejected");
+}
+
+static void test_name_never_unterminated(void)
+{
+   uint8_t buf[64];
+   int dev, port;
+   char name[JLINK_DISC_NAME_MAX];
+   int i;
+
+   JLinkDiscEncode(buf, sizeof(buf), JLINK_DISC_DEV_JAGLINK, 42171,
+                   "0123456789012345678901234567890123456789");
+   /* Stomp every name byte so nothing in the field is NUL. */
+   for (i = 8; i < JLINK_DISC_PKT_LEN; i++)
+      buf[i] = 'A';
+   check(JLinkDiscDecode(buf, JLINK_DISC_PKT_LEN, &dev, &port,
+                         name, sizeof(name)) == 1,
+         "full-width name still decodes");
+   check(name[JLINK_DISC_NAME_MAX - 1] == '\0',
+         "decoded name is always NUL-terminated");
+}
+
+static void test_peer_table(void)
+{
+   JLinkDiscPeersReset();
+   check(JLinkDiscPeerCount() == 0, "table starts empty");
+
+   check(JLinkDiscPeerSeen("192.168.1.2", "a", 0, 42171, 1000) == 1,
+         "first sighting reports a change");
+   check(JLinkDiscPeerCount() == 1, "peer added");
+   check(JLinkDiscPeerSeen("192.168.1.2", "a", 0, 42171, 2000) == 0,
+         "refresh of a known peer reports no change");
+   check(JLinkDiscPeerCount() == 1, "refresh does not duplicate");
+
+   check(JLinkDiscPeerSeen("192.168.1.3", "b", 1, 42172, 2000) == 1,
+         "second peer reports a change");
+   check(JLinkDiscPeerCount() == 2, "two peers tracked");
+
+   check(JLinkDiscPeerExpire(2000 + JLINK_DISC_EXPIRE_MS) == 1,
+         "expiry of the stale peer reports a change");
+   check(JLinkDiscPeerCount() == 1, "stale peer dropped, fresh one kept");
+   check(strcmp(JLinkDiscPeerAt(0)->addr, "192.168.1.3") == 0,
+         "surviving peer is the fresh one");
+   check(JLinkDiscPeerAt(5) == NULL, "out-of-range index returns NULL");
+}
+
+static void test_capacity(void)
+{
+   char addr[JLINK_DISC_ADDR_MAX];
+   int i;
+
+   JLinkDiscPeersReset();
+   for (i = 0; i < JLINK_DISC_MAX_PEERS + 4; i++)
+   {
+      sprintf(addr, "10.0.0.%d", i + 1);
+      JLinkDiscPeerSeen(addr, "n", 0, 42171, 1000);
+   }
+   check(JLinkDiscPeerCount() == JLINK_DISC_MAX_PEERS,
+         "table caps at JLINK_DISC_MAX_PEERS");
+}
+
+int main(void)
+{
+   test_roundtrip();
+   test_rejects_bad();
+   test_name_never_unterminated();
+   test_peer_table();
+   test_capacity();
+   if (failures) { printf("test_jlink_discover: %d FAILURE(S)\n", failures); return 1; }
+   printf("test_jlink_discover: all passed\n");
+   return 0;
+}
+```
+
+- [ ] **Step 3: Add the build rule and run the test to see it fail**
+
+Add to `Makefile`, next to the other `test/test_jlink*` rules (~line 1548):
+
+```make
+test/test_jlink_discover: test/test_jlink_discover.c src/jerry/jlink_discover.c src/jerry/jlink_discover.h
+	$(CC) -O2 -Wall -std=c89 $(INCFLAGS) -Itest \
+		-o $@ test/test_jlink_discover.c src/jerry/jlink_discover.c
+```
+
+Run: `DEVELOPER_DIR=/Library/Developer/CommandLineTools make test/test_jlink_discover`
+Expected: FAIL — `src/jerry/jlink_discover.c` does not exist yet.
+
+- [ ] **Step 4: Implement the codec and peer table**
+
+Create `src/jerry/jlink_discover.c` (codec + table only; sockets land in Task 2):
+
+```c
+/* jlink_discover.c -- LAN discovery beacon.  See jlink_discover.h. */
+#include "jlink_discover.h"
+#include <string.h>
+#include <stdio.h>
+
+static JLinkPeer discPeers[JLINK_DISC_MAX_PEERS];
+static int       discPeerCount = 0;
+
+size_t JLinkDiscEncode(uint8_t *buf, size_t cap, int device, int port,
+                       const char *name)
+{
+   size_t n;
+
+   if (!buf || cap < JLINK_DISC_PKT_LEN)
+      return 0;
+
+   memset(buf, 0, JLINK_DISC_PKT_LEN);
+   buf[0] = 'V'; buf[1] = 'J'; buf[2] = 'A'; buf[3] = 'G';
+   buf[4] = (uint8_t)JLINK_DISC_VERSION;
+   buf[5] = (uint8_t)(device ? JLINK_DISC_DEV_VOICEMODEM
+                             : JLINK_DISC_DEV_JAGLINK);
+   buf[6] = (uint8_t)((port >> 8) & 0xFF);
+   buf[7] = (uint8_t)(port & 0xFF);
+
+   if (name)
+   {
+      n = strlen(name);
+      if (n > JLINK_DISC_NAME_MAX - 1)
+         n = JLINK_DISC_NAME_MAX - 1;
+      memcpy(buf + 8, name, n);
+   }
+   return JLINK_DISC_PKT_LEN;
+}
+
+int JLinkDiscDecode(const uint8_t *buf, size_t len, int *device,
+                    int *port, char *name, size_t name_cap)
+{
+   if (!buf || len < JLINK_DISC_PKT_LEN)
+      return 0;
+   if (buf[0] != 'V' || buf[1] != 'J' || buf[2] != 'A' || buf[3] != 'G')
+      return 0;
+   if (buf[4] != JLINK_DISC_VERSION)
+      return 0;
+
+   if (device)
+      *device = (buf[5] == JLINK_DISC_DEV_VOICEMODEM)
+                ? JLINK_DISC_DEV_VOICEMODEM : JLINK_DISC_DEV_JAGLINK;
+   if (port)
+      *port = ((int)buf[6] << 8) | (int)buf[7];
+
+   if (name && name_cap > 0)
+   {
+      size_t copy = name_cap - 1;
+      /* The sender NUL-pads, but a hostile or corrupt packet need not:
+         copy a bounded span and terminate ourselves, never strncpy from
+         a field that may have no NUL in it. */
+      if (copy > JLINK_DISC_NAME_MAX - 1)
+         copy = JLINK_DISC_NAME_MAX - 1;
+      memcpy(name, buf + 8, copy);
+      name[copy] = '\0';
+   }
+   return 1;
+}
+
+void JLinkDiscPeersReset(void)
+{
+   memset(discPeers, 0, sizeof(discPeers));
+   discPeerCount = 0;
+}
+
+int JLinkDiscPeerSeen(const char *addr, const char *name, int device,
+                      int port, uint32_t now_ms)
+{
+   int i;
+
+   if (!addr || !addr[0])
+      return 0;
+
+   for (i = 0; i < discPeerCount; i++)
+   {
+      if (strcmp(discPeers[i].addr, addr) == 0
+          && discPeers[i].port == port)
+      {
+         discPeers[i].last_seen_ms = now_ms;
+         discPeers[i].device       = device;
+         return 0;   /* known peer refreshed -- option list unchanged */
+      }
+   }
+
+   if (discPeerCount >= JLINK_DISC_MAX_PEERS)
+      return 0;
+
+   memset(&discPeers[discPeerCount], 0, sizeof(JLinkPeer));
+   strncpy(discPeers[discPeerCount].addr, addr, JLINK_DISC_ADDR_MAX - 1);
+   if (name)
+      strncpy(discPeers[discPeerCount].name, name, JLINK_DISC_NAME_MAX - 1);
+   discPeers[discPeerCount].device       = device;
+   discPeers[discPeerCount].port         = port;
+   discPeers[discPeerCount].last_seen_ms = now_ms;
+   discPeerCount++;
+   return 1;
+}
+
+int JLinkDiscPeerExpire(uint32_t now_ms)
+{
+   int i = 0, changed = 0;
+
+   while (i < discPeerCount)
+   {
+      /* Unsigned subtraction so a wrapped millisecond clock cannot make
+         a fresh peer look ancient. */
+      if ((uint32_t)(now_ms - discPeers[i].last_seen_ms)
+          >= JLINK_DISC_EXPIRE_MS)
+      {
+         if (i < discPeerCount - 1)
+            memmove(&discPeers[i], &discPeers[i + 1],
+                    sizeof(JLinkPeer) * (size_t)(discPeerCount - i - 1));
+         discPeerCount--;
+         memset(&discPeers[discPeerCount], 0, sizeof(JLinkPeer));
+         changed = 1;
+         continue;
+      }
+      i++;
+   }
+   return changed;
+}
+
+int JLinkDiscPeerCount(void)
+{
+   return discPeerCount;
+}
+
+const JLinkPeer *JLinkDiscPeerAt(int i)
+{
+   if (i < 0 || i >= discPeerCount)
+      return NULL;
+   return &discPeers[i];
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Library/Developer/CommandLineTools make test/test_jlink_discover && ./test/test_jlink_discover`
+Expected: `test_jlink_discover: all passed`
+
+- [ ] **Step 6: Lint and wire into the suite**
+
+Run: `bash scripts/c89-lint.sh src/jerry/jlink_discover.c`
+Expected: `C89 lint passed`
+
+Add `src/jerry/jlink_discover.o` to the source list in `Makefile.common` next to `jlink_tcp.o`. Add `test/test_jlink_discover` to the `test:` prerequisite list (~line 997), and invoke it in the recipe next to `./test/test_jlink`:
+
+```make
+	./test/test_jlink_discover
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/jerry/jlink_discover.c src/jerry/jlink_discover.h test/test_jlink_discover.c Makefile Makefile.common
+git commit -m "feat(netlink): discovery beacon codec and peer table"
+```
+
+---
+
+### Task 2: UDP socket layer and per-frame integration
+
+**Files:**
+- Modify: `src/jerry/jlink_discover.c` (append socket layer)
+- Modify: `src/jerry/jlink_discover.h` (append socket API)
+- Modify: `src/jerry/jlink.c` (drive from `JLinkPoll`)
+- Create: `test/tools/netlink_discover_pair.sh`
+- Modify: `Makefile` (invoke the pair test)
+
+**Interfaces:**
+- Consumes: everything from Task 1.
+- Produces:
+  - `int  JLinkDiscStart(int listen_only, int device, int link_port)` → 1 on success
+  - `void JLinkDiscStop(void)`
+  - `int  JLinkDiscPoll(uint32_t now_ms)` → 1 if the peer set changed this call
+  - `int  JLinkDiscActive(void)`
+
+- [ ] **Step 1: Write the failing pair test**
+
+Create `test/tools/netlink_discover_pair.sh`:
+
+```bash
+#!/usr/bin/env bash
+# netlink_discover_pair.sh -- two cores on one host: the server beacons,
+# the client's peer table must populate.  SO_REUSEADDR/SO_REUSEPORT on the
+# listener is what makes two instances on one machine work at all, which
+# is exactly how every other netlink test runs.
+set -u
+CORE="${1:?usage: netlink_discover_pair.sh <core>}"
+BIN="$(dirname "$0")/netlink_discover_probe"
+if [ ! -x "$BIN" ]; then
+    echo "netlink_discover_pair: $BIN not built" >&2
+    exit 1
+fi
+"$BIN" "$CORE" --role beacon &
+BPID=$!
+sleep 1
+"$BIN" "$CORE" --role listen --expect 1
+rc=$?
+kill "$BPID" 2>/dev/null; wait "$BPID" 2>/dev/null
+if [ "$rc" -eq 0 ]; then
+    echo "netlink_discover_pair: PASS"
+else
+    echo "netlink_discover_pair: FAIL (listener saw no peer)" >&2
+fi
+exit "$rc"
+```
+
+Run: `bash test/tools/netlink_discover_pair.sh ./virtualjaguar_libretro.dylib`
+Expected: FAIL — `netlink_discover_probe` not built.
+
+- [ ] **Step 2: Append the socket API to the header**
+
+```c
+/* Socket layer.  listen_only = 1 for client/auto (listen but never
+   beacon); 0 for a host (beacon AND listen, so a host still sees peers).
+   link_port is the TCP port advertised in the beacon. */
+int  JLinkDiscStart(int listen_only, int device, int link_port);
+void JLinkDiscStop(void);
+int  JLinkDiscPoll(uint32_t now_ms);
+int  JLinkDiscActive(void);
+```
+
+- [ ] **Step 3: Implement the socket layer**
+
+Append to `src/jerry/jlink_discover.c`, guarded like `jlink_tcp.c` does:
+
+```c
+#if defined(_WIN32) || defined(HAVE_SOCKET_LEGACY) || !defined(__CELLOS_LV2__)
+#define JLINK_DISC_HAVE_NET 1
+#endif
+
+#ifdef JLINK_DISC_HAVE_NET
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#endif
+
+static int      discSock       = -1;
+static int      discListenOnly = 1;
+static int      discDevice     = 0;
+static int      discLinkPort   = 0;
+static uint32_t discLastBeacon = 0;
+static char     discSelfName[JLINK_DISC_NAME_MAX];
+
+int JLinkDiscStart(int listen_only, int device, int link_port)
+{
+   struct sockaddr_in sa;
+   int one = 1;
+
+   JLinkDiscStop();
+   JLinkDiscPeersReset();
+
+   discSock = (int)socket(AF_INET, SOCK_DGRAM, 0);
+   if (discSock < 0)
+      return 0;
+
+   /* Two cores on ONE machine is the normal dev/test layout (see
+      netlink_pair_test.sh, uv_modem_game_test.sh).  Without these the
+      second instance cannot bind and discovery silently does nothing on
+      exactly the setup used to test it. */
+   setsockopt(discSock, SOL_SOCKET, SO_REUSEADDR,
+              (const char *)&one, sizeof(one));
+#ifdef SO_REUSEPORT
+   setsockopt(discSock, SOL_SOCKET, SO_REUSEPORT,
+              (const char *)&one, sizeof(one));
+#endif
+   setsockopt(discSock, SOL_SOCKET, SO_BROADCAST,
+              (const char *)&one, sizeof(one));
+
+   memset(&sa, 0, sizeof(sa));
+   sa.sin_family      = AF_INET;
+   sa.sin_addr.s_addr = htonl(INADDR_ANY);
+   sa.sin_port        = htons((unsigned short)JLINK_DISC_PORT);
+   if (bind(discSock, (struct sockaddr *)&sa, sizeof(sa)) != 0)
+   {
+      JLinkDiscStop();
+      return 0;
+   }
+
+#ifdef _WIN32
+   { u_long nb = 1; ioctlsocket(discSock, FIONBIO, &nb); }
+#else
+   fcntl(discSock, F_SETFL, fcntl(discSock, F_GETFL, 0) | O_NONBLOCK);
+#endif
+
+   discListenOnly = listen_only;
+   discDevice     = device;
+   discLinkPort   = link_port;
+   discLastBeacon = 0;
+
+   discSelfName[0] = '\0';
+#ifdef _WIN32
+   { DWORD n = JLINK_DISC_NAME_MAX - 1; GetComputerNameA(discSelfName, &n); }
+#else
+   if (gethostname(discSelfName, JLINK_DISC_NAME_MAX - 1) != 0)
+      discSelfName[0] = '\0';
+   discSelfName[JLINK_DISC_NAME_MAX - 1] = '\0';
+#endif
+   if (!discSelfName[0])
+      strcpy(discSelfName, "jaguar");
+   return 1;
+}
+
+void JLinkDiscStop(void)
+{
+   if (discSock >= 0)
+   {
+#ifdef _WIN32
+      closesocket(discSock);
+#else
+      close(discSock);
+#endif
+   }
+   discSock = -1;
+}
+
+int JLinkDiscActive(void)
+{
+   return discSock >= 0;
+}
+
+int JLinkDiscPoll(uint32_t now_ms)
+{
+   uint8_t  pkt[JLINK_DISC_PKT_LEN];
+   struct sockaddr_in from;
+   char     addr[JLINK_DISC_ADDR_MAX];
+   char     name[JLINK_DISC_NAME_MAX];
+   int      dev, port, changed = 0;
+   socklen_t flen;
+   int      n;
+
+   if (discSock < 0)
+      return 0;
+
+   if (!discListenOnly
+       && (discLastBeacon == 0 || (uint32_t)(now_ms - discLastBeacon) >= 1000))
+   {
+      struct sockaddr_in to;
+      uint8_t out[JLINK_DISC_PKT_LEN];
+      memset(&to, 0, sizeof(to));
+      to.sin_family      = AF_INET;
+      to.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+      to.sin_port        = htons((unsigned short)JLINK_DISC_PORT);
+      if (JLinkDiscEncode(out, sizeof(out), discDevice, discLinkPort,
+                          discSelfName))
+         sendto(discSock, (const char *)out, JLINK_DISC_PKT_LEN, 0,
+                (struct sockaddr *)&to, sizeof(to));
+      discLastBeacon = now_ms;
+   }
+
+   for (;;)
+   {
+      flen = sizeof(from);
+      memset(&from, 0, sizeof(from));
+      n = (int)recvfrom(discSock, (char *)pkt, sizeof(pkt), 0,
+                        (struct sockaddr *)&from, &flen);
+      if (n <= 0)
+         break;
+      if (!JLinkDiscDecode(pkt, (size_t)n, &dev, &port, name, sizeof(name)))
+         continue;
+      /* Ignore our own beacon.  Matched on name+port, not source IP:
+         the same machine appears under different addresses depending on
+         which interface the broadcast came back through. */
+      if (!discListenOnly && port == discLinkPort
+          && strcmp(name, discSelfName) == 0)
+         continue;
+      addr[0] = '\0';
+      strncpy(addr, inet_ntoa(from.sin_addr), JLINK_DISC_ADDR_MAX - 1);
+      addr[JLINK_DISC_ADDR_MAX - 1] = '\0';
+      if (JLinkDiscPeerSeen(addr, name, dev, port, now_ms))
+         changed = 1;
+   }
+
+   if (JLinkDiscPeerExpire(now_ms))
+      changed = 1;
+   return changed;
+}
+
+#else  /* no networking */
+
+int  JLinkDiscStart(int a, int b, int c) { (void)a; (void)b; (void)c; return 0; }
+void JLinkDiscStop(void) {}
+int  JLinkDiscPoll(uint32_t t) { (void)t; return 0; }
+int  JLinkDiscActive(void) { return 0; }
+
+#endif
+```
+
+- [ ] **Step 4: Build the probe tool and run the pair test**
+
+Create `test/tools/netlink_discover_probe.c` — a direct driver of the module (no core needed, but it takes the core path for CLI symmetry with the other netlink tools):
+
+```c
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include "jlink_discover.h"
+
+static uint32_t now_ms(void)
+{
+   return (uint32_t)(((uint64_t)clock() * 1000ULL) / CLOCKS_PER_SEC);
+}
+
+int main(int argc, char **argv)
+{
+   int listen_only = 1, expect = 0, i, spins;
+   for (i = 1; i < argc; i++)
+   {
+      if (!strcmp(argv[i], "--role") && i + 1 < argc)
+         listen_only = strcmp(argv[++i], "beacon") ? 1 : 0;
+      else if (!strcmp(argv[i], "--expect") && i + 1 < argc)
+         expect = atoi(argv[++i]);
+   }
+   if (!JLinkDiscStart(listen_only, 0, 42171))
+   {
+      printf("discover_probe: start failed\n");
+      return 2;
+   }
+   for (spins = 0; spins < 600; spins++)
+   {
+      JLinkDiscPoll(now_ms());
+      if (expect && JLinkDiscPeerCount() >= expect)
+      {
+         printf("discover_probe: saw %d peer(s)\n", JLinkDiscPeerCount());
+         JLinkDiscStop();
+         return 0;
+      }
+   }
+   JLinkDiscStop();
+   return expect ? 1 : 0;
+}
+```
+
+Add the Makefile rule:
+
+```make
+test/tools/netlink_discover_probe: test/tools/netlink_discover_probe.c src/jerry/jlink_discover.c
+	$(CC) -O2 -Wall -std=c89 $(INCFLAGS) -Itest \
+		-o $@ test/tools/netlink_discover_probe.c src/jerry/jlink_discover.c
+```
+
+Run: `DEVELOPER_DIR=/Library/Developer/CommandLineTools make test/tools/netlink_discover_probe && bash test/tools/netlink_discover_pair.sh ./virtualjaguar_libretro.dylib`
+Expected: `netlink_discover_pair: PASS`
+
+- [ ] **Step 5: Drive discovery from JLinkPoll**
+
+In `src/jerry/jlink.c`, `#include "jlink_discover.h"` and inside `JLinkPoll()`, before the existing TCP handling, add:
+
+```c
+   if (JLinkDiscActive())
+      jlinkDiscChanged |= JLinkDiscPoll(JLinkNowMs());
+```
+
+with a file-scope `static int jlinkDiscChanged = 0;` and an accessor
+`int JLinkDiscConsumeChanged(void)` that returns and clears it, declared in
+`jlink.h`. `JLinkNowMs()` already exists for the reply-wait EWMA; if it is
+static, expose it as `uint32_t JLinkNowMs(void)`.
+
+- [ ] **Step 6: Lint, wire into the suite, verify**
+
+```bash
+bash scripts/c89-lint.sh src/jerry/jlink_discover.c
+bash scripts/c89-lint.sh src/jerry/jlink.c
+```
+
+Add `test/tools/netlink_discover_probe` to the `test:` prerequisites and
+`bash test/tools/netlink_discover_pair.sh ./$(TARGET)` to the recipe after
+`netlink_pair_test.sh`.
+
+Run: `DEVELOPER_DIR=/Library/Developer/CommandLineTools make TEST_EXPORTS=1 test > /tmp/t.log 2>&1; echo "EXIT=$?"; grep -E "discover|netlink_pair|voicemodem_pair|uv_modem" /tmp/t.log`
+Expected: `EXIT=0`, discovery PASS, and every pre-existing netlink test still PASS.
+
+> Capture the exit code without a pipe. `${PIPESTATUS[0]}` is a bashism and this repo's shell is zsh — piping `make test` into `tail` throws away both the exit status and the results you need to read.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/jerry/jlink_discover.c src/jerry/jlink_discover.h src/jerry/jlink.c src/jerry/jlink.h test/tools/netlink_discover_probe.c test/tools/netlink_discover_pair.sh Makefile
+git commit -m "feat(netlink): UDP discovery beacon and listener"
+```
+
+---
+
+### Task 3: `auto` link mode and per-mode option visibility
+
+**Files:**
+- Modify: `libretro_core_options.h` (add `auto` value, retitle, categorize)
+- Modify: `libretro.c` (resolver in `netlink_apply` path; visibility callback)
+- Modify: `test/tools/test_option_visibility.c`
+
+**Interfaces:**
+- Consumes: `JLinkDiscStart/Stop` from Task 2.
+- Produces: `static int netlink_resolve_mode(const char *opt_value)` in `libretro.c`.
+
+- [ ] **Step 1: Write the failing visibility test**
+
+Extend `test/tools/test_option_visibility.c` with a case asserting that with
+`virtualjaguar_netlink=auto` the keys `virtualjaguar_netlink_host` and
+`virtualjaguar_netlink_port` are hidden, with `tcp_client` both are shown, and
+with `tcp_server` only the port is shown.
+
+Run: `DEVELOPER_DIR=/Library/Developer/CommandLineTools make test/tools/test_option_visibility && ./test/tools/test_option_visibility ./virtualjaguar_libretro.dylib`
+Expected: FAIL — `auto` is not a recognised value yet.
+
+- [ ] **Step 2: Add the `auto` value**
+
+In `libretro_core_options.h`, change the `virtualjaguar_netlink` entry:
+
+```c
+      "virtualjaguar_netlink",
+      "Network Link",
+      NULL,
+      "How this console's serial port reaches another player. 'Automatic' uses your frontend's netplay session when one is running -- nothing to configure, no addresses to type -- and otherwise stays idle. 'TCP Host'/'TCP Client' link two emulators directly without netplay; the client picks a host below, and hosts on your LAN are found automatically. 'Loopback' echoes back to this console for testing link-detect menus with no partner.",
+      NULL,
+      "network",
+      {
+         { "auto",       "Automatic (use netplay when available)" },
+         { "disabled",   "Off" },
+         { "loopback",   "Loopback (echo to self)" },
+         { "tcp_server", "TCP Host (listen)" },
+         { "tcp_client", "TCP Client (connect)" },
+         { NULL, NULL },
+      },
+      "auto"
+```
+
+- [ ] **Step 3: Implement the resolver**
+
+In `libretro.c`, replace the inline `strcmp` ladder in `check_variables()`:
+
+```c
+/* Resolve the Network Link option to a concrete JLINK_MODE_*.  "auto"
+ * means: let a frontend netplay session own the link when one exists --
+ * JLinkNPStart() takes over on its own, so auto simply stays out of the
+ * way -- and otherwise fall back to whatever direct mode the user last
+ * chose explicitly.  It deliberately never dials a discovered peer by
+ * itself; with the Voice Modem that would place a call the user did not
+ * initiate. */
+static int netlink_resolve_mode(const char *v)
+{
+   if (!v)
+      return JLINK_MODE_DISABLED;
+   if (!strcmp(v, "loopback"))   return JLINK_MODE_LOOPBACK;
+   if (!strcmp(v, "tcp_server")) return JLINK_MODE_TCP_SERVER;
+   if (!strcmp(v, "tcp_client")) return JLINK_MODE_TCP_CLIENT;
+   if (!strcmp(v, "auto"))
+   {
+      if (JLinkMode() == JLINK_MODE_NETPACKET)
+         return JLINK_MODE_NETPACKET;
+      return JLINK_MODE_DISABLED;
+   }
+   return JLINK_MODE_DISABLED;
+}
+```
+
+Start discovery whenever the resolved mode is `TCP_SERVER` (beacon+listen) or
+`TCP_CLIENT`/`auto` (listen only); stop it otherwise.
+
+- [ ] **Step 4: Implement per-mode visibility**
+
+In the existing `update_option_visibility` path, hide
+`virtualjaguar_netlink_host` unless the mode is `tcp_client`, and
+`virtualjaguar_netlink_port` unless it is `tcp_server` or `tcp_client`.
+
+- [ ] **Step 5: Verify**
+
+Run: `./test/tools/test_option_visibility ./virtualjaguar_libretro.dylib`
+Expected: PASS.
+Run: `bash scripts/c89-lint.sh libretro.c` → `C89 lint passed`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libretro.c libretro_core_options.h test/tools/test_option_visibility.c
+git commit -m "feat(netlink): automatic link mode and per-mode option visibility"
+```
+
+---
+
+### Task 4: Discovered-host option list
+
+**Files:**
+- Modify: `libretro.c`
+
+**Interfaces:**
+- Consumes: `JLinkDiscPeerCount/At` (Task 1), `JLinkDiscConsumeChanged` (Task 2).
+- Produces: `static void netlink_rebuild_host_options(void)`.
+
+- [ ] **Step 1: Implement the rebuild**
+
+In `retro_run`, next to the link-state edge block:
+
+```c
+   /* Rebuild the host picker only when the peer set actually changed --
+    * never on a timer.  A second SET_CORE_OPTIONS_V2 tears down and
+    * rebuilds RetroArch's whole option manager (runloop.c), so doing it
+    * per beacon would thrash the menu under the user's thumb. */
+   if (JLinkDiscConsumeChanged()
+       && (uint32_t)(now_ms - netlink_last_rebuild_ms) >= 2000)
+   {
+      netlink_rebuild_host_options();
+      netlink_last_rebuild_ms = now_ms;
+   }
+```
+
+`netlink_rebuild_host_options()` builds a `retro_core_option_v2_definition`
+array whose `virtualjaguar_netlink_host` values are: `127.0.0.1`, one entry
+per peer labelled `"<name> - <addr>"` (append `" (JagLink)"` or
+`" (Voice Modem)"` when the peer's device differs from ours), then
+`jaghub.local` and `vj_netlink.txt`. Cap at `JLINK_DISC_MAX_PEERS` entries;
+the array is `static` so it outlives the call, as the frontend keeps pointers.
+
+- [ ] **Step 2: Verify no regression**
+
+Run: `DEVELOPER_DIR=/Library/Developer/CommandLineTools make TEST_EXPORTS=1 test > /tmp/t.log 2>&1; echo "EXIT=$?"`
+Expected: `EXIT=0`.
+
+Manual: two RetroArch instances, one `tcp_server`, one `tcp_client`; the
+client's Network Link Host list gains the host within ~2 s.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add libretro.c
+git commit -m "feat(netlink): populate host picker from LAN discovery"
+```
+
+---
+
+### Task 5: OSD narration
+
+**Files:**
+- Modify: `libretro.c`
+
+**Interfaces:**
+- Consumes: the resolver and edge tracker from Tasks 2–3.
+- Produces: `static void netlink_osd(const char *fmt, ...)`.
+
+- [ ] **Step 1: Implement the helper**
+
+```c
+/* OSD narration.  Mirrors the [NETLINK] log lines so screen and log
+ * always agree; fires on transitions only, never per frame. */
+static void netlink_osd(const char *fmt, ...)
+{
+   struct retro_message_ext msg;
+   char text[256];
+   va_list ap;
+
+   va_start(ap, fmt);
+   vsnprintf(text, sizeof(text), fmt, ap);
+   va_end(ap);
+
+   memset(&msg, 0, sizeof(msg));
+   msg.msg      = text;
+   msg.duration = 4000;
+   msg.priority = 2;
+   msg.level    = RETRO_LOG_INFO;
+   msg.target   = RETRO_MESSAGE_TARGET_OSD;
+   msg.type     = RETRO_MESSAGE_TYPE_NOTIFICATION;
+   msg.progress = -1;
+   environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &msg);
+}
+```
+
+- [ ] **Step 2: Call it at each transition**
+
+Emit at: mode resolution after load; link UP; link DOWN; peer-set change
+(`"Found %d Jaguar host(s) on the LAN"`); device mismatch; and the idle case
+`"Voice Modem selected but link is idle -- start netplay or pick a host"`.
+
+- [ ] **Step 3: Verify**
+
+Run: `bash scripts/c89-lint.sh libretro.c` → `C89 lint passed`
+Run the suite; expect `EXIT=0`.
+Manual: confirm each message appears once, in RetroArch, and matches the log.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add libretro.c
+git commit -m "feat(netlink): narrate link state on the OSD"
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+- Modify: `libretro_core_options.h` (host option description)
+- Modify: `docs/netlink-design.md`
+- Modify: `docs/voice-modem.md`
+
+- [ ] **Step 1: Shorten the host description and state the file format**
+
+```c
+      "virtualjaguar_netlink_host",
+      "Network Link Host (TCP Client)",
+      NULL,
+      "Which host to connect to. Hosts running on your LAN appear here automatically within a couple of seconds. 'From file' reads <system>/vj_netlink.txt: one line, the address only, no port -- for example '192.168.1.42' or 'myhost.local'. The port comes from 'Network Link Port'. The VJ_NETLINK_HOST environment variable overrides this option.",
+```
+
+- [ ] **Step 2: Update the design docs**
+
+Add a transport-selection section to `docs/netlink-design.md` covering the
+three modes, the beacon wire format (referencing
+[`docs/netlink-ux-design.md`](netlink-ux-design.md)), and the iOS Bonjour
+constraint. Update the troubleshooting table in `docs/voice-modem.md` for
+`auto` and the new OSD strings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add libretro_core_options.h docs/netlink-design.md docs/voice-modem.md
+git commit -m "docs(netlink): document link modes and vj_netlink.txt format"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** option model → Task 3; discovery protocol → Tasks 1–2;
+OSD → Task 5; dynamic host list → Task 4; documentation → Task 6; testing
+table → covered across Tasks 1, 2, 3 (`test_option_visibility`) and the
+existing suite re-run in every task.
+
+**Deferred by design, per the spec's "not in scope":** mDNS, WAN discovery,
+netpacket takeover changes, modem/JagLink wire-format changes.
+
+**Follow-up ticket to file (not part of this plan):** upstream RetroArch PR
+adding `_vjaglink._tcp` to `NSBonjourServices` in the iOS and tvOS
+`Info.plist`, without which mDNS from this core can never work on those
+platforms.

--- a/docs/netlink-ux-plan.md
+++ b/docs/netlink-ux-plan.md
@@ -231,7 +231,7 @@ Add to `Makefile`, next to the other `test/test_jlink*` rules (~line 1548):
 
 ```make
 test/test_jlink_discover: test/test_jlink_discover.c src/jerry/jlink_discover.c src/jerry/jlink_discover.h
-	$(CC) -O2 -Wall -std=c89 $(INCFLAGS) -Itest \
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
 		-o $@ test/test_jlink_discover.c src/jerry/jlink_discover.c
 ```
 
@@ -424,6 +424,8 @@ git commit -m "feat(netlink): discovery beacon codec and peer table"
   - `void JLinkDiscStop(void)`
   - `int  JLinkDiscPoll(uint32_t now_ms)` → 1 if the peer set changed this call
   - `int  JLinkDiscActive(void)`
+  - `int  JLinkDiscConsumeChanged(void)` -- returns and clears the "peer set changed" flag; Task 4 consumes this
+  - `uint32_t JLinkNowMs(void)` (exposed from `jlink.c`, declared in `jlink.h`)
 
 - [ ] **Step 1: Write the failing pair test**
 
@@ -476,7 +478,11 @@ int  JLinkDiscActive(void);
 Append to `src/jerry/jlink_discover.c`, guarded like `jlink_tcp.c` does:
 
 ```c
-#if defined(_WIN32) || defined(HAVE_SOCKET_LEGACY) || !defined(__CELLOS_LV2__)
+/* Guard mirrors jlink_tcp.c verbatim: discovery has exactly the same
+   platform surface as the TCP transport, and divergent guards are how one
+   builds and the other does not. */
+#if defined(_WIN32) || defined(__unix__) || defined(__APPLE__) || \
+    defined(__linux__) || defined(__ANDROID__)
 #define JLINK_DISC_HAVE_NET 1
 #endif
 
@@ -652,14 +658,26 @@ Create `test/tools/netlink_discover_probe.c` — a direct driver of the module (
 
 ```c
 #include <stdio.h>
+#include <stdlib.h>      /* atoi */
 #include <string.h>
-#include <time.h>
 #include "jlink_discover.h"
 
+#ifdef _WIN32
+#include <windows.h>
+static uint32_t now_ms(void) { return (uint32_t)GetTickCount(); }
+#else
+#include <sys/time.h>
+/* Wall clock, NOT clock(): clock() measures CPU time, and this probe
+   spins, so a CPU-time clock would race ahead of the 10 s peer expiry
+   this test exists to exercise. */
 static uint32_t now_ms(void)
 {
-   return (uint32_t)(((uint64_t)clock() * 1000ULL) / CLOCKS_PER_SEC);
+   struct timeval tv;
+   gettimeofday(&tv, NULL);
+   return (uint32_t)((uint32_t)tv.tv_sec * 1000u
+                     + (uint32_t)(tv.tv_usec / 1000));
 }
+#endif
 
 int main(int argc, char **argv)
 {
@@ -695,7 +713,7 @@ Add the Makefile rule:
 
 ```make
 test/tools/netlink_discover_probe: test/tools/netlink_discover_probe.c src/jerry/jlink_discover.c
-	$(CC) -O2 -Wall -std=c89 $(INCFLAGS) -Itest \
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
 		-o $@ test/tools/netlink_discover_probe.c src/jerry/jlink_discover.c
 ```
 
@@ -713,8 +731,28 @@ In `src/jerry/jlink.c`, `#include "jlink_discover.h"` and inside `JLinkPoll()`, 
 
 with a file-scope `static int jlinkDiscChanged = 0;` and an accessor
 `int JLinkDiscConsumeChanged(void)` that returns and clears it, declared in
-`jlink.h`. `JLinkNowMs()` already exists for the reply-wait EWMA; if it is
-static, expose it as `uint32_t JLinkNowMs(void)`.
+`jlink.h`.
+
+**There is no existing `JLinkNowMs()` — you must add it.** `jlink.c` has
+`static long long JLinkNowUsec(void)`, in *microseconds*, and it is defined
+only inside the `JLINK_HAVE_WAIT` platform ladder. Add next to it:
+
+```c
+uint32_t JLinkNowMs(void)
+{
+#ifdef JLINK_HAVE_WAIT
+   return (uint32_t)(JLinkNowUsec() / 1000LL);
+#else
+   /* No wait helper on this platform means no sockets either, so
+      discovery is inert here and a frozen clock is harmless. */
+   return 0;
+#endif
+}
+```
+
+Declare it in `jlink.h`. Note `JLinkNowUsec` is `static` and defined twice
+(once per platform branch) — `JLinkNowMs` must be placed after both
+definitions, not inside either branch.
 
 - [ ] **Step 6: Lint, wire into the suite, verify**
 
@@ -789,13 +827,17 @@ In `libretro_core_options.h`, change the `virtualjaguar_netlink` entry:
 In `libretro.c`, replace the inline `strcmp` ladder in `check_variables()`:
 
 ```c
-/* Resolve the Network Link option to a concrete JLINK_MODE_*.  "auto"
- * means: let a frontend netplay session own the link when one exists --
- * JLinkNPStart() takes over on its own, so auto simply stays out of the
- * way -- and otherwise fall back to whatever direct mode the user last
- * chose explicitly.  It deliberately never dials a discovered peer by
- * itself; with the Voice Modem that would place a call the user did not
- * initiate. */
+/* Resolve the Network Link option to a concrete JLINK_MODE_*.
+ *
+ * "auto" means netplay-when-live, else idle.  The design doc originally
+ * had auto also fall back to "the direct mode last chosen explicitly";
+ * that was dropped, because with a single option key there is nowhere to
+ * read a previous choice from -- selecting "auto" overwrites it -- so
+ * honouring it would need hidden persisted state whose behaviour the user
+ * cannot see or predict across restarts.
+ *
+ * Auto deliberately never dials a discovered peer by itself either; with
+ * the Voice Modem that would place a call the user did not initiate. */
 static int netlink_resolve_mode(const char *v)
 {
    if (!v)
@@ -848,20 +890,33 @@ git commit -m "feat(netlink): automatic link mode and per-mode option visibility
 
 - [ ] **Step 1: Implement the rebuild**
 
-In `retro_run`, next to the link-state edge block:
+Add a file-scope static beside `netlink_was_up`, and reset it in
+`retro_deinit()` alongside that one (iOS never dlcloses the core):
+
+```c
+static uint32_t netlink_last_rebuild_ms = 0;
+```
+
+Then in `retro_run`, next to the link-state edge block:
 
 ```c
    /* Rebuild the host picker only when the peer set actually changed --
     * never on a timer.  A second SET_CORE_OPTIONS_V2 tears down and
     * rebuilds RetroArch's whole option manager (runloop.c), so doing it
     * per beacon would thrash the menu under the user's thumb. */
-   if (JLinkDiscConsumeChanged()
-       && (uint32_t)(now_ms - netlink_last_rebuild_ms) >= 2000)
    {
-      netlink_rebuild_host_options();
-      netlink_last_rebuild_ms = now_ms;
+      uint32_t disc_now = JLinkNowMs();
+      if (JLinkDiscConsumeChanged()
+          && (uint32_t)(disc_now - netlink_last_rebuild_ms) >= 2000)
+      {
+         netlink_rebuild_host_options();
+         netlink_last_rebuild_ms = disc_now;
+      }
    }
 ```
+
+`JLinkNowMs()` is the helper added in Task 2; it is declared in `jlink.h`,
+which `libretro.c` already includes.
 
 `netlink_rebuild_host_options()` builds a `retro_core_option_v2_definition`
 array whose `virtualjaguar_netlink_host` values are: `127.0.0.1`, one entry

--- a/docs/netlink-ux-plan.md
+++ b/docs/netlink-ux-plan.md
@@ -185,15 +185,24 @@ static void test_peer_table(void)
          "refresh of a known peer reports no change");
    check(JLinkDiscPeerCount() == 1, "refresh does not duplicate");
 
-   check(JLinkDiscPeerSeen("192.168.1.3", "b", 1, 42172, 2000) == 1,
+   /* Seen at 5000, i.e. LATER than .2's last refresh at 2000.  Both at
+      2000 would share a last_seen_ms, and then no expiry boundary can
+      drop one without the other -- the scenario would be unsatisfiable. */
+   check(JLinkDiscPeerSeen("192.168.1.3", "b", 1, 42172, 5000) == 1,
          "second peer reports a change");
    check(JLinkDiscPeerCount() == 2, "two peers tracked");
 
+   /* At 12000: .2 (last 2000) is exactly at the 10000 boundary and goes;
+      .3 (last 5000) is 7000 old and stays. */
    check(JLinkDiscPeerExpire(2000 + JLINK_DISC_EXPIRE_MS) == 1,
          "expiry of the stale peer reports a change");
    check(JLinkDiscPeerCount() == 1, "stale peer dropped, fresh one kept");
-   check(strcmp(JLinkDiscPeerAt(0)->addr, "192.168.1.3") == 0,
-         "surviving peer is the fresh one");
+   /* Guarded: an unguarded deref turns a future regression into a
+      segfault, which reports nothing.  A test must fail, not crash. */
+   check(JLinkDiscPeerAt(0) != NULL, "a peer survived expiry");
+   if (JLinkDiscPeerAt(0))
+      check(strcmp(JLinkDiscPeerAt(0)->addr, "192.168.1.3") == 0,
+            "surviving peer is the fresh one");
    check(JLinkDiscPeerAt(5) == NULL, "out-of-range index returns NULL");
 }
 

--- a/docs/voice-modem.md
+++ b/docs/voice-modem.md
@@ -25,10 +25,46 @@ How Ultra Vortek services the port (all addresses are the retail ROM):
   `$F1BA84`, read pointer at `$F1BA88`. The 68K driver consumes replies
   from that ring only. There is no RX interrupt use despite RINTEN being
   set; JINTCTRL bit 4 is enabled but the transfer path is the DSP poll.
-- **UART programming**: ASICTRL = `$0021` (odd parity + RINTEN), wake
-  attempts at ASICLK = `$1C` (~57.6 kbaud) falling back to `$56`
+- **UART programming**: ASICTRL = `$0021` = ODD (bit 0) + RINTEN (bit 5).
+  Note **parity is DISABLED** here — PAREN is bit 1 and is clear. An earlier
+  version of this line read "odd parity", which is wrong: only the ODD bit is
+  set. Per JTRM Rev 8 p.94, "when parity is disabled the value of the ODD bit
+  is transmitted in the parity bit time", so the slot is still sent and the
+  frame is still **11 bit times** (1 start + 8 data + 1 parity slot + 1 stop).
+  That 11 is what `UARTFrameUsec()` in `src/jerry/uart.c` multiplies by, and
+  it is correct — verified against JTRM Rev 8 p.93, which also gives the
+  divisor as `system clock / (N+1)` then /16.
+  Wake attempts at ASICLK = `$1C` (~57.6 kbaud) falling back to `$56`
   (~19.2 kbaud); after wake succeeds the driver issues `$FFFE` (see below)
-  and settles at ASICLK = `$56` — i.e. the DTE rate in use is **19200**.
+  and settles at ASICLK = `$56` — i.e. the DTE rate in use is **19200**,
+  which works out to ~576 µs per byte.
+
+**The 19200 rate is permanent, and the `$86xx` connect speed cannot change
+it.** Confirmed from two independent directions:
+
+- The official Atari spec (`docs/atari-jaguar-1999/07 - The Jaguar Voice
+  Modem.pdf`, p.13) defines `$FFFE` as "Set host baud rate to 19200. **Only
+  reset (`$FFFF`) can change the baud rate back to 57600.**" The DTE link has
+  exactly two rates and only those two commands select them. The `$8100`
+  reply reports the *analog* modem-to-modem handshake rate and never touches
+  the baud register.
+- In the retail ROM, `$F10034` (ASICLK) is written exactly **six** times in
+  the whole 4 MB image, every one an immediate `MOVE.W #imm,$F10034` with a
+  value of only `$1C` or `$56`, all inside the wake/reset routines
+  (`$80B10A`–`$80B18C`, `$80B1EC`–`$80B238`, `$80B358`). There is no
+  register-sourced write anywhere. The `$86xx` low byte is decoded at
+  `$803C30` and stored solely to RAM `$57D4` for the MODEM CONNECT SPEED
+  display.
+
+So the ~5.8 ms of wire time each way for a 10-byte pad packet is authentic
+and not tunable through the protocol. Reducing it is an emulator-side
+enhancement — see issue #498.
+
+**Note on sourcing:** this decode was derived by disassembling the retail
+ROM, deliberately without consulting other emulators. The official Atari JVM
+manual above (present in the gitignored `docs/atari-jaguar-1999/` tree)
+independently corroborates the command set and both baud rates. Consult it
+first for any future JVM work — it is the primary source.
 
 Menu entry: type **`911` on the numpad while the title logo is on screen**
 ("AWESOME" sting → INITIALIZING VOICE MODEM). With no modem answering, the

--- a/docs/voice-modem.md
+++ b/docs/voice-modem.md
@@ -202,6 +202,13 @@ then the link state, on edges only:
 
 Reading them:
 
+- **"Network Link" is at its default (`auto`) and the OSD says `Voice Modem
+  selected but link is idle -- start netplay or pick a host`** — this is
+  the single most common report and is not a bug. `auto` resolves to
+  netplay-when-a-session-is-live, else idle; it never restores a
+  previously chosen direct mode and never auto-dials a discovered peer.
+  Either start a RetroArch netplay session, or set "Network Link" to
+  `TCP Host (listen)` / `TCP Client (connect)` explicitly on both sides.
 - **No `[NETLINK]` lines at all** — the core is too old to have the voice
   modem. Check the binary the frontend actually loaded, not the build tree:
   `strings <core> | grep -c virtualjaguar_uart_device` must be non-zero.
@@ -209,13 +216,37 @@ Reading them:
   raw cable cannot answer the wake handshake, so the game reports MODEM
   INITIALIZING FAILED. It must be set to Voice Modem on **both** sides.
 - **Stuck at `waiting for peer...`** — the transport never paired. Check both
-  sides agree on the port, and that exactly one is TCP Host.
+  sides agree on the port, and that exactly one is TCP Host. In `tcp_client`
+  mode, hosts running on the same LAN normally appear in the "Network Link
+  Host" list by themselves within a couple of seconds — if the one you want
+  isn't there, confirm it is actually in `tcp_server` mode (discovery only
+  beacons/listens in `tcp_server`/`tcp_client`, never in `auto`) and that
+  nothing on the network blocks UDP broadcast (client-isolated Wi-Fi APs are
+  a common culprit).
 - **`'From file' selected but no address read`** — the "From file" preset was
   chosen but `<system>/vj_netlink.txt` is missing or empty; the address fell
-  back to 127.0.0.1.
+  back to 127.0.0.1. The file format is one line, the address only, no
+  port — e.g. `192.168.1.42` or `myhost.local` — the port always comes from
+  "Network Link Port".
+- **The host you had selected quietly reverted to `127.0.0.1`** — a
+  discovered host that goes offline (or stops beaconing) expires from the
+  list after 10 s; if it was your active selection, the OSD says
+  `Selected host <addr> dropped off the LAN -- falling back to 127.0.0.1`
+  and the option resets. Re-pick it once it reappears, or pin it with
+  `vj_netlink.txt`/`VJ_NETLINK_HOST` if it's on an unreliable network.
+- **OSD says `Host is running JagLink, you are set to Voice Modem`** (or the
+  reverse) — the discovered peer and your "Network Link Device" don't
+  match. JagLink/CatBox and the Voice Modem never interoperate; set both
+  sides to the same device.
 - **`link UP` on both sides but the call still fails** — that is a modem-layer
   problem, not transport. Re-run with `VJ_VM_TRACE=1` for the command/reply
   stream, and see the choreography table above.
+
+On-screen narration mirrors these log lines (`SET_MESSAGE_EXT`, 4 s,
+transitions only) so a player without a log window in front of them sees
+the same facts: link resolved at load, link up, link lost, "Found N Jaguar
+host(s) on the LAN", the device-mismatch warning, the dropped-selection
+warning above, and the idle-Voice-Modem message.
 
 ## Open questions
 

--- a/libretro.c
+++ b/libretro.c
@@ -975,6 +975,21 @@ static int netlink_was_up = -1;
 static uint32_t netlink_last_rebuild_ms = 0;
 static int      netlink_peers_dirty     = 0;
 
+/* Last (mode, device, host) narrated to the OSD by netlink_apply()'s
+ * mode-resolution messages (task 5, #467).  netlink_apply() runs on
+ * EVERY check_variables() call, which fires whenever ANY core option
+ * changes -- not just the netlink ones -- so without this dedup the
+ * player gets a link toast (and, in tcp_client, a repeat of the device-
+ * mismatch warning) for completely unrelated menu edits.  -1 sentinels
+ * guarantee the first call after load always narrates.  File scope (not
+ * function-local) for the same reason as netlink_was_up above: iOS never
+ * dlcloses the core, so a function-local static would carry the previous
+ * session's narrated state into the next one and swallow its first
+ * message. */
+static int  netlink_osd_last_mode      = -1;
+static int  netlink_osd_last_device    = -1;
+static char netlink_osd_last_host[128] = "";
+
 /* Names for the [NETLINK] log lines.  Not exported: nothing outside this
  * file needs to render a mode. */
 static const char *netlink_mode_name(int mode)
@@ -989,6 +1004,36 @@ static const char *netlink_mode_name(int mode)
    default: break;
    }
    return "unknown";
+}
+
+/* Human-readable device label for OSD text ("voicemodem"/"jaglink" in the
+ * log lines are fine for grep, not for a player reading the screen). */
+static const char *netlink_device_label(int device)
+{
+   return device == JLINK_DEVICE_VOICEMODEM ? "Voice Modem" : "JagLink";
+}
+
+/* OSD narration.  Mirrors the [NETLINK] log lines so screen and log
+ * always agree; fires on transitions only, never per frame. */
+static void netlink_osd(const char *fmt, ...)
+{
+   struct retro_message_ext msg;
+   char text[256];
+   va_list ap;
+
+   va_start(ap, fmt);
+   vsnprintf(text, sizeof(text), fmt, ap);
+   va_end(ap);
+
+   memset(&msg, 0, sizeof(msg));
+   msg.msg      = text;
+   msg.duration = 4000;
+   msg.priority = 2;
+   msg.level    = RETRO_LOG_INFO;
+   msg.target   = RETRO_MESSAGE_TARGET_OSD;
+   msg.type     = RETRO_MESSAGE_TYPE_NOTIFICATION;
+   msg.progress = -1;
+   environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &msg);
 }
 
 /* Resolve the TCP endpoint for the network link and apply the mode.
@@ -1021,6 +1066,10 @@ static void netlink_apply(int mode, const char *opt_value)
    const char *src = "default";
    int want_file = 0;
    int got_file = 0;
+   /* OSD dedup state -- see netlink_osd_last_mode's declaration comment. */
+   char narrate_host[128];
+   int narrate_device;
+   int narrate_changed;
 
    host[0] = '\0';
 
@@ -1097,6 +1146,37 @@ static void netlink_apply(int mode, const char *opt_value)
    JLinkSetTCPEndpoint(host[0] ? host : "127.0.0.1", port);
    UARTSetLinkMode(mode);
 
+   /* Whether the resolved (mode, device, host) actually changed since the
+    * last narration.  netlink_apply() runs on every check_variables()
+    * call, which fires on ANY option change -- not just the netlink ones
+    * -- so the LOG_INF lines below are intentionally unconditional (log
+    * scrollback is cheap to re-emit), but the netlink_osd() calls are
+    * gated on this, or a player using Voice Modem in tcp_client would get
+    * a link toast for every unrelated settings tweak.  host only matters
+    * for tcp_client (it is not shown in the other messages), so it is
+    * excluded from the comparison otherwise -- an unrelated host edit
+    * while in another mode must not itself count as a transition. */
+   narrate_device = JLinkDevice();
+   if (mode == JLINK_MODE_TCP_CLIENT)
+   {
+      strncpy(narrate_host, host[0] ? host : "127.0.0.1",
+              sizeof(narrate_host) - 1);
+      narrate_host[sizeof(narrate_host) - 1] = '\0';
+   }
+   else
+      narrate_host[0] = '\0';
+   narrate_changed = (mode != netlink_osd_last_mode)
+                      || (narrate_device != netlink_osd_last_device)
+                      || strcmp(narrate_host, netlink_osd_last_host) != 0;
+   if (narrate_changed)
+   {
+      netlink_osd_last_mode   = mode;
+      netlink_osd_last_device = narrate_device;
+      strncpy(netlink_osd_last_host, narrate_host,
+              sizeof(netlink_osd_last_host) - 1);
+      netlink_osd_last_host[sizeof(netlink_osd_last_host) - 1] = '\0';
+   }
+
    /* One line that answers "what did the core actually do with my
     * settings".  Without it the whole link stack is silent, and a session
     * that never connected is indistinguishable from one that was never
@@ -1107,22 +1187,80 @@ static void netlink_apply(int mode, const char *opt_value)
     * later, by the frontend, and shows up as a link UP below.  Say so, or
     * the pair of lines reads as a contradiction. */
    if (mode == JLINK_MODE_DISABLED)
+   {
       LOG_INF("[NETLINK] built-in TCP link disabled (device=%s) -- frontend "
               "netplay will carry the link if a session is running\n",
               JLinkDevice() == JLINK_DEVICE_VOICEMODEM ? "voicemodem"
                                                        : "jaglink");
+      /* This is the failure that motivated the whole feature: a Voice
+       * Modem selected with "auto" and no netplay session running does
+       * nothing, silently, until the player either starts netplay or
+       * picks a direct mode -- say so on screen. */
+      if (narrate_changed && JLinkDevice() == JLINK_DEVICE_VOICEMODEM)
+         netlink_osd("Voice Modem selected but link is idle -- start "
+                     "netplay or pick a host");
+   }
    else if (mode == JLINK_MODE_TCP_CLIENT)
+   {
       LOG_INF("[NETLINK] mode=%s device=%s peer=%s:%d (address from %s)\n",
               netlink_mode_name(mode),
               JLinkDevice() == JLINK_DEVICE_VOICEMODEM ? "voicemodem"
                                                        : "jaglink",
               host[0] ? host : "127.0.0.1", port, src);
+      if (narrate_changed)
+      {
+         netlink_osd("Network Link: %s (%s) -> %s:%d",
+                     netlink_mode_name(mode),
+                     netlink_device_label(JLinkDevice()),
+                     host[0] ? host : "127.0.0.1", port);
+
+         /* Device mismatch: the discovery beacon carries device type, so
+          * if the host we are about to dial is a peer we've already seen
+          * beaconing the OTHER device, warn now -- JagLink and Voice
+          * Modem never interoperate and today fail silently (docs/
+          * netlink-ux-design.md section 2). */
+         {
+            const char *sel_host;
+            int my_device;
+            int pi, peer_count;
+
+            sel_host = host[0] ? host : "127.0.0.1";
+            my_device = (JLinkDevice() == JLINK_DEVICE_VOICEMODEM)
+                        ? JLINK_DISC_DEV_VOICEMODEM : JLINK_DISC_DEV_JAGLINK;
+            peer_count = JLinkDiscPeerCount();
+            if (peer_count > JLINK_DISC_MAX_PEERS)
+               peer_count = JLINK_DISC_MAX_PEERS;
+
+            for (pi = 0; pi < peer_count; pi++)
+            {
+               const JLinkPeer *peer;
+
+               peer = JLinkDiscPeerAt(pi);
+               if (peer && !strcmp(peer->addr, sel_host)
+                   && peer->device != my_device)
+               {
+                  netlink_osd("Host is running %s, you are set to %s",
+                              peer->device == JLINK_DISC_DEV_VOICEMODEM
+                                 ? "Voice Modem" : "JagLink",
+                              netlink_device_label(JLinkDevice()));
+                  break;
+               }
+            }
+         }
+      }
+   }
    else
+   {
       LOG_INF("[NETLINK] mode=%s device=%s port=%d\n",
               netlink_mode_name(mode),
               JLinkDevice() == JLINK_DEVICE_VOICEMODEM ? "voicemodem"
                                                        : "jaglink",
               port);
+      if (narrate_changed)
+         netlink_osd("Network Link: %s (%s), port %d",
+                     netlink_mode_name(mode),
+                     netlink_device_label(JLinkDevice()), port);
+   }
 
    /* The "From file" preset selected but no usable address in the file is
     * a silent 127.0.0.1 fallback -- the one that cost a debugging session. */
@@ -1217,10 +1355,39 @@ static int netlink_host_option_index(void)
 static void netlink_rebuild_host_options(void)
 {
    int idx, i, n, peer_count, my_device;
+   char cur_host[128];
+   int cur_host_known;
+   int cur_host_is_preset;
+   int cur_host_found;
 
    idx = netlink_host_option_index();
    if (idx < 0)
       return;
+
+   /* Selected-host-expired check (review note from task 4, #467): read
+    * the value currently active in the frontend BEFORE the value list is
+    * overwritten below.  If it names a discovered peer that is about to
+    * drop out of the rebuilt list, RetroArch's core_option_manager resets
+    * the option to its first value (127.0.0.1) with no explanation --
+    * warn on screen before that silently happens rather than after. */
+   cur_host_known     = 0;
+   cur_host_is_preset = 0;
+   cur_host_found     = 0;
+   {
+      struct retro_variable cur;
+
+      cur.key = "virtualjaguar_netlink_host";
+      cur.value = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &cur) && cur.value)
+      {
+         strncpy(cur_host, cur.value, sizeof(cur_host) - 1);
+         cur_host[sizeof(cur_host) - 1] = '\0';
+         cur_host_known = 1;
+         cur_host_is_preset = !strcmp(cur_host, "127.0.0.1")
+                               || !strcmp(cur_host, "jaghub.local")
+                               || !strcmp(cur_host, "vj_netlink.txt");
+      }
+   }
 
    if (!netlink_host_presets_valid)
    {
@@ -1248,6 +1415,10 @@ static void netlink_rebuild_host_options(void)
       peer = JLinkDiscPeerAt(i);
       if (!peer)
          break;
+
+      if (cur_host_known && !cur_host_is_preset
+          && !strcmp(peer->addr, cur_host))
+         cur_host_found = 1;
 
       /* Beacon-supplied name is untrusted and may be empty; fall back to
        * the address so the label is never just " - 1.2.3.4". */
@@ -1299,6 +1470,23 @@ static void netlink_rebuild_host_options(void)
 
    LOG_INF("[NETLINK] host picker rebuilt: %d discovered peer%s\n",
            peer_count, peer_count == 1 ? "" : "s");
+
+   if (cur_host_known && !cur_host_is_preset && !cur_host_found)
+   {
+      LOG_WRN("[NETLINK] selected host %s dropped off the LAN -- falling "
+              "back to 127.0.0.1\n", cur_host);
+      netlink_osd("Selected host %s dropped off the LAN -- falling back "
+                  "to 127.0.0.1", cur_host);
+   }
+
+   /* Only the "found" case gets a toast.  peer_count == 0 means this
+    * rebuild was triggered by the last peer expiring, not a new one
+    * arriving -- "Found 0 Jaguar host(s)" would tell the player nothing
+    * they don't already know from the dropped-selection warning above (if
+    * their host was the one that expired) or from the host list simply
+    * being back down to the static presets (if it wasn't). */
+   if (peer_count > 0)
+      netlink_osd("Found %d Jaguar host(s) on the LAN", peer_count);
 }
 
 /* Gate for per-title enhancement defaults (issue #368). Read raw (never
@@ -3987,6 +4175,13 @@ void retro_deinit(void)
     * core would otherwise start the next session believing the previous
     * one's peer was still attached and skip the first UP edge. */
    netlink_was_up          = -1;
+   /* OSD narration dedup (task 5, #467): same iOS-no-dlclose reasoning --
+    * a resident core would otherwise believe the new session's first
+    * mode/device/host is identical to the previous session's last one and
+    * stay silent instead of narrating it. */
+   netlink_osd_last_mode      = -1;
+   netlink_osd_last_device    = -1;
+   netlink_osd_last_host[0]   = '\0';
    /* LAN discovery (#467): close the beacon/listener socket, drop any
     * peers it found (JLinkDiscStop() only closes the socket -- the peer
     * array survives it, and a resident core would otherwise carry stale
@@ -4235,13 +4430,20 @@ void retro_run(void)
       else if (up != netlink_was_up)
       {
          if (up)
+         {
             LOG_INF("[NETLINK] link UP (%s, device=%s)\n",
                     netlink_mode_name(JLinkMode()),
                     JLinkDevice() == JLINK_DEVICE_VOICEMODEM ? "voicemodem"
                                                              : "jaglink");
+            netlink_osd("Jaguar link connected (%s)",
+                        netlink_device_label(JLinkDevice()));
+         }
          else if (netlink_was_up == 1)
+         {
             LOG_WRN("[NETLINK] link DOWN (%s) -- peer disconnected\n",
                     netlink_mode_name(JLinkMode()));
+            netlink_osd("Jaguar link lost");
+         }
          else
             LOG_INF("[NETLINK] %s open, waiting for peer...\n",
                     netlink_mode_name(JLinkMode()));

--- a/libretro.c
+++ b/libretro.c
@@ -1102,17 +1102,25 @@ static void netlink_apply(int mode, const char *opt_value)
               netlink_mode_name(mode));
 
    /* LAN discovery beacon/listener lifecycle (#467).  A host beacons AND
-    * listens, so it can see other peers too; a client or "auto" listens
-    * only -- neither dials out on its own.  Anything else (disabled,
-    * loopback) has no use for a peer list, so discovery stops. */
+    * listens, so it can see other peers too; a client listens only --
+    * neither dials out on its own.  Deliberately NOT started for "auto":
+    * the host field it would populate is hidden in auto (see the
+    * update_option_visibility() gate), and auto never auto-connects to a
+    * discovered peer either (a Voice Modem "auto-dial" would place a call
+    * the user did not initiate) -- so in auto the peer table is invisible
+    * and unread. Auto is also the option's default, so starting a socket
+    * here would open a UDP listener on port 42170 for every user on
+    * every load, tripping the OS's Local Network permission prompt for
+    * players who never touched the networking options. Anything else
+    * (disabled, loopback) has no use for a peer list either, so discovery
+    * stops. */
    {
       int device = (JLinkDevice() == JLINK_DEVICE_VOICEMODEM)
                    ? JLINK_DISC_DEV_VOICEMODEM : JLINK_DISC_DEV_JAGLINK;
 
       if (opt_value && !strcmp(opt_value, "tcp_server"))
          JLinkDiscStart(0 /* listen_only */, device, port);
-      else if (opt_value && (!strcmp(opt_value, "tcp_client")
-                              || !strcmp(opt_value, "auto")))
+      else if (opt_value && !strcmp(opt_value, "tcp_client"))
          JLinkDiscStart(1 /* listen_only */, device, port);
       else
          JLinkDiscStop();
@@ -3805,10 +3813,14 @@ void retro_deinit(void)
     * core would otherwise start the next session believing the previous
     * one's peer was still attached and skip the first UP edge. */
    netlink_was_up          = -1;
-   /* LAN discovery (#467): close the beacon/listener socket and reset the
+   /* LAN discovery (#467): close the beacon/listener socket, drop any
+    * peers it found (JLinkDiscStop() only closes the socket -- the peer
+    * array survives it, and a resident core would otherwise carry stale
+    * peers from an unrelated ROM into the next session), and reset the
     * host/port visibility gates -- same iOS-no-dlclose reasoning as the
     * rest of this function. */
    JLinkDiscStop();
+   JLinkDiscPeersReset();
    show_netlink_host       = true;
    show_netlink_port       = true;
    show_mouse_options      = true;

--- a/libretro.c
+++ b/libretro.c
@@ -1036,6 +1036,75 @@ static void netlink_osd(const char *fmt, ...)
    environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &msg);
 }
 
+/* Edge-gate for netlink_check_device_mismatch()'s OSD: the last sel_host
+ * value that already got a mismatch toast, so two calls in a row (or
+ * repeated rebuilds while nothing changed) don't repeat it.  File scope
+ * for the same iOS-no-dlclose reason as netlink_osd_last_host above; reset
+ * alongside it in retro_deinit(). */
+static char netlink_mismatch_last_host[128] = "";
+
+/* Device-mismatch check for tcp_client (fix wave, PR review finding 3):
+ * the discovery beacon carries device type, so if the host about to be
+ * dialed (or already selected) is a peer we've seen beaconing the OTHER
+ * device, warn -- JagLink and Voice Modem never interoperate and fail
+ * silently otherwise (docs/netlink-ux-design.md section 2).
+ *
+ * Called from BOTH netlink_apply() (immediate: catches a host edit made
+ * while the peer table was already populated) AND
+ * netlink_rebuild_host_options() (catches the persisted-config load path:
+ * netlink_apply()'s mismatch scan runs BEFORE the JLinkDiscStart() call in
+ * the same function, and a real JLinkDiscStart() resets the peer table --
+ * so at load the apply-time scan always sees an empty table, and the peer
+ * only appears ~1s later when discovery hears the beacon; nothing
+ * re-evaluates the mismatch at that point unless this second call site
+ * does it).  netlink_mismatch_last_host above edge-gates the OSD so the
+ * two call sites (or repeated rebuilds) don't double-toast the same
+ * condition. */
+static void netlink_check_device_mismatch(const char *sel_host)
+{
+   int my_device;
+   int pi, peer_count;
+   int mismatched;
+   const char *mismatch_label;
+
+   mismatched = 0;
+   mismatch_label = "";
+   my_device = (JLinkDevice() == JLINK_DEVICE_VOICEMODEM)
+               ? JLINK_DISC_DEV_VOICEMODEM : JLINK_DISC_DEV_JAGLINK;
+   peer_count = JLinkDiscPeerCount();
+   if (peer_count > JLINK_DISC_MAX_PEERS)
+      peer_count = JLINK_DISC_MAX_PEERS;
+
+   for (pi = 0; pi < peer_count; pi++)
+   {
+      const JLinkPeer *peer;
+
+      peer = JLinkDiscPeerAt(pi);
+      if (peer && !strcmp(peer->addr, sel_host) && peer->device != my_device)
+      {
+         mismatched = 1;
+         mismatch_label = (peer->device == JLINK_DISC_DEV_VOICEMODEM)
+                           ? "Voice Modem" : "JagLink";
+         break;
+      }
+   }
+
+   if (mismatched)
+   {
+      if (strcmp(sel_host, netlink_mismatch_last_host) != 0)
+      {
+         netlink_osd("Host is running %s, you are set to %s",
+                     mismatch_label, netlink_device_label(JLinkDevice()));
+         strncpy(netlink_mismatch_last_host, sel_host,
+                 sizeof(netlink_mismatch_last_host) - 1);
+         netlink_mismatch_last_host[sizeof(netlink_mismatch_last_host) - 1]
+            = '\0';
+      }
+   }
+   else
+      netlink_mismatch_last_host[0] = '\0';
+}
+
 /* Resolve the TCP endpoint for the network link and apply the mode.
  * Host (client mode): VJ_NETLINK_HOST env, else the
  * virtualjaguar_netlink_host option (any string is accepted verbatim so
@@ -1214,39 +1283,11 @@ static void netlink_apply(int mode, const char *opt_value)
                      netlink_device_label(JLinkDevice()),
                      host[0] ? host : "127.0.0.1", port);
 
-         /* Device mismatch: the discovery beacon carries device type, so
-          * if the host we are about to dial is a peer we've already seen
-          * beaconing the OTHER device, warn now -- JagLink and Voice
-          * Modem never interoperate and today fail silently (docs/
-          * netlink-ux-design.md section 2). */
-         {
-            const char *sel_host;
-            int my_device;
-            int pi, peer_count;
-
-            sel_host = host[0] ? host : "127.0.0.1";
-            my_device = (JLinkDevice() == JLINK_DEVICE_VOICEMODEM)
-                        ? JLINK_DISC_DEV_VOICEMODEM : JLINK_DISC_DEV_JAGLINK;
-            peer_count = JLinkDiscPeerCount();
-            if (peer_count > JLINK_DISC_MAX_PEERS)
-               peer_count = JLINK_DISC_MAX_PEERS;
-
-            for (pi = 0; pi < peer_count; pi++)
-            {
-               const JLinkPeer *peer;
-
-               peer = JLinkDiscPeerAt(pi);
-               if (peer && !strcmp(peer->addr, sel_host)
-                   && peer->device != my_device)
-               {
-                  netlink_osd("Host is running %s, you are set to %s",
-                              peer->device == JLINK_DISC_DEV_VOICEMODEM
-                                 ? "Voice Modem" : "JagLink",
-                              netlink_device_label(JLinkDevice()));
-                  break;
-               }
-            }
-         }
+         /* Device mismatch (fix wave, PR review finding 3): see
+          * netlink_check_device_mismatch()'s declaration comment for why
+          * this call alone does not cover the persisted-config load path,
+          * and why netlink_rebuild_host_options() duplicates it. */
+         netlink_check_device_mismatch(host[0] ? host : "127.0.0.1");
       }
    }
    else
@@ -1291,9 +1332,21 @@ static void netlink_apply(int mode, const char *opt_value)
                    ? JLINK_DISC_DEV_VOICEMODEM : JLINK_DISC_DEV_JAGLINK;
 
       if (opt_value && !strcmp(opt_value, "tcp_server"))
-         JLinkDiscStart(0 /* listen_only */, device, port);
+      {
+         if (!JLinkDiscStart(0 /* listen_only */, device, port))
+            LOG_ERR("[NETLINK] LAN discovery failed to bind UDP port %d -- "
+                    "host picker will only show the static presets (macOS/"
+                    "iOS Local Network permission denied or timed out?)\n",
+                    JLINK_DISC_PORT);
+      }
       else if (opt_value && !strcmp(opt_value, "tcp_client"))
-         JLinkDiscStart(1 /* listen_only */, device, port);
+      {
+         if (!JLinkDiscStart(1 /* listen_only */, device, port))
+            LOG_ERR("[NETLINK] LAN discovery failed to bind UDP port %d -- "
+                    "host picker will only show the static presets (macOS/"
+                    "iOS Local Network permission denied or timed out?)\n",
+                    JLINK_DISC_PORT);
+      }
       else
          JLinkDiscStop();
    }
@@ -1359,6 +1412,7 @@ static void netlink_rebuild_host_options(void)
    int cur_host_known;
    int cur_host_is_preset;
    int cur_host_found;
+   bool options_pushed;
 
    idx = netlink_host_option_index();
    if (idx < 0)
@@ -1447,7 +1501,7 @@ static void netlink_rebuild_host_options(void)
    option_defs_us[idx].values[n].value = NULL;
    option_defs_us[idx].values[n].label = NULL;
 
-   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2, &options_us);
+   options_pushed = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2, &options_us);
 
    /* SET_CORE_OPTIONS_V2 rebuilds RetroArch's whole core_option_manager
     * from these definitions, which carry no visibility field -- every
@@ -1468,8 +1522,20 @@ static void netlink_rebuild_host_options(void)
    visibility_force_push = 1;
    update_option_visibility();
 
-   LOG_INF("[NETLINK] host picker rebuilt: %d discovered peer%s\n",
-           peer_count, peer_count == 1 ? "" : "s");
+   /* SET_CORE_OPTIONS_V2 returns false on a frontend reporting core
+    * options v2 unsupported (RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION <
+    * 2) -- option_defs_us above was still mutated in place, but the
+    * frontend never saw it, so the picker did NOT gain the peer.  Claiming
+    * success here (or in the "Found N" toast below) would be the same
+    * silent-failure class this fix wave exists to close. */
+   if (options_pushed)
+      LOG_INF("[NETLINK] host picker rebuilt: %d discovered peer%s\n",
+              peer_count, peer_count == 1 ? "" : "s");
+   else
+      LOG_WRN("[NETLINK] SET_CORE_OPTIONS_V2 rejected by frontend (core "
+              "options v2 unsupported?) -- host picker NOT updated, %d "
+              "discovered peer%s not shown\n",
+              peer_count, peer_count == 1 ? "" : "s");
 
    if (cur_host_known && !cur_host_is_preset && !cur_host_found)
    {
@@ -1484,9 +1550,28 @@ static void netlink_rebuild_host_options(void)
     * arriving -- "Found 0 Jaguar host(s)" would tell the player nothing
     * they don't already know from the dropped-selection warning above (if
     * their host was the one that expired) or from the host list simply
-    * being back down to the static presets (if it wasn't). */
-   if (peer_count > 0)
+    * being back down to the static presets (if it wasn't).  Also gated on
+    * options_pushed: if the frontend rejected the rebuild, the picker
+    * still shows the old list, so telling the player their host was
+    * "Found" would be a lie -- see the LOG_WRN above. */
+   if (peer_count > 0 && options_pushed)
       netlink_osd("Found %d Jaguar host(s) on the LAN", peer_count);
+
+   /* Device-mismatch check (fix wave, PR review finding 3): the scan in
+    * netlink_apply() runs BEFORE the JLinkDiscStart() call in that same
+    * function, and a real JLinkDiscStart() resets the peer table -- so on
+    * a persisted-config load (saved tcp_client + a host that turns out to
+    * beacon the other device) the apply-time scan always sees an empty
+    * table, and the OSD dedup there never re-fires once the peer shows up
+    * ~1s later because (mode, device, host) hasn't changed.  This rebuild
+    * only runs once the peer table just finished being repopulated from
+    * live beacon data, so check again here -- gated on JLinkMode() rather
+    * than the option string because JLinkMode() reflects what actually
+    * got dialed (a socket-level TCP connect succeeds regardless of the
+    * remote's device type; the mismatch is a protocol-level problem this
+    * warning exists to surface before it manifests as silence). */
+   if (JLinkMode() == JLINK_MODE_TCP_CLIENT)
+      netlink_check_device_mismatch(cur_host_known ? cur_host : "127.0.0.1");
 }
 
 /* Gate for per-title enhancement defaults (issue #368). Read raw (never
@@ -4182,6 +4267,10 @@ void retro_deinit(void)
    netlink_osd_last_mode      = -1;
    netlink_osd_last_device    = -1;
    netlink_osd_last_host[0]   = '\0';
+   /* Device-mismatch OSD dedup (fix wave, PR review finding 3): same
+    * iOS-no-dlclose reasoning -- a resident core would otherwise believe
+    * the new session already warned about a host it has never seen. */
+   netlink_mismatch_last_host[0] = '\0';
    /* LAN discovery (#467): close the beacon/listener socket, drop any
     * peers it found (JLinkDiscStop() only closes the socket -- the peer
     * array survives it, and a resident core would otherwise carry stale

--- a/libretro.c
+++ b/libretro.c
@@ -35,6 +35,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "dac.h"
 #include "dsp.h"
 #include "jlink.h"
+#include "jlink_discover.h"
 #include "jlink_netpacket.h"
 #include "uart.h"
 #include "joystick.h"
@@ -213,6 +214,13 @@ static bool show_texdump_16bpp     = true;
 /* Texture replacement (#369 deliverable 2) only means anything when a
  * pack directory exists for the loaded content; hidden otherwise. */
 static bool show_texture_replace   = true;
+/* Network Link host/port fields (task 3, #467) only mean anything for the
+ * direct TCP modes: the client needs somewhere to dial, the server needs a
+ * listen port to advertise.  "auto" and "loopback" need neither -- hidden,
+ * like the other show_* gates, whenever the resolved mode isn't one that
+ * reads them. */
+static bool show_netlink_host      = true;
+static bool show_netlink_port      = true;
 static bool enable_alt_inputs = false;
 static uint8_t *joypad_buttons[2] = { joypad0Buttons, joypad1Buttons };
 
@@ -566,6 +574,33 @@ static int get_button_id(const char *val)
    return BUTTON_NONE;
 }
 
+/* Resolve the Network Link option to a concrete JLINK_MODE_*.
+ *
+ * "auto" means netplay-when-live, else idle.  The design doc originally
+ * had auto also fall back to "the direct mode last chosen explicitly";
+ * that was dropped, because with a single option key there is nowhere to
+ * read a previous choice from -- selecting "auto" overwrites it -- so
+ * honouring it would need hidden persisted state whose behaviour the user
+ * cannot see or predict across restarts.
+ *
+ * Auto deliberately never dials a discovered peer by itself either; with
+ * the Voice Modem that would place a call the user did not initiate. */
+static int netlink_resolve_mode(const char *v)
+{
+   if (!v)
+      return JLINK_MODE_DISABLED;
+   if (!strcmp(v, "loopback"))   return JLINK_MODE_LOOPBACK;
+   if (!strcmp(v, "tcp_server")) return JLINK_MODE_TCP_SERVER;
+   if (!strcmp(v, "tcp_client")) return JLINK_MODE_TCP_CLIENT;
+   if (!strcmp(v, "auto"))
+   {
+      if (JLinkMode() == JLINK_MODE_NETPACKET)
+         return JLINK_MODE_NETPACKET;
+      return JLINK_MODE_DISABLED;
+   }
+   return JLINK_MODE_DISABLED;
+}
+
 static bool update_option_visibility(void)
 {
    struct retro_core_option_display option_display;
@@ -779,6 +814,47 @@ static bool update_option_visibility(void)
       }
    }
 
+   /* Network Link host/port (task 3, #467): host only means anything for
+    * the TCP client (the side that dials out); port only means anything
+    * for a mode with a TCP socket of its own at all -- server (listens)
+    * or client (connects).  "auto" and "loopback" hide both: auto never
+    * asks the user to configure an address (that is the whole point of
+    * it), and loopback never leaves this console.  Read raw, like the
+    * alt-inputs/texture-dump gates above, rather than through
+    * get_variable_pertitle() -- per-title defaults have no business
+    * steering a transport choice the user made explicitly. */
+   {
+      bool show_netlink_host_prev = show_netlink_host;
+      bool show_netlink_port_prev = show_netlink_port;
+      int  resolved;
+
+      var.key = "virtualjaguar_netlink";
+      var.value = NULL;
+      environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var);
+      resolved = netlink_resolve_mode(var.value);
+
+      show_netlink_host = (resolved == JLINK_MODE_TCP_CLIENT);
+      show_netlink_port = (resolved == JLINK_MODE_TCP_CLIENT
+                            || resolved == JLINK_MODE_TCP_SERVER);
+
+      if (show_netlink_host != show_netlink_host_prev)
+      {
+         option_display.visible = show_netlink_host;
+         option_display.key     = "virtualjaguar_netlink_host";
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
+                    &option_display);
+         updated = true;
+      }
+      if (show_netlink_port != show_netlink_port_prev)
+      {
+         option_display.visible = show_netlink_port;
+         option_display.key     = "virtualjaguar_netlink_port";
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
+                    &option_display);
+         updated = true;
+      }
+   }
+
    return updated;
 }
 
@@ -887,8 +963,17 @@ static const char *netlink_mode_name(int mode)
  * frontends with free-text option entry can supply arbitrary addresses;
  * the sentinel "vj_netlink.txt" defers to the file), else first line of
  * <system_dir>/vj_netlink.txt, else 127.0.0.1.  Port: VJ_NETLINK_PORT
- * env overrides the virtualjaguar_netlink_port option. */
-static void netlink_apply(int mode)
+ * env overrides the virtualjaguar_netlink_port option.
+ *
+ * mode is the resolved JLINK_MODE_* (see netlink_resolve_mode()); opt_value
+ * is the RAW option string that produced it, and may be NULL.  The two can
+ * disagree on purpose: "auto" with no netplay session live resolves to
+ * JLINK_MODE_DISABLED for the link itself (there is nothing yet to carry
+ * the emulated UART), but the discovery beacon/listener below is driven by
+ * opt_value so a user who picked "auto" or "tcp_client" still sees LAN
+ * peers to act on -- discovery never auto-connects, it only populates the
+ * list a later task's UI reads. */
+static void netlink_apply(int mode, const char *opt_value)
 {
    char host[128];
    int port = 42171;
@@ -1015,6 +1100,23 @@ static void netlink_apply(int mode)
        && JLinkMode() == JLINK_MODE_DISABLED)
       LOG_ERR("[NETLINK] failed to open %s -- link is DOWN\n",
               netlink_mode_name(mode));
+
+   /* LAN discovery beacon/listener lifecycle (#467).  A host beacons AND
+    * listens, so it can see other peers too; a client or "auto" listens
+    * only -- neither dials out on its own.  Anything else (disabled,
+    * loopback) has no use for a peer list, so discovery stops. */
+   {
+      int device = (JLinkDevice() == JLINK_DEVICE_VOICEMODEM)
+                   ? JLINK_DISC_DEV_VOICEMODEM : JLINK_DISC_DEV_JAGLINK;
+
+      if (opt_value && !strcmp(opt_value, "tcp_server"))
+         JLinkDiscStart(0 /* listen_only */, device, port);
+      else if (opt_value && (!strcmp(opt_value, "tcp_client")
+                              || !strcmp(opt_value, "auto")))
+         JLinkDiscStart(1 /* listen_only */, device, port);
+      else
+         JLinkDiscStop();
+   }
 }
 
 /* Gate for per-title enhancement defaults (issue #368). Read raw (never
@@ -1476,18 +1578,9 @@ static void check_variables(void)
    var.key = "virtualjaguar_netlink";
    var.value = NULL;
    if (get_variable_pertitle(&var) && var.value)
-   {
-      int mode = JLINK_MODE_DISABLED;
-      if (strcmp(var.value, "loopback") == 0)
-         mode = JLINK_MODE_LOOPBACK;
-      else if (strcmp(var.value, "tcp_server") == 0)
-         mode = JLINK_MODE_TCP_SERVER;
-      else if (strcmp(var.value, "tcp_client") == 0)
-         mode = JLINK_MODE_TCP_CLIENT;
-      netlink_apply(mode);
-   }
+      netlink_apply(netlink_resolve_mode(var.value), var.value);
    else
-      netlink_apply(JLINK_MODE_DISABLED);
+      netlink_apply(JLINK_MODE_DISABLED, NULL);
 
    var.key = "virtualjaguar_bios";
    var.value = NULL;
@@ -3712,6 +3805,12 @@ void retro_deinit(void)
     * core would otherwise start the next session believing the previous
     * one's peer was still attached and skip the first UP edge. */
    netlink_was_up          = -1;
+   /* LAN discovery (#467): close the beacon/listener socket and reset the
+    * host/port visibility gates -- same iOS-no-dlclose reasoning as the
+    * rest of this function. */
+   JLinkDiscStop();
+   show_netlink_host       = true;
+   show_netlink_port       = true;
    show_mouse_options      = true;
    show_rotary_options     = true;
    mouse_scale_q8          = 256;

--- a/libretro.c
+++ b/libretro.c
@@ -221,6 +221,19 @@ static bool show_texture_replace   = true;
  * reads them. */
 static bool show_netlink_host      = true;
 static bool show_netlink_port      = true;
+/* One-shot "push every managed key regardless of its cached show_* prev"
+ * flag (task 4, #467).  update_option_visibility() normally only
+ * re-pushes SET_CORE_OPTIONS_DISPLAY for a group when that group's
+ * show_* flag CHANGES since the cached previous value -- cheap, but
+ * wrong immediately after a SET_CORE_OPTIONS_V2 rebuild, which resets
+ * every option to visible on the frontend side while every show_* prev
+ * in this file still matches current state, so nothing would normally
+ * re-push and rows that were hidden (CD-only keys, mouse/rotary/analog
+ * tuning, texdump/texreplace, per-port remaps) reappear and stay
+ * reappeared.  Set this, then call update_option_visibility(); it reads
+ * and clears the flag on entry, so the force applies to exactly the next
+ * call. */
+static int  visibility_force_push  = 0;
 static bool enable_alt_inputs = false;
 static uint8_t *joypad_buttons[2] = { joypad0Buttons, joypad1Buttons };
 
@@ -607,16 +620,24 @@ static bool update_option_visibility(void)
    struct retro_variable var;
    bool updated = false;
    unsigned i;
-
+   /* Read-and-clear: see visibility_force_push's declaration comment.
+    * One-shot so a normal (non-rebuild) call right afterward goes back to
+    * the cheap change-only behavior.  Declared here (with the other
+    * top-of-block locals, C89) rather than assigned as a statement, so the
+    * clear below is the first STATEMENT in the function, after every
+    * declaration. */
+   int force = visibility_force_push;
    // Show/hide input options
    bool show_input_options_prev = show_input_options;
+
+   visibility_force_push = 0;
    show_input_options = true;
 
    var.key = "virtualjaguar_alt_inputs";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && !strcmp(var.value, "disabled"))
       show_input_options = false;
 
-   if (show_input_options != show_input_options_prev)
+   if (force || show_input_options != show_input_options_prev)
    {
       option_display.visible = show_input_options;
 
@@ -661,7 +682,7 @@ static bool update_option_visibility(void)
        * showing it there would advertise a control that does nothing. */
       show_cart_bios_option = (!content_loaded || !jaguar_cd_mode);
 
-      if (show_cd_options != show_cd_prev)
+      if (force || show_cd_options != show_cd_prev)
       {
          option_display.visible = show_cd_options;
          for (i = 0; i < ARRAY_SIZE(cd_only_keys); i++)
@@ -673,7 +694,7 @@ static bool update_option_visibility(void)
          updated = true;
       }
 
-      if (show_cart_bios_option != show_cart_bios_prev)
+      if (force || show_cart_bios_option != show_cart_bios_prev)
       {
          option_display.visible = show_cart_bios_option;
          option_display.key     = "virtualjaguar_bios";
@@ -704,7 +725,7 @@ static bool update_option_visibility(void)
 
       show_mouse_options = inputdev_is_mouse_type(InputDevGetType(1));
 
-      if (show_mouse_options != show_mouse_prev)
+      if (force || show_mouse_options != show_mouse_prev)
       {
          option_display.visible = show_mouse_options;
          for (i = 0; i < ARRAY_SIZE(mouse_keys); i++)
@@ -733,7 +754,7 @@ static bool update_option_visibility(void)
       show_rotary_options = (InputDevGetType(0) == INPUTDEV_ROTARY
                              || InputDevGetType(1) == INPUTDEV_ROTARY);
 
-      if (show_rotary_options != show_rotary_prev)
+      if (force || show_rotary_options != show_rotary_prev)
       {
          option_display.visible = show_rotary_options;
          for (i = 0; i < ARRAY_SIZE(rotary_keys); i++)
@@ -762,7 +783,7 @@ static bool update_option_visibility(void)
       show_analog_options = (inputdev_is_analog_type(InputDevGetType(0))
                              || inputdev_is_analog_type(InputDevGetType(1)));
 
-      if (show_analog_options != show_analog_prev)
+      if (force || show_analog_options != show_analog_prev)
       {
          option_display.visible = show_analog_options;
          for (i = 0; i < ARRAY_SIZE(analog_keys); i++)
@@ -787,7 +808,7 @@ static bool update_option_visibility(void)
           && !strcmp(var.value, "enabled"))
          show_texdump_16bpp = true;
 
-      if (show_texdump_16bpp != show_texdump_prev)
+      if (force || show_texdump_16bpp != show_texdump_prev)
       {
          option_display.visible = show_texdump_16bpp;
          option_display.key     = "virtualjaguar_texdump_16bpp";
@@ -804,7 +825,7 @@ static bool update_option_visibility(void)
       bool show_replace_prev = show_texture_replace;
 
       show_texture_replace = TexReplacePackAvailable() ? true : false;
-      if (show_texture_replace != show_replace_prev)
+      if (force || show_texture_replace != show_replace_prev)
       {
          option_display.visible = show_texture_replace;
          option_display.key     = "virtualjaguar_texture_replace";
@@ -837,7 +858,7 @@ static bool update_option_visibility(void)
       show_netlink_port = (resolved == JLINK_MODE_TCP_CLIENT
                             || resolved == JLINK_MODE_TCP_SERVER);
 
-      if (show_netlink_host != show_netlink_host_prev)
+      if (force || show_netlink_host != show_netlink_host_prev)
       {
          option_display.visible = show_netlink_host;
          option_display.key     = "virtualjaguar_netlink_host";
@@ -845,7 +866,7 @@ static bool update_option_visibility(void)
                     &option_display);
          updated = true;
       }
-      if (show_netlink_port != show_netlink_port_prev)
+      if (force || show_netlink_port != show_netlink_port_prev)
       {
          option_display.visible = show_netlink_port;
          option_display.key     = "virtualjaguar_netlink_port";
@@ -1259,23 +1280,22 @@ static void netlink_rebuild_host_options(void)
 
    /* SET_CORE_OPTIONS_V2 rebuilds RetroArch's whole core_option_manager
     * from these definitions, which carry no visibility field -- every
-    * option comes back visible.  update_option_visibility() caches
-    * show_netlink_host/show_netlink_port and only re-pushes
-    * SET_CORE_OPTIONS_DISPLAY when a value CHANGES, so without this it
-    * would keep believing a row it hid earlier is still hidden and never
-    * re-hide it.  Re-assert both current flags directly (not by calling
-    * update_option_visibility(), which would no-op against its own
-    * cached prevs) so a host row hidden in tcp_server mode -- discovery
-    * runs there too -- doesn't reappear the moment a peer is found. */
-   {
-      struct retro_core_option_display od;
-      od.key     = "virtualjaguar_netlink_host";
-      od.visible = show_netlink_host;
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &od);
-      od.key     = "virtualjaguar_netlink_port";
-      od.visible = show_netlink_port;
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &od);
-   }
+    * option comes back visible, not just virtualjaguar_netlink_host/port:
+    * every group update_option_visibility() manages (CD-only keys,
+    * cart-BIOS keys, per-port input remaps, mouse/rotary/analog tuning,
+    * texdump/texture-replace) comes back too, and that function normally
+    * only re-pushes SET_CORE_OPTIONS_DISPLAY for a group whose show_*
+    * flag CHANGED since last call -- after this rebuild none of them did,
+    * so nothing would re-push and every hidden row (e.g. mouse/rotary/
+    * analog tuning on an ordinary RetroPad session, or the host row
+    * itself in tcp_server mode, where discovery also runs) would reappear
+    * and stay reappeared for the rest of the session.  Force a full
+    * re-push of every managed key from current state -- see
+    * visibility_force_push's declaration comment -- rather than
+    * special-casing just the two keys this feature owns, so there is
+    * still exactly one place that knows which rows are hidden when. */
+   visibility_force_push = 1;
+   update_option_visibility();
 
    LOG_INF("[NETLINK] host picker rebuilt: %d discovered peer%s\n",
            peer_count, peer_count == 1 ? "" : "s");
@@ -3983,6 +4003,13 @@ void retro_deinit(void)
     * for a fresh session where discovery may not even be running yet. */
    netlink_last_rebuild_ms = 0;
    netlink_peers_dirty     = 0;
+   /* One-shot force-push latch (see its declaration comment): a rebuild
+    * mid-session could leave it set to 1 if retro_deinit() ran between
+    * the flag being set and update_option_visibility() consuming it --
+    * not reachable today (netlink_rebuild_host_options() sets and
+    * consumes it back-to-back with no yield in between), but resetting
+    * it costs nothing and matches every other static in this function. */
+   visibility_force_push  = 0;
    if (netlink_host_presets_valid)
    {
       int host_idx = netlink_host_option_index();

--- a/libretro.c
+++ b/libretro.c
@@ -941,6 +941,19 @@ void retro_set_environment(retro_environment_t cb)
  * one and swallow the first UP/DOWN edge. */
 static int netlink_was_up = -1;
 
+/* Discovered-host option list (task 4, #467).  netlink_last_rebuild_ms
+ * paces SET_CORE_OPTIONS_V2 re-registration (a full RetroArch option-
+ * manager teardown, see netlink_rebuild_host_options() below);
+ * netlink_peers_dirty is a sticky latch set the instant a peer-set change
+ * is observed and cleared only once a rebuild actually runs -- see the
+ * gating block in retro_run() for why a bare rate-limit check isn't
+ * enough.  Both are file scope (not function-local) for the same reason
+ * as netlink_was_up: iOS never dlcloses the core, so a function-local
+ * static would carry the previous session's pacing/latch state into the
+ * next one. */
+static uint32_t netlink_last_rebuild_ms = 0;
+static int      netlink_peers_dirty     = 0;
+
 /* Names for the [NETLINK] log lines.  Not exported: nothing outside this
  * file needs to render a mode. */
 static const char *netlink_mode_name(int mode)
@@ -1125,6 +1138,147 @@ static void netlink_apply(int mode, const char *opt_value)
       else
          JLinkDiscStop();
    }
+}
+
+/* Discovered-host option list (task 4, #467): the LAN discovery beacon
+ * (jlink_discover.c) finds peers, but libretro core options are a fixed
+ * enumeration on every platform -- no core can offer a free-text field --
+ * so a peer is useless until it becomes a selectable
+ * virtualjaguar_netlink_host value.  Everything below wires that up.
+ *
+ * retro_core_option_v2_definition::values[] is a fixed-size array INLINE
+ * in the struct (libretro.h), not a pointer, so option_defs_us (compiled
+ * into libretro_core_options.h, already static storage duration) can be
+ * mutated in place -- no separate "static so it outlives the call" array
+ * is needed for the value list itself.  The value/label *strings* still
+ * need their own static storage: netlink_peer_value/label below, since
+ * they are built fresh from JLinkPeer data the frontend does not own. */
+static char netlink_peer_value[JLINK_DISC_MAX_PEERS][JLINK_DISC_ADDR_MAX];
+static char netlink_peer_label[JLINK_DISC_MAX_PEERS][128];
+
+/* The three presets from libretro_core_options.h (127.0.0.1, jaghub.local,
+ * vj_netlink.txt), snapshotted once from the pristine array before the
+ * first peer splice.  Every rebuild below reads this copy rather than the
+ * live option_defs_us array, which this same function overwrites -- so a
+ * second rebuild can never mistake an already-spliced peer entry for a
+ * preset. */
+static struct retro_core_option_value netlink_host_presets[3];
+static int netlink_host_presets_valid = 0;
+
+/* Index of virtualjaguar_netlink_host in option_defs_us, found by key
+ * rather than hard-coded so a reorder of the option table can't silently
+ * corrupt the wrong option's value list.  Shared by the rebuild and the
+ * retro_deinit() restore. */
+static int netlink_host_option_index(void)
+{
+   int i;
+
+   for (i = 0; option_defs_us[i].key; i++)
+      if (!strcmp(option_defs_us[i].key, "virtualjaguar_netlink_host"))
+         return i;
+   return -1;
+}
+
+/* Rebuild virtualjaguar_netlink_host's value list from the current LAN
+ * discovery peer table and push it to the frontend with a second
+ * SET_CORE_OPTIONS_V2.  That is a legal call -- RetroArch's
+ * core_option_manager tears down and rebuilds on it (runloop.c),
+ * flushing current values to disk first -- but it IS a full teardown, so
+ * callers must only invoke this when the peer set actually changed (see
+ * the gated call site in retro_run()), never on a timer or per beacon.
+ *
+ * Values: 127.0.0.1, then one entry per peer labelled "<name> - <addr>"
+ * (with " (JagLink)" / " (Voice Modem)" appended when the peer's device
+ * differs from ours, so a mismatch is visible instead of silently
+ * failing), then jaghub.local and vj_netlink.txt -- the existing presets
+ * stay selectable, peers are added, not substituted. Capped at
+ * JLINK_DISC_MAX_PEERS entries. */
+static void netlink_rebuild_host_options(void)
+{
+   int idx, i, n, peer_count, my_device;
+
+   idx = netlink_host_option_index();
+   if (idx < 0)
+      return;
+
+   if (!netlink_host_presets_valid)
+   {
+      for (i = 0; i < 3 && option_defs_us[idx].values[i].value; i++)
+         netlink_host_presets[i] = option_defs_us[idx].values[i];
+      netlink_host_presets_valid = 1;
+   }
+
+   n = 0;
+   option_defs_us[idx].values[n++] = netlink_host_presets[0]; /* 127.0.0.1 */
+
+   my_device = (JLinkDevice() == JLINK_DEVICE_VOICEMODEM)
+               ? JLINK_DISC_DEV_VOICEMODEM : JLINK_DISC_DEV_JAGLINK;
+
+   peer_count = JLinkDiscPeerCount();
+   if (peer_count > JLINK_DISC_MAX_PEERS)
+      peer_count = JLINK_DISC_MAX_PEERS;
+
+   for (i = 0; i < peer_count; i++)
+   {
+      const JLinkPeer *peer;
+      const char *devtag;
+      const char *name;
+
+      peer = JLinkDiscPeerAt(i);
+      if (!peer)
+         break;
+
+      /* Beacon-supplied name is untrusted and may be empty; fall back to
+       * the address so the label is never just " - 1.2.3.4". */
+      name = peer->name[0] ? peer->name : peer->addr;
+
+      devtag = "";
+      if (peer->device != my_device)
+         devtag = (peer->device == JLINK_DISC_DEV_VOICEMODEM)
+                  ? " (Voice Modem)" : " (JagLink)";
+
+      strncpy(netlink_peer_value[i], peer->addr,
+              sizeof(netlink_peer_value[i]) - 1);
+      netlink_peer_value[i][sizeof(netlink_peer_value[i]) - 1] = '\0';
+
+      snprintf(netlink_peer_label[i], sizeof(netlink_peer_label[i]),
+               "%s - %s%s", name, peer->addr, devtag);
+
+      option_defs_us[idx].values[n].value = netlink_peer_value[i];
+      option_defs_us[idx].values[n].label = netlink_peer_label[i];
+      n++;
+   }
+
+   option_defs_us[idx].values[n++] = netlink_host_presets[1]; /* jaghub.local */
+   option_defs_us[idx].values[n++] = netlink_host_presets[2]; /* vj_netlink.txt */
+
+   option_defs_us[idx].values[n].value = NULL;
+   option_defs_us[idx].values[n].label = NULL;
+
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2, &options_us);
+
+   /* SET_CORE_OPTIONS_V2 rebuilds RetroArch's whole core_option_manager
+    * from these definitions, which carry no visibility field -- every
+    * option comes back visible.  update_option_visibility() caches
+    * show_netlink_host/show_netlink_port and only re-pushes
+    * SET_CORE_OPTIONS_DISPLAY when a value CHANGES, so without this it
+    * would keep believing a row it hid earlier is still hidden and never
+    * re-hide it.  Re-assert both current flags directly (not by calling
+    * update_option_visibility(), which would no-op against its own
+    * cached prevs) so a host row hidden in tcp_server mode -- discovery
+    * runs there too -- doesn't reappear the moment a peer is found. */
+   {
+      struct retro_core_option_display od;
+      od.key     = "virtualjaguar_netlink_host";
+      od.visible = show_netlink_host;
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &od);
+      od.key     = "virtualjaguar_netlink_port";
+      od.visible = show_netlink_port;
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &od);
+   }
+
+   LOG_INF("[NETLINK] host picker rebuilt: %d discovered peer%s\n",
+           peer_count, peer_count == 1 ? "" : "s");
 }
 
 /* Gate for per-title enhancement defaults (issue #368). Read raw (never
@@ -3821,6 +3975,26 @@ void retro_deinit(void)
     * rest of this function. */
    JLinkDiscStop();
    JLinkDiscPeersReset();
+   /* Host option value list (task 4, #467): JLinkDiscPeersReset() above
+    * clears the runtime peer table, but option_defs_us's live value list
+    * is a separate copy this session may have spliced peers into.
+    * Without restoring it, a resident core (iOS never dlcloses) would
+    * have retro_set_environment() republish last session's stale peers
+    * for a fresh session where discovery may not even be running yet. */
+   netlink_last_rebuild_ms = 0;
+   netlink_peers_dirty     = 0;
+   if (netlink_host_presets_valid)
+   {
+      int host_idx = netlink_host_option_index();
+      if (host_idx >= 0)
+      {
+         option_defs_us[host_idx].values[0] = netlink_host_presets[0];
+         option_defs_us[host_idx].values[1] = netlink_host_presets[1];
+         option_defs_us[host_idx].values[2] = netlink_host_presets[2];
+         option_defs_us[host_idx].values[3].value = NULL;
+         option_defs_us[host_idx].values[3].label = NULL;
+      }
+   }
    show_netlink_host       = true;
    show_netlink_port       = true;
    show_mouse_options      = true;
@@ -4045,6 +4219,37 @@ void retro_run(void)
             LOG_INF("[NETLINK] %s open, waiting for peer...\n",
                     netlink_mode_name(JLinkMode()));
          netlink_was_up = up;
+      }
+   }
+
+   /* Rebuild the host picker only when the peer set actually changed --
+    * never on a timer.  A second SET_CORE_OPTIONS_V2 tears down and
+    * rebuilds RetroArch's whole option manager (runloop.c), so doing it
+    * per beacon would thrash the menu under the user's thumb.
+    *
+    * JLinkDiscConsumeChanged() both reads AND CLEARS the flag.  A bare
+    * "flag && rate_limit_ok" (as sketched in the task brief) drops any
+    * change that lands inside the 2s cooldown -- the flag is gone, and
+    * the peer that triggered it is never rebuilt in; the next flag to
+    * fire is likely that same peer's 10s expiry, which publishes a list
+    * that never showed it at all.  The sticky latch below fixes that:
+    * any change latches netlink_peers_dirty, and only the rate limit
+    * gates the rebuild itself, so a change is delayed by at most 2s,
+    * never lost.  JLinkDiscStart() (jlink_discover.c) is already
+    * idempotent on repeated netlink_apply() calls with unchanged
+    * parameters, so this rebuild's own SET_CORE_OPTIONS_V2 -- even if it
+    * causes the frontend to re-signal a variables update -- cannot wipe
+    * the peer table out from under itself. */
+   {
+      uint32_t disc_now = JLinkNowMs();
+      if (JLinkDiscConsumeChanged())
+         netlink_peers_dirty = 1;
+      if (netlink_peers_dirty
+          && (uint32_t)(disc_now - netlink_last_rebuild_ms) >= 2000)
+      {
+         netlink_rebuild_host_options();
+         netlink_last_rebuild_ms = disc_now;
+         netlink_peers_dirty     = 0;
       }
    }
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -305,19 +305,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "virtualjaguar_netlink",
-      "Network Link (JagLink / CatBox)",
+      "Network Link",
       NULL,
-      "Emulates JERRY's serial link port used by networked games (BattleSphere, AirCars, Doom deathmatch). 'Loopback' echoes transmitted bytes back to this console, for testing link-detect menus without a partner. TCP Host listens for a second emulator instance; TCP Client connects to the address in 'Network Link Host'. Localhost/LAN latency recommended.",
+      "How this console's serial port reaches another player. 'Automatic' uses your frontend's netplay session when one is running -- nothing to configure, no addresses to type -- and otherwise stays idle. 'TCP Host'/'TCP Client' link two emulators directly without netplay; the client picks a host below, and hosts on your LAN are found automatically. 'Loopback' echoes back to this console for testing link-detect menus with no partner.",
       NULL,
       "network",
       {
-         { "disabled",   NULL },
+         { "auto",       "Automatic (use netplay when available)" },
+         { "disabled",   "Off" },
          { "loopback",   "Loopback (echo to self)" },
          { "tcp_server", "TCP Host (listen)" },
          { "tcp_client", "TCP Client (connect)" },
          { NULL, NULL },
       },
-      "disabled"
+      "auto"
    },
    {
       "virtualjaguar_uart_device",

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -338,7 +338,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_netlink_host",
       "Network Link Host (TCP Client)",
       NULL,
-      "Address the TCP client connects to -- an IP, a DNS name, or a Bonjour/mDNS name. Easiest LAN setup with no typing at all: name the host machine 'jaghub' (its local hostname), then pick the 'jaghub.local' preset here on each client. Frontends with free-text option entry accept any address directly; in stock RetroArch the alternative is 'From file' with the address on the first line of vj_netlink.txt in the system directory. The VJ_NETLINK_HOST environment variable overrides this option. If you would rather not configure anything, use RetroArch's own netplay instead -- it finds hosts on the LAN by itself and carries the link with this option left disabled.",
+      "Which host to connect to. Hosts running on your LAN appear here automatically within a couple of seconds. 'From file' reads <system>/vj_netlink.txt: one line, the address only, no port -- for example '192.168.1.42' or 'myhost.local'. The port comes from 'Network Link Port'. The VJ_NETLINK_HOST environment variable overrides this option.",
       NULL,
       "network",
       {

--- a/src/jerry/jlink.c
+++ b/src/jerry/jlink.c
@@ -10,6 +10,7 @@
 #include "jlink.h"
 #include "jlink_tcp.h"
 #include "jlink_netpacket.h"
+#include "jlink_discover.h"
 #include "voicemodem.h"
 #include "state.h"
 
@@ -56,6 +57,21 @@ static void JLinkSleepUsec(int usec)
 }
 #endif
 
+/* Wall-clock milliseconds for the discovery beacon/expiry cadence
+   (JLinkDiscPoll).  Placed after both JLinkNowUsec definitions above --
+   it is defined once, not per platform branch -- and just downconverts
+   whichever one this platform compiled. */
+uint32_t JLinkNowMs(void)
+{
+#ifdef JLINK_HAVE_WAIT
+   return (uint32_t)(JLinkNowUsec() / 1000LL);
+#else
+   /* No wait helper on this platform means no sockets either, so
+      discovery is inert here and a frozen clock is harmless. */
+   return 0;
+#endif
+}
+
 static int jlinkMode = JLINK_MODE_DISABLED;
 static int jlinkDevice = JLINK_DEVICE_JAGLINK;
 static uint8_t jlinkRing[JLINK_RING_SIZE];
@@ -67,6 +83,11 @@ static int jlinkTCPPort = 42171;
 
 static uint32_t jlinkTxTotal = 0;
 static uint32_t jlinkRxTotal = 0;
+
+/* Set by JLinkFrameTick when JLinkDiscPoll reports the peer set changed;
+   consumed (read + cleared) by JLinkDiscConsumeChanged so a UI layer can
+   poll cheaply without re-deriving the diff itself. */
+static int jlinkDiscChanged = 0;
 
 /* Reply wait: after a TX burst goes out over a real transport, the games
    spin on ASISTAT for the partner's answer.  The spin burns its emulated
@@ -314,6 +335,17 @@ uint32_t JLinkRxTotal(void)
    return jlinkRxTotal;
 }
 
+/* Returns whether the discovery peer set has changed since the last
+   call, clearing the flag.  Set by JLinkFrameTick's JLinkDiscPoll call;
+   a UI layer polls this once per frame to know when to re-read the peer
+   list, instead of diffing it itself. */
+int JLinkDiscConsumeChanged(void)
+{
+   int changed = jlinkDiscChanged;
+   jlinkDiscChanged = 0;
+   return changed;
+}
+
 void JLinkPoll(void)
 {
    if (jlinkMode == JLINK_MODE_NETPACKET)
@@ -343,10 +375,23 @@ void JLinkSetWaitEnabled(int enabled)
 }
 
 /* Called once per video frame from retro_run: refill the wait budget
-   from the measured reply latency. */
+   from the measured reply latency, and service LAN discovery.
+
+   Discovery is driven from here rather than JLinkPoll(): JLinkPoll() is
+   also reached via JLinkPump(), which games call thousands of times per
+   frame while spinning on a reply (see JLinkAwaitReply's comment on the
+   fast-path bail needing to stay cheap) -- a recvfrom() drain loop on
+   every one of those calls would be wasteful and, unlike TCP polling,
+   has no gate on jlinkMode to keep it rare.  JLinkFrameTick has no mode
+   gate either, so discovery still runs while the link itself is
+   JLINK_MODE_DISABLED (exactly the state it exists to help escape), but
+   it runs at guaranteed once-per-video-frame cadence, which matches the
+   1 Hz beacon and 10 s peer expiry this module works on. */
 void JLinkFrameTick(void)
 {
    long long budget;
+   if (JLinkDiscActive())
+      jlinkDiscChanged |= JLinkDiscPoll(JLinkNowMs());
    if (jlinkDevice == JLINK_DEVICE_VOICEMODEM)
       VMFrameTick();
    if (!jlinkWaitEnabled)

--- a/src/jerry/jlink.h
+++ b/src/jerry/jlink.h
@@ -73,6 +73,13 @@ void JLinkPump(void);
 uint32_t JLinkTxTotal(void);
 uint32_t JLinkRxTotal(void);
 
+/* Wall-clock milliseconds, used to drive jlink_discover.c's beacon
+   cadence and peer expiry from JLinkFrameTick. */
+uint32_t JLinkNowMs(void);
+/* Has the LAN discovery peer set changed since the last call?  Reads
+   and clears the flag set by JLinkFrameTick's discovery poll. */
+int JLinkDiscConsumeChanged(void);
+
 size_t JLinkStateSave(uint8_t *buf);
 size_t JLinkStateLoad(const uint8_t *buf);
 

--- a/src/jerry/jlink_discover.c
+++ b/src/jerry/jlink_discover.c
@@ -174,6 +174,16 @@ int JLinkDiscStart(int listen_only, int device, int link_port)
    struct sockaddr_in sa;
    int one = 1;
 
+   /* Idempotent when nothing changed.  libretro.c re-applies the netlink
+      option (and this call along with it) on EVERY frontend
+      variable-update flag, not just when netlink's own key changed --
+      that flag is a single dirty bit shared by all options.  Without this
+      guard, tweaking an unrelated option would silently wipe the
+      discovered peer table a host picker reads from. */
+   if (discSock >= 0 && discListenOnly == listen_only
+       && discDevice == device && discLinkPort == link_port)
+      return 1;
+
    JLinkDiscStop();
    JLinkDiscPeersReset();
 

--- a/src/jerry/jlink_discover.c
+++ b/src/jerry/jlink_discover.c
@@ -138,3 +138,176 @@ const JLinkPeer *JLinkDiscPeerAt(int i)
       return NULL;
    return &discPeers[i];
 }
+
+/* Guard mirrors jlink_tcp.c verbatim: discovery has exactly the same
+   platform surface as the TCP transport, and divergent guards are how one
+   builds and the other does not. */
+#if defined(_WIN32) || defined(__unix__) || defined(__APPLE__) || \
+    defined(__linux__) || defined(__ANDROID__)
+#define JLINK_DISC_HAVE_NET 1
+#endif
+
+#ifdef JLINK_DISC_HAVE_NET
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#endif
+
+static int      discSock       = -1;
+static int      discListenOnly = 1;
+static int      discDevice     = 0;
+static int      discLinkPort   = 0;
+static uint32_t discLastBeacon = 0;
+static char     discSelfName[JLINK_DISC_NAME_MAX];
+
+int JLinkDiscStart(int listen_only, int device, int link_port)
+{
+   struct sockaddr_in sa;
+   int one = 1;
+
+   JLinkDiscStop();
+   JLinkDiscPeersReset();
+
+   discSock = (int)socket(AF_INET, SOCK_DGRAM, 0);
+   if (discSock < 0)
+      return 0;
+
+   /* Two cores on ONE machine is the normal dev/test layout (see
+      netlink_pair_test.sh, uv_modem_game_test.sh).  Without these the
+      second instance cannot bind and discovery silently does nothing on
+      exactly the setup used to test it. */
+   setsockopt(discSock, SOL_SOCKET, SO_REUSEADDR,
+              (const char *)&one, sizeof(one));
+#ifdef SO_REUSEPORT
+   setsockopt(discSock, SOL_SOCKET, SO_REUSEPORT,
+              (const char *)&one, sizeof(one));
+#endif
+   setsockopt(discSock, SOL_SOCKET, SO_BROADCAST,
+              (const char *)&one, sizeof(one));
+
+   memset(&sa, 0, sizeof(sa));
+   sa.sin_family      = AF_INET;
+   sa.sin_addr.s_addr = htonl(INADDR_ANY);
+   sa.sin_port        = htons((unsigned short)JLINK_DISC_PORT);
+   if (bind(discSock, (struct sockaddr *)&sa, sizeof(sa)) != 0)
+   {
+      JLinkDiscStop();
+      return 0;
+   }
+
+#ifdef _WIN32
+   { u_long nb = 1; ioctlsocket(discSock, FIONBIO, &nb); }
+#else
+   fcntl(discSock, F_SETFL, fcntl(discSock, F_GETFL, 0) | O_NONBLOCK);
+#endif
+
+   discListenOnly = listen_only;
+   discDevice     = device;
+   discLinkPort   = link_port;
+   discLastBeacon = 0;
+
+   discSelfName[0] = '\0';
+#ifdef _WIN32
+   { DWORD n = JLINK_DISC_NAME_MAX - 1; GetComputerNameA(discSelfName, &n); }
+#else
+   if (gethostname(discSelfName, JLINK_DISC_NAME_MAX - 1) != 0)
+      discSelfName[0] = '\0';
+   discSelfName[JLINK_DISC_NAME_MAX - 1] = '\0';
+#endif
+   if (!discSelfName[0])
+      strcpy(discSelfName, "jaguar");
+   return 1;
+}
+
+void JLinkDiscStop(void)
+{
+   if (discSock >= 0)
+   {
+#ifdef _WIN32
+      closesocket(discSock);
+#else
+      close(discSock);
+#endif
+   }
+   discSock = -1;
+}
+
+int JLinkDiscActive(void)
+{
+   return discSock >= 0;
+}
+
+int JLinkDiscPoll(uint32_t now_ms)
+{
+   uint8_t  pkt[JLINK_DISC_PKT_LEN];
+   struct sockaddr_in from;
+   char     addr[JLINK_DISC_ADDR_MAX];
+   char     name[JLINK_DISC_NAME_MAX];
+   int      dev, port, changed = 0;
+   socklen_t flen;
+   int      n;
+
+   if (discSock < 0)
+      return 0;
+
+   if (!discListenOnly
+       && (discLastBeacon == 0 || (uint32_t)(now_ms - discLastBeacon) >= 1000))
+   {
+      struct sockaddr_in to;
+      uint8_t out[JLINK_DISC_PKT_LEN];
+      memset(&to, 0, sizeof(to));
+      to.sin_family      = AF_INET;
+      to.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+      to.sin_port        = htons((unsigned short)JLINK_DISC_PORT);
+      if (JLinkDiscEncode(out, sizeof(out), discDevice, discLinkPort,
+                          discSelfName))
+         sendto(discSock, (const char *)out, JLINK_DISC_PKT_LEN, 0,
+                (struct sockaddr *)&to, sizeof(to));
+      discLastBeacon = now_ms;
+   }
+
+   for (;;)
+   {
+      flen = sizeof(from);
+      memset(&from, 0, sizeof(from));
+      n = (int)recvfrom(discSock, (char *)pkt, sizeof(pkt), 0,
+                        (struct sockaddr *)&from, &flen);
+      if (n <= 0)
+         break;
+      if (!JLinkDiscDecode(pkt, (size_t)n, &dev, &port, name, sizeof(name)))
+         continue;
+      /* Ignore our own beacon.  Matched on name+port, not source IP:
+         the same machine appears under different addresses depending on
+         which interface the broadcast came back through. */
+      if (!discListenOnly && port == discLinkPort
+          && strcmp(name, discSelfName) == 0)
+         continue;
+      addr[0] = '\0';
+      strncpy(addr, inet_ntoa(from.sin_addr), JLINK_DISC_ADDR_MAX - 1);
+      addr[JLINK_DISC_ADDR_MAX - 1] = '\0';
+      if (JLinkDiscPeerSeen(addr, name, dev, port, now_ms))
+         changed = 1;
+   }
+
+   if (JLinkDiscPeerExpire(now_ms))
+      changed = 1;
+   return changed;
+}
+
+#else  /* no networking */
+
+int  JLinkDiscStart(int a, int b, int c) { (void)a; (void)b; (void)c; return 0; }
+void JLinkDiscStop(void) {}
+int  JLinkDiscPoll(uint32_t t) { (void)t; return 0; }
+int  JLinkDiscActive(void) { return 0; }
+
+#endif

--- a/src/jerry/jlink_discover.c
+++ b/src/jerry/jlink_discover.c
@@ -1,0 +1,140 @@
+/* jlink_discover.c -- LAN discovery beacon.  See jlink_discover.h. */
+#include "jlink_discover.h"
+#include <string.h>
+#include <stdio.h>
+
+static JLinkPeer discPeers[JLINK_DISC_MAX_PEERS];
+static int       discPeerCount = 0;
+
+size_t JLinkDiscEncode(uint8_t *buf, size_t cap, int device, int port,
+                       const char *name)
+{
+   size_t n;
+
+   if (!buf || cap < JLINK_DISC_PKT_LEN)
+      return 0;
+
+   memset(buf, 0, JLINK_DISC_PKT_LEN);
+   buf[0] = 'V'; buf[1] = 'J'; buf[2] = 'A'; buf[3] = 'G';
+   buf[4] = (uint8_t)JLINK_DISC_VERSION;
+   buf[5] = (uint8_t)(device ? JLINK_DISC_DEV_VOICEMODEM
+                             : JLINK_DISC_DEV_JAGLINK);
+   buf[6] = (uint8_t)((port >> 8) & 0xFF);
+   buf[7] = (uint8_t)(port & 0xFF);
+
+   if (name)
+   {
+      n = strlen(name);
+      if (n > JLINK_DISC_NAME_MAX - 1)
+         n = JLINK_DISC_NAME_MAX - 1;
+      memcpy(buf + 8, name, n);
+   }
+   return JLINK_DISC_PKT_LEN;
+}
+
+int JLinkDiscDecode(const uint8_t *buf, size_t len, int *device,
+                    int *port, char *name, size_t name_cap)
+{
+   size_t copy;
+
+   if (!buf || len < JLINK_DISC_PKT_LEN)
+      return 0;
+   if (buf[0] != 'V' || buf[1] != 'J' || buf[2] != 'A' || buf[3] != 'G')
+      return 0;
+   if (buf[4] != JLINK_DISC_VERSION)
+      return 0;
+
+   if (device)
+      *device = (buf[5] == JLINK_DISC_DEV_VOICEMODEM)
+                ? JLINK_DISC_DEV_VOICEMODEM : JLINK_DISC_DEV_JAGLINK;
+   if (port)
+      *port = ((int)buf[6] << 8) | (int)buf[7];
+
+   if (name && name_cap > 0)
+   {
+      /* The sender NUL-pads, but a hostile or corrupt packet need not:
+         copy a bounded span and terminate ourselves, never strncpy from
+         a field that may have no NUL in it. */
+      copy = name_cap - 1;
+      if (copy > JLINK_DISC_NAME_MAX - 1)
+         copy = JLINK_DISC_NAME_MAX - 1;
+      memcpy(name, buf + 8, copy);
+      name[copy] = '\0';
+   }
+   return 1;
+}
+
+void JLinkDiscPeersReset(void)
+{
+   memset(discPeers, 0, sizeof(discPeers));
+   discPeerCount = 0;
+}
+
+int JLinkDiscPeerSeen(const char *addr, const char *name, int device,
+                      int port, uint32_t now_ms)
+{
+   int i;
+
+   if (!addr || !addr[0])
+      return 0;
+
+   for (i = 0; i < discPeerCount; i++)
+   {
+      if (strcmp(discPeers[i].addr, addr) == 0
+          && discPeers[i].port == port)
+      {
+         discPeers[i].last_seen_ms = now_ms;
+         discPeers[i].device       = device;
+         return 0;   /* known peer refreshed -- option list unchanged */
+      }
+   }
+
+   if (discPeerCount >= JLINK_DISC_MAX_PEERS)
+      return 0;
+
+   memset(&discPeers[discPeerCount], 0, sizeof(JLinkPeer));
+   strncpy(discPeers[discPeerCount].addr, addr, JLINK_DISC_ADDR_MAX - 1);
+   if (name)
+      strncpy(discPeers[discPeerCount].name, name, JLINK_DISC_NAME_MAX - 1);
+   discPeers[discPeerCount].device       = device;
+   discPeers[discPeerCount].port         = port;
+   discPeers[discPeerCount].last_seen_ms = now_ms;
+   discPeerCount++;
+   return 1;
+}
+
+int JLinkDiscPeerExpire(uint32_t now_ms)
+{
+   int i = 0, changed = 0;
+
+   while (i < discPeerCount)
+   {
+      /* Unsigned subtraction so a wrapped millisecond clock cannot make
+         a fresh peer look ancient. */
+      if ((uint32_t)(now_ms - discPeers[i].last_seen_ms)
+          >= JLINK_DISC_EXPIRE_MS)
+      {
+         if (i < discPeerCount - 1)
+            memmove(&discPeers[i], &discPeers[i + 1],
+                    sizeof(JLinkPeer) * (size_t)(discPeerCount - i - 1));
+         discPeerCount--;
+         memset(&discPeers[discPeerCount], 0, sizeof(JLinkPeer));
+         changed = 1;
+         continue;
+      }
+      i++;
+   }
+   return changed;
+}
+
+int JLinkDiscPeerCount(void)
+{
+   return discPeerCount;
+}
+
+const JLinkPeer *JLinkDiscPeerAt(int i)
+{
+   if (i < 0 || i >= discPeerCount)
+      return NULL;
+   return &discPeers[i];
+}

--- a/src/jerry/jlink_discover.c
+++ b/src/jerry/jlink_discover.c
@@ -1,7 +1,6 @@
 /* jlink_discover.c -- LAN discovery beacon.  See jlink_discover.h. */
 #include "jlink_discover.h"
 #include <string.h>
-#include <stdio.h>
 
 static JLinkPeer discPeers[JLINK_DISC_MAX_PEERS];
 static int       discPeerCount = 0;
@@ -297,7 +296,13 @@ int JLinkDiscPoll(uint32_t now_ms)
          continue;
       /* Ignore our own beacon.  Matched on name+port, not source IP:
          the same machine appears under different addresses depending on
-         which interface the broadcast came back through. */
+         which interface the broadcast came back through.
+         Caveat: this is a false-positive risk, not just a false-negative
+         fix. Two distinct hosts on the LAN that happen to share a
+         hostname (common for cloned VM images or default hostnames like
+         "raspberrypi") AND the default link port will filter each
+         other's beacons out as "self", and neither will ever appear in
+         the other's peer table. */
       if (!discListenOnly && port == discLinkPort
           && strcmp(name, discSelfName) == 0)
          continue;

--- a/src/jerry/jlink_discover.h
+++ b/src/jerry/jlink_discover.h
@@ -43,4 +43,12 @@ int    JLinkDiscPeerExpire(uint32_t now_ms);
 int    JLinkDiscPeerCount(void);
 const JLinkPeer *JLinkDiscPeerAt(int i);
 
+/* Socket layer.  listen_only = 1 for client/auto (listen but never
+   beacon); 0 for a host (beacon AND listen, so a host still sees peers).
+   link_port is the TCP port advertised in the beacon. */
+int  JLinkDiscStart(int listen_only, int device, int link_port);
+void JLinkDiscStop(void);
+int  JLinkDiscPoll(uint32_t now_ms);
+int  JLinkDiscActive(void);
+
 #endif

--- a/src/jerry/jlink_discover.h
+++ b/src/jerry/jlink_discover.h
@@ -1,0 +1,46 @@
+/* jlink_discover.h -- LAN discovery beacon for the Jaguar network link.
+   Split in two halves on purpose: the codec + peer table below are pure
+   logic with no sockets, so every awkward case (truncated packet, wrong
+   magic, expiry, capacity) is unit-testable without a network.  The
+   socket layer lives in the same .c file behind JLINK_DISC_HAVE_NET. */
+#ifndef __JLINK_DISCOVER_H__
+#define __JLINK_DISCOVER_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Outside the virtualjaguar_netlink_port option range (42171-42174) so a
+   discovery socket can never collide with a link socket. */
+#define JLINK_DISC_PORT        42170
+#define JLINK_DISC_VERSION     1
+#define JLINK_DISC_PKT_LEN     40
+#define JLINK_DISC_NAME_MAX    32   /* 31 chars + NUL */
+#define JLINK_DISC_ADDR_MAX    46   /* INET6_ADDRSTRLEN */
+#define JLINK_DISC_MAX_PEERS   8
+#define JLINK_DISC_EXPIRE_MS   10000
+
+#define JLINK_DISC_DEV_JAGLINK    0
+#define JLINK_DISC_DEV_VOICEMODEM 1
+
+typedef struct
+{
+   char     name[JLINK_DISC_NAME_MAX];
+   char     addr[JLINK_DISC_ADDR_MAX];
+   int      device;
+   int      port;
+   uint32_t last_seen_ms;
+} JLinkPeer;
+
+size_t JLinkDiscEncode(uint8_t *buf, size_t cap, int device, int port,
+                       const char *name);
+int    JLinkDiscDecode(const uint8_t *buf, size_t len, int *device,
+                       int *port, char *name, size_t name_cap);
+
+void   JLinkDiscPeersReset(void);
+int    JLinkDiscPeerSeen(const char *addr, const char *name, int device,
+                         int port, uint32_t now_ms);
+int    JLinkDiscPeerExpire(uint32_t now_ms);
+int    JLinkDiscPeerCount(void);
+const JLinkPeer *JLinkDiscPeerAt(int i);
+
+#endif

--- a/test/test_jlink_discover.c
+++ b/test/test_jlink_discover.c
@@ -1,0 +1,124 @@
+#include <stdio.h>
+#include <string.h>
+#include "jlink_discover.h"
+
+static int failures = 0;
+
+static void check(int cond, const char *what)
+{
+   if (!cond) { printf("FAIL: %s\n", what); failures++; }
+   else        printf("  ok: %s\n", what);
+}
+
+static void test_roundtrip(void)
+{
+   uint8_t buf[64];
+   int dev = -1, port = -1;
+   char name[JLINK_DISC_NAME_MAX];
+   size_t n;
+
+   n = JLinkDiscEncode(buf, sizeof(buf), JLINK_DISC_DEV_VOICEMODEM,
+                       42171, "jaghub");
+   check(n == JLINK_DISC_PKT_LEN, "encode writes exactly 40 bytes");
+   check(JLinkDiscDecode(buf, n, &dev, &port, name, sizeof(name)) == 1,
+         "decode accepts its own packet");
+   check(dev == JLINK_DISC_DEV_VOICEMODEM, "device survives round-trip");
+   check(port == 42171, "port survives round-trip");
+   check(strcmp(name, "jaghub") == 0, "name survives round-trip");
+}
+
+static void test_rejects_bad(void)
+{
+   uint8_t buf[64];
+   int dev, port;
+   char name[JLINK_DISC_NAME_MAX];
+
+   JLinkDiscEncode(buf, sizeof(buf), JLINK_DISC_DEV_JAGLINK, 42171, "x");
+
+   check(JLinkDiscDecode(buf, JLINK_DISC_PKT_LEN - 1, &dev, &port,
+                         name, sizeof(name)) == 0,
+         "truncated packet rejected");
+   buf[0] = 'X';
+   check(JLinkDiscDecode(buf, JLINK_DISC_PKT_LEN, &dev, &port,
+                         name, sizeof(name)) == 0,
+         "wrong magic rejected");
+   buf[0] = 'V'; buf[4] = 99;
+   check(JLinkDiscDecode(buf, JLINK_DISC_PKT_LEN, &dev, &port,
+                         name, sizeof(name)) == 0,
+         "wrong version rejected");
+}
+
+static void test_name_never_unterminated(void)
+{
+   uint8_t buf[64];
+   int dev, port;
+   char name[JLINK_DISC_NAME_MAX];
+   int i;
+
+   JLinkDiscEncode(buf, sizeof(buf), JLINK_DISC_DEV_JAGLINK, 42171,
+                   "0123456789012345678901234567890123456789");
+   /* Stomp every name byte so nothing in the field is NUL. */
+   for (i = 8; i < JLINK_DISC_PKT_LEN; i++)
+      buf[i] = 'A';
+   check(JLinkDiscDecode(buf, JLINK_DISC_PKT_LEN, &dev, &port,
+                         name, sizeof(name)) == 1,
+         "full-width name still decodes");
+   check(name[JLINK_DISC_NAME_MAX - 1] == '\0',
+         "decoded name is always NUL-terminated");
+}
+
+static void test_peer_table(void)
+{
+   JLinkDiscPeersReset();
+   check(JLinkDiscPeerCount() == 0, "table starts empty");
+
+   check(JLinkDiscPeerSeen("192.168.1.2", "a", 0, 42171, 1000) == 1,
+         "first sighting reports a change");
+   check(JLinkDiscPeerCount() == 1, "peer added");
+   check(JLinkDiscPeerSeen("192.168.1.2", "a", 0, 42171, 2000) == 0,
+         "refresh of a known peer reports no change");
+   check(JLinkDiscPeerCount() == 1, "refresh does not duplicate");
+
+   /* Seen at 5000, i.e. LATER than .2's last refresh at 2000.  Both at
+      2000 would share a last_seen_ms, and then no expiry boundary can
+      drop one without the other -- the scenario would be unsatisfiable. */
+   check(JLinkDiscPeerSeen("192.168.1.3", "b", 1, 42172, 5000) == 1,
+         "second peer reports a change");
+   check(JLinkDiscPeerCount() == 2, "two peers tracked");
+
+   check(JLinkDiscPeerExpire(2000 + JLINK_DISC_EXPIRE_MS) == 1,
+         "expiry of the stale peer reports a change");
+   check(JLinkDiscPeerCount() == 1, "stale peer dropped, fresh one kept");
+   check(JLinkDiscPeerAt(0) != NULL, "a peer survived expiry");
+   if (JLinkDiscPeerAt(0))
+      check(strcmp(JLinkDiscPeerAt(0)->addr, "192.168.1.3") == 0,
+            "surviving peer is the fresh one");
+   check(JLinkDiscPeerAt(5) == NULL, "out-of-range index returns NULL");
+}
+
+static void test_capacity(void)
+{
+   char addr[JLINK_DISC_ADDR_MAX];
+   int i;
+
+   JLinkDiscPeersReset();
+   for (i = 0; i < JLINK_DISC_MAX_PEERS + 4; i++)
+   {
+      sprintf(addr, "10.0.0.%d", i + 1);
+      JLinkDiscPeerSeen(addr, "n", 0, 42171, 1000);
+   }
+   check(JLinkDiscPeerCount() == JLINK_DISC_MAX_PEERS,
+         "table caps at JLINK_DISC_MAX_PEERS");
+}
+
+int main(void)
+{
+   test_roundtrip();
+   test_rejects_bad();
+   test_name_never_unterminated();
+   test_peer_table();
+   test_capacity();
+   if (failures) { printf("test_jlink_discover: %d FAILURE(S)\n", failures); return 1; }
+   printf("test_jlink_discover: all passed\n");
+   return 0;
+}

--- a/test/tools/netlink_discover_pair.sh
+++ b/test/tools/netlink_discover_pair.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# netlink_discover_pair.sh -- two cores on one host: the server beacons,
+# the client's peer table must populate.  SO_REUSEADDR/SO_REUSEPORT on the
+# listener is what makes two instances on one machine work at all, which
+# is exactly how every other netlink test runs.
+set -u
+CORE="${1:?usage: netlink_discover_pair.sh <core>}"
+BIN="$(dirname "$0")/netlink_discover_probe"
+if [ ! -x "$BIN" ]; then
+    echo "netlink_discover_pair: $BIN not built" >&2
+    exit 1
+fi
+"$BIN" "$CORE" --role beacon &
+BPID=$!
+sleep 1
+"$BIN" "$CORE" --role listen --expect 1
+rc=$?
+kill "$BPID" 2>/dev/null; wait "$BPID" 2>/dev/null
+if [ "$rc" -eq 0 ]; then
+    echo "netlink_discover_pair: PASS"
+else
+    echo "netlink_discover_pair: FAIL (listener saw no peer)" >&2
+fi
+exit "$rc"

--- a/test/tools/netlink_discover_probe.c
+++ b/test/tools/netlink_discover_probe.c
@@ -1,0 +1,59 @@
+#define _DEFAULT_SOURCE 1   /* glibc/macOS: expose usleep() under -std=c99 */
+#include <stdio.h>
+#include <stdlib.h>      /* atoi */
+#include <string.h>
+#include "jlink_discover.h"
+
+#ifdef _WIN32
+#include <windows.h>
+static uint32_t now_ms(void) { return (uint32_t)GetTickCount(); }
+static void pace(void) { Sleep(5); }
+#else
+#include <sys/time.h>
+#include <unistd.h>
+/* Wall clock, NOT clock(): clock() measures CPU time, and this probe
+   spins, so a CPU-time clock would race ahead of the 10 s peer expiry
+   this test exists to exercise. */
+static uint32_t now_ms(void)
+{
+   struct timeval tv;
+   gettimeofday(&tv, NULL);
+   return (uint32_t)((uint32_t)tv.tv_sec * 1000u
+                     + (uint32_t)(tv.tv_usec / 1000));
+}
+static void pace(void) { usleep(5000); }
+#endif
+
+int main(int argc, char **argv)
+{
+   int listen_only = 1, expect = 0, i, spins;
+   for (i = 1; i < argc; i++)
+   {
+      if (!strcmp(argv[i], "--role") && i + 1 < argc)
+         listen_only = strcmp(argv[++i], "beacon") ? 1 : 0;
+      else if (!strcmp(argv[i], "--expect") && i + 1 < argc)
+         expect = atoi(argv[++i]);
+   }
+   if (!JLinkDiscStart(listen_only, 0, 42171))
+   {
+      printf("discover_probe: start failed\n");
+      return 2;
+   }
+   for (spins = 0; spins < 600; spins++)
+   {
+      JLinkDiscPoll(now_ms());
+      if (expect && JLinkDiscPeerCount() >= expect)
+      {
+         printf("discover_probe: saw %d peer(s)\n", JLinkDiscPeerCount());
+         JLinkDiscStop();
+         return 0;
+      }
+      /* Pace the loop (same 5 ms budget as test/tools/netlink_pair.c):
+         the beacon side only broadcasts once per second, so an
+         unpaced 600-iteration busy-spin exhausts itself in a few
+         milliseconds and never lives long enough to see one. */
+      pace();
+   }
+   JLinkDiscStop();
+   return expect ? 1 : 0;
+}

--- a/test/tools/netlink_rebuild_witness.c
+++ b/test/tools/netlink_rebuild_witness.c
@@ -1,0 +1,446 @@
+/* test/tools/netlink_rebuild_witness.c -- proves netlink_rebuild_host_options()
+ * (task 4, #467) actually executes, end to end, through a real dlopen'd
+ * core.
+ *
+ * Why this exists: two other tests look adjacent but don't cover it.
+ * netlink_discover_probe.c calls JLinkDiscStart/Poll/PeerCount directly --
+ * it never loads the core or calls retro_run(), so it can never reach
+ * netlink_rebuild_host_options() (that function lives in libretro.c and is
+ * only ever called from inside retro_run()).  netlink_pair.c does load the
+ * real core and drive retro_run() in tcp_server/tcp_client mode, but it
+ * exits the moment its two sides exchange a test byte -- observed around
+ * frame 36, well under a second of wall-clock time.  netlink_last_rebuild_ms
+ * starts at 0 and JLinkNowMs() (jlink.c) is real wall-clock milliseconds,
+ * not a frame count, so the rebuild's 2s rate-limit gate cannot open until
+ * about two real seconds after the core starts running frames.  No test in
+ * the suite ran a core that long in a mode that starts discovery, so the
+ * "[NETLINK] host picker rebuilt" log line had never fired anywhere.
+ *
+ * This test closes that gap directly:
+ *   1. dlopen the real core, load a synthetic cartridge with
+ *      virtualjaguar_netlink=tcp_server (discovery beacons AND listens in
+ *      this mode -- see the comment in netlink_apply()).
+ *   2. Craft one fake-peer beacon packet with the core's OWN
+ *      JLinkDiscEncode() (dlsym'd from the very library under test, so the
+ *      wire format can never drift from what its own JLinkDiscDecode()
+ *      expects) and deliver it over a real UDP socket to the core's real
+ *      discovery listener on 127.0.0.1:JLINK_DISC_PORT.  JLinkDiscPeerSeen()
+ *      alone would NOT do: only JLinkDiscPoll()'s real socket-receive path
+ *      sets the jlinkDiscChanged flag JLinkDiscConsumeChanged() reads
+ *      (jlink.c), so the peer has to arrive as a genuine packet.
+ *   3. Call retro_run() in a loop paced against REAL wall-clock time (not
+ *      frame count) for several seconds, past the 2s gate.
+ *   4. A GET_LOG_INTERFACE callback captures every core log line and
+ *      checks for the rebuild's own log text -- a real witness, not an
+ *      inference from a green suite.
+ *
+ * Doubles as the regression test for the review-round-1 visibility fix:
+ * SET_CORE_OPTIONS_V2 (which the rebuild calls) tears down and rebuilds
+ * RetroArch's whole core_option_manager from definitions that carry no
+ * visibility field, so every option comes back visible on the frontend
+ * side.  update_option_visibility() only re-pushes SET_CORE_OPTIONS_DISPLAY
+ * for a group whose show_* flag CHANGED since the last call, and right
+ * after a rebuild none of them did -- so without the force-push fix, rows
+ * hidden before the rebuild (CD-only keys on a cartridge session, the
+ * mouse-tuning keys with no mouse attached, the host row itself in
+ * tcp_server mode) would silently reappear and stay reappeared.  This test
+ * records SET_CORE_OPTIONS_DISPLAY like test_option_visibility.c does,
+ * checks three independent hidden rows before the rebuild, then re-checks
+ * the SAME rows after it fires.
+ *
+ * Deliberately NOT built on test/harness/harness.h: that shared harness's
+ * environment callback (harness.c) has no SET_CORE_OPTIONS_DISPLAY
+ * recording and its log callback isn't interceptable from test code (it
+ * always writes straight to stderr), and both are needed here.  Adding
+ * either to the shared harness would touch infrastructure every other test
+ * depends on for one caller; a small standalone dlopen loader (the same
+ * shape test_option_visibility.c already uses) keeps the risk contained to
+ * this one file.
+ *
+ * Build:
+ *   cc -O2 -Wall -std=c99 -I. -I./src -I./src/jerry -I./libretro-common/include \
+ *      -o test/tools/netlink_rebuild_witness \
+ *      test/tools/netlink_rebuild_witness.c -ldl
+ *
+ * Usage: netlink_rebuild_witness [core]
+ * Exit 0 on PASS, 1 on FAIL. Requires TEST_EXPORTS=1 (JLinkDiscEncode /
+ * JLinkDiscPeerCount / JLinkNowMs must be exported; see exports-test.list's
+ * _JLink* wildcard).
+ */
+
+#define _DEFAULT_SOURCE 1
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <dlfcn.h>
+
+#include <libretro.h>
+#include "jlink_discover.h"
+
+#define ROM_SIZE          131072
+#define FRAME_USEC        16667  /* ~60 fps, matches the real frontend cadence
+                                   * JLinkNowMs()'s real-time-based gate assumes */
+#define WITNESS_TIMEOUT_MS 6000  /* generous margin over the 2000ms gate: 1s
+                                   * beacon cadence + 2s rate limit + CI slop */
+#define MAX_REC           64
+
+/* ---------------------------------------------------------------------
+ * SET_CORE_OPTIONS_DISPLAY recording (same shape as test_option_visibility.c)
+ * --------------------------------------------------------------------- */
+static struct { char key[64]; bool visible; } rec[MAX_REC];
+static unsigned rec_count;
+static int failures;
+static int checks;
+
+static void record(const char *key, bool visible)
+{
+   unsigned i;
+   for (i = 0; i < rec_count; i++)
+   {
+      if (!strcmp(rec[i].key, key))
+      {
+         rec[i].visible = visible;
+         return;
+      }
+   }
+   if (rec_count < MAX_REC)
+   {
+      strncpy(rec[rec_count].key, key, sizeof(rec[0].key) - 1);
+      rec[rec_count].key[sizeof(rec[0].key) - 1] = '\0';
+      rec[rec_count].visible = visible;
+      rec_count++;
+   }
+}
+
+/* Options default to visible: the core only calls SET_CORE_OPTIONS_DISPLAY
+ * when a state CHANGES, so "never mentioned" means visible. */
+static bool visible_of(const char *key)
+{
+   unsigned i;
+   for (i = 0; i < rec_count; i++)
+      if (!strcmp(rec[i].key, key))
+         return rec[i].visible;
+   return true;
+}
+
+static void expect_hidden(const char *what, const char *key)
+{
+   bool got = visible_of(key);
+   checks++;
+   if (!got)
+      printf("  ok   %-28s %s hidden\n", key, what);
+   else
+   {
+      printf("  FAIL %-28s %s visible, expected hidden\n", key, what);
+      failures++;
+   }
+}
+
+/* ---------------------------------------------------------------------
+ * Log capture: the actual witness for "the rebuild ran".
+ * --------------------------------------------------------------------- */
+static int rebuild_seen;
+
+static void log_cb(enum retro_log_level level, const char *fmt, ...)
+{
+   char buf[512];
+   va_list ap;
+   (void)level;
+   va_start(ap, fmt);
+   vsnprintf(buf, sizeof(buf), fmt, ap);
+   va_end(ap);
+   /* Echo everything -- useful when this test goes red and someone needs
+    * to see what the core actually logged instead of just "FAIL". */
+   fputs(buf, stdout);
+   if (strstr(buf, "host picker rebuilt"))
+      rebuild_seen = 1;
+}
+
+/* ---------------------------------------------------------------------
+ * Environment callback
+ * --------------------------------------------------------------------- */
+static char g_port[16];
+
+static bool env_cb(unsigned cmd, void *data)
+{
+   switch (cmd)
+   {
+      case RETRO_ENVIRONMENT_GET_LOG_INTERFACE:
+         ((struct retro_log_callback *)data)->log = log_cb;
+         return true;
+
+      case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+      case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+         *(const char **)data = ".";
+         return true;
+
+      case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+      case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+      case RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS:
+      case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
+      case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK:
+         return true;
+
+      case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
+         *(unsigned *)data = 2;
+         return true;
+
+      case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY:
+      {
+         const struct retro_core_option_display *d =
+            (const struct retro_core_option_display *)data;
+         if (d && d->key)
+            record(d->key, d->visible);
+         return true;
+      }
+
+      case RETRO_ENVIRONMENT_GET_VARIABLE:
+      {
+         struct retro_variable *v = (struct retro_variable *)data;
+         v->value = NULL;
+         if (v->key && !strcmp(v->key, "virtualjaguar_netlink"))
+            v->value = "tcp_server";
+         else if (v->key && !strcmp(v->key, "virtualjaguar_netlink_port"))
+            v->value = g_port;
+         else if (v->key && !strcmp(v->key, "virtualjaguar_netlink_wait"))
+            v->value = "disabled";
+         return true;
+      }
+   }
+   return false;
+}
+
+static void video_cb(const void *d, unsigned w, unsigned h, size_t p)
+{ (void)d; (void)w; (void)h; (void)p; }
+static void audio_cb(int16_t l, int16_t r) { (void)l; (void)r; }
+static size_t audio_batch_cb(const int16_t *d, size_t f) { (void)d; return f; }
+static void input_poll_cb(void) {}
+static int16_t input_state_cb(unsigned a, unsigned b, unsigned c, unsigned d)
+{ (void)a; (void)b; (void)c; (void)d; return 0; }
+
+typedef void   (*set_env_fn)(retro_environment_t);
+typedef void   (*set_video_fn)(retro_video_refresh_t);
+typedef void   (*set_audio_fn)(retro_audio_sample_t);
+typedef void   (*set_audio_batch_fn)(retro_audio_sample_batch_t);
+typedef void   (*set_ipoll_fn)(retro_input_poll_t);
+typedef void   (*set_istate_fn)(retro_input_state_t);
+typedef void   (*void_fn)(void);
+typedef bool   (*load_fn)(const struct retro_game_info *);
+typedef void   (*run_fn)(void);
+typedef size_t (*disc_encode_fn)(uint8_t *, size_t, int, int, const char *);
+typedef int    (*disc_count_fn)(void);
+typedef uint32_t (*now_ms_fn)(void);
+
+static long long now_usec(void)
+{
+   struct timeval tv;
+   gettimeofday(&tv, NULL);
+   return (long long)tv.tv_sec * 1000000LL + tv.tv_usec;
+}
+
+/* One frontend-like frame slot: run, then sleep out the remainder -- same
+ * idiom as netlink_latency.c's paced_frame(), needed here because
+ * JLinkNowMs() (the rebuild's rate-limit clock) is real wall-clock, not
+ * frame count. */
+static void paced_frame(run_fn run_frame)
+{
+   long long fstart = now_usec(), spent;
+   run_frame();
+   spent = now_usec() - fstart;
+   if (spent < FRAME_USEC)
+      usleep((useconds_t)(FRAME_USEC - spent));
+}
+
+static const uint8_t *make_synth_rom(void)
+{
+   static uint8_t rom_buf[ROM_SIZE];
+   memset(rom_buf, 0, ROM_SIZE);
+   rom_buf[0x404] = 0x00; rom_buf[0x405] = 0x80;
+   rom_buf[0x406] = 0x20; rom_buf[0x407] = 0x00;
+   rom_buf[0x2000] = 0x60; rom_buf[0x2001] = 0xFE;   /* bra.s * */
+   return rom_buf;
+}
+
+int main(int argc, char **argv)
+{
+   void *lib;
+   const char *core = (argc > 1) ? argv[1] : "./virtualjaguar_libretro.dylib";
+   struct retro_game_info gi;
+   load_fn        p_load;
+   void_fn        p_unload, p_deinit;
+   run_fn         p_run;
+   disc_encode_fn p_encode;
+   disc_count_fn  p_peer_count;
+   now_ms_fn      p_now_ms;
+   int            udp_sock;
+   struct sockaddr_in dest;
+   uint8_t        beacon[JLINK_DISC_PKT_LEN];
+   size_t         beacon_len;
+   long long      loop_start, elapsed_ms;
+   int            frame_i;
+   int            resent = 0;
+
+   printf("=== Netlink host-picker rebuild witness ===\n");
+
+   snprintf(g_port, sizeof(g_port), "%d", 17000 + (int)(getpid() % 4000));
+
+   lib = dlopen(core, RTLD_NOW);
+   if (!lib)
+   {
+      printf("  FAIL: dlopen %s: %s\n", core, dlerror());
+      return 1;
+   }
+
+   ((set_env_fn)dlsym(lib, "retro_set_environment"))(env_cb);
+   ((set_video_fn)dlsym(lib, "retro_set_video_refresh"))(video_cb);
+   ((set_audio_fn)dlsym(lib, "retro_set_audio_sample"))(audio_cb);
+   ((set_audio_batch_fn)dlsym(lib, "retro_set_audio_sample_batch"))(audio_batch_cb);
+   ((set_ipoll_fn)dlsym(lib, "retro_set_input_poll"))(input_poll_cb);
+   ((set_istate_fn)dlsym(lib, "retro_set_input_state"))(input_state_cb);
+   ((void_fn)dlsym(lib, "retro_init"))();
+
+   p_load       = (load_fn)dlsym(lib, "retro_load_game");
+   p_unload     = (void_fn)dlsym(lib, "retro_unload_game");
+   p_deinit     = (void_fn)dlsym(lib, "retro_deinit");
+   p_run        = (run_fn)dlsym(lib, "retro_run");
+   p_encode     = (disc_encode_fn)dlsym(lib, "JLinkDiscEncode");
+   p_peer_count = (disc_count_fn)dlsym(lib, "JLinkDiscPeerCount");
+   p_now_ms     = (now_ms_fn)dlsym(lib, "JLinkNowMs");
+
+   if (!p_load || !p_unload || !p_deinit || !p_run || !p_encode)
+   {
+      printf("  FAIL: symbols missing -- build with TEST_EXPORTS=1\n");
+      dlclose(lib);
+      return 1;
+   }
+
+   memset(&gi, 0, sizeof(gi));
+   gi.path = "witness.j64";
+   gi.data = make_synth_rom();
+   gi.size = ROM_SIZE;
+
+   if (!p_load(&gi))
+   {
+      printf("  FAIL: retro_load_game failed\n");
+      dlclose(lib);
+      return 1;
+   }
+
+   /* --- Before the rebuild: three independent hidden-row baselines ---
+    * host row: tcp_server never shows it (only tcp_client dials out).
+    * CD-only keys: hidden because a cartridge, not a disc, is loaded.
+    * mouse tuning: hidden because no mouse is attached to port 2.
+    * These three cover three different update_option_visibility() groups,
+    * not just the one task 4 added -- the point of the review finding. */
+   printf("[before rebuild]\n");
+   expect_hidden("(tcp_server)", "virtualjaguar_netlink_host");
+   expect_hidden("(cart)",       "virtualjaguar_cd_boot_mode");
+   expect_hidden("(no mouse)",   "virtualjaguar_mouse_sensitivity");
+
+   /* --- Deliver one real UDP beacon for a fake peer, encoded with the
+    * core's own JLinkDiscEncode() so the wire format can never drift from
+    * what its own decoder expects.  Use a device/port/name that cannot
+    * collide with our own core's self-beacon (JLinkDiscPoll ignores a
+    * packet whose name+port match its own -- a different fake port alone
+    * guarantees no match regardless of hostname). --- */
+   beacon_len = p_encode(beacon, sizeof(beacon), JLINK_DISC_DEV_JAGLINK,
+                          9999, "witnesspeer");
+   if (beacon_len == 0)
+   {
+      printf("  FAIL: JLinkDiscEncode produced 0 bytes\n");
+      p_unload(); p_deinit(); dlclose(lib);
+      return 1;
+   }
+
+   udp_sock = socket(AF_INET, SOCK_DGRAM, 0);
+   if (udp_sock < 0)
+   {
+      printf("  FAIL: socket(): could not create injector socket\n");
+      p_unload(); p_deinit(); dlclose(lib);
+      return 1;
+   }
+   memset(&dest, 0, sizeof(dest));
+   dest.sin_family = AF_INET;
+   dest.sin_port   = htons(JLINK_DISC_PORT);
+   inet_pton(AF_INET, "127.0.0.1", &dest.sin_addr);
+   sendto(udp_sock, beacon, beacon_len, 0, (struct sockaddr *)&dest, sizeof(dest));
+
+   /* --- Run retro_run() paced against real wall-clock time until either
+    * the rebuild's log line appears or WITNESS_TIMEOUT_MS elapses. A
+    * bounded deadline so a genuinely broken build fails in seconds rather
+    * than hanging. --- */
+   loop_start = now_usec();
+   frame_i = 0;
+   for (;;)
+   {
+      elapsed_ms = (now_usec() - loop_start) / 1000;
+      if (rebuild_seen || elapsed_ms >= WITNESS_TIMEOUT_MS)
+         break;
+
+      /* Cheap insurance against a race between the sendto() above and the
+       * discovery socket's bind (JLinkDiscStart already ran synchronously
+       * inside retro_load_game(), so this should not be needed, but a
+       * resend is nearly free and removes the doubt): resend until the
+       * core actually reports a peer. */
+      if (!resent && p_peer_count && p_peer_count() == 0 && elapsed_ms > 300)
+      {
+         sendto(udp_sock, beacon, beacon_len, 0,
+                (struct sockaddr *)&dest, sizeof(dest));
+         resent = 1;
+      }
+
+      paced_frame(p_run);
+      frame_i++;
+
+      if (frame_i % 60 == 0)
+      {
+         printf("  ... frame %d, elapsed %lldms, peers=%d\n", frame_i,
+                elapsed_ms, p_peer_count ? p_peer_count() : -1);
+      }
+   }
+
+   if (p_now_ms)
+      printf("  JLinkNowMs() at exit: %u\n", (unsigned)p_now_ms());
+   printf("  peers seen: %d\n", p_peer_count ? p_peer_count() : -1);
+
+   checks++;
+   if (rebuild_seen)
+      printf("  ok   rebuild log line observed after %lldms\n", elapsed_ms);
+   else
+   {
+      printf("  FAIL rebuild log line NEVER observed (timeout %dms)\n",
+             WITNESS_TIMEOUT_MS);
+      failures++;
+   }
+
+   /* --- After the rebuild: the same three rows must STILL be hidden.
+    * SET_CORE_OPTIONS_V2 (which the rebuild calls) un-hides every option
+    * on the frontend side; without the visibility force-push fix, none of
+    * update_option_visibility()'s groups would re-push (their show_*
+    * flags didn't change), so all three would incorrectly read back
+    * visible here. --- */
+   if (rebuild_seen)
+   {
+      printf("[after rebuild]\n");
+      expect_hidden("(tcp_server)", "virtualjaguar_netlink_host");
+      expect_hidden("(cart)",       "virtualjaguar_cd_boot_mode");
+      expect_hidden("(no mouse)",   "virtualjaguar_mouse_sensitivity");
+   }
+
+   close(udp_sock);
+   p_unload();
+   p_deinit();
+   dlclose(lib);
+
+   printf("--- Netlink host-picker rebuild witness: %d checks, %d failed ---\n",
+          checks, failures);
+   return failures ? 1 : 0;
+}

--- a/test/tools/test_option_visibility.c
+++ b/test/tools/test_option_visibility.c
@@ -86,6 +86,12 @@ static void log_cb(enum retro_log_level level, const char *fmt, ...)
    (void)level; (void)fmt;
 }
 
+/* Raw value the harness hands back for the virtualjaguar_netlink key on the
+ * next GET_VARIABLE call, or NULL for "not set" (every other option below
+ * always returns NULL -- only netlink's per-mode visibility needs a real
+ * value to react to). */
+static const char *netlink_opt_value;
+
 static bool env_cb(unsigned cmd, void *data)
 {
    switch (cmd)
@@ -123,6 +129,8 @@ static bool env_cb(unsigned cmd, void *data)
       {
          struct retro_variable *v = (struct retro_variable *)data;
          v->value = NULL;
+         if (v->key && !strcmp(v->key, "virtualjaguar_netlink"))
+            v->value = netlink_opt_value;
          return true;
       }
    }
@@ -244,6 +252,66 @@ int main(int argc, char **argv)
     * dump option sits at its disabled default. */
    expect("(cart)", "virtualjaguar_texdump_16bpp", false);
    p_unload();
+
+   /* --- Network Link (task 3, #467): host/port visibility per mode ---
+    * auto:       neither field means anything (never asks for an address)
+    * tcp_client: both fields apply (dials host:port)
+    * tcp_server: only the listen port applies
+    *
+    * update_option_visibility() only calls SET_CORE_OPTIONS_DISPLAY on a
+    * CHANGE, and the gates are module statics that persist across loads
+    * (like every other show_* gate in libretro.c). The cartridge checks
+    * above already evaluated netlink visibility once with no value set
+    * (GET_VARIABLE returns NULL), which resolves to disabled -- host/port
+    * already hidden. Prime a known "shown" baseline first so the very
+    * first real assertion below (auto, expecting hidden) is guaranteed to
+    * see the toggle fire rather than silently inheriting a state that
+    * happens to already match. */
+   netlink_opt_value = "tcp_client";
+   if (!load_content(cart))
+   {
+      printf("  FAIL: could not load cartridge %s (netlink priming)\n", cart);
+      dlclose(lib);
+      return 1;
+   }
+   p_unload();
+
+   netlink_opt_value = "auto";
+   if (!load_content(cart))
+   {
+      printf("  FAIL: could not load cartridge %s (netlink=auto)\n", cart);
+      dlclose(lib);
+      return 1;
+   }
+   printf("[netlink=auto] %s\n", cart);
+   expect("(netlink=auto)", "virtualjaguar_netlink_host", false);
+   expect("(netlink=auto)", "virtualjaguar_netlink_port", false);
+   p_unload();
+
+   netlink_opt_value = "tcp_client";
+   if (!load_content(cart))
+   {
+      printf("  FAIL: could not load cartridge %s (netlink=tcp_client)\n", cart);
+      dlclose(lib);
+      return 1;
+   }
+   printf("[netlink=tcp_client] %s\n", cart);
+   expect("(netlink=tcp_client)", "virtualjaguar_netlink_host", true);
+   expect("(netlink=tcp_client)", "virtualjaguar_netlink_port", true);
+   p_unload();
+
+   netlink_opt_value = "tcp_server";
+   if (!load_content(cart))
+   {
+      printf("  FAIL: could not load cartridge %s (netlink=tcp_server)\n", cart);
+      dlclose(lib);
+      return 1;
+   }
+   printf("[netlink=tcp_server] %s\n", cart);
+   expect("(netlink=tcp_server)", "virtualjaguar_netlink_host", false);
+   expect("(netlink=tcp_server)", "virtualjaguar_netlink_port", true);
+   p_unload();
+   netlink_opt_value = NULL;
 
    /* --- CD: CD options shown, cartridge BIOS option hidden --- */
    if (disc)

--- a/test/tools/test_option_visibility.c
+++ b/test/tools/test_option_visibility.c
@@ -153,9 +153,36 @@ typedef void (*set_ipoll_fn)(retro_input_poll_t);
 typedef void (*set_istate_fn)(retro_input_state_t);
 typedef void (*void_fn)(void);
 typedef bool (*load_fn)(const struct retro_game_info *);
+typedef int  (*int_fn)(void);
 
 static load_fn  p_load;
 static void_fn  p_unload;
+static int_fn   p_disc_active; /* JLinkDiscActive(), or NULL if unresolved */
+
+/* Assert the LAN discovery socket's on/off state directly, rather than
+ * through the SET_CORE_OPTIONS_DISPLAY recording used by expect() --
+ * JLinkDiscActive() is a live query, not an option-visibility toggle. */
+static void expect_active(const char *what, bool want)
+{
+   bool got;
+   if (!p_disc_active)
+   {
+      printf("  SKIP JLinkDiscActive()             %s -- symbol not resolved\n",
+             what);
+      return;
+   }
+   checks++;
+   got = p_disc_active() != 0;
+   if (got == want)
+      printf("  ok   JLinkDiscActive()              %s active=%d\n",
+             what, (int)got);
+   else
+   {
+      printf("  FAIL JLinkDiscActive()              %s active=%d, expected %d\n",
+             what, (int)got, (int)want);
+      failures++;
+   }
+}
 
 static bool load_content(const char *path)
 {
@@ -231,8 +258,9 @@ int main(int argc, char **argv)
    ((set_istate_fn)dlsym(lib, "retro_set_input_state"))(input_state_cb);
    ((void_fn)dlsym(lib, "retro_init"))();
 
-   p_load   = (load_fn)dlsym(lib, "retro_load_game");
-   p_unload = (void_fn)dlsym(lib, "retro_unload_game");
+   p_load       = (load_fn)dlsym(lib, "retro_load_game");
+   p_unload     = (void_fn)dlsym(lib, "retro_unload_game");
+   p_disc_active = (int_fn)dlsym(lib, "JLinkDiscActive");
 
    /* --- cartridge: CD options hidden, cartridge BIOS option shown --- */
    if (!load_content(cart))
@@ -286,6 +314,13 @@ int main(int argc, char **argv)
    printf("[netlink=auto] %s\n", cart);
    expect("(netlink=auto)", "virtualjaguar_netlink_host", false);
    expect("(netlink=auto)", "virtualjaguar_netlink_port", false);
+   /* auto must never open the discovery socket: the host row it would
+    * feed is hidden (checked above) and auto never auto-connects to a
+    * found peer anyway, so the peer list is invisible and unread --
+    * opening it here would be a silent UDP listener (and OS Local
+    * Network permission prompt) for every user, since auto is now the
+    * option's default. */
+   expect_active("(netlink=auto)", false);
    p_unload();
 
    netlink_opt_value = "tcp_client";
@@ -298,6 +333,9 @@ int main(int argc, char **argv)
    printf("[netlink=tcp_client] %s\n", cart);
    expect("(netlink=tcp_client)", "virtualjaguar_netlink_host", true);
    expect("(netlink=tcp_client)", "virtualjaguar_netlink_port", true);
+   /* tcp_client listens for LAN hosts (never beacons) so the host row's
+    * "hosts on your LAN are found automatically" claim is real. */
+   expect_active("(netlink=tcp_client)", true);
    p_unload();
 
    netlink_opt_value = "tcp_server";


### PR DESCRIPTION
Makes JagLink/CatBox/Voice Modem setup comprehensible and near-zero-config. Implements [`docs/netlink-ux-design.md`](docs/netlink-ux-design.md) via [`docs/netlink-ux-plan.md`](docs/netlink-ux-plan.md).

## Why

Three concrete failures, all observed:

1. **The netplay path was invisible.** The core already registers the netpacket interface unconditionally and `JLinkNPStart()` takes the link over for a netplay session — so "link over RetroArch netplay, zero configuration" *already worked*. Nothing said so; it was buried in a 60-word blurb on the TCP **client** option, findable only once you were already committed to typing an IP.
2. **The host address cannot be typed.** libretro core options are strictly enumerated — RetroArch stores a value *index* into a `string_list` and there is no keyboard path in any core-option menu callback. Free-text host entry is impossible for **any** core on any platform. The workarounds (a `.local` preset, `vj_netlink.txt`, localhost) were all poor, and on iOS they were the only choices.
3. **`vj_netlink.txt` was over-explained and never specified.** The description was long and never stated the format.

## What

- **`auto` link mode**, now the default: uses the frontend's netplay session when one is live, otherwise idle. Every existing option key and value still parses — no `.opt` migration.
- **UDP LAN discovery** (`src/jerry/jlink_discover.{c,h}`, port 42170): 40-byte beacon, expiring peer table, discovered hosts appear in the picker as `"name - addr"`. Chosen over mDNS because RetroArch's iOS/tvOS plists enumerate only `_ra-bless._tcp` and `_ra_netplay._tcp` under `NSBonjourServices`, so a core advertising its own service type is blocked — while the iOS entitlements *do* carry `com.apple.developer.networking.multicast`. **UDP is the only mechanism that works on iOS**, not a fallback.
- **Per-mode option visibility** — host/port rows appear only where they apply.
- **OSD narration** of link state, mirroring the `[NETLINK]` log lines so screen and log agree.
- Docs, including the `vj_netlink.txt` format: **one line, address only, no port**.

## Notable decisions

- **`auto` never starts discovery.** It hides the host row and never auto-connects, so a listener there would raise an OS Local Network permission prompt for *every* default user, to fill a list nobody can see. Test-asserted.
- **`auto` never auto-dials a discovered peer** — with the Voice Modem that would place a call the user did not initiate.
- **Discovery poll lives in `JLinkFrameTick()`, not `JLinkPoll()`** — `JLinkPump()` reaches `JLinkPoll()` and games spin it thousands of times per frame; a `recvfrom` drain there sits in a documented hot path.
- The design doc's "`auto` restores the last direct mode" was **dropped**: with one option key there is nowhere to read a prior choice from, since selecting `auto` overwrites it. Doc amended in-branch.

## Testing

Full suite `EXIT=0` on a clean tree, C89 lint clean. New: `test_jlink_discover` (codec + peer table, no sockets), `netlink_discover_pair.sh` (two cores, real beacon), `netlink_rebuild_witness` (drives a real beacon into the core's socket, paces `retro_run()` past the 2s gate, and **observes `[NETLINK] host picker rebuilt` actually fire** — plus asserts three independently-hidden option groups stay hidden across the rebuild).

That last one exists because the reviewer found `SET_CORE_OPTIONS_V2` un-hides *every* managed row: without a general force-push, the first discovered peer would have permanently unhidden 18+ mouse/rotary/analog rows in an ordinary cart session.

## Known gaps

- **The OSD toasts have only been verified headlessly.** CLAUDE.md's own rule says verify in RetroArch before declaring done; that has not happened for the on-screen text.
- #501 — the device-mismatch warning is silent on the `vj_netlink.txt` and `VJ_NETLINK_HOST` paths (the rebuild call site passes the raw option value, not the resolved host). Parked deliberately: the link works, the primary picker path is fixed, and behaviour is no worse than before this branch.
- #494 — voice modem over netpacket is verified only to "link UP", not through the data phase.

Related: #498 (netlink latency enhancement), #499 (audit the two remaining ungated interrupt raise sites).