### PR TITLE
build(makefile): remove unconditional -ffast-math (#517)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,20 @@ OPT_O3_PLATFORMS := unix osx win ios-arm64 ios9 tvos-arm64
 # It never took effect: the shared release branch appended -O2 afterwards and
 # the last -O wins, so the target silently built at -O2 (issue #516).  The
 # level is resolved here instead, where it is both effective and stamped.
-# -Ofast's headline implication, -ffast-math, is already applied
-# unconditionally to every non-MSVC build further down, so honouring the
-# declared flag adds no numerical semantics that were not already shipping.
+#
+# NOTE (issue #517): -Ofast's headline implication is -ffast-math, which
+# used to be applied unconditionally to every non-MSVC build further down
+# and so added no new semantics here.  #517's audit measured that global
+# -ffast-math at ~0% (integer-only hot loops; the only floating point in
+# the tree is a savestated I2S resampler and event-scheduling code, neither
+# on a hot path) and removed it everywhere else as a latent determinism
+# hazard.  classic_armv7_a7 was left alone -- its -Ofast is longstanding,
+# and this is an ARM cross-compile target this repo cannot benchmark on x86
+# or arm64 hardware -- so it is now the ONLY platform that still ships
+# -ffast-math.  If that ever needs to change: -Ofast -fno-fast-math is
+# last-wins (same mechanism as the -O2/-O3 override above) and cancels just
+# the fast-math half while keeping -Ofast's other -O3-family optimizations.
+# Measure before touching; don't assume the null result here transfers.
 OPT_OFAST_PLATFORMS := classic_armv7_a7
 ifeq ($(origin OPT_LEVEL),undefined)
    ifneq ($(filter $(platform),$(OPT_OFAST_PLATFORMS)),)
@@ -308,7 +319,11 @@ else ifeq ($(platform), libnx)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	DEFINES := -DSWITCH=1 -D__SWITCH__
 	CFLAGS := $(DEFINES) -fPIE -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec -specs=$(LIBNX)/switch.specs
-	CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -ffast-math
+	# -ffast-math dropped here too (issue #517): the hot loops it could
+	# possibly speed up are integer-only regardless of target architecture,
+	# so the x86_64/arm64 A/B null result (see the FLAGS block below)
+	# generalizes here without needing a Switch-specific measurement.
+	CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd
 	CXXFLAGS := $(ASFLAGS) $(CFLAGS)
 	STATIC_LINKING = 1
 
@@ -720,8 +735,21 @@ ifeq ($(COVERAGE),1)
    endif
 endif
 
+# -ffast-math removed (issue #517 audit): every hot loop in this core (68K,
+# GPU/DSP RISC interpreters, blitter) is integer-only, so it cannot speed
+# them up, and the A/B measurement confirmed no effect (p=0.55, well under
+# significance -- see test/tools/opt_ab.sh, `FASTMATH=0` vs `FASTMATH=1`).
+# The only floating point in the tree that isn't test/trace-only is the I2S
+# resampler in src/jerry/dac.c (i2sPhase/i2sRateRatio, both in the
+# savestate) and event scheduling in src/core/event.c / src/tom/gpu.c
+# (riscUSec/consumed feeding EVENT_MAIN) -- both of those are emulated
+# state, and -ffast-math's reassociation/FMA-contraction/denormal-flushing
+# is host- and compiler-dependent, so it was a latent netplay/savestate
+# determinism hazard (same class as #400, #479) for zero measured benefit.
+# See axistune.c's header comment for the project's existing position on
+# host-dependent FP in emulated state.
 ifeq (,$(findstring msvc,$(platform)))
-FLAGS += -ffast-math -fomit-frame-pointer -fno-common
+   FLAGS += -fomit-frame-pointer -fno-common
 endif
 
 # ----------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -737,8 +737,14 @@ endif
 
 # -ffast-math removed (issue #517 audit): every hot loop in this core (68K,
 # GPU/DSP RISC interpreters, blitter) is integer-only, so it cannot speed
-# them up, and the A/B measurement confirmed no effect (p=0.55, well under
-# significance -- see test/tools/opt_ab.sh, `FASTMATH=0` vs `FASTMATH=1`).
+# them up, and the A/B measurement confirmed no effect: interleaved
+# A/B/B/A, n=16 per arm, median 217.5 fps without vs 215.0 fps with
+# (-1.1%, i.e. fast-math was fractionally SLOWER), Mann-Whitney z=-0.60
+# p=0.5465 -- under the noise floor, report no effect.  To reproduce you
+# must first re-add a FASTMATH toggle (the audit used a temporary variable
+# in this block, added to BUILD_AXES so the flip flushes every object) and
+# then drive it with test/tools/opt_ab.sh; there is no standing knob,
+# because the flag no longer has two states worth switching between.
 # The only floating point in the tree that isn't test/trace-only is the I2S
 # resampler in src/jerry/dac.c (i2sPhase/i2sRateRatio, both in the
 # savestate) and event scheduling in src/core/event.c / src/tom/gpu.c


### PR DESCRIPTION
## Summary

Audit of issue #517: `Makefile:724` applied `-ffast-math` unconditionally to every non-MSVC build with no record of what it bought. This core's hot loops (68K interpreter, GPU/DSP RISC interpreters, blitter) are entirely integer -- `-ffast-math` cannot speed those up. Measurement confirms the expected ~0% and removes the flag globally rather than adding per-file exemptions.

## What was audited

Floating point in the tree, confirmed still accurate on current develop (small line-number drift from the 2026-08-20 snapshot, noted below):

| Component | float/double | Notes |
|---|---|---|
| `src/jerry/dsp.c` | zero | fixed-point integer ISA |
| `src/tom/blitter.c` | trace only | behind `BLITTER_TRACE`, not shipped |
| `src/jerry/axistune.c` | deliberately none | `powf()` rejected -- host-libm rounding would make FNV digests host-dependent |
| `src/jerry/dac.c` | 27 uses, `i2sPhase`/`i2sRateRatio` **in the savestate** (now lines 521-522/581-582) | the real exposure -- I2S resampler |
| `src/core/event.c`, `src/tom/gpu.c` (now line 1036) | event scheduling in `double` (`riscUSec`/`consumed` feeding `EVENT_MAIN`) | the other real exposure |

No `isnan`/`isinf`/`isfinite` guards exist anywhere, so `-ffinite-math-only` kills no check. This was a latent netplay/savestate determinism hazard (same class as #400, #479), not a reported bug.

## Measurement

`test/tools/opt_ab.sh` (A/B/B/A interleaved, 8 quartets) required parameterizing the flag first -- it was hardcoded, not a make variable. Added `FASTMATH` gate and ran:

```
test/tools/opt_ab.sh 'FASTMATH=0' 'FASTMATH=1' 8
```

Distinct SHA-256 binaries confirmed (`85cbd833e445` vs `612188ea8ae6`). Host load was checked (<12 on 12 cores) and a shared benchmark lock acquired/released around the run.

```
FASTMATH=0   n=16 min=186.9 median=217.5 max=230.2
FASTMATH=1   n=16 min=182.1 median=215.0 max=232.5
median delta B vs A: -1.1%   best-run: +1.0%
Mann-Whitney p=0.55 -> NOT significant, under the noise floor
```

A savestate FNV digest A/B (`test/tools/hires_state_digest`, Iron Soldier, frames 300/600/900, an audio-heavy title) was also byte-identical with and without `-ffast-math` on this host/compiler (clang, arm64 macOS) -- consistent with the divergence hazard being cross-host/cross-compiler rather than reproducible on a single toolchain.

Since the measurement confirmed ~0% benefit, the flag was **deleted globally** rather than kept with per-file `-fno-fast-math` exemptions -- simpler and safer than a list someone will forget to extend, and the actual FP exposure (DAC resampler, event scheduling) is architecture-independent, so there's no reason to keep host-dependent rounding behavior anywhere in the tree.

## Changes (Makefile only, no `.c` touched -- c89-lint N/A)

- `Makefile`: removed unconditional `-ffast-math` from the shared `FLAGS` block (was line 724).
- `Makefile` (switch/libnx block, was line 311): removed the `-ffast-math` that block re-added on its own. Justification differs from the desktop measurement: the "no hot float code" reasoning is architecture-independent (it's about what data types are in the hot path, not compiler backend behavior), so the x86_64/arm64 null result generalizes here without a Switch-specific measurement -- unlike `-O3`/opt-level choices, which are legitimately compiler-backend-specific and do need per-platform measurement.
- `Makefile` (classic_armv7_a7 `-Ofast`, ~line 53-70): left alone. `-Ofast` implies `-ffast-math`; this is a longstanding platform-specific setting (issue #516) on an ARM cross-compile target this repo cannot benchmark on x86_64/arm64 hardware. Updated the now-stale comment (it previously said honouring `-Ofast` "adds no numerical semantics not already shipping" -- no longer true once the global flag is gone) to note this platform is now the *only* one still shipping `-ffast-math`, and documented `-Ofast -fno-fast-math` (last-wins, same mechanism already used for the `-O2`/`-O3` override) as the path to cancel it later if ever measured.

## Test plan

- [x] `make -j8` clean build succeeds, `-ffast-math` absent from default and switch/libnx dry-run flags (`make -n` grep)
- [x] `make TEST_EXPORTS=1 test` exits 0
- [x] Audio tests confirmed by name in the log (not just exit code): `Clipping check: Iron Soldier 2` (0.000% saturated, RMS 2598.3) and `Presence check: Iron Soldier 1` / `Presence check: Iron Soldier 1 (risc=2x)` both `PASS: audio is present and within expected envelope`
- [x] Savestate FNV digest A/B (Iron Soldier, frames 300/600/900) identical with/without `-ffast-math` on this host
- [x] `scripts/c89-lint.sh` N/A -- no `.c` files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)