### PR TITLE
perf(68k): gate the 16-register traceback capture behind a runtime flag (#540)

### DIFF
--- a/exports-test.list
+++ b/exports-test.list
@@ -24,6 +24,7 @@ _m68kPCSample
 _m68kPCSampleIdx
 _pcQueue
 _pcQPtr
+_startM68KTracing
 _a6Queue
 _d0Queue
 _GPU*

--- a/libretro.c
+++ b/libretro.c
@@ -4328,6 +4328,12 @@ void retro_deinit(void)
    port_device_active[1]   = INPUTDEV_PAD;
    inputdev_live[0]        = false;
    inputdev_live[1]        = false;
+   /* 68K register traceback rings (#540): off is the shipped default and a
+    * resident core must go back to it.  A harness that armed the flag
+    * cannot dlclose the core on iOS, so leaving it set would make the next
+    * game silently pay 16 register stores per emulated 68K instruction
+    * with nothing in the log to explain where the frame rate went. */
+   startM68KTracing        = false;
    /* Link-state edge tracker: same reason as the block above -- a resident
     * core would otherwise start the next session believing the previous
     * one's peer was still attached and skip the first UP edge. */

--- a/link-test.T
+++ b/link-test.T
@@ -27,6 +27,7 @@
       m68kPCSampleIdx;
       pcQueue;
       pcQPtr;
+      startM68KTracing;
       a6Queue;
       d0Queue;
       GPU*;

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -315,7 +315,32 @@ uint32_t d5Queue[0x400];
 uint32_t d6Queue[0x400];
 uint32_t d7Queue[0x400];
 uint32_t pcQPtr = 0;
+
+/* When set, M68KInstructionHook() also fills the 16 D0-D7/A0-A7 traceback
+ * rings alongside pcQueue.  Default OFF, and that default is the point
+ * (issue #540): filling them costs 16 register fetches plus 16 scattered
+ * stores on EVERY emulated 68K instruction, and NOTHING in the core reads
+ * them -- vjtrace_backtrace() and test/tools/cd_wedge_probe.c both read
+ * pcQueue only, and the 16 register rings are not even exported from the
+ * shipped ABI (only pcQueue/pcQPtr/a6Queue/d0Queue are, and only in the
+ * TEST_EXPORTS list), so a production build cannot observe them at all.
+ *
+ * Their one reader is test/test_wmcj_debug.c, which flips this on before
+ * the first retro_run().  Set it at init, NOT mid-run: pcQPtr advances
+ * either way, so flipping during emulation leaves the register rings a
+ * mix of zeros and live data while pcQueue stays continuous -- a
+ * traceback dump would silently misalign the two. */
 bool startM68KTracing = false;
+
+/* Indexed by the m68k_register_t values M68K_REG_D0..M68K_REG_A7 (0..15),
+ * which is exactly the layout of regs.regs[] (src/m68000/cpudefs.h).  The
+ * rings stay 17 separate symbols rather than one array of structs because
+ * cd_wedge_probe/test_wmcj_debug dlsym them by name. */
+static uint32_t * const m68kRegQueue[16] =
+{
+   d0Queue, d1Queue, d2Queue, d3Queue, d4Queue, d5Queue, d6Queue, d7Queue,
+   a0Queue, a1Queue, a2Queue, a3Queue, a4Queue, a5Queue, a6Queue, a7Queue
+};
 
 /* Halfline-rate 68K PC sampler (BENCH_PROFILE only).  524 samples per
  * field is enough to tell WHICH wait a title's frame loop is parked in
@@ -339,27 +364,23 @@ static bool start = false;
 void M68KInstructionHook(void)
 {
    unsigned i;
-   uint32_t m68kPC = m68k_get_reg(NULL, M68K_REG_PC);
+   /* regs.pc is literally what m68k_get_reg(NULL, M68K_REG_PC) returns
+    * (see m68k_get_reg in src/m68000/m68kinterface.c) -- read it here
+    * instead, because this hook runs once per emulated 68K instruction
+    * and a cross-TU call is not free at that rate. */
+   uint32_t m68kPC = regs.pc;
 
    // For tracebacks...
-   // Ideally, we'd save all the registers as well...
    pcQueue[pcQPtr] = m68kPC;
-   a0Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_A0);
-   a1Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_A1);
-   a2Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_A2);
-   a3Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_A3);
-   a4Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_A4);
-   a5Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_A5);
-   a6Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_A6);
-   a7Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_A7);
-   d0Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_D0);
-   d1Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_D1);
-   d2Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_D2);
-   d3Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_D3);
-   d4Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_D4);
-   d5Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_D5);
-   d6Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_D6);
-   d7Queue[pcQPtr] = m68k_get_reg(NULL, M68K_REG_D7);
+
+   /* The other 16 registers only when someone is actually going to read
+    * them -- see startM68KTracing above. */
+   if (startM68KTracing)
+   {
+      for (i = 0; i < 16; i++)
+         m68kRegQueue[i][pcQPtr] = regs.regs[i];
+   }
+
    pcQPtr++;
    pcQPtr &= 0x3FF;
 

--- a/src/core/jaguar.h
+++ b/src/core/jaguar.h
@@ -39,6 +39,10 @@ extern bool jaguarCartInserted;
 extern bool jaguarMemTrackInserted;
 extern bool bpmActive;
 extern uint32_t bpmAddress1;
+/* Fills the 16 D0-D7/A0-A7 traceback rings in M68KInstructionHook().
+ * Default off -- see the comment on its definition in jaguar.c (#540).
+ * Exported in the test ABI only; set it before the first retro_run(). */
+extern bool startM68KTracing;
 
 #ifdef __cplusplus
 extern "C" {

--- a/test/test_wmcj_debug.c
+++ b/test/test_wmcj_debug.c
@@ -31,6 +31,11 @@ static uint32_t *p_pcQueue;
 static uint32_t *p_pcQPtr;
 static uint32_t *p_a6Queue;
 static uint32_t *p_d0Queue;
+/* The 16 register traceback rings are filled only when the core's
+ * startM68KTracing flag is set -- default off, because filling them costs
+ * 16 register fetches per emulated 68K instruction (issue #540).  This
+ * tool is their only reader, so it turns them on itself. */
+static bool *p_startM68KTracing;
 
 /* DSP registers via TOM/JERRY read functions */
 static uint16_t (*p_JERRYReadWord)(uint32_t, uint32_t);
@@ -150,6 +155,7 @@ int main(int argc, char **argv)
    LOADSYM_OPT(handle, pcQPtr);
    LOADSYM_OPT(handle, a6Queue);
    LOADSYM_OPT(handle, d0Queue);
+   LOADSYM_OPT(handle, startM68KTracing);
    LOADSYM_OPT(handle, JERRYReadWord);
    LOADSYM_OPT(handle, JERRYReadByte);
    LOADSYM_OPT(handle, GPUReadLong);
@@ -164,6 +170,17 @@ int main(int argc, char **argv)
    p_retro_set_input_poll(input_poll);
    p_retro_set_input_state(input_state);
    p_retro_init();
+
+   /* Arm the register traceback rings BEFORE the first retro_run().  Not
+    * mid-run: pcQPtr advances whether or not tracing is on, so a late flip
+    * interleaves live registers with zeros against a continuous pcQueue. */
+   if (p_startM68KTracing)
+      *p_startM68KTracing = true;
+   else
+      fprintf(stderr,
+              "WARNING: core does not export startM68KTracing -- the A6/D0\n"
+              "         columns below will read $00000000 regardless of what\n"
+              "         the 68K actually held.  Rebuild with TEST_EXPORTS=1.\n");
 
    memset(&info, 0, sizeof(info));
    info.path = argv[argc - 1];


### PR DESCRIPTION
Closes #540.

Measured *with* the `ir_ab.sh` harness from #539, so this opened stacked on `perf/534-cachegrind-ab`. #539 has since merged and GitHub retargeted this to `develop` cleanly — the diff is the two commits below.

## The 37.6% number does not survive re-measurement

#540 opened with `M68KInstructionHook` at 22.91% + `m68k_get_reg` at 14.71% on `jagniccc.j64 @ 90 frames`, and flagged its own caveat: that window is BIOS boot. Re-measured first, as the issue asked. Baseline `ir_ab.sh --profile` on a real 68K/DSP-heavy game:

```
Alien vs Predator (1994).jag, 300 frames
  M68KInstructionHook   524,265,696 Ir   1.93%
  m68k_get_reg          336,565,664 Ir   1.24%
  NVMBiosHook            77,668,992 Ir   0.29%
```

≈3.2%, not 37.6%. The honest range is **0–4.3% of total work**, scaling with how 68K-bound the title is.

## What changed

`M68KInstructionHook()` runs once per emulated 68K instruction — the call site in `m68kinterface.c:203` is guarded only by `M68K_HOOK_FUNCTION`, which the shipped release build defines — and its first act was filling seventeen 1024-entry rings via seventeen cross-TU `m68k_get_reg()` calls.

I checked every reader before gating anything, since #540 explicitly warned that `cd_wedge_probe`'s traceback must not quietly become useless:

| ring | readers |
|---|---|
| `pcQueue` / `pcQPtr` | `vjtrace_backtrace()`, `test/tools/cd_wedge_probe.c`, `test/test_wmcj_debug.c` |
| `a6Queue`, `d0Queue` | `test/test_wmcj_debug.c` only, and via `LOADSYM_OPT` |
| `a0-a5`, `a7`, `d1-d7` | **none, anywhere in the tree** |

And `a0..a7`/`d1..d7` are in **neither** export list, so a shipped build cannot expose them even to `dlsym`.

So: `pcQueue` stays unconditional (one store, and it is what the crash-path readers use); the other sixteen fill only under `startM68KTracing` — a flag that already existed and was never read. Also reads `regs.pc` directly instead of `m68k_get_reg(NULL, M68K_REG_PC)`, which is literally `return regs.pc`.

arm64 -O3 codegen for the hook: **146 instructions / 19 calls → 93 / 2**.

## Results — `ir_ab.sh --ref HEAD~1 HEAD`

| workload | Ir | D1 miss | LL miss | frame hashes |
|---|---|---|---|---|
| `jagniccc.j64` @300 (balanced) | **−4.265%** | −88.450% | −5.666% | identical |
| Alien vs Predator @300 (real game) | **−2.756%** | −63.482% | −5.327% | identical |
| `yarc.j64` @90 (GPU-heavy demo) | −0.054% (no change) | −16.452% | −1.254% | identical |

The **D1 miss collapse** is the part Ir does not capture: sixteen scattered stores per 68K instruction across sixteen separate 4 KB arrays were thrashing L1D constantly. Ir understates a change of this shape.

`yarc`'s null is correct, not a failure — at 90 frames it is 71% GPU interpreter with the 68K barely running, so there is almost no hook to remove. One honest wart: `yarc` I1 miss rose 7.5% (827,890 → 890,203), 62k events against 8.8B Ir — code-layout noise from the resized function.

Byte-identical frame-hash CSVs on all three arms are the correctness proof: both halves of the change are semantic no-ops for the emulated machine, so a CSV diff would have falsified the "nothing reads these rings" premise.

## Wall clock: inconclusive, and reported as such

Host load was 17-22 on 12 cores. Interleaved A/B/B/A ×3, AvP 900 frames:

```
A (HEAD~1) n=6 median=7.191 min=6.596 stdev=1.075
B (HEAD)   n=6 median=7.263 min=6.437 stdev=0.343
median delta = +1.01%   min-vs-min = -2.41%
within-arm spread (A) = 45.3%  (B) = 15.2%
```

The two statistics **disagree on the sign** and within-arm spread dwarfs the effect — the #515 failure mode exactly. Ir and D1 are the trustworthy evidence here; a real wall-clock confirmation is owed on a quiet host (#535).

## Not done, deliberately

The two remaining per-instruction calls (`JaguarCDHLEHook`, `NVMBiosHook`) are real cross-TU calls with cheap first-line guards. Measured: `NVMBiosHook` 0.29%, `JaguarCDHLEHook` below the 0.25% cutoff. Inline-gating them means exporting or mirroring `hle_active` / memtrack state, where a missed update silently breaks CD HLE or Memory Track. Not worth ~0.5% — noted rather than shipped.

## Verification

- `make TEST_EXPORTS=1 test` — **exit 0**, 0 failed. 2 skips, both unrelated (no fountain ROM; no CHSE-capable `chdman`).
- Audio pair run explicitly (suite output is tail-truncated): presence **PASS**, clipping **PASS** at RMS 1174.2 vs develop's recorded ~1175 baseline.
- `cd_wedge_probe` still dumps a usable traceback — 36 unique PCs, `RESULT: wedge caught`. Its register dump comes from live `m68k_get_reg` at wedge time, never from the gated rings.
- `test_wmcj_debug` register columns still carry live data (`A6=$00001000  D0=$00000100`), not zeros.
- `bash scripts/c89-lint.sh src/core/jaguar.c` — passed.
- Both ABI directions link and the suite is green on each: `TEST_EXPORTS=1` → plain `make` → `TEST_EXPORTS=1` again, with `make TEST_EXPORTS=1 test` exit 0 on both ends. (The repo's notes are emphatic that this flip is where chimera binaries come from, so both legs were actually run rather than one being inferred.)

The flag is exported in **both** `exports-test.list` (Mach-O) and `link-test.T` (ELF). Adding one without the other would have left Linux silently printing `$00000000` register columns while macOS looked fine — `LOADSYM_OPT` is optional, so it would not have failed, just lied. `test_wmcj_debug.c` sets the flag at init and warns loudly instead of falling through to zeros.

## Second commit: `startM68KTracing` reset in `retro_deinit`

Kept as its own commit so the audit trail stays honest — every A/B number above was taken against `0388c46`, and this adds nothing to the hot path (it runs once, at deinit).

Leaving the flag unreset was fine while nothing could write it. Exporting it in the test ABI and giving it a writer changes that: iOS cannot `dlclose` a core, so a harness that armed the rings would leave them armed across the next load, and that session would silently pay 16 register stores per emulated 68K instruction with nothing in the log to explain the lost frame rate. It now sits with the `ShadowFBShutdown` / `TexReplaceShutdown` / `InputDevShutdown` / `netlink_was_up` resets that exist for exactly this reason.

Declared in `jaguar.h` beside `bpmActive` — its sibling debug global, defined a few lines away in `jaguar.c` — rather than as a floating `extern`. `make TEST_EXPORTS=1 test` re-run after this commit: exit 0, same 2 unrelated skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)