### PR TITLE
feat(netlink): opt-in link wire-speed enhancement (#498)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1118,6 +1118,14 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	 fi
 	bash test/tools/voicemodem_pair_test.sh ./$(TARGET)
 	bash test/tools/netlink_latency_test.sh ./$(TARGET)
+	@# Wire-speed enhancement (#498).  Three real core pairs whose only
+	@# difference is each side's virtualjaguar_netlink_speed, so the
+	@# MISMATCHED pair is exercised as a first-class configuration: the
+	@# option's whole documented contract is "both sides, same value; one
+	@# side just gets less benefit", and nothing else would notice if a
+	@# one-sided setup actually stalled the link instead. Uses the same
+	@# below-ephemeral PID-spread port band as the witnesses below.
+	bash test/tools/netlink_wire_speed_test.sh ./$(TARGET)
 	@# Review-round-1 finding (task 4, #467): no other test runs a core in
 	@# a discovery-active mode long enough in REAL wall-clock time (not
 	@# frame count) for netlink_rebuild_host_options()'s 2s rate-limit

--- a/docs/netlink-design.md
+++ b/docs/netlink-design.md
@@ -393,6 +393,56 @@ Validation:
 Frontend matrix: RetroArch ≥ 1.16 → netpacket netplay; any other frontend
 (Provenance, etc.) → TCP modes; every frontend → loopback/disabled.
 
+## Wire-latency enhancement (2026-08-20 addendum, #498)
+
+`UARTFrameUsec()` is the single choke point for the whole link's emulated
+latency — **both** the TX drain and the RX arrival schedule through it — so
+`virtualjaguar_netlink_speed` (default off, values 2 / 4) divides exactly
+that one number. Three things about the shape are load-bearing:
+
+- **Gated on an active transport, evaluated per call.** With
+  `JLinkMode() == JLINK_MODE_DISABLED` the function takes a branch that is
+  textually develop's original expression, not a divide-by-one, so a stale
+  setting can never perturb a non-link session by a rounding step.
+  `"auto"` resolves to DISABLED until a netplay session actually exists,
+  so the gate is honest about the default. Not cached, so netpacket
+  takeover is followed automatically.
+- **The accelerated receiver applies back-pressure.** Stock hardware drops
+  the new byte when a character completes into a full RBF (an overrun) —
+  correct silicon, and preserved exactly when the option is off. But the
+  *reader's* polling rate belongs to the game, so dividing the character
+  time divides the reader's budget with it. Measured, not theorised: at 4x
+  with the plain hardware rule, Ultra Vortek's DSP-poll driver lost the
+  second byte of the `$B800` wake reply and the modem handshake never
+  completed — **0 pad words against 7044 stock**. With `UARTKickRx()`
+  refusing to start a character while RBF is unread, 4x completes normally
+  (6948). Without back-pressure, only 2x is shippable; with it, the byte
+  stream is provably unchanged and only timing moves.
+- **Not in the savestate.** Like NTSC/PAL it is a runtime setting, and
+  `event.c` saves the *remaining* time of each queued callback rather than
+  a rate — so a state captured accelerated and reloaded stock plays out the
+  one already-scheduled character at its saved deadline and reschedules at
+  stock timing from there.
+
+Symmetry is a documentation matter, not a guard: a lockstep exchange is
+gated by the sum of both sides' clocking, so a mismatched pair still
+completes and stays in sync, it simply gets less of the benefit. Measured
+on the synthetic ping-pong cart at ASICLK 1999 (`netlink_wire_speed_test.sh`),
+two independent runs: **16.9 / 22.6 / 52.5** and **16.4 / 25.0 / 49.9**
+exchanges per second for off-off, 4x-off, 4x-4x. One side alone lands
+between the two symmetric configurations, well short of half the benefit.
+Ultra Vortek's full-game pair completes the choreography in the mismatched
+configuration too (6972 pad words), and 4x-4x reproduces across runs
+(6948, 6920) rather than being bimodal — which matters, because the
+pre-back-pressure failure was catastrophic (0), so a single pass would not
+have shown the margin.
+
+Because the wall-clock ladder is measured off two paced processes, the
+ratio assertions are gated on the probe's own pacing telemetry and SKIP
+(loudly, through `scripts/test-skip.sh`) on a runner that could not hold
+its frame slots. The liveness assertions — every configuration, including
+the mismatched one, still exchanges — are unconditional failures.
+
 ## Decisions log
 
 - TCP before netpacket (user, 2026-07-31) — frontend-agnostic + testable first.

--- a/docs/netlink-user-guide.md
+++ b/docs/netlink-user-guide.md
@@ -72,6 +72,40 @@ Up to 8 units total (1 host + 7 clients) — enough for AirCars' CatNet.
 Desktop/testing shortcuts: environment variables `VJ_NETLINK_HOST` and
 `VJ_NETLINK_PORT` override both the options and the file.
 
+## Making link play feel snappier (optional, not authentic)
+
+*Network Link Wire Speed* (default **Off**) clocks the emulated serial
+port 2x or 4x faster than the real hardware ran it.
+
+You do not need it to play. What it fixes is a specific feel: in a
+strictly lockstep title neither console can draw the next frame until the
+pad data has been swapped both ways, and the Jaguar's link is slow enough
+that the swap can outlast the frame it belongs to — so your own move shows
+up a frame late even on a perfect connection. Ultra Vortek's Voice Modem
+mode is the clearest case: it settles at 19200 baud and trades about ten
+bytes each way every frame, roughly 5.8 ms of pure wire time per
+direction against a 16.7 ms frame.
+
+That slowness is *real* — a Voice Modem or a JagLink cable behaved exactly
+this way — which is why this is off by default and labelled an
+enhancement rather than a fix.
+
+- **Set it on both consoles, to the same value.** Each side only speeds
+  up its own half of the exchange, so one side alone gives you part of
+  the improvement. A mismatched pair still plays correctly and stays in
+  sync; it just gets less benefit. (Verified, not assumed:
+  `test/tools/netlink_wire_speed_test.sh`.)
+- Start at 2x. Go to 4x if you still notice it.
+- If a game starts behaving oddly on the link, put it back to Off before
+  reporting anything — link timing bug reports are only meaningful at
+  Off.
+- The setting does nothing at all unless *Network Link* is actually
+  selected, so leaving it on will never affect a single-player session.
+
+This is a different knob from *Network Link Latency Hiding*, which deals
+with the **network** between the two machines. Wire Speed deals with the
+emulated **cable**, and helps even at zero network latency.
+
 ## Troubleshooting
 
 - **Never mix options A and B** in one session — a netplay host and a TCP

--- a/docs/voice-modem.md
+++ b/docs/voice-modem.md
@@ -163,6 +163,30 @@ pads are fed to the player slots (`$57E4`/`$57E8`, selected by `$57DB`).
 - Async `$A4` with bit 0 set (e.g. `$A401`) during a call = line drop →
   LOST PHONE CONNECTION.
 
+### Why the local player sees their own move late (issue #498)
+
+The data phase is ~10 console bytes per direction per frame (4 × `$F0xx`
++ the `$F301` marker). At the ASICLK = `$56` the driver settles on, one
+character frame is `11 × 16 × 87 = 15312` RISC cycles ≈ **576 µs**, so a
+packet is ~5.8 ms of pure wire time each way — against a 16.7 ms video
+frame, with `$57DD`'s strict lockstep meaning the local pad cannot be
+*displayed* until the whole exchange completes. The instinct is to blame
+the network; the arithmetic says the emulated cable is the choke point,
+and `TCP_NODELAY` plus the adaptive reply wait already cover the network
+side.
+
+This is authentic — a real Voice Modem at 19200 baud was exactly this
+slow — so it is addressed as an **opt-in enhancement**, not a bug fix:
+core option `virtualjaguar_netlink_speed` (default Off) divides the
+character frame time by 2 or 4. The knob is a single one:
+`UARTFrameUsec()` in `src/jerry/uart.c` schedules both the TX drain and
+the RX arrival, and it takes the untouched stock branch whenever the
+option is off *or* no link transport is selected. It changes only *when*
+bytes appear, never which bytes or in what order, and is not part of the
+savestate (event.c already saves the remaining time of the queued UART
+callbacks). Both consoles should set it, to the same value — see
+`docs/netlink-user-guide.md`.
+
 ## What the emulation does (src/jerry/voicemodem.c)
 
 A virtual modem in front of the jlink transport (`virtualjaguar_uart_device

--- a/libretro.c
+++ b/libretro.c
@@ -1227,6 +1227,7 @@ static void netlink_apply(int mode, const char *opt_value)
    const char *src = "default";
    int want_file = 0;
    int got_file = 0;
+   int speedup;                  /* #498 wire-latency divisor, 1 = stock */
    /* OSD dedup state -- see netlink_osd_last_mode's declaration comment. */
    char narrate_host[128];
    int narrate_device;
@@ -1250,6 +1251,21 @@ static void netlink_apply(int mode, const char *opt_value)
    pvar.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pvar) && pvar.value)
       JLinkSetWaitEnabled(strcmp(pvar.value, "disabled") != 0);
+
+   /* Wire-latency enhancement (#498).  Read raw, like netlink_wait and
+    * the mode itself: a per-title default has no business overriding a
+    * deliberately non-authentic timing choice the user made, and the
+    * setting is only meaningful in the same breath as the transport. */
+   pvar.key = "virtualjaguar_netlink_speed";
+   pvar.value = NULL;
+   speedup = 1;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pvar) && pvar.value)
+   {
+      int n = atoi(pvar.value);      /* "disabled" -> 0 -> clamped to 1 */
+      if (n > 1)
+         speedup = n;
+   }
+   UARTSetWireSpeedup((unsigned)speedup);
 
    netlink_resolve_host(host, sizeof(host), &src, &want_file, &got_file);
 
@@ -1343,6 +1359,16 @@ static void netlink_apply(int mode, const char *opt_value)
                      netlink_mode_name(mode),
                      netlink_device_label(JLinkDevice()), port);
    }
+
+   /* Same contract as the [CLOCK] non-stock-scale line: an enhancement
+    * that changes emulated timing has to announce itself, or a link bug
+    * filed from an accelerated session reads as an emulation defect.
+    * Only worth a line when it can actually take effect -- with no
+    * transport selected UARTFrameUsec() takes the stock branch anyway. */
+   if (speedup > 1 && mode != JLINK_MODE_DISABLED)
+      LOG_INF("[NETLINK] wire speed %dx -- emulated UART runs faster than "
+              "real hardware (enhancement; both consoles should match, and "
+              "link timing bug reports are only valid at Off)\n", speedup);
 
    /* The "From file" preset selected but no usable address in the file is
     * a silent 127.0.0.1 fallback -- the one that cost a debugging session. */

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -380,6 +380,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "enabled"
    },
    {
+      "virtualjaguar_netlink_speed",
+      "Network Link Wire Speed (Enhancement)",
+      NULL,
+      "Clocks the emulated serial port faster than the real hardware did, so a link game's lockstep exchange finishes inside one video frame instead of spilling into the next. Ultra Vortek's Voice Modem mode settles at 19200 baud and swaps about ten bytes each way per frame, roughly 5.8 ms of pure wire time per direction, which is why you do not see your own move until the round trip completes. Not authentic -- a real Voice Modem or JagLink cable is exactly this slow -- so it is off by default. BOTH consoles should set it, and to the same value: each side only speeds up its own half of the exchange, so one side alone gives you part of the benefit. If a game starts dropping link data, step it back down. Ignored unless Network Link is actually selected.",
+      NULL,
+      "network",
+      {
+         { "disabled", "Off (authentic hardware timing)" },
+         { "2",        "2x faster" },
+         { "4",        "4x faster" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "virtualjaguar_cd_trace",
       "CD Trace (Diagnostic)",
       NULL,

--- a/src/jerry/uart.c
+++ b/src/jerry/uart.c
@@ -48,12 +48,56 @@ static uint8_t uartTxShift;
 static uint8_t uartTxBusy;      /* shift register clocking out */
 static uint8_t uartRxBusy;      /* an RX frame is in flight */
 
+/* Wire-latency enhancement (#498).  1 = stock; see UARTSetWireSpeedup. */
+static unsigned uartWireSpeedup = 1;
+
 /* One character frame in microseconds at the current divider. */
 static double UARTFrameUsec(void)
 {
-   double cyc = 11.0 * 16.0 * (double)((uint32_t)asiClk + 1u);
-   return cyc * (vjs.hardwareTypeNTSC ? RISC_CYCLE_IN_USEC
-                                      : RISC_CYCLE_PAL_IN_USEC);
+   /* Stock path, byte-for-byte what this function has always computed.
+      Deliberately NOT folded into a "divide by 1" of the accelerated
+      branch: with the enhancement off (or no link transport selected)
+      the arithmetic must be textually identical to develop's, so
+      option-off cannot perturb event scheduling by a rounding step. */
+   if (uartWireSpeedup <= 1 || JLinkMode() == JLINK_MODE_DISABLED)
+   {
+      double cyc = 11.0 * 16.0 * (double)((uint32_t)asiClk + 1u);
+      return cyc * (vjs.hardwareTypeNTSC ? RISC_CYCLE_IN_USEC
+                                         : RISC_CYCLE_PAL_IN_USEC);
+   }
+   {
+      double cyc = 11.0 * 16.0 * (double)((uint32_t)asiClk + 1u)
+                   / (double)uartWireSpeedup;
+      return cyc * (vjs.hardwareTypeNTSC ? RISC_CYCLE_IN_USEC
+                                         : RISC_CYCLE_PAL_IN_USEC);
+   }
+}
+
+/* Enhancement knob (#498).  Set from the libretro option layer, never
+   from emulated code, and deliberately outside the savestate: like
+   NTSC/PAL it is a runtime setting, and event.c saves the REMAINING time
+   of the queued UART callbacks rather than a rate, so a state captured
+   with the option on and reloaded with it off just plays out the one
+   already-scheduled character at its saved deadline and reschedules at
+   stock timing from there. */
+void UARTSetWireSpeedup(unsigned divisor)
+{
+   if (divisor < 1u)
+      divisor = 1u;
+   /* Upper clamp matches the largest value the option offers.  The option
+      layer never produces more, but a RetroArch .cfg is a text file a user
+      can put anything in, and an unbounded divisor drives the character
+      time toward zero -- tens of thousands of UART events per emulated
+      frame.  Raise this in step with the option's value list, never
+      independently. */
+   if (divisor > UART_WIRE_SPEEDUP_MAX)
+      divisor = UART_WIRE_SPEEDUP_MAX;
+   uartWireSpeedup = divisor;
+}
+
+unsigned UARTWireSpeedup(void)
+{
+   return uartWireSpeedup;
 }
 
 static void UARTRaiseIRQ(void)
@@ -69,14 +113,40 @@ static void UARTRaiseIRQ(void)
    }
 }
 
-/* Start an RX frame if the transport has data and none is in flight. */
+/* Start an RX frame if the transport has data and none is in flight.
+
+   With the #498 wire-speed enhancement active the receiver additionally
+   refuses to start a character while the last one is still unread (RBF
+   set), holding the byte on the transport instead.  Stock hardware has no
+   such back-pressure -- a character completing into a full RBF is an
+   overrun and the new byte is LOST -- and that is exactly the hazard
+   acceleration creates: the reader's polling rate is set by the game, so
+   dividing the character time divides the reader's budget with it.  Ultra
+   Vortek's driver moves UART bytes with a DSP poll loop, and at 4x the
+   second byte of a two-byte modem reply ($B800) could complete before the
+   poll drained the first, dropping it -- the whole wake handshake then
+   stalls, which is a game-observable change and not allowed.  Holding the
+   wire instead keeps the byte stream byte-for-byte identical and leaves
+   only timing altered, which is the entire contract of the option.
+   ASIDATA reads call back into here, so a held byte starts the instant
+   the reader drains RBF.  With the option off this is the untouched stock
+   condition.
+
+   No JLinkMode() term here, unlike UARTFrameUsec(): dropping the link
+   drains the RX ring (JLinkClose zeroes jlinkCount), so "speedup set but
+   no transport" cannot coexist with a pending byte and the test would be
+   an untested branch rather than a safety net.  UARTFrameUsec() does need
+   its mode check -- the option can be left at 4x with no link selected,
+   and every UART timing in that state must stay stock.  Pinned by
+   test_wire_speedup_link_drop_drains() in test/test_uart_loopback.c. */
 static void UARTKickRx(void)
 {
-   if (!uartRxBusy && JLinkRxPending())
-   {
-      uartRxBusy = 1;
-      SetCallbackTime(UARTRXCallback, UARTFrameUsec(), EVENT_JERRY);
-   }
+   if (uartRxBusy || !JLinkRxPending())
+      return;
+   if (uartWireSpeedup > 1 && uartRxFull)
+      return;
+   uartRxBusy = 1;
+   SetCallbackTime(UARTRXCallback, UARTFrameUsec(), EVENT_JERRY);
 }
 
 void UARTTXCallback(void)
@@ -242,6 +312,12 @@ void UARTReset(void)
 void UARTDone(void)
 {
    UARTReset();
+   /* Teardown, not per-game reset: the option layer re-applies the divisor
+      on every check_variables(), and UARTReset() runs from JERRYInit()
+      AFTER that, so clearing it there would silently discard the setting.
+      Cleared here so the iOS "cores are never dlclosed, reset every static
+      in deinit" rule holds. */
+   uartWireSpeedup = 1;
    JLinkClose();
 }
 

--- a/src/jerry/uart.h
+++ b/src/jerry/uart.h
@@ -15,6 +15,16 @@ void UARTDone(void);
 void UARTSetLinkMode(int mode);   /* JLINK_MODE_* from jlink.h */
 void UARTPoll(void);              /* per frame, after JLinkPoll */
 
+/* Enhancement (issue #498, NOT authentic): divide the emulated character
+   frame time on an active link so a lockstep pad exchange finishes inside
+   one video frame.  1 = stock hardware timing (the default); only values
+   > 1 change anything, and only while a link transport is selected.
+   Clamped to [1, UART_WIRE_SPEEDUP_MAX] -- keep the max in step with the
+   virtualjaguar_netlink_speed option's value list. */
+#define UART_WIRE_SPEEDUP_MAX 4u
+void     UARTSetWireSpeedup(unsigned divisor);
+unsigned UARTWireSpeedup(void);
+
 uint16_t UARTReadWord(uint32_t offset);
 void UARTWriteWord(uint32_t offset, uint16_t data);
 

--- a/test/test_uart_loopback.c
+++ b/test/test_uart_loopback.c
@@ -57,6 +57,7 @@ static void fresh(void)
 {
     InitializeEventList();
     UARTReset();
+    UARTSetWireSpeedup(1);        /* #498 enhancement off unless a test sets it */
     UARTSetLinkMode(JLINK_MODE_LOOPBACK);
     stubIrqMask = IRQ2_ASI;   /* J_ASYNENA on unless a test clears it */
     stubPending = 0;
@@ -235,6 +236,140 @@ static void test_tx_interrupt_on_holding_drain(void)
     CHECK((stubPending & IRQ2_ASI) != 0, "TINTEN: holding drain raises IRQ");
 }
 
+/* ---- #498: opt-in netlink wire-latency enhancement ----
+   UARTFrameUsec() is the single choke point for BOTH the TX drain and the
+   RX arrival, so these cases pin the whole feature: the divisor applies,
+   it only applies on an active link, and it changes nothing but time. */
+
+/* Emulated microseconds until the pending UART character completes, for
+   one byte written at the given ASICLK.  Uses ASICLK $56 (86) -- the
+   value Ultra Vortek's Voice Modem driver settles at (docs/voice-modem.md),
+   i.e. the case the enhancement exists for. */
+static double frame_usec_at(unsigned speedup, int link_mode)
+{
+    fresh();
+    UARTSetLinkMode(link_mode);
+    UARTSetWireSpeedup(speedup);
+    UARTWriteWord(ASICLK, 0x56);
+    UARTWriteWord(ASIDATA, 0x41);
+    return GetTimeToNextEvent(EVENT_JERRY);
+}
+
+static void test_wire_speedup_scales_frame_time(void)
+{
+    /* Stock reference computed the way uart.c's untouched branch does. */
+    double stock = 11.0 * 16.0 * 87.0 * RISC_CYCLE_IN_USEC;
+    double t;
+
+    fresh();
+    CHECK(UARTWireSpeedup() == 1, "wire speedup defaults to 1 (off)");
+
+    t = frame_usec_at(1, JLINK_MODE_LOOPBACK);
+    CHECK(fabs(t - stock) < 0.001, "speedup off: stock 576 us character frame");
+
+    t = frame_usec_at(2, JLINK_MODE_LOOPBACK);
+    CHECK(fabs(t - stock / 2.0) < 0.001, "speedup 2x halves the character frame");
+
+    t = frame_usec_at(4, JLINK_MODE_LOOPBACK);
+    CHECK(fabs(t - stock / 4.0) < 0.001, "speedup 4x quarters the character frame");
+}
+
+/* The gate that keeps every non-link user on stock timing: with no
+   transport selected the divisor must be ignored outright, so a stale
+   "4x" left in a config can never perturb a single-player session. */
+static void test_wire_speedup_ignored_without_link(void)
+{
+    double stock = 11.0 * 16.0 * 87.0 * RISC_CYCLE_IN_USEC;
+    double t = frame_usec_at(4, JLINK_MODE_DISABLED);
+    CHECK(fabs(t - stock) < 0.001, "link disabled: 4x ignored, stock timing");
+}
+
+static void test_wire_speedup_clamps(void)
+{
+    fresh();
+    UARTSetWireSpeedup(0);
+    CHECK(UARTWireSpeedup() == 1, "divisor 0 clamps to 1");
+    /* A RetroArch .cfg is a text file: the option layer never produces
+       more than the option's largest value, but a hand-edited config can,
+       and an unbounded divisor drives the character time toward zero. */
+    UARTSetWireSpeedup(100000);
+    CHECK(UARTWireSpeedup() == UART_WIRE_SPEEDUP_MAX,
+          "absurd divisor clamps to UART_WIRE_SPEEDUP_MAX");
+}
+
+/* "Nothing game-observable changes except timing": the same bytes arrive
+   in the same order with the same status-register transitions at 4x as at
+   1x.  Only the emulated interval between them differs. */
+static void test_wire_speedup_stream_identical(void)
+{
+    uint16_t st;
+    fresh();
+    UARTSetWireSpeedup(4);
+    UARTWriteWord(ASICLK, 0x56);
+    UARTWriteWord(ASIDATA, 0x01);          /* -> shift */
+    UARTWriteWord(ASIDATA, 0x02);          /* -> holding */
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_TBE) == 0, "4x: holding full still clears TBE");
+    pump(1);
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_TBE) != 0, "4x: holding drained still sets TBE");
+    pump(2);
+    CHECK((UARTReadWord(ASIDATA) & 0xFF) == 0x01, "4x: 1st byte received first");
+    pump(1);
+    CHECK((UARTReadWord(ASIDATA) & 0xFF) == 0x02, "4x: 2nd byte follows");
+    CHECK((UARTReadWord(ASISTAT) & ST_OE) == 0, "4x: no overrun on read-per-byte");
+}
+
+/* The hazard that decides how far the enhancement may go, and the reason
+   the accelerated receiver applies back-pressure.  test_overrun() above
+   pins the stock behaviour: a character completing into a full RBF is an
+   overrun and the NEW byte is lost.  That is correct hardware, but the
+   reader's polling rate belongs to the game, so dividing the character
+   time divides the reader's budget with it -- and a dropped byte in a
+   framed lockstep protocol is a desync, i.e. a game-observable change.
+   Measured, not theorised: at 4x with the plain hardware rule, Ultra
+   Vortek's DSP-poll driver lost the second byte of the $B800 wake reply
+   and the modem handshake never completed (0 pad words vs 7044 stock).
+   Accelerated, the byte waits on the wire instead. */
+static void test_wire_speedup_no_overrun_loss(void)
+{
+    uint16_t st;
+    fresh();
+    UARTSetWireSpeedup(4);
+    UARTWriteWord(ASICLK, 0x56);
+    UARTWriteWord(ASIDATA, 0x01);
+    UARTWriteWord(ASIDATA, 0x02);
+    pump(4);                               /* TX#1, TX#2, RX#1 -- no reads */
+    st = UARTReadWord(ASISTAT);
+    CHECK((st & ST_RBF) != 0, "4x: first byte buffered");
+    CHECK((st & ST_OE) == 0,  "4x: unread RBF holds the wire, no overrun");
+    CHECK((UARTReadWord(ASIDATA) & 0xFF) == 0x01, "4x: first byte intact");
+    pump(1);                               /* the held byte now clocks in */
+    CHECK((UARTReadWord(ASISTAT) & ST_RBF) != 0, "4x: held byte then arrives");
+    CHECK((UARTReadWord(ASIDATA) & 0xFF) == 0x02,
+          "4x: second byte DELIVERED, not dropped");
+}
+
+/* The invariant that lets UARTKickRx()'s back-pressure test omit a
+   JLinkMode() term: dropping the link drains the RX ring, so "speedup set
+   but no transport selected" can never coexist with a byte pending on the
+   wire.  If a future transport change stops clearing the ring on close,
+   this fails here rather than silently applying accelerated back-pressure
+   while UARTFrameUsec() is on its stock branch. */
+static void test_wire_speedup_link_drop_drains(void)
+{
+    fresh();
+    UARTSetWireSpeedup(4);
+    UARTWriteWord(ASICLK, 0x56);
+    UARTWriteWord(ASIDATA, 0x11);
+    UARTWriteWord(ASIDATA, 0x22);
+    pump(2);                               /* both TX frames -> loopback ring */
+    UARTSetLinkMode(JLINK_MODE_DISABLED);  /* pull the cable */
+    pump(2);
+    CHECK((UARTReadWord(ASISTAT) & ST_RBF) == 0,
+          "link dropped: RX ring drained, nothing pending to hold");
+}
+
 int main(void)
 {
     vjs.hardwareTypeNTSC = true;
@@ -249,6 +384,12 @@ int main(void)
     test_rx_interrupt_tom_gate();
     test_rx_interrupt_disabled();
     test_tx_interrupt_on_holding_drain();
+    test_wire_speedup_scales_frame_time();
+    test_wire_speedup_ignored_without_link();
+    test_wire_speedup_clamps();
+    test_wire_speedup_stream_identical();
+    test_wire_speedup_no_overrun_loss();
+    test_wire_speedup_link_drop_drains();
     printf(failures ? "FAILED (%d)\n" : "OK\n", failures);
     return failures ? 1 : 0;
 }

--- a/test/tools/netlink_latency.c
+++ b/test/tools/netlink_latency.c
@@ -22,7 +22,18 @@
  * (pass/fail bounds on exchanges/sec), --wait enabled|disabled (the
  * virtualjaguar_netlink_wait core option; the wait budget itself is
  * adaptive inside the core, not user-tuned).
- * Exit 0 on pass, 1 on fail/error.  Driven by netlink_latency_test.sh.
+ *
+ * Both roles also take --asiclk N (the ASICLK divider the synthetic cart
+ * programs, default 1) and --speed disabled|2|4 (the #498
+ * virtualjaguar_netlink_speed enhancement, this side only).  Together
+ * they turn this tool into the wire-latency A/B: raise --asiclk until the
+ * emulated character frame, not the 60 fps frame slot, sets the exchange
+ * rate, then compare both-stock / one-side-fast / both-fast.  Because
+ * --speed is per side, a mismatched pair is a first-class configuration
+ * here -- see netlink_wire_speed_test.sh.
+ *
+ * Exit 0 on pass, 1 on fail/error.  Driven by netlink_latency_test.sh
+ * and netlink_wire_speed_test.sh.
  */
 #define _DEFAULT_SOURCE 1
 #include <stdio.h>
@@ -69,18 +80,26 @@ static const uint8_t echo_prog[] = {
     0x60, 0xE8
 };
 
-static const char *make_synth_rom(const char *role)
+/* asiclk is the ASICLK divider the synthetic cart programs.  The stock
+   $0001 makes a character frame ~13 us -- far below anything the link
+   stack or the #498 wire-speed enhancement can move -- so a latency A/B
+   run has to raise it until the emulated wire, not the 60 fps frame slot,
+   is the binding constraint.  Patched into the move.w immediate at
+   echo_prog[8..9] rather than assembled a second time. */
+static const char *make_synth_rom(const char *role, int asiclk)
 {
     static char path[256];
     static uint8_t rom_buf[ROM_SIZE];
     FILE *f;
     const char *tmp = getenv("TMPDIR");
-    snprintf(path, sizeof(path), "%s/vj_netlink_lat_%s.j64",
-             tmp ? tmp : "/tmp", role);
+    snprintf(path, sizeof(path), "%s/vj_netlink_lat_%s_%d.j64",
+             tmp ? tmp : "/tmp", role, asiclk);
     memset(rom_buf, 0, ROM_SIZE);
     rom_buf[0x404] = 0x00; rom_buf[0x405] = 0x80;
     rom_buf[0x406] = 0x20; rom_buf[0x407] = 0x00;
     memcpy(rom_buf + 0x2000, echo_prog, sizeof(echo_prog));
+    rom_buf[0x2000 + 8] = (uint8_t)((asiclk >> 8) & 0xFF);
+    rom_buf[0x2000 + 9] = (uint8_t)(asiclk & 0xFF);
     f = fopen(path, "wb");
     if (!f) return NULL;
     fwrite(rom_buf, 1, ROM_SIZE, f);
@@ -111,6 +130,9 @@ int main(int argc, char **argv)
     const char *role = NULL;
     const char *port = "42171";
     const char *wait_opt = "enabled";
+    const char *speed_opt = "disabled";   /* #498 wire speed, this side */
+    int asiclk = 1;
+    int pace_echo = 0;
     int measure_sec = 3;
     double min_rate = -1.0, max_rate = -1.0;
     char port_env[64];
@@ -153,12 +175,33 @@ int main(int argc, char **argv)
             wait_opt = argv[++i];
             argv[i - 1] = argv[i] = (char *)"--quiet";
         }
+        else if (!strcmp(argv[i], "--asiclk") && i + 1 < argc)
+        {
+            asiclk = atoi(argv[++i]);
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+        else if (!strcmp(argv[i], "--speed") && i + 1 < argc)
+        {
+            speed_opt = argv[++i];
+            argv[i - 1] = argv[i] = (char *)"--quiet";
+        }
+        else if (!strcmp(argv[i], "--pace"))
+        {
+            pace_echo = 1;
+            argv[i] = (char *)"--quiet";
+        }
+    }
+    if (asiclk < 0 || asiclk > 65535)
+    {
+        fprintf(stderr, "netlink_latency: --asiclk out of range\n");
+        return 1;
     }
     if (!role || (strcmp(role, "echo") && strcmp(role, "probe")))
     {
         fprintf(stderr, "usage: netlink_latency <core> --role echo|probe "
                         "[--port N] [--measure-sec N] [--min-rate X] "
-                        "[--max-rate X] [--wait enabled|disabled]\n");
+                        "[--max-rate X] [--wait enabled|disabled] "
+                        "[--asiclk N] [--speed disabled|2|4]\n");
         return 1;
     }
 
@@ -173,12 +216,14 @@ int main(int argc, char **argv)
     cfg.options[1].value = port;
     cfg.options[2].key = "virtualjaguar_netlink_wait";
     cfg.options[2].value = wait_opt;
-    cfg.num_options = 3;
+    cfg.options[3].key = "virtualjaguar_netlink_speed";
+    cfg.options[3].value = speed_opt;
+    cfg.num_options = 4;
 
     if (!harness_init_from_args(&cfg, argc, argv)) return 1;
     if (!cfg.rom_path)
     {
-        cfg.rom_path = make_synth_rom(role);
+        cfg.rom_path = make_synth_rom(role, asiclk);
         if (!cfg.rom_path) return 1;
     }
     if (!harness_load_rom(&cfg)) return 1;
@@ -213,18 +258,33 @@ int main(int argc, char **argv)
 
     if (!strcmp(role, "echo"))
     {
-        /* The 68K does all the work.  Deliberately NOT paced at 60 fps:
-           a free-running echo answers within ~2 ms consistently, so the
-           measured rate isolates the PROBE side's frame quantization
-           instead of beating against a second paced loop's drifting
-           phase (which made the metric noisy run-to-run). */
+        /* The 68K does all the work.  By default deliberately NOT paced at
+           60 fps: a free-running echo answers within ~2 ms consistently, so
+           the measured rate isolates the PROBE side's frame quantization
+           instead of beating against a second paced loop's drifting phase
+           (which made the metric noisy run-to-run).
+
+           --pace turns that off, and any measurement of the #498 wire-speed
+           enhancement NEEDS it: a free-running echo burns its emulated
+           character frames far faster than real time, so its own wire speed
+           barely shows up in the probe's wall-clock exchange rate.  That
+           would make a genuinely one-sided setup look symmetric -- an
+           artifact of this harness, not of the link. */
         uint32_t last = rx_total();
         int idle = 0;
-        while (jlink_connected() && idle < 8000)   /* ~10 s of silence */
+        /* ~10 s of silence either way: the loop period is ~1 ms free-running
+           but a whole 16.7 ms frame slot when paced. */
+        int idle_limit = pace_echo ? 600 : 8000;
+        while (jlink_connected() && idle < idle_limit)
         {
             uint32_t now_rx;
-            run_frame();
-            usleep(1000);
+            if (pace_echo)
+                paced_frame(run_frame);
+            else
+            {
+                run_frame();
+                usleep(1000);
+            }
             now_rx = rx_total();
             idle = (now_rx != last) ? 0 : idle + 1;
             last = now_rx;

--- a/test/tools/netlink_wire_speed_test.sh
+++ b/test/tools/netlink_wire_speed_test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# netlink_wire_speed_test.sh — proves what the #498 wire-speed enhancement
+# (virtualjaguar_netlink_speed) actually does to link latency, and what it
+# does when only ONE side turns it on.
+#
+# Three real core pairs over TCP, same synthetic 68K ping-pong cart, the
+# only difference being each side's virtualjaguar_netlink_speed:
+#
+#   off/off    both consoles stock          -> baseline exchanges/sec
+#   4x/off     one console accelerated      -> in between
+#   4x/4x      both accelerated             -> best
+#
+# Two things are being asserted, and the second matters more than the first:
+#
+#   1. Turning it on raises the exchange rate (it does something).
+#   2. The MISMATCHED pair still exchanges, and lands BETWEEN the two
+#      symmetric configurations.  A lockstep link is gated by the slower
+#      side, so one-sided enablement can only under-deliver the benefit --
+#      it must never break or stall the exchange.  If the mismatched run
+#      ever comes back at zero, the option needs a both-sides guard rather
+#      than a documentation note.
+#
+# The cart is driven at --asiclk 1999 (a ~13.2 ms character frame) on
+# purpose.  At the tool's stock ASICLK of 1 a character costs ~13 us and
+# NOTHING here would be measurable: the 60 fps frame slot, not the emulated
+# wire, would set the rate in every configuration and all three runs would
+# tie.  Both sides are also --pace'd, because a free-running echo burns its
+# emulated wire time faster than real time and would hide exactly the
+# asymmetry this script exists to measure.
+#
+# --wait disabled throughout: the adaptive reply wait hides NETWORK
+# latency, which on loopback is ~0.  Leaving it on only adds wall-clock
+# noise on top of the emulated wire time being measured.
+#
+# Usage: netlink_wire_speed_test.sh <core> [base_port]
+# Exit codes: 0 pass, 1 fail.
+set -u
+
+CORE="${1:?usage: netlink_wire_speed_test.sh <core> [base_port]}"
+# Never >= 32768: the Linux ephemeral range is where CI collided on
+# EADDRINUSE (see project_ci_port_flake).  PID-spread inside a fixed band,
+# the same pattern the Makefile uses for the other netlink tools.
+BASE_PORT="${2:-$(( 29000 + ($$ % 3000) ))}"
+BIN="$(dirname "$0")/netlink_latency"
+OUT="${TMPDIR:-/tmp}/vj_wire_speed_$$"
+ASICLK="${VJ_WIRE_ASICLK:-1999}"
+SECS="${VJ_WIRE_SECS:-2}"
+
+if [ ! -x "$BIN" ]; then
+    echo "netlink_wire_speed_test: $BIN not built" >&2
+    echo "  Rebuild it with:  make TEST_EXPORTS=1 $BIN" >&2
+    exit 1
+fi
+mkdir -p "$OUT"
+
+# run_pair <tag> <probe_speed> <echo_speed> <port>; echoes exchanges/sec.
+run_pair() {
+    tag="$1"; pspeed="$2"; espeed="$3"; port="$4"
+    "$BIN" "$CORE" --role echo --port "$port" --asiclk "$ASICLK" \
+        --speed "$espeed" --wait disabled --pace \
+        > "$OUT/$tag.echo.log" 2>&1 &
+    epid=$!
+    sleep 1
+    "$BIN" "$CORE" --role probe --port "$port" --asiclk "$ASICLK" \
+        --speed "$pspeed" --wait disabled --measure-sec "$SECS" \
+        > "$OUT/$tag.probe.log" 2>&1
+    prc=$?
+    wait "$epid" 2>/dev/null || true
+    if [ "$prc" -ne 0 ]; then
+        echo "netlink_wire_speed_test: FAIL ($tag probe exited $prc;" \
+             "log: $OUT/$tag.probe.log)" >&2
+        return 1
+    fi
+    # "<exchanges/sec> <frames/sec paced>".  The pacing figure is the
+    # runner's own achieved frame cadence -- the load telemetry the ratio
+    # assertions below need to tell "the option did nothing" apart from
+    # "this machine could not hold 60 fps in any configuration".
+    awk '/exchanges\/sec/  { ex = $2 }
+         /frames\/sec paced/ { fps = $2 }
+         END { print ex, fps }' "$OUT/$tag.probe.log"
+}
+
+R=$(run_pair off_off   disabled disabled "$BASE_PORT")      || exit 1
+RATE_OFF=${R%% *};  FPS_OFF=${R##* }
+R=$(run_pair four_off  4        disabled "$((BASE_PORT+1))") || exit 1
+RATE_ONE=${R%% *};  FPS_ONE=${R##* }
+R=$(run_pair four_four 4        4        "$((BASE_PORT+2))") || exit 1
+RATE_BOTH=${R%% *}; FPS_BOTH=${R##* }
+
+printf 'netlink_wire_speed_test: asiclk=%s  off/off=%s  4x/off=%s  4x/4x=%s exchanges/sec (paced %s/%s/%s fps)\n' \
+    "$ASICLK" "$RATE_OFF" "$RATE_ONE" "$RATE_BOTH" "$FPS_OFF" "$FPS_ONE" "$FPS_BOTH"
+
+rc=0
+check() {
+    if awk "BEGIN { exit !($1) }"; then
+        echo "netlink_wire_speed_test: PASS $2"
+    else
+        echo "netlink_wire_speed_test: FAIL $2" >&2
+        rc=1
+    fi
+}
+
+# Liveness is the load-bearing assertion and always a hard failure: a
+# configuration that stalls the link reads as rate 0, and ruling that out
+# for the MISMATCHED pair is the whole reason this script exists.
+check "$RATE_OFF  > 0" "off/off exchanges (baseline alive)"
+check "$RATE_ONE  > 0" "4x/off exchanges (mismatched pair does NOT stall)"
+check "$RATE_BOTH > 0" "4x/4x exchanges"
+
+# The ladder is a wall-clock measurement off two paced processes, so it
+# needs the same load guard netlink_latency_test.sh uses: on a runner that
+# could not hold its frame slots, the rates measure the machine, not the
+# option, and a red line there would be noise. 1.10 rather than a tighter
+# bound for the same reason -- measured headroom on an idle host is 1.34x
+# (16.9 -> 22.6) and 2.3x (22.6 -> 52.5), so 1.10 still fails a genuinely
+# inert option while surviving contention.
+PACE_MIN="${VJ_WIRE_MIN_FPS:-45}"
+paced=$(awk -v a="$FPS_OFF" -v b="$FPS_ONE" -v c="$FPS_BOTH" -v m="$PACE_MIN" \
+    'BEGIN { print (a >= m && b >= m && c >= m) ? "yes" : "no" }')
+if [ "$paced" = "yes" ]; then
+    check "$RATE_ONE  > $RATE_OFF * 1.10" "one side accelerated beats stock"
+    check "$RATE_BOTH > $RATE_ONE * 1.10" "both sides beats one side"
+else
+    echo "netlink_wire_speed_test: SKIP ladder assertions (paced" \
+         "$FPS_OFF/$FPS_ONE/$FPS_BOTH fps, need >= $PACE_MIN) -- runner too" \
+         "loaded to demonstrate the effect in either direction; liveness" \
+         "checks above still applied"
+    if [ -f "$(dirname "$0")/../../scripts/test-skip.sh" ]; then
+        bash "$(dirname "$0")/../../scripts/test-skip.sh" record \
+            "Netlink wire speed ladder (#498)" \
+            "runner paced $FPS_OFF/$FPS_ONE/$FPS_BOTH fps, below $PACE_MIN"
+    fi
+fi
+
+if [ "$rc" -eq 0 ]; then
+    echo "netlink_wire_speed_test: PASS (ports $BASE_PORT-$((BASE_PORT+2)))"
+    command rm -rf "$OUT"
+else
+    echo "netlink_wire_speed_test: logs in $OUT" >&2
+fi
+exit "$rc"

--- a/test/tools/uv_modem_game_test.sh
+++ b/test/tools/uv_modem_game_test.sh
@@ -62,20 +62,31 @@ MAPOPTS=(--option virtualjaguar_uart_device=voicemodem
   --option virtualjaguar_p1_retropad_l1=num_9
   --option virtualjaguar_p1_retropad_r1=num_1)
 
+# Wire-speed enhancement (#498), per side, so this script doubles as the
+# safety gate for it: the whole point of the feature is that it may not
+# change anything the GAME can see, and the modem choreography plus the
+# pad-word counts below are the only end-to-end check that holds.  Set
+# both to prove the symmetric case, one to prove that a mismatched pair
+# still completes (it does -- it just gets less of the benefit).
+# "disabled" is the option's own default, so an unset run is the stock
+# baseline this has always measured.
+SPEED_SRV="${VJ_UV_SPEED_SERVER:-disabled}"
+SPEED_CLI="${VJ_UV_SPEED_CLIENT:-disabled}"
+
 # netlink_game putenv()s VJ_NETLINK_PORT itself from --port (default
 # 42171), overriding any inherited value -- the port MUST go on the
 # command line or concurrent pairs cross-connect on the default.
 export VJ_VM_TRACE=1
 
 "$BIN" "$CORE" "$ROM" --role server --port "$PORT" --frames 5400 --realtime \
-  "${MAPOPTS[@]}" \
+  "${MAPOPTS[@]}" --option virtualjaguar_netlink_speed="$SPEED_SRV" \
   --press 905:1:6 --press 918:2:6 --press 931:2:6 \
   --press 1250:up:6 --press 1290:up:6 --press 1360:a:6 \
   > "$OUT/answer.log" 2>&1 &
 SRV=$!
 sleep 2
 "$BIN" "$CORE" "$ROM" --role client --port "$PORT" --frames 5400 --realtime \
-  "${MAPOPTS[@]}" \
+  "${MAPOPTS[@]}" --option virtualjaguar_netlink_speed="$SPEED_CLI" \
   --press 905:1:6 --press 918:2:6 --press 931:2:6 \
   --press 1250:up:6 --press 1350:a:6 --press 1450:2:6 --press 1530:a:6 \
   > "$OUT/dial.log" 2>&1 &
@@ -95,7 +106,8 @@ for side in answer dial; do
     fi
 done
 if [ "$rc" -eq 0 ]; then
-    echo "uv_modem_game_test: PASS (port $PORT)"
+    echo "uv_modem_game_test: PASS (port $PORT, wire speed" \
+         "server=$SPEED_SRV client=$SPEED_CLI)"
     command rm -rf "$OUT"
 fi
 exit "$rc"


### PR DESCRIPTION
Closes #498.

## The problem, and why it is not the network

Playing Ultra Vortek's Voice Modem versus mode across two devices, the local player does not see their own move immediately, though both sides stay synchronised. The instinct is to blame the network. The measurement says otherwise:

- `TCP_NODELAY` **is** set on all three connect paths (`jlink_tcp.c:121-125`, called at :265, :510, :538) — Nagle is not a factor.
- Sends are batched per UART burst, not per byte; per-byte packets were tried and rejected for causing visible Wi-Fi lag.
- The adaptive bounded reply wait (`jlink.c:430-460`) already pulls a reply into the same emulated frame.

The choke point is the **emulated cable**. At the `ASICLK = $56` Ultra Vortek's driver settles on, one character frame is `11 * 16 * 87 = 15312` RISC cycles ≈ **576 µs** (verified against JTRM Rev 8 pp.93-94: divisor is `sysclk/(N+1)` then /16, and the parity slot is transmitted even with parity disabled, so the frame really is 11 bit times). UV sends ~10 bytes per direction per frame, so ~5.8 ms of pure wire time each way against a 16.7 ms frame — and `$57DD`'s strict lockstep means the local pad cannot be *displayed* until the exchange completes.

**That is authentic.** A real Voice Modem at 19200 baud was exactly this slow, and the `$86xx` connect-speed reply cannot change it (Atari JVM spec p.13: only `$FFFE`/`$FFFF` select the DTE rate; the retail ROM writes ASICLK six times, always `$1C` or `$56`). So this ships as an **opt-in enhancement, default off, labelled non-authentic** — the `virtualjaguar_enhancement_hooks` precedent.

## The option

`virtualjaguar_netlink_speed` = **disabled** (default) / **2** / **4**, in the `network` category. It divides the one number that both the TX drain and the RX arrival schedule through: `UARTFrameUsec()`.

**Scale, not boolean.** 2x and 4x are perceptibly different against a 16.7 ms frame, and a user whose title misbehaves on the link needs somewhere to step back down to rather than a single all-or-nothing stop. Clamped to `UART_WIRE_SPEEDUP_MAX` — a RetroArch `.cfg` is a text file, and an unbounded divisor drives the character time toward zero.

## Three load-bearing details

**1. Gated on an active transport, evaluated per call.** With no link selected, `UARTFrameUsec()` takes a branch that is *textually develop's original expression*, not a divide-by-one — so a stale setting cannot perturb a non-link session even by a rounding step. `"auto"` resolves to `DISABLED` until a netplay session actually exists, so the gate is honest about the default.

**2. The accelerated receiver applies back-pressure — this is the whole feature.** Stock hardware drops the new byte when a character completes into a full RBF (an overrun), and that is preserved exactly when the option is off. But the *reader's* polling rate belongs to the game, so dividing the character time divides the reader's budget with it.

Measured, not theorised. At 4x with the plain hardware rule, Ultra Vortek's DSP-poll driver lost the second byte of the `$B800` wake reply and the modem handshake never completed:

| config | answer side | dial side |
|---|---|---|
| stock | 7044 pad words | 7048 |
| 4x, plain hardware overrun rule | **0** | **0** |
| 4x, with back-pressure | 6948 | 6956 |
| 4x, with back-pressure (repeat) | 6920 | 6924 |

Without back-pressure only 2x is shippable. With it, the byte stream is provably unchanged and only timing moves. The repeat run matters because the pre-fix failure was *catastrophic* rather than marginal, so one sample would not have shown the margin.

**3. Not in the savestate.** Like NTSC/PAL it is a runtime setting, and `event.c` saves the *remaining* time of each queued callback rather than a rate — so a state captured accelerated and reloaded stock plays out the one already-scheduled character at its saved deadline and reschedules stock from there. State size is unchanged at 2,621,440 bytes and `test_runahead_determinism` still reconverges byte-identically.

## Symmetry: under-delivers, never desyncs

Both consoles should set it, to the same value. This was **proven, not assumed** — the question was specifically whether one-sided enablement merely under-delivers (acceptable) or actually desynchronises (would need a guard).

A lockstep exchange is gated by the sum of both sides' clocking, so a mismatched pair still completes and stays in sync; it just gets less benefit. Three runs of the synthetic ping-pong cart at ASICLK 1999 (`netlink_wire_speed_test.sh`), exchanges/sec for off-off / 4x-off / 4x-4x:

```
16.9 / 22.6 / 52.5
16.4 / 25.0 / 49.9
17.5 / 26.4 / 53.5
```

One side alone lands between the two symmetric configurations, well short of half the benefit. And Ultra Vortek's full-game pair completes the whole modem choreography mismatched too (6972 / 6976 pad words). **No guard needed — it is a documentation matter**, and the option description and user guide both say so.

## Option-off inertness: proven against a pristine develop build

Not asserted. 200 frames of a continuous-UART-load cart under loopback, with `vjtrace --watch` on ASIDATA, compared against a pristine `libretro/develop` build:

```
develop           101,969 records
branch, option off 101,969 records   -> IDENTICAL
branch, 4x         119,083 records   -> DIFFERS
```

Byte-identical event trace, every ASIDATA access with its PC, halfline and sequence number. The 4x arm is the **sensitivity control** — the instrument demonstrably detects what is being claimed absent. (`--field-csv` was tried first and rejected: it has no UART-sensitive column, so it reported "identical" for the 4x arm too. Re-verified after rebasing onto e7aa57f, since #517's `-ffast-math` removal changes float codegen in exactly this function.)

## Tests

- **`test/test_uart_loopback.c`** — 12 new deterministic checks: scaling at each step, the no-link gate, both clamps, stream identity at 4x, the overrun-loss case back-pressure exists for, and the ring-drain invariant that lets `UARTKickRx()` omit a `JLinkMode()` term rather than carry an untested branch.
- **`test/tools/netlink_wire_speed_test.sh`** (new, wired into `make test`) — three real core pairs whose only difference is each side's setting, so the **mismatched pair is a first-class configuration**. Liveness assertions are unconditional failures; the ladder ratios sit behind the same pacing-telemetry SKIP guard `netlink_latency_test.sh` uses, so a loaded CI runner cannot turn them red. Ports PID-spread below 32768.
- **`test/tools/uv_modem_game_test.sh`** — takes `VJ_UV_SPEED_SERVER` / `VJ_UV_SPEED_CLIENT`, so it doubles as the safety gate above.
- **`test/tools/netlink_latency.c`** — gains `--asiclk`, `--speed`, `--pace`. Both were necessary, not polish: its stock ASICLK of 1 makes a character ~13 µs, far below anything this option can move, so an A/B through it would have returned a **false null**; and a free-running echo side burns emulated wire time faster than real time, which would have made a genuinely one-sided setup look symmetric.

`make TEST_EXPORTS=1 test` exits 0 post-rebase, with the audio pair confirmed by name (Skyhammer 0.000% saturated / RMS 3083.3, IS2 0.000% / RMS 2598.3, IS1 presence PASS in both arms). Only the two pre-existing unrelated skips.

## Not verified headlessly

Everything above is a headless measurement of byte flow and emulated timing. What no harness here can judge is whether the *feel* actually improves for a human at 2x vs 4x on two real devices over Wi-Fi — that is the thing the ticket set out to fix, and it wants a two-device play-test of Ultra Vortek before anyone claims the perceived lag is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
