### PR TITLE
ci: require every PR to be linked to an issue

### DIFF
--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,0 +1,95 @@
+name: PR issue link
+
+# Every PR must be linked to an issue via the **Development** panel.
+#
+# WHY THIS EXISTS, and why a `Closes #N` in the body is not enough:
+#
+# GitHub only creates the linked-issue relationship from a closing keyword
+# when the PR targets the repository's DEFAULT branch.  This repo's default
+# is `master` and virtually every PR targets `develop`, so keywords here
+# create **no link at all** -- not just "no auto-close".
+#
+# Verified 2026-08-20: PRs #537, #539, #542, #544, #545 and #547 all carried
+# `Closes #N` and all reported zero linked issues; #546, linked by hand in
+# the Development panel, was the only one that reported one.  Timeline
+# cross-references still show up, which is exactly why this went unnoticed:
+# the issue *looks* connected while the Development panel stays empty, so
+# the issue never shows which release or pre-release tag contains the work.
+#
+# There is no public API to create that link, so it has to be done in the
+# UI -- this job's only job is to make forgetting it visible.
+#
+# Opt out for a genuinely issue-less PR by adding the `no-issue` label.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-issue-link-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: PR is linked to an issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the Development panel for a linked issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # `no-issue` opt-out.
+          if gh pr view "$PR" --repo "$REPO" --json labels \
+               --jq '.labels[].name' | grep -qx 'no-issue'; then
+            echo "::notice::'no-issue' label present -- skipping the linked-issue check."
+            exit 0
+          fi
+
+          linked=$(gh pr view "$PR" --repo "$REPO" \
+                     --json closingIssuesReferences \
+                     --jq '.closingIssuesReferences | length')
+
+          if [ "$linked" -gt 0 ]; then
+            gh pr view "$PR" --repo "$REPO" --json closingIssuesReferences \
+              --jq '.closingIssuesReferences[] | "linked: #\(.number)"'
+            exit 0
+          fi
+
+          # Not linked.  If the body mentions an issue, name it in the error --
+          # that is the number the author almost certainly meant to link.
+          body=$(gh pr view "$PR" --repo "$REPO" --json body --jq '.body // ""')
+          guess=$(printf '%s' "$body" \
+                  | grep -oiE '(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed))[[:space:]]+#[0-9]+' \
+                  | grep -oE '#[0-9]+' | head -1 || true)
+
+          {
+            echo "### ❌ This PR is not linked to an issue"
+            echo
+            echo "No entry in the **Development** panel."
+            if [ -n "$guess" ]; then
+              echo
+              echo "The body says it closes \`$guess\`, but **that keyword does nothing here**:"
+              echo "GitHub only creates the link when a PR targets the default branch"
+              echo "(\`master\`), and this PR targets \`develop\`."
+            fi
+            echo
+            echo "**Fix it in the UI:** open the PR → **Development** (right sidebar) →"
+            echo "gear icon → pick the issue. There is no public API for this, so it"
+            echo "cannot be automated."
+            echo
+            echo "Without the link the issue never shows which release or pre-release"
+            echo "tag contains the work, which is the whole point of linking."
+            echo
+            echo "Genuinely no issue? Add the \`no-issue\` label."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::PR #$PR has no linked issue. Link it in the Development panel, or add the 'no-issue' label."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,35 @@ The "Acid suite (linux x86_64)" job can show `conclusion: failure` for two unrel
 - `make -C test/acid test` exits non-zero by design (returns FAIL count). The job uses `set +e` and gates on `check-baseline.py` instead. Real regression = `Regressions: N` (N>0) in `acid-summary.txt`.
 - Job conclusion `failure` with `OK: no regressions` in the step output = the artifact-upload step timed out (`Operation could not be completed within the specified time`). Re-run the job; no code action needed.
 
+## Every PR must be linked to an issue — and a `Closes #N` will NOT do it
+
+**Hard rule: link the PR to its issue in the GitHub *Development* panel
+(right sidebar → gear icon → pick the issue). A closing keyword in the body
+is not a substitute and does not work here.**
+
+GitHub creates the linked-issue relationship from a closing keyword only
+when the PR targets the repository's **default branch**. This repo's default
+is `master` and essentially every PR targets `develop`, so `Closes #N` on a
+PR here creates **no link at all** — not merely "no auto-close", which is
+how this was previously (and wrongly) documented.
+
+Measured 2026-08-20: PRs #537, #539, #542, #544, #545 and #547 all carried
+`Closes #N` in the body; every one reported `closingIssuesReferences: []`.
+The only PR with a real link was #546, linked by hand in the UI.
+
+It went unnoticed for months because **timeline cross-references still
+appear** — the issue looks connected while its Development panel stays
+empty, so the issue never shows which release or pre-release tag contains
+the work. That tag is the whole reason to link.
+
+- Check a PR: `gh pr view N --json closingIssuesReferences --jq '.closingIssuesReferences | length'` — `0` means unlinked.
+- **There is no public API to create the link.** It must be done in the web
+  UI; do not burn time looking for a `gh` flag or GraphQL mutation.
+- CI enforces it: `.github/workflows/pr-issue-link.yml` fails any PR with no
+  linked issue. Genuinely issue-less PR → add the `no-issue` label.
+- Still close the issue by hand when the PR merges (keywords don't fire on
+  `develop` either) — see the release-process notes.
+
 ## GitHub Copilot PR reviews
 
 - List unresolved threads: `gh api graphql -f query='{repository(owner:"libretro",name:"virtualjaguar-libretro"){pullRequest(number:N){reviewThreads(first:30){nodes{id isResolved comments(first:1){nodes{id author{login} body}}}}}}}'`


### PR DESCRIPTION
## The problem

A `Closes #N` in a PR body **does not link the issue in this repo**, and our docs only said keywords "don't auto-close on `develop`" — which understated it badly.

GitHub creates the linked-issue relationship from a closing keyword **only when the PR targets the repository's default branch.** Our default is `master`; essentially every PR targets `develop`. So the keyword creates *no link at all*.

Measured on today's PRs:

| PR | `Closes #N` in body | linked issues |
|---|---|---|
| #537, #539, #542, #544, #545, #547 | yes | **0** |
| #546 (linked by hand in the UI) | — | **1** |

## Why it went unnoticed for months

**Timeline cross-references still appear.** The issue *looks* connected — you see "referenced this in PR #N" — while the Development panel stays empty. The consequence only shows up where you'd least look for it: the issue never displays which release or pre-release tag contains the work. That tag is the entire reason to link.

## What this adds

- `.github/workflows/pr-issue-link.yml` — fails a PR with no linked issue, and if the body contains a closing keyword it names the number and explains why the keyword did nothing. Opt out with the `no-issue` label (created).
- A CLAUDE.md section stating the rule and the mechanism, so agents stop writing `Closes #N` and assuming it worked.

## Honest limitation

**There is no public API to create the link** — no `gh` flag, no GraphQL mutation. It must be done in the web UI (PR → Development → gear → pick the issue). This job cannot fix the problem, only make forgetting it visible. I'd rather ship that than pretend it's automatable.

Uses `pull_request_target` so it works on fork PRs, with `permissions: read` only — it reads metadata and writes a job summary, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)