### PR TITLE
perf(bench): default `make benchmark` to jagniccc, not yarc (#533)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2212,9 +2212,40 @@ coverage:
 #   make benchmark BENCH_ROM=test/roms/private/Atari\ Karts.jag
 #   make benchmark BENCH_FRAMES=3000 BENCH_WARMUP=120
 #   make benchmark BENCH_BLITTER=accurate    # default: fast
-BENCH_ROM     ?= test/roms/yarc.j64
-BENCH_FRAMES  ?= 600
-BENCH_WARMUP  ?= 60
+#
+# ROM/window choice (issue #533).  Profiled with `test/tools/ir_ab.sh
+# --profile`, which reports where retired instructions actually go:
+#
+#   workload             GPU interp   DSP interp   blitter   68K
+#   jagniccc @ 90              0.0%         0.0%      0.0%   ~38%   <- BIOS boot
+#   jagniccc @ 300            38.6%        22.3%      7.1%   ~5.9%
+#   jagniccc @ 600            40.2%        23.7%     10.3%   ~2%
+#   yarc     @ 90             71.2%        0.08%     17.5%   ~0%
+#
+# yarc.j64 was the default and is a poor one: its GPU time is 73.3% `jr`
+# (a spin loop) and its DSP share is ~0.08%, so a DSP or blitter change
+# measures as no effect on it.  It is an *amplifier* for GPU-loop work --
+# the #532 hoist scored -4.33% on yarc vs -3.77% on jagniccc, same change.
+# Keep it for making a GPU-loop effect visible; do not use it to size one.
+#
+# jagniccc.j64 (the NICCC 2000 port -- a GPU program rasterising 75,340
+# precalculated polygons while the 68K sits in `stop #$2000`) is the only
+# public ROM that exercises GPU, DSP, blitter and 68K in real proportion.
+#
+# WARMUP IS LOAD-BEARING HERE, not a rounding knob: jagniccc executes
+# ZERO GPU-interpreter instructions at 90 frames because it is still in
+# BIOS boot.  Warming up only 60 frames would put most of the measured
+# window in boot code and quietly report the wrong thing.  300 clears it.
+# If you shorten BENCH_WARMUP, re-run `ir_ab.sh --profile` and confirm the
+# mix survives.
+#
+# Historical note: numbers recorded before this change (e.g. issue #515's
+# -O2/-O3 figures) were taken on yarc @ 600/60 and are NOT comparable to
+# the new default.  `make benchmark` is a same-host commit-to-commit tool
+# either way -- never compare across machines.
+BENCH_ROM     ?= test/roms/jagniccc.j64
+BENCH_FRAMES  ?= 900
+BENCH_WARMUP  ?= 300
 BENCH_BLITTER ?= fast
 # BENCH_PROFILE=1 enables src/core/perf_counters.h instrumentation and
 # wide-export ABI so test_benchmark can dlsym `perf_counters_dump`.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -90,6 +90,19 @@ vj_gpu_sync      calls=0       total=0           <- this title never syncs
 vj_dsp_sync      calls=0       total=0
 ```
 
+> **Benchmark-ROM caveat (#533).** `yarc.j64` is an *amplifier*, not a
+> benchmark: 73.3% of its GPU time is `jr` (a spin loop) and its DSP share is
+> ~0.08%, so a DSP or blitter change measures as "no effect" on it. The #532
+> GPU hoist scored −4.33% on yarc against −3.77% on jagniccc — same change,
+> and the gap is that bias. Use yarc to make a GPU-loop effect *visible*;
+> never to *size* one. The figures on this page taken on yarc are still valid
+> for what they measured, but are not a whole-core picture.
+>
+> `make benchmark` now defaults to `jagniccc.j64` @ 900 frames with a **300-frame
+> warmup** — the warmup matters, because jagniccc is still in BIOS boot (zero
+> GPU-interpreter instructions) at 90 frames. Use `test/tools/ir_ab.sh --profile`
+> to check any ROM/window before trusting it.
+
 ### Adding a counter
 
 Add a slot to the enum in [`src/core/perf_iface.h`](../src/core/perf_iface.h),
@@ -104,7 +117,8 @@ nothing for the rest of the session. `perf_iface_witness` gates that.
 Wall-clock baseline you can run on every commit:
 
 ```bash
-make benchmark                              # default: yarc.j64, 600 frames, fast blitter
+make benchmark                              # default: jagniccc.j64, 900 frames, 300 warmup
+make benchmark BENCH_ROM=test/roms/yarc.j64 # GPU-loop amplifier -- see the caveat below
 make benchmark BENCH_FRAMES=3000            # longer run (smoother numbers)
 make benchmark BENCH_BLITTER=accurate       # A/B against the "accurate" path.  Measured
                                              # on arm64 (#511): fast is never slower, and


### PR DESCRIPTION
Closes #533.

## Why

`yarc.j64` has been `make benchmark`'s default and it is a poor one. Profiled with `ir_ab.sh --profile` (landed in #539):

| workload | GPU interp | DSP interp | blitter | 68K |
|---|---|---|---|---|
| jagniccc @ 90 | **0.0%** | 0.0% | 0.0% | ~38% (BIOS boot) |
| jagniccc @ 300 | 38.6% | 22.3% | 7.1% | ~5.9% |
| jagniccc @ 600 | 40.2% | 23.7% | 10.3% | ~2% |
| yarc @ 90 | **71.2%** | **0.08%** | 17.5% | ~0% |

73.3% of yarc's GPU time is `jr` — a spin loop — and its DSP share is ~0.08%, so **a DSP or blitter change measures as "no effect" on it.** It is an *amplifier* for GPU-loop work, not a benchmark: the #532 hoist scored **−4.33% on yarc vs −3.77% on jagniccc** for the same change, and that gap is exactly the bias.

`jagniccc.j64` — the NICCC 2000 port, a GPU program rasterising 75,340 precalculated polygons while the 68K sits in `stop #$2000` — is the only public ROM exercising GPU, DSP, blitter and 68K in real proportion.

## The warmup is load-bearing, not a rounding knob

**jagniccc executes zero GPU-interpreter instructions at 90 frames** — it is still in BIOS boot. Keeping the old 60-frame warmup would have put most of the measured window in boot code and quietly reported the wrong thing: the same blind spot this issue is about, one level up. Warmup 60 → 300 clears boot; frames 600 → 900 leaves a real window.

## Compatibility

`yarc` stays available (`make benchmark BENCH_ROM=test/roms/yarc.j64`) and is documented as an amplifier — useful to make a GPU-loop effect *visible*, never to *size* one.

**Numbers recorded before this change are not comparable to the new default** (e.g. #515's -O2/-O3 figures were yarc @ 600/60). `make benchmark` was already a same-host commit-to-commit tool, so this narrows an existing caveat rather than adding one. Called out in both the Makefile comment and `docs/profiling.md`.

## Verification

`make benchmark` runs clean on the new defaults: 157.97 fps, 6.330 ms/frame avg, 900 frames after 300 warmup, 6/900 frames over 16.67 ms.

Docs-and-defaults only — no core code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)