### PR TITLE
perf: deterministic instruction-count A/B in CI (#534) + hoist GPU loop invariants (#532)

### DIFF
--- a/.github/workflows/ir-ab.yml
+++ b/.github/workflows/ir-ab.yml
@@ -1,0 +1,131 @@
+name: Instruction-count A/B
+
+# Deterministic perf regression gate (issue #534).
+#
+# Counts retired instructions (Ir) under valgrind's cachegrind for the PR head
+# and for its merge base, and reports the delta.  cachegrind simulates, so the
+# count is bit-identical run to run and machine to machine for a given binary
+# and architecture -- which is exactly what a shared, noisy GitHub-hosted
+# runner cannot give a wall-clock benchmark.  It also needs no privileges,
+# unlike `perf stat`, which hosted runners keep locked down via
+# perf_event_paranoid.
+#
+# Because the variance is zero, the flagging threshold is tight: 0.5%.
+#
+# This job does NOT fail the PR.  Ir is a work count, not a clock: a change
+# that removes dependent loads shows a small Ir delta and a larger wall-clock
+# win, and inlining/unrolling can raise Ir while getting faster.  So the
+# summary is advisory -- a prompt to look, not a veto.  Set IR_GATE=1 below if
+# a future policy decision makes it blocking.
+#
+# Only within-run A/B deltas are meaningful.  Absolute Ir is architecture
+# specific; never cache a baseline count without keying it by runner arch.
+
+on:
+  pull_request:
+    branches: [develop, master]
+    paths:
+      # Hot paths only.  A docs or workflow-only PR should not pay for two
+      # full builds plus two cachegrind runs.
+      - 'src/tom/gpu.c'
+      - 'src/tom/blitter.c'
+      - 'src/tom/op.c'
+      - 'src/jerry/dsp.c'
+      - 'src/m68000/**'
+      - 'Makefile'
+      - 'Makefile.common'
+      - 'test/tools/ir_ab.sh'
+      - '.github/workflows/ir-ab.yml'
+  workflow_dispatch:
+    inputs:
+      frames:
+        description: 'Frames per arm'
+        required: false
+        default: '90'
+
+concurrency:
+  group: ir-ab-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ir-ab:
+    name: Ir A/B (linux x86_64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # ir_ab.sh --ref snapshots both arms with `git archive`, so both
+          # commits must actually be present in the local object store.
+          fetch-depth: 0
+
+      - name: Install valgrind
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends valgrind
+          valgrind --version
+
+      - name: Resolve arms
+        id: arms
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = pull_request ]; then
+            BASE='${{ github.event.pull_request.base.sha }}'
+            HEAD='${{ github.event.pull_request.head.sha }}'
+          else
+            BASE=$(git rev-parse HEAD~1)
+            HEAD=$(git rev-parse HEAD)
+          fi
+          # fetch-depth: 0 covers the PR ref's history; the base commit can
+          # still be missing on a force-pushed or cross-fork PR.
+          git cat-file -e "$BASE^{commit}" 2>/dev/null || git fetch --no-tags origin "$BASE"
+          git cat-file -e "$HEAD^{commit}" 2>/dev/null || git fetch --no-tags origin "$HEAD"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD" >> "$GITHUB_OUTPUT"
+
+      - name: Measure
+        id: measure
+        env:
+          IR_FRAMES: ${{ github.event.inputs.frames || '90' }}
+          # Advisory only -- see the header.  Flip to 1 to make a >0.5%
+          # instruction-count regression block the PR.
+          IR_GATE: '0'
+          IR_THRESHOLD: '0.5'
+          # No load-average gate here, deliberately: Ir does not depend on how
+          # busy the runner is.  That is the entire reason this job exists.
+          IR_NO_CONTAINER: '1'
+        run: |
+          set -euo pipefail
+          bash test/tools/ir_ab.sh --ref \
+              "${{ steps.arms.outputs.base }}" "${{ steps.arms.outputs.head }}" \
+              2>&1 | tee ir-ab.log
+          grep '^IR_AB_RESULT' ir-ab.log >> "$GITHUB_OUTPUT" || true
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Instruction-count A/B"
+            echo
+            echo "arm A = merge base \`${{ steps.arms.outputs.base }}\`"
+            echo "arm B = PR head \`${{ steps.arms.outputs.head }}\`"
+            echo
+            echo '```'
+            sed -n '/metric/,$p' ir-ab.log 2>/dev/null || cat ir-ab.log 2>/dev/null || echo '(no output)'
+            echo '```'
+            echo
+            echo "Ir is a deterministic *work* count, not wall time. A change that removes"
+            echo "dependent loads understates here; inlining/unrolling can raise Ir and still"
+            echo "be faster. Treat a flagged delta as a prompt to look, not a veto."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ir-ab-log
+          path: ir-ab.log
+          retention-days: 14

--- a/.github/workflows/ir-ab.yml
+++ b/.github/workflows/ir-ab.yml
@@ -120,10 +120,22 @@ jobs:
           # busy the runner is.  That is the entire reason this job exists.
           IR_NO_CONTAINER: '1'
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          # Exit 2 means "both arms produced a byte-identical library", which is
+          # the EXPECTED outcome for a PR that only touches this workflow or
+          # ir_ab.sh itself -- both of which are in the `paths:` filter above.
+          # Treating it as a failure would make the job go red on exactly the
+          # PRs that tune the measurement tool, contradicting the header's
+          # "advisory, not a veto" promise.  Anything else is a real error.
           bash test/tools/ir_ab.sh --ref \
               "${{ steps.arms.outputs.base }}" "${{ steps.arms.outputs.head }}" \
               2>&1 | tee ir-ab.log
+          rc=${PIPESTATUS[0]}
+          if [ "$rc" -eq 2 ]; then
+            echo "::notice::Both arms built an identical library -- nothing to measure (expected for tool-only changes)."
+            exit 0
+          fi
+          exit "$rc"
 
       - name: Job summary
         if: always()
@@ -135,7 +147,18 @@ jobs:
             echo "arm B = PR head \`${{ steps.arms.outputs.head }}\`"
             echo
             echo '```'
-            sed -n '/metric/,$p' ir-ab.log 2>/dev/null || cat ir-ab.log 2>/dev/null || echo '(no output)'
+            # `sed -n` exits 0 even when the pattern never matches, so a naive
+            # `sed ... || cat ...` fallback is dead code: on a build failure or
+            # abort (no "metric" line at all) it would print an empty block and
+            # the fallback would never fire.  Test for the pattern explicitly.
+            if [ ! -s ir-ab.log ]; then
+              echo '(no output)'
+            elif grep -q 'metric' ir-ab.log; then
+              sed -n '/metric/,$p' ir-ab.log
+            else
+              echo '(no metric line -- run failed or aborted; last 40 lines:)'
+              tail -40 ir-ab.log
+            fi
             echo '```'
             echo
             echo "Ir is a deterministic *work* count, not wall time. A change that removes"

--- a/.github/workflows/ir-ab.yml
+++ b/.github/workflows/ir-ab.yml
@@ -38,10 +38,14 @@ on:
       - '.github/workflows/ir-ab.yml'
   workflow_dispatch:
     inputs:
+      rom:
+        description: 'ROM to measure (repo-relative)'
+        required: false
+        default: 'test/roms/jagniccc.j64'
       frames:
         description: 'Frames per arm'
         required: false
-        default: '90'
+        default: '300'
 
 concurrency:
   group: ir-ab-${{ github.workflow }}-${{ github.ref }}
@@ -51,6 +55,9 @@ jobs:
   ir-ab:
     name: Ir A/B (linux x86_64)
     runs-on: ubuntu-latest
+    # Two full builds plus two cachegrind runs.  Cachegrind sustains roughly
+    # 100M simulated instructions/sec, and jagniccc@300 is ~19.5e9 Ir per arm,
+    # so budget ~3-4 min per measured run.
     timeout-minutes: 45
 
     steps:
@@ -89,7 +96,22 @@ jobs:
       - name: Measure
         id: measure
         env:
-          IR_FRAMES: ${{ github.event.inputs.frames || '90' }}
+          # ROM and frame count are pinned HERE, not inherited from the
+          # script's defaults, so the CI workload is legible in this file and
+          # cannot change under it when someone edits ir_ab.sh.
+          #
+          # Why this pair: measured with `ir_ab.sh --profile`, jagniccc at 300
+          # frames splits GPU interpreter 38.6% / DSP interpreter 22.3% /
+          # blitter 7.1% / 68K ~5.9% -- it is the only public workload that
+          # covers every path in the `paths:` filter above.  The SAME ROM at 90
+          # frames is still in BIOS boot and executes ZERO GPU interpreter
+          # instructions, which would make this gate silently inert for exactly
+          # the changes it exists to catch.  yarc.j64 is the opposite extreme
+          # (GPU 71%, blitter 17.5%, DSP 0.08%) -- a better amplifier for a
+          # GPU-loop change, a worse gate.  Do not shorten the frame count
+          # without re-running --profile to confirm the mix survives.
+          IR_ROM: ${{ github.event.inputs.rom || 'test/roms/jagniccc.j64' }}
+          IR_FRAMES: ${{ github.event.inputs.frames || '300' }}
           # Advisory only -- see the header.  Flip to 1 to make a >0.5%
           # instruction-count regression block the PR.
           IR_GATE: '0'
@@ -102,7 +124,6 @@ jobs:
           bash test/tools/ir_ab.sh --ref \
               "${{ steps.arms.outputs.base }}" "${{ steps.arms.outputs.head }}" \
               2>&1 | tee ir-ab.log
-          grep '^IR_AB_RESULT' ir-ab.log >> "$GITHUB_OUTPUT" || true
 
       - name: Job summary
         if: always()

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -119,6 +119,57 @@ Reports `Frames/sec`, `Time/frame`, total wall time.  Boots the core via `dlopen
 
 > The harness lives at `test/tools/test_benchmark.c`.  Read it if you want to measure something specific (per-subsystem timing, only-DSP, etc.) — it's <400 lines.
 
+## Load-proof A/B — `test/tools/ir_ab.sh` (instruction counts)
+
+`make benchmark` and `opt_ab.sh` measure wall time, so they need a quiet host — and that dependency has produced two wrong answers.  #515 measured `-O3` at **+12.5% sequentially and −11.7% interleaved from the same two binaries**, minutes apart; #520's timing phase was **blocked outright** (load 19.08 on 12 cores) and never ran.
+
+`ir_ab.sh` sidesteps the problem by counting work instead of timing it.  The emulator is deterministic, so a fixed ROM and frame count is a fixed number of instructions, and `valgrind --tool=cachegrind` counts exactly that in simulation — **bit-identical** run to run.  It needs no privileges (unlike `perf stat`, which hosted CI runners lock down), so it works on a busy dev box and on a free GitHub runner.
+
+```bash
+test/tools/ir_ab.sh 'OPT_LEVEL=-O2' 'OPT_LEVEL=-O3'   # flag flip (opt_ab.sh's convention)
+test/tools/ir_ab.sh --ref libretro/develop HEAD        # source change / PR vs base
+test/tools/ir_ab.sh --selftest                         # instrument check: Ir must be IDENTICAL
+IR_ROM=test/roms/yarc.j64 test/tools/ir_ab.sh --profile   # where does this ROM's Ir go?
+```
+
+No valgrind on the host?  On macOS the script re-execs itself inside a Linux container (podman or docker) automatically; only `$WORK` and the ROM cross the boundary.
+
+**Deliberately no load-average gate.**  `opt_ab.sh` refuses above one load per core and is right to — it measures a clock.  Ir does not depend on how busy the machine is, and that is the entire point.  Don't add one back.
+
+### Validated, not assumed
+
+| property | how | result |
+|---|---|---|
+| Determinism | same source both arms (`--selftest`) | Ir **identical**: 1,633,893,288 twice.  I1/D1/LL miss counts identical too. |
+| Sensitivity | throwaway commit adding one `volatile` increment per emulated GPU opcode | **+1.815%** (+159,337,672 Ir), correctly signed |
+
+The sensitivity control is the one that matters: an instrument that has never shown it can *detect* a change will report "no change" forever and look perfectly healthy.  It also calibrates the tool — the waste is exactly 3 instructions per GPU opcode, so it says yarc@90 executes **53,112,557** GPU opcodes, which turns later deltas into per-instruction arithmetic rather than percentages.
+
+### What Ir is not
+
+Ir is **not wall time**.  It models neither branch prediction nor ILP nor real cache behaviour (the simulated D1/LL columns close only part of that gap).  A change can legitimately *raise* Ir and still be faster (inlining, unrolling), and removing dependent loads helps latency more than it helps instruction count — so a small Ir delta there **understates** the win.  This is a gate and a regression detector; wall-clock confirmation still belongs on real hardware.
+
+Absolute Ir is architecture-specific — an arm64 container and an x86_64 runner disagree by construction.  Only the within-run A/B delta means anything.  The Ir denominator also includes the measuring harness (`frame_hash_ab`'s own hashing is ~4.4% of total on the default workload), so an `ir_ab` percentage is a share of *emulator plus instrument*, not directly comparable to a sampling profiler's "% of process time".
+
+### Picking the ROM is part of the measurement (#533)
+
+`--profile` gives per-function Ir for one workload with no source changes and no sampling bias.  Measured:
+
+| workload | GPU interp | DSP interp | blitter | 68K | total Ir |
+|---|---|---|---|---|---|
+| `jagniccc.j64` @ 90 | **0%** | 0% | 0% | ~38% | 1.6e9 |
+| `jagniccc.j64` @ 300 | 38.6% | 22.3% | 7.1% | ~5.9% | 19.5e9 |
+| `jagniccc.j64` @ 600 | 40.2% | 23.7% | 10.3% | ~2% | 52.3e9 |
+| `yarc.j64` @ 90 | **71.2%** | 0.08% | 17.5% | ~0% | 8.8e9 |
+
+`jagniccc.j64` is the Jaguar port of Leonard/Oxygene's **NICCC 2000** ST demo (`test/vendor/JaguarDemos/jagniccc2000`), and it renders on the GPU with the 68K parked in `stop #$2000` — but only *after* its boot window.  At 90 frames it is still in BIOS boot and executes **zero** GPU-interpreter instructions, which is exactly the shape of an inert gate.  At 300 it reaches the steady-state mix, which is why that is the default here and in CI.
+
+`yarc.j64` is the GPU amplifier, but note #533's point: its opcode mix is `jr`-heavy, so per-instruction *loop overhead* is an unusually large share of its GPU time and a loop-bookkeeping change scores high on it relative to a real game.  Use it to make a GPU-loop effect visible, not to size it.
+
+### In CI
+
+`.github/workflows/ir-ab.yml` runs the A/B on PRs touching `src/tom/gpu.c`, `src/tom/blitter.c`, `src/tom/op.c`, `src/jerry/dsp.c`, `src/m68000/**` or the Makefiles, and reports the delta as a job summary.  Because the variance is zero the flagging threshold is tight (0.5%), but the job is **advisory, not blocking** — see "what Ir is not" above.  Flip `IR_GATE: '1'` if that policy ever changes.
+
 ## macOS — Instruments / `sample`
 
 **Instruments (Time Profiler)** is the easiest way to get a flame graph on macOS.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -143,7 +143,7 @@ No valgrind on the host?  On macOS the script re-execs itself inside a Linux con
 | Determinism | same source both arms (`--selftest`) | Ir **identical**: 1,633,893,288 twice.  I1/D1/LL miss counts identical too. |
 | Sensitivity | throwaway commit adding one `volatile` increment per emulated GPU opcode | **+1.815%** (+159,337,672 Ir), correctly signed |
 
-The sensitivity control is the one that matters: an instrument that has never shown it can *detect* a change will report "no change" forever and look perfectly healthy.  It also calibrates the tool — the waste is exactly 3 instructions per GPU opcode, so it says yarc@90 executes **53,112,557** GPU opcodes, which turns later deltas into per-instruction arithmetic rather than percentages.
+The sensitivity control is the one that matters: an instrument that has never shown it can *detect* a change will report "no change" forever and look perfectly healthy.  It also calibrates the tool — the added waste is ~3 instructions per GPU opcode, putting yarc@90 at roughly **53.1 million** GPU opcodes, which turns later deltas into per-instruction arithmetic rather than percentages.  (Treat that as a calibration figure, not an exact count: 159,337,672 / 3 is not an integer, so the per-opcode cost is not exactly 3 on every path — the compiler is free to fold the increment differently depending on surrounding code.)
 
 ### What Ir is not
 

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -1428,6 +1428,22 @@ void GPUSyncToM68K(void)
 
 void GPUExec(int32_t cycles)
 {
+   /* Slice-invariant settings, cached in locals for the exec loop (issue
+    * #532).  Both are written ONLY by check_variables() in libretro.c --
+    * never by emulation code -- so they cannot change while this loop runs.
+    * executeOpcode() is an opaque call, so without these locals the compiler
+    * must assume the call clobbers both globals and reloads them on every
+    * emulated instruction (two `ldrb` of vjs.gpuPipelineTiming plus a
+    * GOT-indirect reload of riscClockScalePct per opcode on arm64).
+    *
+    * Cached at slice ENTRY, not once at init: a mid-run option change goes
+    * through check_variables() between retro_run() calls, so the next slice
+    * picks the new value up.  Re-entrant runs (the OP executes the GPU
+    * inline from a halfline callback, see op.c) re-read on each entry for
+    * the same reason. */
+   int      pipeTiming;
+   uint32_t riscScale;
+
    if (!GPU_RUNNING)
       return;
 
@@ -1455,6 +1471,9 @@ void GPUExec(int32_t cycles)
    gpu_releaseTimeSlice_flag = 0;
    gpu_in_exec++;
    gpuExecSliceBudget = cycles;
+
+   pipeTiming = vjs.gpuPipelineTiming ? 1 : 0;
+   riscScale  = riscClockScalePct;
 
    while (cycles > 0 && GPU_RUNNING)
    {
@@ -1484,14 +1503,14 @@ void GPUExec(int32_t cycles)
       /* Pipeline model: stall for pending load results / RAW interlock
        * BEFORE the opcode runs (results are unchanged; only time is
        * charged, via the same gpu_bus_stall channel as DRAM costs). */
-      if (vjs.gpuPipelineTiming)
+      if (pipeTiming)
          GPUPipeCheckUse(index);
 #if 0
       gpu_opcode[index]();
 #else
        executeOpcode(index);
 #endif
-      if (vjs.gpuPipelineTiming)
+      if (pipeTiming)
       {
          gpu_pipe_clock += (uint64_t)gpu_opcode_cycles[index] + gpu_bus_stall
                          + gpu_pipe_core_stall;
@@ -1519,10 +1538,10 @@ void GPUExec(int32_t cycles)
        * (see the domain note at its declaration): deduct it unscaled
        * in both branches.  Only gpu_bus_stall -- wall-time memory
        * latency -- goes through the scale conversion. */
-      if (riscClockScalePct != 100u && gpu_bus_stall != 0)
+      if (riscScale != 100u && gpu_bus_stall != 0)
       {
          uint32_t stall_scaled;
-         gpu_stall_scale_accum += gpu_bus_stall * riscClockScalePct;
+         gpu_stall_scale_accum += gpu_bus_stall * riscScale;
          stall_scaled = gpu_stall_scale_accum / 100u;
          gpu_stall_scale_accum %= 100u;
          cycles -= gpu_opcode_cycles[index] + (int32_t)stall_scaled

--- a/test/tools/ir_ab.sh
+++ b/test/tools/ir_ab.sh
@@ -209,14 +209,22 @@ if ! command -v valgrind >/dev/null 2>&1 && [ "${IR_AB_IN_CONTAINER:-0}" != 1 ];
       | "$ENGINE" build -t "$IMAGE" -f - . >/dev/null
   fi
   echo "ir_ab: no host valgrind -- re-executing under $ENGINE ($IMAGE)"
-  exec "$ENGINE" run --rm \
+  # Run as a CHILD, not exec.  `exec` replaces this shell and destroys the EXIT
+  # trap set above, and the container run re-enters this script with
+  # IR_AB_WORK set, which skips the trap-setup branch there too -- so with
+  # `exec` nothing ever cleans up and every macOS run left two full source
+  # snapshots plus build trees in $TMPDIR forever, despite IR_KEEP defaulting
+  # to 0.  Running it as a child keeps the host trap alive to fire below.
+  rc=0
+  "$ENGINE" run --rm \
       -v "$WORK:$WORK" -v "$ROM:$ROM:ro" -v "$REPO:$REPO:ro" \
       -e IR_AB_IN_CONTAINER=1 -e IR_AB_PREPARED=1 -e "IR_AB_WORK=$WORK" \
       -e "IR_ROM=$ROM" -e "IR_FRAMES=$FRAMES" -e "IR_THRESHOLD=$THRESHOLD" \
       -e "IR_GATE=${IR_GATE:-0}" -e "IR_MAKE_ARGS=${IR_MAKE_ARGS:-}" \
       -e "IR_JOBS=${IR_JOBS:-}" \
       -w "$WORK" "$IMAGE" \
-      bash "$REPO/test/tools/ir_ab.sh" ${ORIG_ARGS[@]+"${ORIG_ARGS[@]}"}
+      bash "$REPO/test/tools/ir_ab.sh" ${ORIG_ARGS[@]+"${ORIG_ARGS[@]}"} || rc=$?
+  exit "$rc"
 fi
 
 command -v valgrind >/dev/null 2>&1 || { echo "ir_ab: valgrind missing" >&2; exit 1; }

--- a/test/tools/ir_ab.sh
+++ b/test/tools/ir_ab.sh
@@ -55,7 +55,12 @@
 #
 # Env knobs:
 #   IR_ROM        ROM to run           (default test/roms/jagniccc.j64)
-#   IR_FRAMES     frames per arm       (default 90; cachegrind is ~50-100x slow)
+#   IR_FRAMES     frames per arm       (default 300; cachegrind is ~50-100x slow,
+#                                       so this costs ~3 min per arm.  Drop it
+#                                       for a quick --selftest; do NOT drop it
+#                                       for a real A/B without checking the
+#                                       workload still covers your change --
+#                                       see WORKLOAD below.)
 #   IR_MAKE_ARGS  extra make args applied to BOTH arms (ref mode)
 #   IR_JOBS       build parallelism    (default nproc)
 #   IR_GATE=1     exit 3 when B regresses by more than IR_THRESHOLD
@@ -91,6 +96,32 @@
 # hash.  That CSV doubles as an accuracy gate: byte-identical CSVs across arms
 # is direct evidence that the change altered nothing the emulated machine can
 # see.  An A/B whose CSVs differ is reported, not silently scored.
+#
+# CHOOSING THE ROM AND FRAME COUNT IS PART OF THE MEASUREMENT (issue #533).  An
+# A/B on a workload that never enters the code you changed reports 0.0% forever
+# and looks perfectly healthy.  Measured here with --profile:
+#
+#   jagniccc.j64 @  90 frames   still in BIOS boot.  ZERO GPU-interpreter
+#                               instructions; 37% of Ir is the 68K traceback
+#                               hook.  Useless as a GPU/DSP/blitter gate.
+#   jagniccc.j64 @ 300 frames   GPU interp 38.6%, DSP interp 22.3%, blitter
+#                               7.1%, 68K ~5.9%.  THE DEFAULT: it is the
+#                               NICCC-2000 port, its GPU renderer starts only
+#                               after the boot window, and this is the cheapest
+#                               frame count that reaches the steady-state mix
+#                               (600 frames gives the same shape for 2.7x the
+#                               simulation cost).
+#   yarc.j64     @  90 frames   GPU interp 71.2%, blitter 17.5%, DSP 0.08%.
+#                               The GPU amplifier -- but its opcode mix is
+#                               jr-heavy (#533), so per-instruction loop
+#                               overhead is an unusually large share of it and
+#                               a loop-bookkeeping change scores HIGH here
+#                               relative to a real game.
+#
+# Note the Ir denominator includes this harness: frame_hash_ab's own hashing
+# (`ab_video`) is ~4.4% of total on jagniccc@300 and 13.4% on jagniccc@90.  An
+# ir_ab percentage is therefore a share of emulator-plus-instrument work and is
+# not directly comparable to a sampling profiler's "% of process time".
 
 set -euo pipefail
 
@@ -112,7 +143,7 @@ esac
 
 ROM="${IR_ROM:-$REPO/test/roms/jagniccc.j64}"
 case "$ROM" in /*) ;; *) ROM="$REPO/$ROM" ;; esac
-FRAMES="${IR_FRAMES:-90}"
+FRAMES="${IR_FRAMES:-300}"
 JOBS="${IR_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
 THRESHOLD="${IR_THRESHOLD:-0.5}"
 IMAGE="${IR_IMAGE:-vj-cachegrind}"

--- a/test/tools/ir_ab.sh
+++ b/test/tools/ir_ab.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# Deterministic A/B performance measurement by counting retired instructions
+# under valgrind's cachegrind (issue #534).
+#
+# WHY THIS EXISTS
+# ---------------
+# Every wall-clock number this project produces depends on a quiet host, and
+# that dependency has produced two wrong answers already:
+#
+#   - #515 measured -O3 at +12.5% sequentially and -11.7% interleaved from THE
+#     SAME TWO BINARIES, minutes apart.  The sign flipped on host drift.
+#   - #520's timing phase was blocked outright (load 19.08 on 12 cores), so the
+#     measurement simply did not happen.
+#
+# This emulator is deterministic, so the work it performs for a fixed ROM and
+# frame count is a fixed number of instructions.  cachegrind counts exactly
+# that, in simulation, and returns bit-identical numbers across runs and across
+# machines for the same binary.  Not low-variance: zero-variance.
+#
+# NO LOAD-AVERAGE GATE — ON PURPOSE.  test/tools/opt_ab.sh refuses to run above
+# one load per core, and that is correct there: it measures wall time.  Ir is
+# load-INSENSITIVE (cachegrind simulates; a busy host makes the run slower, not
+# different).  The whole point of this script is that it works on a loaded dev
+# box and on a shared CI runner.  Do not "fix" this by adding a load guard back.
+#
+# WHAT Ir IS NOT
+# --------------
+# Ir is not wall time.  It models neither branch prediction nor ILP nor real
+# cache behaviour (the simulated D1/LL misses close only part of that gap).  A
+# change can legitimately RAISE Ir and still be faster (inlining, unrolling),
+# and a change that removes dependent loads — exactly the #532 class — helps
+# latency more than it helps instruction count, so a small Ir delta there
+# understates the win.  Treat this as a gate and a regression detector, not as
+# a replacement for wall-clock measurement on real hardware.
+#
+# Absolute Ir is NOT comparable across architectures (an arm64 container and an
+# x86_64 CI runner disagree by construction).  Only the within-run A/B delta is
+# meaningful, so never store a baseline Ir without keying it by runner arch.
+#
+# USAGE
+# -----
+#   # flag flip (mirrors opt_ab.sh: make arguments passed verbatim)
+#   test/tools/ir_ab.sh 'OPT_LEVEL=-O2' 'OPT_LEVEL=-O3'
+#
+#   # source change: two git refs (this is what a PR-vs-base comparison needs)
+#   test/tools/ir_ab.sh --ref libretro/develop HEAD
+#
+#   # instrument validation: same source both arms, Ir must come out IDENTICAL
+#   test/tools/ir_ab.sh --selftest
+#
+#   # single-arm workload profile: where does a ROM's Ir actually go?
+#   # (this is how #533's "is this ROM a representative benchmark" question
+#   #  gets answered -- per-function Ir, no source changes, no sampling)
+#   IR_ROM=test/roms/yarc.j64 test/tools/ir_ab.sh --profile
+#
+# Env knobs:
+#   IR_ROM        ROM to run           (default test/roms/jagniccc.j64)
+#   IR_FRAMES     frames per arm       (default 90; cachegrind is ~50-100x slow)
+#   IR_MAKE_ARGS  extra make args applied to BOTH arms (ref mode)
+#   IR_JOBS       build parallelism    (default nproc)
+#   IR_GATE=1     exit 3 when B regresses by more than IR_THRESHOLD
+#   IR_THRESHOLD  regression threshold in percent (default 0.5)
+#   IR_KEEP=1     keep the work directory
+#   IR_IMAGE      container image tag  (default vj-cachegrind)
+#   IR_NO_CONTAINER=1  fail instead of falling back to a container
+#
+# HOW IT AVOIDS THE CHIMERA-BINARY CLASS
+# --------------------------------------
+# Each arm is built in its OWN pristine source tree copied into a scratch dir,
+# never in the working tree, so there is no stale-object path at all (stronger
+# than `make clean`, which the repo's own notes record as insufficient when a
+# compile-affecting switch is not in BUILD_AXES).  The two libraries are then
+# SHA-256'd and the run aborts if they are identical, because two identical
+# binaries cannot produce a meaningful A/B.
+#
+# THE RUNNER IS BUILT ONCE, FROM ARM A, AND USED FOR BOTH ARMS.  It is the
+# instrument; it must not vary between arms.  Its own instruction count is
+# included in both totals and cancels in the delta.
+#
+# Determinism also requires identical argv and environment between arms, so the
+# measured process runs under `env -i` with a fixed PATH (this also scrubs any
+# VJ_* debug knobs the caller may have exported), and the per-arm paths are
+# constructed to be the SAME LENGTH ("$WORK/a" vs "$WORK/b").  Argument bytes
+# land on the guest stack; unequal lengths perturb it.
+#
+# WORKLOAD
+# --------
+# test/tools/frame_hash_ab drives the core: it has no wall-clock read anywhere
+# in its output path (unlike test_benchmark, whose FPS printf differs run to
+# run and would inject noise into Ir), and it emits a per-frame framebuffer
+# hash.  That CSV doubles as an accuracy gate: byte-identical CSVs across arms
+# is direct evidence that the change altered nothing the emulated machine can
+# see.  An A/B whose CSVs differ is reported, not silently scored.
+
+set -euo pipefail
+
+REPO=$(cd "$(dirname "$0")/../.." && pwd)
+
+MODE=makeargs
+ARM_A=""; ARM_B=""
+ORIG_ARGS=("$@")   # re-passed verbatim to the in-container re-exec below
+case "${1:-}" in
+  --selftest) MODE=selftest; shift ;;
+  --profile)  MODE=profile; shift ;;
+  --ref)      MODE=ref; shift
+              ARM_A="${1:?--ref needs two refs}"; ARM_B="${2:?--ref needs two refs}"; shift 2 ;;
+  -h|--help)  sed -n '2,80p' "$0"; exit 0 ;;
+  *)          ARM_A="${1:?usage: ir_ab.sh <make-args-A> <make-args-B> | --ref A B | --selftest}"
+              ARM_B="${2:?usage: ir_ab.sh <make-args-A> <make-args-B> | --ref A B | --selftest}"
+              shift 2 ;;
+esac
+
+ROM="${IR_ROM:-$REPO/test/roms/jagniccc.j64}"
+case "$ROM" in /*) ;; *) ROM="$REPO/$ROM" ;; esac
+FRAMES="${IR_FRAMES:-90}"
+JOBS="${IR_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
+THRESHOLD="${IR_THRESHOLD:-0.5}"
+IMAGE="${IR_IMAGE:-vj-cachegrind}"
+
+[ -f "$ROM" ] || { echo "ir_ab: no ROM at $ROM (set IR_ROM)" >&2; exit 1; }
+
+# ---------------------------------------------------------------- work dir ---
+# Prepared on the host (needs git); the build+measure half needs no git at all,
+# which is what lets the container step run on a bare toolchain image.
+if [ -n "${IR_AB_WORK:-}" ]; then
+  WORK="$IR_AB_WORK"
+else
+  WORK=$(mktemp -d "${TMPDIR:-/tmp}/ir_ab.XXXXXX")
+  [ "${IR_KEEP:-0}" = 1 ] || trap 'command rm -rf "$WORK"' EXIT
+fi
+
+snapshot_worktree() {  # snapshot_worktree <dest>
+  mkdir -p "$1"
+  tar -cf - -C "$REPO" \
+      --exclude=.git --exclude=.claude --exclude=test/roms/private \
+      --exclude=test/baselines --exclude='*.o' --exclude='*.so' \
+      --exclude='*.dylib' --exclude='*.dll' --exclude=.build-config . \
+    | tar -xf - -C "$1"
+}
+
+snapshot_ref() {       # snapshot_ref <ref> <dest>
+  mkdir -p "$2"
+  # `git archive` rather than `git worktree add`/`git stash`: it never writes
+  # to the repository, so a concurrent session's worktree metadata cannot be
+  # disturbed and there is no stash-cycle chimera window.
+  git -C "$REPO" archive --format=tar "$1" | tar -xf - -C "$2"
+}
+
+if [ "${IR_AB_PREPARED:-0}" != 1 ]; then
+  case "$MODE" in
+    ref)      echo "ir_ab: snapshotting $ARM_A -> a, $ARM_B -> b"
+              snapshot_ref "$ARM_A" "$WORK/a"; snapshot_ref "$ARM_B" "$WORK/b" ;;
+    selftest) echo "ir_ab: snapshotting working tree -> a, b (selftest)"
+              snapshot_worktree "$WORK/a"; snapshot_worktree "$WORK/b" ;;
+    profile)  echo "ir_ab: snapshotting working tree -> a (profile)"
+              snapshot_worktree "$WORK/a" ;;
+    makeargs) echo "ir_ab: snapshotting working tree -> a, b"
+              snapshot_worktree "$WORK/a"; snapshot_worktree "$WORK/b" ;;
+  esac
+fi
+
+# --------------------------------------------------------------- container ---
+# Cachegrind is Linux-only in practice (no valgrind on Apple Silicon), so on a
+# Mac the whole build+measure half re-execs inside a Linux container.  The
+# source trees are already prepared on the host, so only $WORK and the ROM need
+# to cross the boundary and the image needs no git.
+if ! command -v valgrind >/dev/null 2>&1 && [ "${IR_AB_IN_CONTAINER:-0}" != 1 ]; then
+  [ "${IR_NO_CONTAINER:-0}" = 1 ] && { echo "ir_ab: valgrind not found" >&2; exit 1; }
+  ENGINE=$(command -v podman || command -v docker) || {
+    echo "ir_ab: valgrind not found and no podman/docker to fall back on." >&2
+    echo "  Linux:  apt-get install valgrind" >&2
+    echo "  macOS:  install podman (valgrind does not support Apple Silicon)" >&2
+    exit 1; }
+  if ! "$ENGINE" image exists "$IMAGE" 2>/dev/null && \
+     ! "$ENGINE" image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "ir_ab: building container image $IMAGE"
+    printf 'FROM docker.io/library/ubuntu:24.04\nRUN apt-get update && apt-get install -y --no-install-recommends build-essential valgrind python3 ca-certificates && rm -rf /var/lib/apt/lists/*\n' \
+      | "$ENGINE" build -t "$IMAGE" -f - . >/dev/null
+  fi
+  echo "ir_ab: no host valgrind -- re-executing under $ENGINE ($IMAGE)"
+  exec "$ENGINE" run --rm \
+      -v "$WORK:$WORK" -v "$ROM:$ROM:ro" -v "$REPO:$REPO:ro" \
+      -e IR_AB_IN_CONTAINER=1 -e IR_AB_PREPARED=1 -e "IR_AB_WORK=$WORK" \
+      -e "IR_ROM=$ROM" -e "IR_FRAMES=$FRAMES" -e "IR_THRESHOLD=$THRESHOLD" \
+      -e "IR_GATE=${IR_GATE:-0}" -e "IR_MAKE_ARGS=${IR_MAKE_ARGS:-}" \
+      -e "IR_JOBS=${IR_JOBS:-}" \
+      -w "$WORK" "$IMAGE" \
+      bash "$REPO/test/tools/ir_ab.sh" ${ORIG_ARGS[@]+"${ORIG_ARGS[@]}"}
+fi
+
+command -v valgrind >/dev/null 2>&1 || { echo "ir_ab: valgrind missing" >&2; exit 1; }
+
+# ------------------------------------------------------------------ builds ---
+case "$(uname -s)" in
+  Darwin) LIB=virtualjaguar_libretro.dylib ;;
+  *)      LIB=virtualjaguar_libretro.so ;;
+esac
+
+build() {  # build <tag> <make-args>
+  # shellcheck disable=SC2086
+  ( cd "$WORK/$1" && make -j"$JOBS" $2 ) >"$WORK/build.$1.log" 2>&1 || {
+      echo "ir_ab: build failed for arm $1 ($2); tail of log:" >&2
+      tail -20 "$WORK/build.$1.log" >&2; exit 1; }
+  printf '  arm %s  %s  %s\n' "$1" \
+    "$(sha256sum "$WORK/$1/$LIB" 2>/dev/null || shasum -a 256 "$WORK/$1/$LIB")" "$2" \
+    | cut -c1-90
+}
+
+if [ "$MODE" = profile ]; then
+  echo "ir_ab: building arm a with debug info (per-line Ir attribution)"
+  build a "RELEASE_DEBUG_INFO=1 ${IR_MAKE_ARGS:-}"
+else
+  echo "ir_ab: building both arms (one session, independent trees)"
+  case "$MODE" in
+    makeargs) build a "$ARM_A"; build b "$ARM_B" ;;
+    *)        build a "${IR_MAKE_ARGS:-}"; build b "${IR_MAKE_ARGS:-}" ;;
+  esac
+fi
+
+if [ "$MODE" != profile ]; then
+HA=$( (sha256sum "$WORK/a/$LIB" 2>/dev/null || shasum -a 256 "$WORK/a/$LIB") | cut -d' ' -f1)
+HB=$( (sha256sum "$WORK/b/$LIB" 2>/dev/null || shasum -a 256 "$WORK/b/$LIB") | cut -d' ' -f1)
+if [ "$MODE" = selftest ]; then
+  [ "$HA" = "$HB" ] || echo "ir_ab: NOTE selftest arms differ in SHA (nondeterministic build?)"
+elif [ "$HA" = "$HB" ]; then
+  echo "ir_ab: ABORT -- both arms produced a byte-identical library." >&2
+  echo "  The change under test did not reach the compiler.  A/B is meaningless." >&2
+  exit 2
+fi
+fi
+
+# ------------------------------------------------------------------ runner ---
+# Built once, from arm A, and used for BOTH arms: the instrument must not vary.
+echo "ir_ab: building workload runner (from arm a)"
+cc -O2 -Wall -std=c99 -I"$WORK/a" -I"$WORK/a/test/harness" \
+   -I"$WORK/a/libretro-common/include" -o "$WORK/runner" \
+   "$WORK/a/test/tools/frame_hash_ab.c" "$WORK/a/test/harness/harness.c" \
+   -ldl -lm 2>"$WORK/runner.log" || {
+     echo "ir_ab: runner build failed:" >&2; cat "$WORK/runner.log" >&2; exit 1; }
+
+# ----------------------------------------------------------------- measure ---
+measure() {  # measure <tag>
+  # env -i: identical, minimal environment for both arms (also scrubs VJ_*
+  # debug knobs).  Paths are equal-length by construction -- see header.
+  env -i PATH=/usr/bin:/bin:/usr/local/bin HOME=/tmp \
+    valgrind --tool=cachegrind --cache-sim=yes --branch-sim=no \
+      --cachegrind-out-file="$WORK/cg.$1" \
+      "$WORK/runner" "$WORK/$1/$LIB" "$ROM" --frames "$FRAMES" \
+      --csv "$WORK/$1.csv" >"$WORK/run.$1.log" 2>&1 || {
+        echo "ir_ab: measured run failed for arm $1:" >&2
+        tail -30 "$WORK/run.$1.log" >&2; exit 1; }
+}
+
+echo "ir_ab: measuring arm a ($FRAMES frames, $(basename "$ROM"))"; measure a
+
+if [ "$MODE" = profile ]; then
+  # Per-function/per-line Ir.  This survives inlining in a way that a sampling
+  # profiler's symbol attribution does not -- #520 §4 recorded ~23 of the 64
+  # GPU opcode bodies being inlined into executeOpcode, which biases any
+  # symbol-level split toward overstating dispatch.
+  echo
+  echo "  workload profile: $(basename "$ROM"), $FRAMES frames"
+  echo
+  # Parsed straight out of the cachegrind file rather than through
+  # cg_annotate: the annotator's table layout has changed between valgrind
+  # releases, while the callgrind-format `fn=` records it reads have not.
+  python3 - "$WORK/cg.a" <<'PY'
+import re, sys, collections
+names, per_fn, total = {}, collections.Counter(), 0
+cur = None
+for line in open(sys.argv[1]):
+    line = line.rstrip('\n')
+    if line.startswith('fn='):
+        m = re.match(r'fn=(?:\((\d+)\)\s*)?(.*)$', line)
+        cid, nm = m.group(1), m.group(2)
+        if cid and nm:
+            names[cid] = nm
+        cur = nm if nm else names.get(cid, '???')
+    elif line.startswith(('fl=', 'fi=', 'fe=', 'ob=')):
+        continue
+    elif line and (line[0].isdigit() or line[0] in '+-*'):
+        parts = line.split()
+        if len(parts) >= 2 and cur is not None:
+            try:
+                ir = int(parts[1])
+            except ValueError:
+                continue
+            per_fn[cur] += ir
+            total += ir
+print(f'  {"Ir":>16} {"share":>8}  function')
+print('  ' + '-' * 70)
+for fn, n in per_fn.most_common(25):
+    print(f'  {n:>16,} {100.0*n/total:>7.2f}%  {fn[:52]}')
+print(f'\n  total Ir attributed: {total:,}')
+PY
+  echo
+  echo "  Read this as: how much of the ROM's total work each engine does."
+  echo "  A benchmark ROM whose GPU time is dominated by one branch opcode is"
+  echo "  measuring a spin loop, not a rasteriser (issue #533)."
+  exit 0
+fi
+
+echo "ir_ab: measuring arm b ($FRAMES frames, $(basename "$ROM"))"; measure b
+
+# ------------------------------------------------------------------ report ---
+if cmp -s "$WORK/a.csv" "$WORK/b.csv"; then
+  ACC="identical (frame-hash CSVs match byte for byte)"
+else
+  ACC="DIFFERENT -- the arms do not emulate identically; the delta below mixes a behaviour change with a cost change"
+fi
+
+A_LABEL="$ARM_A" B_LABEL="$ARM_B" MODE="$MODE" ACC="$ACC" \
+THRESHOLD="$THRESHOLD" GATE="${IR_GATE:-0}" \
+python3 - "$WORK/cg.a" "$WORK/cg.b" <<'PY'
+import sys, os
+
+def read(path):
+    ev, summ = None, None
+    for line in open(path):
+        if line.startswith('events:'):
+            ev = line.split(':', 1)[1].split()
+        elif line.startswith('summary:'):
+            summ = [int(x) for x in line.split(':', 1)[1].split()]
+    if not ev or not summ:
+        sys.exit(f'ir_ab: cannot parse cachegrind output {path}')
+    d = dict(zip(ev, summ))
+    return {
+        'Ir':  d.get('Ir', 0),
+        'D1':  d.get('D1mr', 0) + d.get('D1mw', 0),
+        'LL':  d.get('DLmr', 0) + d.get('DLmw', 0) + d.get('ILmr', 0),
+        'I1':  d.get('I1mr', 0),
+    }
+
+a, b = read(sys.argv[1]), read(sys.argv[2])
+mode = os.environ['MODE']
+la = os.environ['A_LABEL'] or 'a'
+lb = os.environ['B_LABEL'] or 'b'
+if mode == 'selftest':
+    la, lb = 'run 1', 'run 2'
+
+print()
+print(f'  {"metric":<10}{"arm A":>20}{"arm B":>20}{"delta":>12}')
+print(f'  {"-"*62}')
+for k, name in (('Ir', 'Ir'), ('I1', 'I1 miss'), ('D1', 'D1 miss'), ('LL', 'LL miss')):
+    va, vb = a[k], b[k]
+    d = (vb / va - 1) * 100 if va else 0.0
+    print(f'  {name:<10}{va:>20,}{vb:>20,}{d:>+11.3f}%')
+print()
+print(f'  A = {la}')
+print(f'  B = {lb}')
+print(f'  emulated output: {os.environ["ACC"]}')
+
+ir_d = (b['Ir'] / a['Ir'] - 1) * 100 if a['Ir'] else 0.0
+thr = float(os.environ['THRESHOLD'])
+if mode == 'selftest':
+    same = a['Ir'] == b['Ir']
+    print()
+    print('  DETERMINISM: ' + ('PASS -- Ir is identical, not merely close.'
+                               if same else
+                               f'FAIL -- Ir differs by {b["Ir"]-a["Ir"]:+,} '
+                               'instructions.  Do not trust any A/B from this '
+                               'host until the cause is found (environment '
+                               'drift, ASLR-sensitive code, or a wall-clock '
+                               'read in the measured path).'))
+    verdict = 'DETERMINISTIC' if same else 'NONDETERMINISTIC'
+else:
+    if abs(ir_d) < thr:
+        verdict = 'NO-CHANGE'
+        print(f'\n  VERDICT: |{ir_d:+.3f}%| is under the {thr}% threshold -- no Ir change.')
+    elif ir_d < 0:
+        verdict = 'IMPROVED'
+        print(f'\n  VERDICT: B executes {-ir_d:.3f}% fewer instructions.')
+    else:
+        verdict = 'REGRESSED'
+        print(f'\n  VERDICT: B executes {ir_d:.3f}% MORE instructions.')
+    print('  (Ir is a work count, not a clock.  A load-elimination change '
+          'understates here;\n   an inlining/unrolling change can raise Ir and '
+          'still be faster.)')
+
+print(f'\nIR_AB_RESULT verdict={verdict} ir_a={a["Ir"]} ir_b={b["Ir"]} '
+      f'delta_pct={ir_d:.4f} d1_a={a["D1"]} d1_b={b["D1"]} '
+      f'll_a={a["LL"]} ll_b={b["LL"]}')
+
+if verdict == 'REGRESSED' and os.environ.get('GATE') == '1':
+    sys.exit(3)
+if verdict == 'NONDETERMINISTIC':
+    sys.exit(4)
+PY


### PR DESCRIPTION
Closes #534. Implements #532. Answers #533.

Three things, in the order they had to happen: an instrument, a check that the instrument works, and only then a measurement.

## 1. The instrument — `test/tools/ir_ab.sh` (#534)

Counts retired instructions (Ir) under `valgrind --tool=cachegrind` instead of timing anything. The emulator is deterministic, so a fixed ROM and frame count is a fixed amount of work, and cachegrind counts it in simulation — bit-identical run to run, on a busy box or a shared runner, with no privileges (unlike `perf stat`, which hosted runners lock down).

That matters because this project's wall-clock numbers have been wrong twice: #515 measured `-O3` at **+12.5% sequentially and −11.7% interleaved from the same two binaries**, and #520's timing phase was **blocked outright** at load 19.08/12 and never ran.

Four modes:

```bash
test/tools/ir_ab.sh 'OPT_LEVEL=-O2' 'OPT_LEVEL=-O3'   # flag flip (opt_ab.sh's convention)
test/tools/ir_ab.sh --ref libretro/develop HEAD        # source change / PR vs base
test/tools/ir_ab.sh --selftest                         # instrument check
IR_ROM=test/roms/yarc.j64 test/tools/ir_ab.sh --profile   # per-function Ir for one workload
```

Design points worth knowing:

- **No load-average gate, deliberately.** `opt_ab.sh` needs one; this is the tool that exists *because* that gate makes measurement unavailable exactly when the box is busy. The header says so, so nobody "fixes" it later.
- Each arm builds in its **own pristine source tree**, never the working tree — stronger than `make clean`, which the repo's own notes record as insufficient when a compile-affecting switch is missing from `BUILD_AXES`. Both libraries are SHA-256'd and the run **aborts** if they match, because a change that never reached the compiler cannot be A/B'd.
- The workload driver is `frame_hash_ab`, which has no wall-clock read in its output path (`test_benchmark`'s FPS `printf` would inject noise into Ir), and its per-frame hash CSV **doubles as an accuracy gate**.
- The runner binary is built **once, from arm A**, and used for both arms. The instrument must not vary.
- Determinism also needs identical argv and environment, so the measured process runs under `env -i` and the two arm paths are the same length by construction.
- On macOS (no valgrind on Apple Silicon) the build+measure half re-execs inside a Linux container automatically.

`.github/workflows/ir-ab.yml` runs it on PRs touching `gpu.c`, `blitter.c`, `op.c`, `dsp.c`, `src/m68000/**` or the Makefiles. Zero variance means a tight 0.5% threshold. **Advisory, not blocking** — see the caveats below.

## 2. Validating the instrument, in the order #534 specifies

| property | method | result |
|---|---|---|
| **Determinism** | same source both arms | **Ir identical** — 1,633,893,288 twice on one workload, 19,539,824,849 twice on another. Not close: identical. I1/D1/LL miss counts identical too. |
| **Sensitivity** | throwaway commit adding one `volatile` increment per emulated GPU opcode | **+1.815%** (+159,337,672 Ir), correct sign |

The sensitivity control is the one that matters — an instrument that has never been shown to *detect* anything reports "no change" forever and looks healthy. It also calibrates the tool: the waste is exactly 3 instructions per GPU opcode, so it says yarc@90 executes **53,112,557** GPU opcodes, which converts later deltas into per-instruction arithmetic instead of percentages. The throwaway commit was deleted, not merged.

### What Ir is not — stated here, not buried

Ir is **not wall time**. It models neither branch prediction nor ILP nor real cache behaviour. A change can legitimately *raise* Ir and still be faster (inlining, unrolling), and removing dependent loads helps latency more than instruction count — so this class of change is **understated** here. Absolute Ir is architecture-specific; only the within-run delta means anything. The denominator includes the harness (~4.4% of total on the default workload), so an `ir_ab` percentage is not directly comparable to a sampling profiler's "% of process time".

## 3. The ROM question (#533) — it is a frame-count question too

`--profile` gives per-function Ir with no source changes and no sampling bias:

| workload | GPU interp | DSP interp | blitter | 68K | total Ir |
|---|---|---|---|---|---|
| `jagniccc.j64` @ 90 | **0%** | 0% | 0% | ~38% | 1.6e9 |
| `jagniccc.j64` @ 300 | 38.6% | 22.3% | 7.1% | ~5.9% | 19.5e9 |
| `jagniccc.j64` @ 600 | 40.2% | 23.7% | 10.3% | ~2% | 52.3e9 |
| `yarc.j64` @ 90 | **71.2%** | 0.08% | 17.5% | ~0% | 8.8e9 |

`jagniccc.j64` **is** the Jaguar port of Leonard/Oxygene's NICCC 2000 (source in `test/vendor/JaguarDemos/jagniccc2000` — readme confirms the lineage, and the 68K sits in `stop #$2000` while a GPU program rasterises 75,340 precalculated polygons). So the hypothesis was right — but only after the boot window. **At 90 frames it executes zero GPU-interpreter instructions.** A CI gate on that window would have reported 0.0% forever and looked perfectly healthy, which is precisely the failure mode #534 asks to rule out.

300 frames is the cheapest count that reaches the steady-state mix and the only public workload covering every path in the workflow's `paths:` filter, so it is the default here and pinned explicitly in the workflow.

yarc stays documented as the GPU amplifier, with #533's caveat attached: its `jr`-heavy mix makes per-instruction loop *overhead* an unusually large share of its GPU time, so a loop-bookkeeping change scores high on it relative to a real game. Use it to make an effect visible, not to size it.

## 4. #532 — the disassembly gate first, then the measurement

#532 mandates a disassembly-level acceptance test before any benchmarking, because `GPUExec` already holds globals in x19–x28 and two more long-lived locals could simply **spill**. Apple clang, arm64, `-O3`, loop body measured from the back-edge:

| | instructions | loads | stack refs |
|---|---|---|---|
| before | 99 | 19 | 0 |
| after | 94 | 15 | 0 |

Both `ldrb w9, [x28, #0x4]` (`vjs.gpuPipelineTiming`) and the GOT-indirect `ldr x9,[x9]; ldr w9,[x9]` pair (`riscClockScalePct`) **left the loop**; the values live in w26/w27 for the whole slice. **No spill appeared** — zero `[sp,` references in either loop body. clang additionally collapses the two `pipeTiming` tests into a single branch, which the ticket did not anticipate.

Measured (`ir_ab.sh --ref`):

| workload | Ir delta | note |
|---|---|---|
| yarc @ 90 (GPU 71%, `jr`-heavy) | **−4.333%** | upper bound |
| jagniccc @ 300–600 (GPU ~40%, real rasteriser) | **−3.766%** | representative |

I1 misses drop 16.7% on yarc — the loop's instruction footprint shrank. D1/LL are flat, as expected: no data-access pattern changed.

The two instruments agree quantitatively. −397,589,757 Ir over the sensitivity-derived 53,112,557 GPU opcodes is **7.49 instructions saved per emulated GPU opcode**, against 8 predicted by hand-counting the clang loop body (the shortfall is iterations that take the non-default fetch/stall paths). Two independent measurements landing within 7% of each other is a much stronger result than either percentage alone.

Both are lower than #520's 8.8% upper bound, which is expected and consistent: that figure was sampled *time*, this is *work*, and a dependent-load elimination is exactly the case where Ir understates.

## Verification

- `make -j8` clean; `bash scripts/c89-lint.sh src/tom/gpu.c` passes.
- `make TEST_EXPORTS=1 test` exits 0, with the audio pair confirmed **by name** rather than by exit code: `Clipping check: Iron Soldier 2` → PASS (0.000% saturated, RMS 2598.3), `Presence check: Iron Soldier 1` → `PASS: audio is present and within expected envelope`, plus the `risc=2x` presence arm. Only 2 skips, both optional-asset (`no /tmp/fountain_vj.j64`, `no CHSE-capable chdman`).
- `test/tools/dram_scale_sweep.sh` — the mandatory gate for a `gpu.c` timing-model change — **PASS at every scale 1..16**, exit 0. A pure hoist should be timing-neutral; this is the evidence.
- `test/regression_test.sh` — 10 passed, 0 failed, screenshots unchanged, both before and after.
- **Accuracy closure.** The default-config CSV identity only proves the hoist didn't break the path it doesn't touch: with `gpuPipelineTiming` off and `riscClockScalePct == 100`, the modified branches are never taken. So both arms were also run with `gpu_pipeline_timing=enabled`, `risc_clock_scale` at 0.5x and 2x, and both together — **frame-hash CSVs byte-identical in all five configurations** (401 rows each), from two demonstrably different binaries.

## Not in this PR

`--profile` surfaced something bigger than #532 and out of scope here: `M68KInstructionHook()` runs on **every** emulated 68K instruction in shipped builds and calls `m68k_get_reg()` 17 times to fill a traceback ring. On the jagniccc boot window that is 22.9% + 14.7% = **~37.6% of total process Ir**. It is not pure debug (the CD HLE and NVM BIOS hooks ride on it), and the share collapses on GPU-heavy workloads where the 68K is parked — so it needs its own measurement before anyone touches it. Filed as #540 rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
