### PR TITLE
feat(texreplace): RGB16-direct presents, and static tiles keep Nx art (#528)

### DIFF
--- a/docs/texture-dump.md
+++ b/docs/texture-dump.md
@@ -346,9 +346,10 @@ Consequences, all load-bearing:
 
 - **Tier 1 (shipped): 16bpp source tiles, 1x, straight-copy blits** —
   the sprite/UI blit class dump mode was built for.  Presentation
-  requires the CRY 16bpp OP path (the dominant framebuffer case);
-  RGB16-mode displays and GPU-computed surfaces (Doom's texture
-  mapper) are out of scope, same as dump mode.
+  requires the 16bpp OP path; GPU-computed surfaces (Doom's texture
+  mapper) are out of scope, same as dump mode.  Both 16bpp scanout
+  modes present: CRY **and** RGB16-direct (issue #528, see
+  "RGB16-direct scanout" below).
 - **Tier 3 (shipped): >1x pack art on the Nx shadow surface** — see
   "Tier 3" below.  Pack art may be authored at exactly N times the
   dumped dimensions while **Internal Resolution** is Nx, and is then
@@ -427,28 +428,84 @@ pack's top-left subpixel (recorded in the 1x shadow, so a hi-res
 resolve miss degrades to pack colour rather than to stock).  Top-left,
 not an average: an average would invent a colour the author never drew.
 
-**Known tier-3 limit — epoch expiry on static content.** Nx blocks
-carry the surface's frame epoch and are only trusted for
-`HIRES_EPOCH_WINDOW` (16) presented frames; the 1x shadow has no epoch
-and persists on value-check alone.  So a tile blitted once and left on
-screen — a static HUD, a menu, a title card — presents crisp N× art for
-~16 frames and then ages out to the 1× representative, i.e. the same
-tile as flat blocky top-left colours.  It does *not* revert to stock,
-which is exactly why the 1× representative is recorded; that is the
-load-bearing reason for it.  Continuously re-blitting engines
-(Doom-class) are unaffected, and any block self-heals at the next blit.
-The battery gates cannot observe this (they probe with a current
-epoch), so it is documented rather than asserted.
+**Static content keeps its N× art (issue #528; was a tier-3 limit).**
+Nx blocks carry the surface's frame epoch and stock supersampled
+content is only trusted for `HIRES_EPOCH_WINDOW` (16) presented
+frames.  Pack art is **exempt from that age check**; only the stock
+sub block behind an author alpha hole still ages.  Before the
+exemption, a tile blitted once and left on screen — a static HUD, a
+menu, a title card — showed crisp N× art for ~16 frames and then aged
+out to the 1× representative: the same tile as flat blocky top-left
+colours.
+
+The exemption is safe because it adds no new failure class.  The
+window bounds *stale structure* — an N×N interior derived from a write
+RAM no longer holds — and for pack art that class is already unbounded
+and already shipping at 1×, where the tier-1 shadow carries no epoch
+at all and is presenting the same tile's 1× representative at the same
+pixel on the same value check.  Refusing the N× block therefore
+prevented no wrong-tile artifact; it only dropped that artifact's
+resolution.  (Note `shadowHiresResolveMissEpoch` still counts such
+words: the resolve counters describe the stock block, so the counter
+climbing while pack art is on screen is expected.)
+
+Asserted by gate 9, `hires_static_persist`, which steps **real**
+presented frames between the battery blits and the probe — nothing
+fakes the epoch, `harness_step` drives `retro_run` which drives
+`ShadowHiresFrameTick` — and first checks that the destination RAM is
+byte-unchanged across those frames, so "art gone" can only mean
+expiry.  (The earlier claim that catching this needed a faked epoch
+was wrong; the battery simply never stepped any frames after blitting.)
 
 Unchanged by tier 3: zero savestate fields, zero RAM writes, zero
 bus-model time.  The replacement plane is a derived cache like every
 other shadow surface, dropped by `ShadowHiresInvalidate` on savestate
 load and when a pack is unloaded.
 
-Not wired in (deliberate): the RGB16-direct Nx renderer
-(`tom_render_16bpp_rgb_scanline_hires`).  Tier 1 does not present on
-the 1x RGB16 path either, so wiring only the 2x one would make a pack
-look different at 2x than at 1x for reasons unrelated to resolution.
+### RGB16-direct scanout (issue #528)
+
+Packs present on TOM's **RGB16-direct** scanout mode
+(`TOMGetVideoMode() == 3`) as well as CRY, at **1× and N× together**.
+Both were wired in one change on purpose: tier 3 left RGB16 unwired at
+*both* resolutions precisely so a pack could not look different at 2×
+than at 1× for a reason unrelated to resolution, and doing half of it
+would have recreated exactly that defect.
+
+A corpus census settled the "which titles" question the deferral left
+open — 157 ROMs, TOM `VMODE` sampled once per presented frame over 900
+frames with scripted input: **66 titles reach mode 3 at all, 58 spend
+the majority of their frames there, and 32 never leave it.**
+RGB16-direct is not a niche path; it is the majority scanout mode for
+a large slice of the library, including Alien vs Predator (parks at
+`VMODE=$06C7` from frame 30 and never leaves), Rayman, Atari Karts,
+Iron Soldier 2, Towers II, Pinball Fantasies and Club Drive.
+
+Mechanically the store side needed nothing: the shadow surfaces
+capture the raw 16-bit destination word, and TOM's video mode only
+decides how that word is *interpreted* at scanout.  What was missing
+was a consumer, plus one bit to tell the two kinds of shadow entry
+apart:
+
+- `SHADOWFB_TAG_REPL` (bit 17 of the 1× tag, mirroring
+  `HIRES_TAG_REPL` on the Nx tag) marks an entry as **pack art** —
+  absolute RGB888 the author drew — rather than a **true-color CRY
+  reconstruction**, which is a decomposition of the 16-bit word
+  through the chroma tables and is meaningless for a word being
+  scanned out as RGB16.  The RGB16 renderers substitute on that bit
+  and only that bit; the CRY renderers mask it out and substitute on
+  either kind.  As with the Nx tag, an ordinary `ShadowFBStoreCry`
+  rewrites the tag *without* the bit, so stale pack art self-clears.
+- `TomLinePackRGB()` is the single seam both RGB16 renderers call per
+  presented pixel — one source of truth for the substitution, and what
+  gate 10 drives, the same way gate 4 drives `ShadowFBLineFromRAM`.
+- True color is still **not** wired into either RGB16 renderer, for
+  the original reason: track 3 is CRY-only, and substituting a CRY
+  reconstruction there would show a colour nothing ever drew.
+
+With no pack loaded, `shadowFBReplActive` and `shadowHiresReplActive`
+are both 0, the 1× RGB16 renderer takes a separate loop that is
+byte-for-byte the one that shipped before, and the Nx box-replication
+identity is untouched.
 
 ### Test gates (all in `make test`)
 
@@ -486,6 +543,28 @@ and a 32bpp tier-skip entry):
    (see the resolve-counter note in `shadowfb.h`), so this gate
    asserts delivery, not stores.
 8. `hires_determinism` — two identical 2x pack runs agree.
+9. `hires_static_persist` (#528) — a tile blitted **once** and then
+   left alone still delivers its N× art after 24 real presented frames
+   have carried the epoch past the 16-frame window (24 also stays far
+   from the 256-frame epoch wrap, which clears every tag for an
+   unrelated reason).  Precondition, checked first: the battery
+   destination RAM must be byte-unchanged across those frames, or the
+   gate cannot tell expiry from a coherence miss.
+10. `rgb16_presents` (#528) — `TomLinePackRGB`, the seam both RGB16
+   renderers call per presented pixel, delivers the pack at 1x and at
+   2x, **and delivers only the pack**: a true-color CRY reconstruction
+   sitting in the same shadow line plane must never substitute on an
+   RGB16 scanout.  That second half is what carries the correctness
+   claim — "substitute whenever the line entry hits" passes everything
+   else in this file and fails here.
+
+Both new gates were shown non-vacuous against deliberately broken
+builds rather than only against a baseline missing their symbols
+(#526's negative control was weaker than ideal on exactly that point):
+removing only the epoch exemption fails gate 9 alone, at 0/64 words
+delivered with RAM confirmed unchanged; dropping only the
+`SHADOWFB_TAG_REPL` requirement fails gate 10 alone, with 66 non-pack
+entries wrongly claimed at 1x and 65 at 2x.
 
 The 2x pack is generated by the same first-principles code as the 1x
 one, with one tile deliberately left at 1× art (proving replication)

--- a/exports-test.list
+++ b/exports-test.list
@@ -91,6 +91,11 @@ _texReplaceEnabled
 _ShadowFB*
 _shadowLineRGB
 _shadowLineTag
+# RGB16-direct pack presentation (#528): the gate drives the seam both
+# RGB16 renderers use.  _TomLinePackRGB is NOT covered by _TOM* -- the
+# prefix differs in case.
+_shadowFBReplActive
+_TomLinePackRGB
 # Nx surface probes: the tier-3 (>1x pack art) gates drive the OP's own
 # resolve function and read the Nx line planes directly.
 _ShadowHires*

--- a/link-test.T
+++ b/link-test.T
@@ -94,6 +94,11 @@
       ShadowFB*;
       shadowLineRGB;
       shadowLineTag;
+      /* RGB16-direct pack presentation (#528): the gate drives the seam
+       * both RGB16 renderers use.  TomLinePackRGB is NOT covered by
+       * TOM* -- the prefix differs in case. */
+      shadowFBReplActive;
+      TomLinePackRGB;
       /* Nx surface probes: the tier-3 (>1x pack art) gates drive the OP's
        * own resolve function and read the Nx line planes directly. */
       ShadowHires*;

--- a/src/tom/shadowfb.c
+++ b/src/tom/shadowfb.c
@@ -34,6 +34,10 @@ int shadowFBActive = 0;
 int shadowFBPrecision = 0;
 static int shadowFBPrecisionWant = 0;
 
+/* Issue #528: nonzero once a pack has stored one 1x replacement entry.
+ * Gates the RGB16-direct renderers' per-pixel work (shadowfb.h). */
+int shadowFBReplActive = 0;
+
 uint32_t shadowLineRGB[SHADOWFB_LINE_PIXELS];
 uint32_t shadowLineTag[SHADOWFB_LINE_PIXELS];
 
@@ -83,33 +87,65 @@ void ShadowFBStoreRGB(uint32_t addr, uint16_t value16, uint32_t rgb888)
       return;
    idx = (addr & 0x1FFFFE) >> 1;
    shadowRGB[idx] = rgb888 & 0x00FFFFFF;
-   shadowTag[idx] = (uint32_t)value16 | SHADOWFB_TAG_VALID;
+   /* SHADOWFB_TAG_REPL marks this as pack art rather than a CRY
+    * reconstruction (issue #528): the RGB16-direct renderers may
+    * substitute it, the CRY renderers mask the bit out. */
+   shadowTag[idx] = (uint32_t)value16 | SHADOWFB_TAG_VALID
+                  | SHADOWFB_TAG_REPL;
+   shadowFBReplActive = 1;
 }
 
-int ShadowFBLookup(uint32_t addr, uint16_t current16, uint32_t *rgb888)
+/* Shared value-check.  `replOut` (optional) reports whether the entry is
+ * pack art. */
+static int shadow_fb_lookup(uint32_t addr, uint16_t current16,
+                            uint32_t *rgb888, int *replOut)
 {
-   uint32_t idx;
+   uint32_t idx, tag;
+   if (replOut)
+      *replOut = 0;
    if (!shadowFBActive)
       return 0;
    addr &= 0xFFFFFF;
    if (addr >= 0x800000)
       return 0;
    idx = (addr & 0x1FFFFE) >> 1;
-   if (shadowTag[idx] != ((uint32_t)current16 | SHADOWFB_TAG_VALID))
+   tag = shadowTag[idx];
+   if ((tag & SHADOWFB_TAG_VMASK)
+         != ((uint32_t)current16 | SHADOWFB_TAG_VALID))
       return 0;
+   if (replOut)
+      *replOut = (tag & SHADOWFB_TAG_REPL) ? 1 : 0;
    *rgb888 = shadowRGB[idx];
    return 1;
+}
+
+int ShadowFBLookup(uint32_t addr, uint16_t current16, uint32_t *rgb888)
+{
+   return shadow_fb_lookup(addr, current16, rgb888, NULL);
+}
+
+int ShadowFBLookupRepl(uint32_t addr, uint16_t current16, uint32_t *rgb888)
+{
+   int repl;
+   if (!shadow_fb_lookup(addr, current16, rgb888, &repl))
+      return 0;
+   return repl;
 }
 
 void ShadowFBLineFromRAM(int idx, uint32_t srcAddr, uint16_t value16)
 {
    uint32_t rgb;
+   int repl;
    if (idx < 0 || idx >= SHADOWFB_LINE_PIXELS)
       return;
-   if (!ShadowFBLookup(srcAddr, value16, &rgb))
-      rgb = CRY16ToRGB32[value16] & 0x00FFFFFF;
+   if (!shadow_fb_lookup(srcAddr, value16, &rgb, &repl))
+   {
+      rgb  = CRY16ToRGB32[value16] & 0x00FFFFFF;
+      repl = 0;
+   }
    shadowLineRGB[idx] = rgb;
-   shadowLineTag[idx] = (uint32_t)value16 | SHADOWFB_TAG_VALID;
+   shadowLineTag[idx] = (uint32_t)value16 | SHADOWFB_TAG_VALID
+                      | (repl ? SHADOWFB_TAG_REPL : 0u);
 }
 
 void ShadowFBInvalidate(void)
@@ -160,6 +196,7 @@ void ShadowFBShutdown(void)
    shadowFBActive = 0;
    shadowFBPrecision = 0;
    shadowFBPrecisionWant = 0;
+   shadowFBReplActive = 0;
    memset(shadowLineRGB, 0, sizeof(shadowLineRGB));
    memset(shadowLineTag, 0, sizeof(shadowLineTag));
 }
@@ -440,7 +477,13 @@ void ShadowHiresStoreReplBlock(uint32_t addr, uint16_t stock16,
  *             an allocated page that was never itself written).
  *   epoch  -- the entry matches by value and was rejected only for age.
  *             This is the silent-total-failure bucket: a slow or
- *             double-buffered engine can push 100% of its blocks here. */
+ *             double-buffered engine can push 100% of its blocks here.
+ *
+ * Counted buckets describe the SUB (stock supersampled) block only.  An
+ * epoch-expired word that carries pack art still returns its
+ * replacement plane (see the HIRES_TAG_REPL block below), so `missEpoch`
+ * climbing while pack art is visibly on screen is expected, not a
+ * contradiction. */
 static const shadowfb_sub *shadow_hires_block(uint32_t addr, uint16_t current16,
                                               const uint32_t **replOut)
 {
@@ -471,6 +514,31 @@ static const shadowfb_sub *shadow_hires_block(uint32_t addr, uint16_t current16,
    if (((hiresEpoch - ep) & 0xFF) >= HIRES_EPOCH_WINDOW)
    {
       shadowHiresResolveMissEpoch++;
+      /* Issue #528: pack art is EXEMPT from the age check, stock
+       * supersampled content is not.
+       *
+       * The epoch window bounds the R3 stale-STRUCTURE class: an entry
+       * whose value16 still matches RAM but whose N*N interior was
+       * derived from a write that is no longer the one RAM holds.  For
+       * pack art that class is already unbounded and already shipping
+       * at 1x -- the tier-1 shadow (ShadowFBStoreRGB / shadowLineTag)
+       * carries NO epoch, so the very same pack tile's 1x
+       * representative is being presented at this very pixel right now
+       * on exactly the same value-check.  Rejecting the Nx block for
+       * age therefore cannot prevent a wrong-tile artifact; it only
+       * drops that artifact's resolution from the author's art to a
+       * flat 1x block.  That is what made a tile blitted once and left
+       * on screen (HUD, menu, title card) go blocky after
+       * HIRES_EPOCH_WINDOW frames.
+       *
+       * The SUB block is still refused: stale stock structure is
+       * precisely what the window exists to reject, and returning NULL
+       * makes author alpha holes fall back to box replication of the
+       * word RAM actually holds -- the exact 1x result, never invented
+       * detail. */
+      if ((tag & HIRES_TAG_REPL) && hiresPageRepl[page])
+         *replOut = hiresPageRepl[page]
+                  + word * (uint32_t)shadowHiresN * (uint32_t)shadowHiresN;
       return NULL;
    }
    shadowHiresResolveHits++;
@@ -521,7 +589,12 @@ int ShadowHiresLineFromRAM(int idx, uint32_t srcAddr, uint16_t value16)
       }
    }
    shadowHiresLineTag[idx] = (uint32_t)value16 | SHADOWFB_TAG_VALID;
-   return blk != NULL;
+   /* Pack art counts as content even when the sub block was refused for
+    * age (issue #528): op.c's Stage 3 miss fallback would otherwise call
+    * ShadowHiresLineFromScaledSamples, which zeroes the line
+    * replacement plane -- wiping the art one statement after it was
+    * delivered.  Point samples never beat the author's pixels anyway. */
+   return (blk != NULL) || (rblk != NULL);
 }
 
 void ShadowHiresLineFromScaledSamples(int idx, const shadowfb_sub *cols,

--- a/src/tom/shadowfb.h
+++ b/src/tom/shadowfb.h
@@ -35,6 +35,25 @@ extern "C" {
 
 #define SHADOWFB_LINE_PIXELS 720
 #define SHADOWFB_TAG_VALID   0x10000
+/* Bit 17: this entry's RGB888 is texture-pack art (ShadowFBStoreRGB),
+ * not a CRY reconstruction (ShadowFBStoreCry).  Issue #528.
+ *
+ * The distinction only matters at presentation.  A CRY reconstruction is
+ * meaningful ONLY on the CRY scanline path -- it is a decomposition of
+ * the 16-bit word through the chroma tables, and running it on a word
+ * TOM is scanning out as RGB16 would show an invented colour.  Pack art
+ * is an ABSOLUTE RGB888 the author drew: it carries no format
+ * assumption, so it is correct wherever the word it is tagged against
+ * reaches the screen.  Hence the RGB16-direct renderers substitute on
+ * this bit and this bit only, while the CRY renderers mask it out and
+ * substitute on either kind.
+ *
+ * Tag value comparisons must therefore mask with 0x1FFFF, exactly as the
+ * hi-res tag does for HIRES_TAG_REPL: an ordinary ShadowFBStoreCry
+ * rewrites the tag WITHOUT this bit, so stale pack art self-clears with
+ * no invalidation hook. */
+#define SHADOWFB_TAG_REPL    0x20000
+#define SHADOWFB_TAG_VMASK   0x1FFFF
 
 /* Nonzero when the surface is on AND the buffers are allocated.  Hot
  * paths gate on this before doing any shadow work.  The surface can be
@@ -51,6 +70,13 @@ extern int shadowFBPrecision;
 /* Set by the True Color option (independent of surface allocation
  * order; the effective flag is recomputed on enable). */
 void ShadowFBSetPrecision(int on);
+
+/* Nonzero once a pack has stored at least one 1x replacement entry
+ * (issue #528).  The RGB16-direct scanline renderers gate on this so a
+ * run without a pack -- including a plain True Color run -- does zero
+ * extra per-pixel work and stays bit-identical to stock.  Counterpart
+ * of shadowHiresReplActive on the Nx surface. */
+extern int shadowFBReplActive;
 
 /* Shadow line buffer, parallel to tomRam8[0x1800..], one entry per
  * 16-bit line-buffer pixel.  Tag = value16 | SHADOWFB_TAG_VALID. */
@@ -84,13 +110,23 @@ void ShadowFBStoreCry(uint32_t addr, uint16_t value16, uint16_t frac16);
 void ShadowFBStoreRGB(uint32_t addr, uint16_t value16, uint32_t rgb888);
 
 /* Value-checked lookup: returns nonzero and fills *rgb888 only when the
- * entry's tag matches current16 (the value just read from RAM). */
+ * entry's tag matches current16 (the value just read from RAM).  Both
+ * kinds of entry (CRY reconstruction and pack art) hit. */
 int ShadowFBLookup(uint32_t addr, uint16_t current16, uint32_t *rgb888);
+
+/* As ShadowFBLookup, but hits ONLY on a texture-pack entry
+ * (SHADOWFB_TAG_REPL).  The RGB16-direct presentation path uses this:
+ * see the SHADOWFB_TAG_REPL comment for why a CRY reconstruction must
+ * not be substituted on an RGB16 scanout. */
+int ShadowFBLookupRepl(uint32_t addr, uint16_t current16, uint32_t *rgb888);
 
 /* OP 16bpp write site helper: resolve srcAddr against the shadow RAM
  * (hit -> shadow RGB888, miss -> stock CRY16ToRGB32 conversion) and
  * store the result + tag into shadow line entry `idx`.  Out-of-range
- * idx is ignored (renderer then falls back via tag mismatch). */
+ * idx is ignored (renderer then falls back via tag mismatch).
+ *
+ * The line tag carries SHADOWFB_TAG_REPL through from the RAM entry, so
+ * the scanline renderers can tell pack art from a CRY reconstruction. */
 void ShadowFBLineFromRAM(int idx, uint32_t srcAddr, uint16_t value16);
 
 /* ==================================================================
@@ -153,6 +189,12 @@ extern int shadowHiresActive;
  *   missNoPage -- no shadow page for the address (production never got here)
  *   missValue  -- entry exists, RAM value no longer matches its tag
  *   missEpoch  -- value matched, entry rejected for age only (the silent one)
+ *
+ * The buckets describe the STOCK supersampled block only.  Texture-pack
+ * art is exempt from the age check (issue #528; see the REPL section
+ * below), so an epoch-expired word carrying pack art bumps missEpoch and
+ * still delivers its replacement plane -- missEpoch climbing while pack
+ * art is on screen is expected, not a contradiction.
  *
  * Stage 3 (design section 6.4) note: OP scaled-bitmap pixels resolve
  * against the RAM shadow FIRST (ShadowHiresLineFromRAM, counted here
@@ -236,9 +278,22 @@ void ShadowHiresShutdown(void);
  *   - any ordinary ShadowHiresStoreCry/Block to the word rewrites the
  *     tag WITHOUT the replacement bit, so stale pack art self-clears
  *     through the machinery that already exists;
- *   - the value+epoch coherence check is unchanged and shared;
+ *   - the value coherence check is unchanged and shared;
  *   - a 1x run, or a 2x run with no pack, allocates nothing and pays
  *     one already-predicted branch.
+ *
+ * The EPOCH half of the coherence check does not apply to pack art
+ * (issue #528).  HIRES_EPOCH_WINDOW bounds stale STRUCTURE -- an N*N
+ * interior derived from a write RAM no longer holds -- and for pack art
+ * that class is already unbounded and already shipping at 1x, where the
+ * tier-1 shadow carries no epoch at all and is presenting the same
+ * tile's 1x representative at the same pixel on the same value check.
+ * Ageing the Nx block out therefore prevented no artifact; it only
+ * dropped a statically-blitted tile (HUD, menu, title card) from the
+ * author's art to a flat 1x block after ~16 frames.  The stock sub
+ * block behind an author alpha hole IS still refused on age, so holes
+ * fall back to box replication of the word RAM holds -- never invented
+ * detail.
  *
  * Entry encoding: SHADOWFB_HIRES_REPL_VALID | RGB888 to replace that
  * subpixel, or 0 to keep the stock/supersampled content underneath
@@ -291,9 +346,12 @@ void ShadowHiresStoreCryBlock(uint32_t addr, uint16_t stock16,
  * value16, the word the OP just read); on miss, replicate
  * {value16, 0} N*N times.  Runs inside the OP's single per-scanline
  * pass, producing all N sub-rows at once (design section 6.1).
- * Returns nonzero on a shadow-block hit, 0 on any miss (the Stage 3
+ * Returns nonzero on a shadow-block hit -- or on a pack-art hit with no
+ * usable stock block (issue #528) -- and 0 on any miss.  The Stage 3
  * caller in op.c uses this to fall back to point samples ONLY when no
- * real supersampled content exists for the word). */
+ * real content exists for the word: ShadowHiresLineFromScaledSamples
+ * zeroes the line replacement plane, so reporting a miss for a word
+ * that just delivered pack art would wipe it. */
 int ShadowHiresLineFromRAM(int idx, uint32_t srcAddr, uint16_t value16);
 
 /* Stage 3 (design section 6.4): OP scaled-bitmap miss fallback.  Used

--- a/src/tom/texreplace.c
+++ b/src/tom/texreplace.c
@@ -21,7 +21,7 @@
  *      pixel's RGB888 is stored into the true-color shadow
  *      framebuffer, tagged with that RAM value.  The OP's existing
  *      shadow presentation path (op.c -> ShadowFBLineFromRAM -> the
- *      CRY scanline renderer) then presents the pack art.
+ *      scanline renderer) then presents the pack art.
  *
  * The per-pixel witness makes wrong models harmless: transparent
  * (BCOMPEN/DCOMPEN) pixels, shaded/Gouraud outputs, non-rectangular
@@ -42,12 +42,22 @@
  * too, replicated -- without that the Nx surface would MASK 1x packs,
  * because its line entries win wherever they hit.
  *
+ * RGB16-DIRECT SCANOUT (issue #528): presentation is no longer
+ * CRY-only.  Both 16bpp scanout modes present, at 1x and Nx together
+ * -- the store side never cared (it captures the raw destination word;
+ * TOM's video mode only decides how that word is INTERPRETED at
+ * scanout), so this was a missing consumer plus one tag bit,
+ * SHADOWFB_TAG_REPL, telling pack art apart from a true-color CRY
+ * reconstruction.  A CRY reconstruction must NOT present on an RGB16
+ * scanout; pack art is absolute RGB888 and is correct on either.  See
+ * TomLinePackRGB in tom.c and the SHADOWFB_TAG_REPL comment in
+ * shadowfb.h.
+ *
  * Known limits (documented in docs/texture-dump.md): presentation
- * requires the CRY 16bpp OP path (the dominant framebuffer case); the
- * shadow tag is value-checked, so a later NON-blit write of the same
- * 16-bit value to a replaced address keeps presenting pack RGB until
- * the next store to that word; indexed (<=8bpp) sources are a future
- * tier.
+ * requires the 16bpp OP path; the shadow tag is value-checked, so a
+ * later NON-blit write of the same 16-bit value to a replaced address
+ * keeps presenting pack RGB until the next store to that word;
+ * indexed (<=8bpp) sources are a future tier.
  */
 
 #include "texreplace.h"

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -754,6 +754,35 @@ static uint16_t tom_clamp_line_buffer_width(
    return (width > safe_width) ? (uint16_t)safe_width : width;
 }
 
+/* Texture-pack substitution for ONE presented pixel on a non-CRY
+ * scanline path (issue #528).
+ *
+ * This is the single seam the RGB16-direct renderers -- 1x and Nx --
+ * use, so both paths present a pack identically and a resolution change
+ * can never make a pack look different for a reason unrelated to
+ * resolution.  It is also exactly what the test gate drives, the same
+ * way gates 4 and 7 drive ShadowFBLineFromRAM / ShadowHiresLineFromRAM.
+ *
+ * A hit requires SHADOWFB_TAG_REPL, i.e. the entry is absolute RGB888
+ * the pack author drew.  A true-color CRY reconstruction deliberately
+ * does NOT hit here: it is a decomposition of the 16-bit word through
+ * the chroma tables and means nothing for a word TOM is scanning out as
+ * RGB16 (see the SHADOWFB_TAG_REPL comment in shadowfb.h).
+ *
+ * Returns nonzero and fills *out (with alpha) on a hit. */
+int TomLinePackRGB(int idx, uint16_t color, uint32_t *out)
+{
+   if (!shadowFBActive || !shadowFBReplActive)
+      return 0;
+   if (idx < 0 || idx >= SHADOWFB_LINE_PIXELS)
+      return 0;
+   if (shadowLineTag[idx] != ((uint32_t)color | SHADOWFB_TAG_VALID
+                              | SHADOWFB_TAG_REPL))
+      return 0;
+   *out = 0xFF000000 | shadowLineRGB[idx];
+   return 1;
+}
+
 // 16 BPP CRY/RGB mixed mode rendering
 void tom_render_16bpp_cry_rgb_mix_scanline(uint32_t * backbuffer)
 {
@@ -844,8 +873,11 @@ void tom_render_16bpp_cry_scanline(uint32_t * backbuffer)
          uint16_t color = (*current_line_buffer++) << 8;
          color |= *current_line_buffer++;
          out = CRY16ToRGB32[color];
+         /* SHADOWFB_TAG_REPL is masked out: on the CRY path BOTH kinds
+          * of entry (true-color reconstruction and pack art) present. */
          if (sfbIdx >= 0 && sfbIdx < SHADOWFB_LINE_PIXELS
-               && shadowLineTag[sfbIdx] == ((uint32_t)color | SHADOWFB_TAG_VALID))
+               && (shadowLineTag[sfbIdx] & SHADOWFB_TAG_VMASK)
+                  == ((uint32_t)color | SHADOWFB_TAG_VALID))
             out = 0xFF000000 | shadowLineRGB[sfbIdx];
          sfbIdx++;
          for (s = 0; s < pwidth_scale; s++)
@@ -935,7 +967,8 @@ static void tom_render_16bpp_cry_scanline_hires(uint32_t * backbuffer)
        * the true-color substitution when that option is on). */
       base = CRY16ToRGB32[color];
       if (shadowFBActive && sfbIdx >= 0 && sfbIdx < SHADOWFB_LINE_PIXELS
-            && shadowLineTag[sfbIdx] == ((uint32_t)color | SHADOWFB_TAG_VALID))
+            && (shadowLineTag[sfbIdx] & SHADOWFB_TAG_VMASK)
+               == ((uint32_t)color | SHADOWFB_TAG_VALID))
          base = 0xFF000000 | shadowLineRGB[sfbIdx];
 
       for (sub = 0; sub < n; sub++)
@@ -1034,7 +1067,15 @@ static void tom_render_16bpp_cry_scanline_hires(uint32_t * backbuffer)
  * RGB renderer) has no true-color hookup either -- track 3 is CRY-only --
  * so adding one here at 2x would make the 2x frame differ from the 1x
  * frame by something that is not supersampling, breaking the
- * box-replication identity this renderer must uphold on every miss. */
+ * box-replication identity this renderer must uphold on every miss.
+ *
+ * Texture-pack art IS wired in (issue #528), and by that same rule: the
+ * 1x RGB renderer presents packs too, through the same TomLinePackRGB
+ * seam, so `base` here carries the pack's 1x representative exactly as
+ * the CRY hires renderer's `base` carries the 1x substitution.  With no
+ * pack loaded shadowHiresReplActive and shadowFBReplActive are both 0,
+ * every branch below is predicted-not-taken, and the box-replication
+ * identity is untouched. */
 static void tom_render_16bpp_rgb_scanline_hires(uint32_t * backbuffer)
 {
    unsigned i;
@@ -1049,6 +1090,9 @@ static void tom_render_16bpp_rgb_scanline_hires(uint32_t * backbuffer)
    uint16_t startPos_disp;
    uint32_t *rows[SHADOWFB_HIRES_MAX_N];
    int sfbIdx;
+   /* Hoisted exactly as in the CRY hires renderer: 0 for every run of
+    * the base hi-res feature, so the pack branches cost nothing. */
+   int replActive = (shadowHiresReplActive && shadowHiresLineRepl) ? 1 : 0;
    startPos /= pwidth;
 
    for (sub = 0; sub < n; sub++)
@@ -1077,29 +1121,44 @@ static void tom_render_16bpp_rgb_scanline_hires(uint32_t * backbuffer)
    {
       uint32_t base;
       const shadowfb_sub *ent;
+      const uint32_t *rent;
       uint16_t color = (*current_line_buffer++) << 8;
       color |= *current_line_buffer++;
 
       /* `base` = the exact 1x result for this stock pixel: a plain
        * RGB16ToRGB32 lookup, same as tom_render_16bpp_rgb_scanline --
-       * no true-color substitution (see comment above). */
+       * no true-color substitution (see comment above), but WITH the
+       * pack's 1x representative when one exists, because the 1x RGB
+       * renderer presents that too (issue #528). */
       base = RGB16ToRGB32[color];
+      TomLinePackRGB(sfbIdx, color, &base);
 
       for (sub = 0; sub < n; sub++)
       {
-         ent = NULL;
+         ent  = NULL;
+         rent = NULL;
          if (sfbIdx >= 0 && sfbIdx < SHADOWFB_LINE_PIXELS
                && shadowHiresLineTag[sfbIdx] ==
                   ((uint32_t)color | SHADOWFB_TAG_VALID))
-            ent = shadowHiresLineSub
-                + ((uint32_t)sub * SHADOWFB_LINE_PIXELS + (uint32_t)sfbIdx)
-                  * (uint32_t)n;
+         {
+            uint32_t off = ((uint32_t)sub * SHADOWFB_LINE_PIXELS
+                            + (uint32_t)sfbIdx) * (uint32_t)n;
+            ent = shadowHiresLineSub + off;
+            if (replActive)
+               rent = shadowHiresLineRepl + off;
+         }
          for (sx = 0; sx < n; sx++)
          {
-            /* A hit renders each entry's raw value16 through the stock
-             * RGB16 LUT (frac16 ignored -- see comment above); a miss
-             * falls back to `base`, the exact 1x result. */
-            uint32_t out = ent ? RGB16ToRGB32[ent[sx].value16] : base;
+            /* Pack art is absolute RGB888 and wins outright; an author
+             * alpha hole (entry 0) falls through.  Otherwise a hit
+             * renders each entry's raw value16 through the stock RGB16
+             * LUT (frac16 ignored -- see comment above); a miss falls
+             * back to `base`, the exact 1x result. */
+            uint32_t out;
+            if (rent && (rent[sx] & SHADOWFB_HIRES_REPL_VALID))
+               out = 0xFF000000 | (rent[sx] & 0x00FFFFFF);
+            else
+               out = ent ? RGB16ToRGB32[ent[sx].value16] : base;
             for (s = 0; s < pwidth_scale; s++)
                *rows[sub]++ = out;
          }
@@ -1230,7 +1289,21 @@ void tom_render_16bpp_direct_scanline(uint32_t * backbuffer)
 }
 
 
-// 16 BPP RGB mode rendering
+/* 16 BPP RGB mode rendering.
+ *
+ * Texture packs present here as well as on the CRY path (issue #528).
+ * The two were wired TOGETHER on purpose: tier 3 (#526) left RGB16
+ * unwired at both 1x and Nx precisely so a pack could not look
+ * different at 2x than at 1x for a reason unrelated to resolution, and
+ * wiring one without the other would recreate exactly that defect.
+ * A corpus census (162 ROMs, TOM VMODE sampled per frame) settled the
+ * "which titles" question the deferral left open: RGB16-direct is not a
+ * niche path -- it is the majority scanout mode for most of the library,
+ * including Alien vs Predator, which parks at VMODE=$06C7 from frame 30
+ * and never leaves it.
+ *
+ * Only pack art substitutes here, never a true-color CRY
+ * reconstruction; see TomLinePackRGB above. */
 void tom_render_16bpp_rgb_scanline(uint32_t * backbuffer)
 {
    unsigned i;
@@ -1262,6 +1335,29 @@ void tom_render_16bpp_rgb_scanline(uint32_t * backbuffer)
 #endif
 
    width = tom_clamp_line_buffer_width(current_line_buffer, width, 2, pwidth_scale);
+
+   /* Pack-present path.  Split from the stock loop rather than folded
+    * into it so that with no pack loaded -- every ordinary run, True
+    * Color included -- the code below is byte-for-byte the loop that
+    * shipped before #528. */
+   if (shadowFBActive && shadowFBReplActive)
+   {
+      int sfbIdx = (int)((current_line_buffer - &tomRam8[0x1800]) >> 1);
+      while (width >= pwidth_scale)
+      {
+         uint32_t out;
+         uint16_t color = (*current_line_buffer++) << 8;
+         color |= *current_line_buffer++;
+         out = RGB16ToRGB32[color];
+         TomLinePackRGB(sfbIdx, color, &out);
+         sfbIdx++;
+         for (s = 0; s < pwidth_scale; s++)
+            *backbuffer++ = out;
+         width -= pwidth_scale;
+      }
+      return;
+   }
+
    while (width >= pwidth_scale)
    {
       uint32_t color = (*current_line_buffer++) << 8;

--- a/src/tom/tom.h
+++ b/src/tom/tom.h
@@ -53,6 +53,11 @@ uint16_t TOMGetVP(void);
 uint16_t TOMGetMEMCON1(void);
 uint16_t TOMGetMEMCON2(void);
 
+/* Texture-pack substitution for one presented pixel on the RGB16-direct
+ * scanline paths (issue #528).  The single seam both the 1x and the Nx
+ * RGB16 renderers use -- see the comment on the definition in tom.c. */
+int TomLinePackRGB(int idx, uint16_t color, uint32_t *out);
+
 int TOMIRQEnabled(int irq);
 uint16_t TOMIRQControlReg(void);
 void TOMSetIRQLatch(int irq, int enabled);

--- a/test/tools/test_texreplace.c
+++ b/test/tools/test_texreplace.c
@@ -46,6 +46,21 @@
  *                        the pack's TOP-LEFT subpixel, which is what a
  *                        hi-res resolve miss degrades to.
  *   8. hires_determinism  two identical 2x pack runs agree.
+ *   9. hires_static_persist (#528) a tile blitted ONCE and then left
+ *                        alone still delivers its Nx art after real
+ *                        presented frames have carried the frame epoch
+ *                        past HIRES_EPOCH_WINDOW.  The epoch is not
+ *                        faked: harness_step drives retro_run, which
+ *                        drives ShadowHiresFrameTick.  Guarded by a
+ *                        precondition that the destination RAM is
+ *                        byte-unchanged across those frames, so "art
+ *                        gone" can only mean expiry.
+ *  10. rgb16_presents   (#528) the RGB16-direct scanout paths present
+ *                        the pack -- 1x and Nx through the same seam
+ *                        (TomLinePackRGB) -- and present ONLY the pack:
+ *                        a true-color CRY reconstruction in the same
+ *                        shadow line plane must never substitute on an
+ *                        RGB16 scanout.
  *
  * The synthetic pack is built from FIRST PRINCIPLES: the test computes
  * each battery tile's identity hash from the documented contract
@@ -451,6 +466,21 @@ typedef struct {
     unsigned hi_sub_ok[N_TILES];   /* subpixels carrying the right RGB  */
     unsigned hi_sub_bad[N_TILES];  /* subpixels carrying the WRONG RGB  */
     unsigned hi_sub_hole[N_TILES]; /* subpixels left to the stock pixel */
+    /* Issue #528. */
+    unsigned post_frames;          /* frames stepped between the battery
+                                    * blits and the probes (ages the Nx
+                                    * epoch for the static-content gate) */
+    uint64_t dest_hash2[N_TILES];  /* battery destination RAM re-hashed
+                                    * AT PROBE TIME: proves the emulated
+                                    * game did not stomp the tiles while
+                                    * post_frames were stepped, so "art
+                                    * gone" can only mean it aged out    */
+    int      repl_1x_active;       /* shadowFBReplActive after battery   */
+    unsigned rgb16_ok;             /* pack words TomLinePackRGB delivers */
+    unsigned rgb16_bad;            /* ...delivers with the WRONG RGB     */
+    unsigned rgb16_false;          /* NON-pack line entries it wrongly
+                                    * claimed (a CRY reconstruction must
+                                    * never present on an RGB16 scanout) */
 } run_result;
 
 static run_result *g_cur;
@@ -631,6 +661,82 @@ static void probe_shadow(harness_config *cfg, run_result *out, int hires)
     }
 }
 
+/* ---------- issue #528: the RGB16-direct presentation seam ----------
+ *
+ * TomLinePackRGB is the ONE function both RGB16-direct renderers (1x
+ * tom_render_16bpp_rgb_scanline and Nx tom_render_16bpp_rgb_scanline_hires)
+ * call per presented pixel, so driving it is the RGB16 analogue of gate
+ * 4 driving ShadowFBLineFromRAM.
+ *
+ * Two halves, and the second is the one that matters:
+ *   - pack words must be DELIVERED with the author's RGB;
+ *   - non-pack shadow entries must NOT be.  A true-color CRY
+ *     reconstruction is a decomposition of the 16-bit word through the
+ *     chroma tables; presenting it on a word TOM is scanning out as
+ *     RGB16 would show a colour nothing ever drew.  "Substitute
+ *     whenever the shadow line hits" would pass the first half and fail
+ *     this one. */
+typedef int (*tom_pack_fn)(int, uint16_t, uint32_t *);
+
+static void probe_rgb16(harness_config *cfg, run_result *out, int hires)
+{
+    tom_pack_fn pack_fn = (tom_pack_fn)harness_dlsym(cfg, "TomLinePackRGB");
+    sfb_line_fn line_fn =
+        (sfb_line_fn)harness_dlsym(cfg, "ShadowFBLineFromRAM");
+    int *ra = (int *)harness_dlsym(cfg, "shadowFBReplActive");
+    void *ram_sym = harness_dlsym(cfg, "jaguarMainRAM");
+    uint8_t *ram;
+    unsigned tile, x, y;
+    const int idx = 11;                 /* arbitrary line slot */
+
+    if (!pack_fn || !line_fn || !ra || !ram_sym)
+        return;
+    out->repl_1x_active = *ra;
+    ram = *(uint8_t **)ram_sym;
+
+    for (tile = 0; tile < N_TILES; tile++) {
+        const bat_tile *t = &tiles[tile];
+        unsigned s = pack_scale(tile, hires);
+        unsigned pw = t->w * s, ph = t->h * s;
+        if (t->psize != 4)
+            continue;
+        for (y = 0; y < t->h; y++)
+            for (x = 0; x < t->w; x++) {
+                uint32_t daddr = tile_dst(tile) + (y * t->w + x) * 2;
+                uint16_t cur16 =
+                    (uint16_t)(((uint16_t)ram[daddr & 0x1FFFFF] << 8)
+                             | ram[(daddr + 1) & 0x1FFFFF]);
+                uint32_t got = 0;
+                uint8_t exp[3];
+                int want;
+                /* Populate the line slot exactly as op.c does, then ask
+                 * the renderer's seam what it would present. */
+                line_fn(idx, daddr, cur16);
+                /* A pack word is one whose 1x representative (the
+                 * TOP-LEFT subpixel) is not an author alpha hole -- the
+                 * same rule expect_1x_hits() derives independently. */
+                want = out->repl_1x_active
+                     && (s == 1 || (hires && s == 2))
+                     && !pack_hole_at(tile, pw, ph, x * s, y * s);
+                if (!pack_fn(idx, cur16, &got)) {
+                    if (want)
+                        out->rgb16_bad++;   /* pack art not delivered */
+                    continue;
+                }
+                if (!want) {
+                    out->rgb16_false++;     /* non-pack entry claimed */
+                    continue;
+                }
+                pack_rgb(tile, x * s, y * s, exp);
+                if (got == (0xFF000000u | ((uint32_t)exp[0] << 16)
+                          | ((uint32_t)exp[1] << 8) | exp[2]))
+                    out->rgb16_ok++;
+                else
+                    out->rgb16_bad++;
+            }
+    }
+}
+
 /* ---------- expectations, from the same first principles ---------- */
 
 /* Words whose 1x shadow entry must carry pack RGB.  The 1x
@@ -775,7 +881,7 @@ static void probe_shadow_hires(harness_config *cfg, run_result *out,
 
 static int do_run(const char *core, const char *rom, unsigned frames,
                   int replace_on, int hires, const char *sysdir,
-                  run_result *out)
+                  unsigned post_frames, run_result *out)
 {
     harness_config cfg = HARNESS_CONFIG_DEFAULT;
     unsigned i;
@@ -783,6 +889,7 @@ static int do_run(const char *core, const char *rom, unsigned frames,
     crc_fn crc_get;
 
     memset(out, 0, sizeof(*out));
+    out->post_frames = post_frames;
     cfg.core_path  = core;
     cfg.rom_path   = rom;
     cfg.frames     = frames;
@@ -843,8 +950,27 @@ static int do_run(const char *core, const char *rom, unsigned frames,
         harness_shutdown(&cfg);
         return 0;
     }
+    /* Issue #528: step real presented frames between the battery blits
+     * and the probes.  Nothing is faked -- harness_step drives
+     * retro_run, which drives ShadowHiresFrameTick, which is the ONLY
+     * thing that advances the epoch.  post_frames must clear
+     * HIRES_EPOCH_WINDOW (16) and stay far from the 256-frame epoch
+     * wrap, which clears every tag for an unrelated reason. */
+    if (post_frames) {
+        void *ram_sym = harness_dlsym(&cfg, "jaguarMainRAM");
+        uint8_t *ram = ram_sym ? *(uint8_t **)ram_sym : NULL;
+        unsigned t;
+        for (i = 0; i < post_frames; i++)
+            harness_step(&cfg);
+        if (ram)
+            for (t = 0; t < N_TILES; t++)
+                out->dest_hash2[t] =
+                    fnv1a(FNV_OFFSET, ram + (tile_dst(t) & 0x1FFFFF),
+                          tile_bytes(&tiles[t]));
+    }
     probe_shadow(&cfg, out, hires);
     probe_shadow_hires(&cfg, out, hires);
+    probe_rgb16(&cfg, out, hires);
 
     harness_shutdown(&cfg);
     unlink(state_path);
@@ -920,13 +1046,14 @@ int main(int argc, char **argv)
     unsigned frames;
     int i;
     run_result *ro, *rn, *rp, *rq;
-    run_result *rh, *rH, *rI;
+    run_result *rh, *rH, *rI, *rJ;
     char dir_o[64], dir_n[64], dir_p[64], dir_h[64];
-    harness_result results[12];
+    harness_result results[14];
     unsigned nres = 0;
     int failed = 0;
     static char d_nopack[224], d_inert[224], d_pres[320], d_line[128],
-                d_det[224], d_hinert[320], d_hpres[512], d_hdet[224];
+                d_det[224], d_hinert[320], d_hpres[512], d_hdet[224],
+                d_stat[448], d_rgb[384];
 
     for (i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "--json"))
@@ -958,7 +1085,8 @@ int main(int argc, char **argv)
     rh = (run_result *)calloc(1, sizeof(run_result));
     rH = (run_result *)calloc(1, sizeof(run_result));
     rI = (run_result *)calloc(1, sizeof(run_result));
-    if (!ro || !rn || !rp || !rq || !rh || !rH || !rI) {
+    rJ = (run_result *)calloc(1, sizeof(run_result));
+    if (!ro || !rn || !rp || !rq || !rh || !rH || !rI || !rJ) {
         fprintf(stderr, "FAIL: out of memory\n");
         return 1;
     }
@@ -973,10 +1101,10 @@ int main(int argc, char **argv)
     mkdir(dir_h, 0777);
 
     /* Run O: replacement disabled (the machine baseline). */
-    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 0, 0, dir_o, ro))
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 0, 0, dir_o, 0, ro))
         goto run_fail;
     /* Run N: enabled, but no pack directory exists in this sysdir. */
-    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 0, dir_n, rn))
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 0, dir_n, 0, rn))
         goto run_fail;
     /* Build the synthetic pack from first principles, then run P
      * (enabled, pack present) twice for determinism. */
@@ -984,23 +1112,34 @@ int main(int argc, char **argv)
         fprintf(stderr, "FAIL: could not build the synthetic pack\n");
         goto run_fail;
     }
-    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 0, dir_p, rp))
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 0, dir_p, 0, rp))
         goto run_fail;
-    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 0, dir_p, rq))
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 0, dir_p, 0, rq))
         goto run_fail;
 
     /* Tier 3: internal resolution 2x, with no pack (H) and with a 2x
      * pack (I, run twice).  dir_o never gains a pack, so it doubles as
      * the no-pack sysdir for the 2x baseline. */
-    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 0, 1, dir_o, rh))
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 0, 1, dir_o, 0, rh))
         goto run_fail;
     if (!build_pack(dir_h, ro->crc, 1)) {
         fprintf(stderr, "FAIL: could not build the synthetic 2x pack\n");
         goto run_fail;
     }
-    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 1, dir_h, rH))
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 1, dir_h, 0, rH))
         goto run_fail;
-    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 1, dir_h, rI))
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 1, dir_h, 0, rI))
+        goto run_fail;
+    /* Run J (issue #528): the same 2x pack run, but with REAL presented
+     * frames stepped between the battery blits and the probes -- past
+     * HIRES_EPOCH_WINDOW (16), nowhere near the 256-frame epoch wrap.
+     * This is what the existing battery could never see: it blits after
+     * the frame loop and probes at the current epoch, so nothing ever
+     * ages.  Nothing here fakes the epoch; harness_step drives
+     * retro_run, which is the only thing that advances it. */
+#define POST_FRAMES 24u
+    if (!do_run(argcfg.core_path, argcfg.rom_path, frames, 1, 1, dir_h,
+                POST_FRAMES, rJ))
         goto run_fail;
 
     /* Gate 1: no pack -> bit-identical machine AND gate off. */
@@ -1210,6 +1349,104 @@ int main(int argc, char **argv)
         nres++;
     }
 
+    /* Gate 9 (issue #528): STATIC content keeps its Nx pack art.
+     *
+     * A tile blitted once and left on screen -- HUD, menu, title card --
+     * used to show crisp Nx art for HIRES_EPOCH_WINDOW frames and then
+     * age out to the 1x representative: flat blocky colour.  Run J
+     * blits the battery, steps POST_FRAMES real presented frames, and
+     * then asks the Nx surface for the same art run H got at age zero.
+     *
+     * The precondition is checked FIRST and is not optional: if the
+     * emulated game wrote to the battery destinations during those
+     * frames, "the art is gone" would mean a coherence miss, not
+     * expiry, and the gate would be measuring the wrong thing.
+     * dest_hash2 is the destination RAM re-hashed at probe time. */
+    {
+        int ok = 1;
+        unsigned t;
+        char frag[96];
+        for (t = 0; t < N_TILES && ok; t++)
+            if (rJ->dest_hash2[t] != rJ->dest_hash[t]) {
+                ok = 0;
+                snprintf(d_stat, sizeof(d_stat),
+                         "precondition failed: the game overwrote battery "
+                         "tile %u during the %u aged frames -- this gate "
+                         "cannot distinguish expiry from a coherence miss",
+                         t, rJ->post_frames);
+            }
+        if (ok && (rJ->hires_active != 1 || rJ->repl_active != 1)) {
+            ok = 0;
+            snprintf(d_stat, sizeof(d_stat), "2x pack run did not arm "
+                     "(hires=%d repl=%d)", rJ->hires_active,
+                     rJ->repl_active);
+        }
+        if (ok) {
+            snprintf(d_stat, sizeof(d_stat),
+                     "after %u presented frames (window=16), RAM unchanged; "
+                     "Nx words:", rJ->post_frames);
+            for (t = 0; t < N_TILES; t++) {
+                if (rJ->hi_words[t]   != rH->hi_words[t]
+                    || rJ->hi_sub_ok[t]  != rH->hi_sub_ok[t]
+                    || rJ->hi_sub_bad[t] || rJ->hi_sub_hole[t] != rH->hi_sub_hole[t])
+                    ok = 0;
+                snprintf(frag, sizeof(frag), " t%u=%u/%u(%u/%u sub%s)",
+                         t, rJ->hi_words[t], rH->hi_words[t],
+                         rJ->hi_sub_ok[t], rH->hi_sub_ok[t],
+                         rJ->hi_sub_bad[t] ? ",WRONG" : "");
+                strncat(d_stat, frag, sizeof(d_stat) - strlen(d_stat) - 1);
+            }
+        }
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "hires_static_persist";
+        results[nres].detail = d_stat;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
+    /* Gate 10 (issue #528): the RGB16-direct paths present the pack --
+     * and present ONLY the pack.
+     *
+     * Driven through TomLinePackRGB, the one seam both the 1x and the
+     * Nx RGB16 renderers call per presented pixel.  Wired at both
+     * resolutions together on purpose: half of it would make a pack look
+     * different at 2x than at 1x for a reason unrelated to resolution.
+     *
+     * rgb16_false is the half that carries the correctness claim -- a
+     * true-color CRY reconstruction sitting in the same shadow line
+     * plane must NOT present on an RGB16 scanout, so "substitute
+     * whenever the line entry hits" fails here while passing everything
+     * else. */
+    {
+        int ok = 1;
+        unsigned want1 = 0, want2 = 0, t;
+        for (t = 0; t < N_TILES; t++) {
+            want1 += expect_1x_hits(t, 0);
+            want2 += expect_1x_hits(t, 1);
+        }
+        if (rn->repl_1x_active != 0 || rn->rgb16_ok || rn->rgb16_false)
+            ok = 0;
+        if (rp->repl_1x_active != 1 || rp->rgb16_ok != want1
+            || rp->rgb16_bad || rp->rgb16_false)
+            ok = 0;
+        if (rH->repl_1x_active != 1 || rH->rgb16_ok != want2
+            || rH->rgb16_bad || rH->rgb16_false)
+            ok = 0;
+        snprintf(d_rgb, sizeof(d_rgb),
+                 "TomLinePackRGB: 1x %u/%u delivered (%u wrong, %u "
+                 "non-pack entries wrongly claimed); 2x %u/%u (%u wrong, "
+                 "%u wrongly claimed); no-pack run inert "
+                 "(shadowFBReplActive=%d, %u claims)",
+                 rp->rgb16_ok, want1, rp->rgb16_bad, rp->rgb16_false,
+                 rH->rgb16_ok, want2, rH->rgb16_bad, rH->rgb16_false,
+                 rn->repl_1x_active, rn->rgb16_ok + rn->rgb16_false);
+        results[nres].status = ok ? "PASS" : "FAIL";
+        results[nres].name   = "rgb16_presents";
+        results[nres].detail = d_rgb;
+        if (!ok) failed = 1;
+        nres++;
+    }
+
     {
         harness_config rcfg = HARNESS_CONFIG_DEFAULT;
         rcfg.json_output = json;
@@ -1222,7 +1459,7 @@ int main(int argc, char **argv)
     rm_rf_pack(dir_p);
     rm_rf_pack(dir_h);
     free(ro); free(rn); free(rp); free(rq);
-    free(rh); free(rH); free(rI);
+    free(rh); free(rH); free(rI); free(rJ);
     return failed ? 1 : 0;
 
 run_fail:
@@ -1232,6 +1469,6 @@ run_fail:
     rm_rf_pack(dir_p);
     rm_rf_pack(dir_h);
     free(ro); free(rn); free(rp); free(rq);
-    free(rh); free(rH); free(rI);
+    free(rh); free(rH); free(rI); free(rJ);
     return 1;
 }


### PR DESCRIPTION
Closes #528. Both limitations #526 (tier 3) shipped with, deliberately deferred and documented in its limits section.

## 1. RGB16-direct Nx renderer was unwired

Wired for **both 1x and Nx**, not only 2x. That was the whole reason it was deferred: tier 1 does not present on the 1x RGB16 path either, so wiring only the Nx one would make a pack look *different at 2x than at 1x* for a reason unrelated to resolution.

## 2. Static tiles aged out to flat colour

Nx blocks carry the surface's frame epoch, and stock supersampled content is trusted only for `HIRES_EPOCH_WINDOW` (16) presented frames. Pack art is now **exempt** from that age check; the stock sub block behind an author alpha hole still ages.

Before this, a tile blitted once and left on screen — a HUD, a menu, a title card — showed crisp Nx art for ~16 frames and then degraded to the 1x representative: the same tile as flat blocky top-left colours.

**Why the exemption is safe, rather than just convenient.** The window bounds *stale structure* — an NxN interior derived from a write the RAM no longer holds. For pack art that class is **already unbounded and already shipping at 1x**, where the tier-1 shadow carries no epoch at all and presents the same tile's 1x representative, at the same pixel, on the same value check. Refusing the Nx block therefore prevented no wrong-tile artifact; it only dropped that artifact's resolution.

Note `shadowHiresResolveMissEpoch` still counts such words — the resolve counters describe the stock block, so that counter climbing while pack art is on screen is expected, not a bug.

## Gates

Both are non-vacuous by construction:

- **`hires_static_persist`** steps **real presented frames** between the battery blits and the probe — `harness_step` drives `retro_run` drives `ShadowHiresFrameTick`, nothing fakes the epoch — and **first asserts the destination RAM is unchanged**, so expiry cannot be confused with a coherence miss. 24 frames against a window of 16.
- **`rgb16_presents`** — 1x **574/574** and 2x **575/575** delivered, 0 wrong, 0 non-pack entries wrongly claimed, and the no-pack run **inert** (`shadowFBReplActive == 0`, 0 claims).

## Verification

`make TEST_EXPORTS=1 test`: **1658 PASS, 0 FAIL**, audio pair confirmed by name (`Clipping check: Iron Soldier 2`, two `audio is present and within expected envelope` passes). C89 lint clean on every touched `.c`.

**Rebased onto `libretro/develop`** after #531/#537/#539/#541 landed and fully re-verified afterwards — worth stating because the pre-rebase branch would have **deleted `test/tools/ir_ab.sh`**, the harness #539 had just merged. Pre-rebase validation would have proven nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)