### PR TITLE
fix(dsp): gate the DSP CPUINT on TOM's C_JERENA (#499)

### DIFF
--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -28,6 +28,7 @@
 #include "log.h"
 #include "m68000/m68kinterface.h"
 #include "settings.h"
+#include "tom.h"
 #include "../core/vjtrace.h"
 
 // Seems alignment in loads & stores was off...
@@ -788,7 +789,17 @@ void DSPWriteLong(uint32_t offset, uint32_t data, uint32_t who/*=UNKNOWN*/)
                   {
                      JERRYSetPendingIRQ(IRQ2_DSP);
                      DSPReleaseTimeslice();
-                     m68k_set_irq(2);			// Set 68000 IPL 2...
+                     /* JERRY has no wire of its own to the 68K: the DSP
+                        interrupt merges with every other JERRY source
+                        onto DINT, which enters TOM as INT1 bit 4
+                        (C_JERENA).  The latch above stays outside this
+                        gate, so a later C_JERENA write still delivers
+                        via TOMWriteByte's newlyEnabled & TOMPendingMask()
+                        path -- withheld, not lost.  Same gate as
+                        JERRYPIT1Callback/JERRYPIT2Callback and
+                        UARTRaiseIRQ. */
+                     if (TOMIRQEnabled(IRQ_DSP))
+                        m68k_set_irq(2);		// Set 68000 IPL 2...
                   }
                   data &= ~CPUINT;
                }

--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -40,6 +40,7 @@
 [PASS tests/bus/cpu_blitter_concurrent.jag
 [PASS tests/dsp/dsp_basic_run.jag
 [PASS tests/dsp/dsp_irq_to_68k.jag
+[PASS tests/dsp/dsp_irq_tom_gate.jag
 [PASS tests/dsp/dsp_mailbox.jag
 [PASS tests/dsp/dsp_op_abs.jag
 [PASS tests/dsp/dsp_op_add.jag

--- a/test/acid/tests/dsp/dsp_irq_to_68k.s
+++ b/test/acid/tests/dsp/dsp_irq_to_68k.s
@@ -6,7 +6,13 @@
 ;      (Jaguar TOM/JERRY return user vector 64 on IACK -- they don't
 ;      assert VPA -- so even a level-2 IRQ goes to $100, not the
 ;      autovector slot at $68.)
-;   2. 68K enables JERRY IRQ2_DSP mask via J_INT ($F10020 low byte = $02).
+;   2. 68K enables JERRY IRQ2_DSP mask via J_INT ($F10020 low byte = $02)
+;      AND TOM C_JERENA (INT1 $F000E0 low byte bit 4).  Both are
+;      required: JERRY has no wire of its own to the 68K, its sources
+;      all merge onto TOM INT1 bit 4 (docs/jtrm-jerry.md,
+;      "JERRY-to-TOM Interrupt Routing").  tests/irq/jerry_pit_irq.s
+;      sets up the same pair for the PIT path.  The C_JERENA half of
+;      the enable is pinned on its own by dsp_irq_tom_gate.s.
 ;   3. 68K loads a tiny DSP program that writes CPUINT (=$0002) to its
 ;      own D_CTRL.  That asks JERRY to fire IRQ2_DSP.
 ;   4. 68K runs in supervisor with IPL=0 so level-2 IRQs unmask.
@@ -39,6 +45,8 @@ D_CTRL          equ     DSP_BASE+$14
 CPUINT          equ     $00000002
 GO              equ     $00000001
 J_INT           equ     $00F10020
+TOM_INT1_W      equ     $00F000E0
+TOM_INT_DSP_EN  equ     $0010           ; INT1 bit 4 = C_JERENA (IRQ_DSP)
 
 IRQ_MARKER_ADDR equ     $00080010
 IRQ_MARKER_VAL  equ     $C0FFEE01
@@ -73,6 +81,11 @@ entry:
                 move.w  #$FF02,J_INT.l   ; low byte mask=$02 (IRQ2_DSP);
                                          ; high byte $FF clears any
                                          ; stale pending bits.
+
+                ;; Open TOM's JERRY gate -- without C_JERENA, JERRY's
+                ;; DINT never reaches the 68K on real silicon.
+                move.w  #$1F00,TOM_INT1_W          ; clear TOM pendings
+                move.w  #TOM_INT_DSP_EN,TOM_INT1_W ; C_JERENA on
 
                 ;; Build DSP program: write CPUINT to D_CTRL via store.
                 lea     DSP_RAM.l,a0

--- a/test/acid/tests/dsp/dsp_irq_tom_gate.s
+++ b/test/acid/tests/dsp/dsp_irq_tom_gate.s
@@ -1,0 +1,147 @@
+;
+; tests/dsp/dsp_irq_tom_gate.s - DSP CPUINT is gated by TOM C_JERENA,
+; and the withheld request is delivered when C_JERENA is later set.
+;
+; JERRY has no wire of its own to the 68K.  Every JERRY interrupt
+; source -- DSP (J_DSPENA), the two PITs, the UART, the external
+; input -- merges onto a single DINT line that enters TOM as INT1
+; bit 4 (C_JERENA, mask $0010).  With C_JERENA clear, a DSP CPUINT
+; must raise NOTHING on the 68K, no matter what JINTCTRL says.
+; (docs/jtrm-jerry.md "JERRY-to-TOM Interrupt Routing"; the INT1 bit
+; layout is docs/jtrm-register-map.md "TOM Interrupt Registers".)
+;
+; The latch is a separate thing from the gate: JERRY still records the
+; pending bit while C_JERENA is clear, so a later write that sets
+; C_JERENA hands the still-asserted DINT to the 68K.  Withheld, not
+; lost.  This test pins both halves, because a "fix" that drops the
+; interrupt entirely passes half of it.
+;
+; Sequence:
+;   1. 68K installs the hardware IRQ handler at vector 64 ($100).
+;   2. TOM INT1 = $0000: every TOM source disabled, C_JERENA clear.
+;      (Video too, so the only thing that can reach the handler in
+;      phase 1 is the DSP.)
+;   3. JERRY JINTCTRL mask = $02 (IRQ2_DSP), pending cleared.
+;   4. 68K runs at IPL 0, so a leaked level-2 WOULD be taken.
+;   5. DSP writes CPUINT to its own D_CTRL, then spins.
+;   6. Phase 1 assert: the marker must still be zero.
+;   7. 68K writes TOM INT1 = $0010 (C_JERENA on).
+;   8. Phase 2 assert: the marker must now appear -- the pending
+;      JERRY request was withheld, not discarded.
+;
+; Detail codes:
+;   1 = IRQ leaked to the 68K with C_JERENA clear (missing gate)
+;   2 = enabling C_JERENA did not deliver the withheld IRQ
+;       (gate applied to the latch instead of to delivery)
+;
+                include "include/jaguar_header.s"
+                include "include/acid_test.s"
+                include "include/jaguar_regs.s"
+
+D_FLAGS         equ     DSP_BASE+$00
+D_PC            equ     DSP_BASE+$10
+D_CTRL          equ     DSP_BASE+$14
+
+CPUINT          equ     $00000002
+GO              equ     $00000001
+
+J_INT           equ     $00F10020
+TOM_INT1_W      equ     $00F000E0
+
+;; TOM INT1 low byte, bit 4 -- see IRQ_DSP in include/jaguar_regs.s.
+TOM_INT_DSP_EN  equ     $0010
+
+IRQ_MARKER_ADDR equ     $00080010
+IRQ_MARKER_VAL  equ     $C0FFEE02
+
+;; Jaguar HW does not assert VPA on IACK -- TOM/JERRY return user
+;; vector 64 ($100) for all hardware IRQs (see irq_ack_handler in
+;; src/core/jaguar.c), so the handler lives at $100 and not at the
+;; 68K-architectural level-2 autovector slot at $68.
+HW_IRQ_VECTOR   equ     $00000100
+
+PHASE1_SPIN     equ     200000
+PHASE2_SPIN     equ     200000
+
+                org     $802000
+entry:
+                ;; Supervisor, IPL=0: a leaked level-2 would be taken.
+                move.w  #$2000,sr
+
+                ACID_INIT
+
+                move.l  #$00000000,IRQ_MARKER_ADDR.l
+
+                lea     irq2_handler(pc),a1
+                move.l  a1,HW_IRQ_VECTOR.l
+
+                ;; Clear every TOM pending latch, then disable every
+                ;; TOM source -- C_JERENA included.
+                move.w  #$1F00,TOM_INT1_W
+                move.w  #$0000,TOM_INT1_W
+
+                ;; JERRY: clear stale pending, enable IRQ2_DSP only.
+                move.w  #$FF02,J_INT.l
+
+                ;; Build the DSP program: store CPUINT into D_CTRL,
+                ;; then spin.
+                lea     DSP_RAM.l,a0
+                ;; movei #CPUINT, r0
+                move.w  #$9800,(a0)+
+                move.w  #(CPUINT&$FFFF),(a0)+
+                move.w  #((CPUINT>>16)&$FFFF),(a0)+
+                ;; movei #D_CTRL, r1
+                move.w  #$9801,(a0)+
+                move.w  #(D_CTRL&$FFFF),(a0)+
+                move.w  #((D_CTRL>>16)&$FFFF),(a0)+
+                ;; store r0,(r1)   (RN=r0=value, RM=r1=addr) -> $BC20
+                move.w  #$BC20,(a0)+
+                ;; jr T,-1 / nop spin
+                move.w  #$D7E0,(a0)+
+                move.w  #$E400,(a0)+
+
+                ;; Start the DSP.
+                move.l  #0,D_FLAGS
+                move.l  #DSP_RAM,D_PC
+                move.l  #GO,D_CTRL
+
+                ;; Phase 1: give the DSP cycles and the 68K plenty of
+                ;; instruction boundaries at which a leaked request
+                ;; would be dispatched.
+                move.l  #PHASE1_SPIN,d2
+.spin1:         nop
+                subq.l  #1,d2
+                bne.s   .spin1
+
+                move.l  #0,D_CTRL
+
+                move.l  IRQ_MARKER_ADDR.l,d6
+                tst.l   d6
+                bne.s   .leaked
+
+                ;; Phase 2: open C_JERENA.  JERRY is still driving
+                ;; DINT (its pending bit was latched and never acked),
+                ;; so TOM must hand the request over now.
+                move.w  #TOM_INT_DSP_EN,TOM_INT1_W
+
+                move.l  #PHASE2_SPIN,d2
+.spin2:         move.l  IRQ_MARKER_ADDR.l,d6
+                cmp.l   #IRQ_MARKER_VAL,d6
+                beq.s   .delivered
+                subq.l  #1,d2
+                bne.s   .spin2
+
+                ACID_FAIL #2,d6,#IRQ_MARKER_VAL
+
+.delivered:     ACID_PASS
+
+.leaked:        ACID_FAIL #1,d6,#0
+
+;; -----------------------------------------------------------------
+;; IRQ2 handler: mark, ack JERRY's pending DSP bit (high byte $02),
+;; ack TOM's INT1 JERRY pending bit while keeping C_JERENA enabled.
+irq2_handler:
+                move.l  #IRQ_MARKER_VAL,IRQ_MARKER_ADDR.l
+                move.w  #$0202,J_INT.l
+                move.w  #$1010,TOM_INT1_W
+                rte


### PR DESCRIPTION
Closes #499. Audit of every JERRY/TOM 68K interrupt raise site after #500 fixed the UART's missing `C_JERENA` gate.

## The rule, from the hardware docs

JERRY has **no wire of its own** to the 68K. Every JERRY source — external, DSP, PIT1, PIT2, UART, I2S — merges onto a single DINT line entering TOM as **INT1 bit 4 (`C_JERENA` / `IRQ_DSP`, mask `$0010`)**. TOM's own sources have their own bits: video 0, GPU 1, OP 2, TOM PIT 3.

So the gate a site needs is decided by **which chip owns the source**, not by analogy to #500. And `m68k_set_irq()` → `checkForIRQToHandle` → `m68ki_exception_interrupt()` never consults `TOMIRQRequestActive()`, so every raise site must gate itself.

## Every site, exhaustively (`git grep -n m68k_set_irq -- . ':!src/m68000'`)

| Site | Correct INT1 bit | Verdict |
|---|---|---|
| `src/jerry/dsp.c:792` DSP CPUINT | 4 `C_JERENA` | **defect — fixed here** |
| `src/jerry/uart.c:68` UART ASI | 4 | correct (#500) |
| `src/jerry/jerry.c:270/287` PIT1/PIT2 | 4 | correct |
| `src/cd/cdrom.c:1153` BUTCH external | 4 | correct |
| `src/tom/gpu.c:1046` GPU CPUINT | 1 `C_GPUENA` | correct — **already gated** at line 1021 |
| `src/tom/op.c:759` OP STOP-object | 2 `C_OPENA` | correct |
| `src/tom/tom.c:2050/2066` TOM PIT | 3 `C_PITENA` | correct |
| `src/tom/tom.c:574/1847` latch setters | all | correct |

**One defect in the whole tree.** The issue's suspicion that the GPU site might share the bug is wrong — I verified the enclosing `if (TOMIRQEnabled(IRQ_GPU))` independently.

## The fix

One gate in `src/jerry/dsp.c`, mirroring `uart.c` exactly. The latch and `DSPReleaseTimeslice()` stay **outside** it — only `m68k_set_irq(2)` is gated. `JERRYSetPendingIRQ(IRQ2_DSP)` still runs, so `JERRYIRQRequestActive()` keeps bit 4 in `TOMPendingMask()` and `tom.c:1847`'s `newlyEnabled & TOMPendingMask()` delivers on a later `C_JERENA` write. **Withheld, not lost.**

## An existing acid test was passing *because of* the bug

`test/acid/tests/dsp/dsp_irq_to_68k.s` enabled `J_DSPENA` but never `C_JERENA` — a sequence that raises nothing on real silicon. It only passed because our DSP site skipped the TOM gate.

That is confirmed by counterfactual, not by argument: the **original** source assembled and run against the **fixed** core gives `FAIL detail=0x1 observed=0x0`. It genuinely depended on the missing gate. Now it opens both, matching `tests/irq/jerry_pit_irq.s`, which already did this for the PIT path.

New `test/acid/tests/dsp/dsp_irq_tom_gate.s` pins both halves independently: `C_JERENA` clear ⇒ no 68K IPL2 (detail 1 on leak), and a subsequent `INT1 = $0010` ⇒ the withheld request is delivered (detail 2 if dropped). Measured **FAIL detail=1 pre-fix, PASS post-fix**.

## Corpus impact: none observed

A temporary counter on the raise site (removed before commit, proved live by the acid ROMs) over **160 cartridge ROMs + 35 CD images, 900 frames each: zero events**.

Scope stated precisely: the counter sits inside `if (JERRYIRQEnabled(IRQ2_DSP))`, so this means no title wrote CPUINT to `D_CTRL` *while `J_DSPENA` was set*. No scripted input, so most titles sat in attract/title screens — evidence of inertness on reachable states, not universal proof.

## Verification

- Acid suite **147/150, `Regressions: 0`** (the 3 FAILs are the known `bus/*` baseline rows; the 4 NEW `tests/timing/*_loop_rate.jag` rows are pre-existing on develop and deliberately untouched)
- `make TEST_EXPORTS=1 test` → **exit 0**. Iron Soldier 1 presence RMS **1174.2** (baseline ~1175); Skyhammer 3083.3, IS2 2598.3, both 0.000% saturated
- `scripts/c89-lint.sh src/jerry/dsp.c` → passed
- No RetroArch run — headless only. Given the corpus null result this should be invisible in-game, but that is inference.

## Open questions, deliberately not acted on

1. **Pending latches placed *inside* the enable gate** (`gpu.c:1045`, `op.c:758`, `jerry.c:268/285`) — a raise-while-disabled is *lost*, not withheld. The distilled docs imply pending latches independently of enable but never state it, and the risk cuts against changing it: latching a JERRY PIT while `C_JERENA` is clear creates an enabled-source latch nobody acks, which `jtrm-jerry.md:133-138` says re-presents IPL2 at every instruction boundary forever. The comment above `JERRYPIT1Callback` names Cybermorph and Missile Command 3D as the historical casualties. Needs a JTRM page citation or silicon evidence first.
2. **`IRQ2_SSI` is never raised anywhere** — an unimplemented JERRY→68K source, not a missing gate. Own ticket if a title needs it.
3. **`TOMSetPendingJERRYInt()` has no production caller** — acking TOM's INT1 bit 12 (`C_JERCLR`) is a no-op in our model. A divergence from the documented two-sided ack, consistent with observed game behaviour.
4. The issue's BrainDead 13 warning was misattributed: the lost-wakeup work is `gpu.c:683`/`1021-1041`, not this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
