### PR TITLE
docs(true-color): deterministic A/B capture recipe + measured nulls (#506)

### DIFF
--- a/docs/true-color-ab-captures.md
+++ b/docs/true-color-ab-captures.md
@@ -1,0 +1,179 @@
+# True-color A/B captures — measured, issue #506
+
+Evidence pass for issue #506 part 2 (colour/upscaling A/B media). Scope was
+`virtualjaguar_true_color` ("True Color (Gouraud Precision)") — the CRY
+16bpp-only Gouraud-banding reducer, **not** the general CRY/RGB16 -> RGB888
+path (#529, still open). Goal: produce additional true-color A/B pairs beyond
+the one already published (Cybermorph, `site/assets/truecolor_ab_cybermorph.png`
++ `cyber_off_850.png`/`cyber_on_850.png`, from PR #341's validation run).
+
+**Result: no new pairs met the "genuinely visible" bar.** Every titledb row
+sampled beyond Cybermorph measured **0.0000% changed pixels** between
+`true_color=disabled` and `true_color=enabled` at a fixed, scripted frame.
+This is recorded here — with the reproduction recipe — instead of a padded
+site addition, per the issue's explicit rule that a null published as a win
+is worse than no pair at all.
+
+## Headline finding: the titledb heuristic does not predict a visible difference
+
+`src/core/titledb.c`'s derivation policy (top-of-file comment) sets
+`virtualjaguar_true_color=enabled` whenever a title's census measured
+`(shaded blits / frames) >= 10` — a blit-count heuristic. Its own comment
+states only the seed entries (AvP, Cybermorph) were checked at all, and only
+**Cybermorph** was ever screenshot-verified to actually change the displayed
+frame (the PR #341 capture this doc's Cybermorph run reproduces below).
+
+Three other rows that clear the threshold by wide margins — **Alien vs
+Predator** (544.3k shaded / 4800f = 113/f), **Missile Command 3D** (3.96M
+shaded / 5.73M blits), and **Doom** (~1.07M shaded, effectively all of its
+blits) — were measured here and every one produced **zero** changed pixels
+at a sampled gameplay frame with true-color on vs off. The heuristic
+threshold does not imply a visible result; it implies enough *blitter*
+Gouraud traffic somewhere in the run, which is not the same claim.
+
+This is not a report that true-color "does nothing" on these titles in
+general — see the per-title caveats below — but it does mean the issue's
+implicit premise (more true-color candidates are sitting in titledb ready
+to screenshot) did not hold for any row tried. Recorded here rather than
+edited in titledb.c, which is out of scope for this no-code issue.
+
+## Method — deterministic, one option changed
+
+Built once per session:
+
+```bash
+DEVELOPER_DIR=/Library/Developer/CommandLineTools make -j"$(getconf _NPROCESSORS_ONLN)" TEST_EXPORTS=1
+cc -O2 -Wall -std=c99 -I. -I./test/harness -I./libretro-common/include \
+   -o test/tools/hires_shot test/tools/hires_shot.c test/harness/harness.c -ldl -lm
+```
+
+Every capture pair uses the **same four explicit options** except the one
+under test, so the only variable is `virtualjaguar_true_color`:
+
+```
+--option virtualjaguar_internal_resolution=1x        # isolates true-color from hi-res
+--option virtualjaguar_usefastblitter=disabled        # Accurate engine, the shipped default
+--option virtualjaguar_pertitle_defaults=disabled     # explicit options only, no titledb override
+--option virtualjaguar_true_color=disabled|enabled    # the variable under test
+```
+
+Same ROM, same `--press` ladder, same `--shot` frame for both runs of a pair
+— `hires_shot` dumps a PPM per shot; the two PPMs are diffed pixel-for-pixel
+with a small Python/PIL script (unique-color count + % changed pixels,
+matching the methodology already used for the shipped Cybermorph figure).
+
+Reproduce any row below with:
+
+```bash
+VJ_EXPECT_BUILD=$(./scripts/build-id.sh) ./test/tools/hires_shot \
+  ./virtualjaguar_libretro.dylib "<rom>" \
+  --option virtualjaguar_internal_resolution=1x \
+  --option virtualjaguar_usefastblitter=disabled \
+  --option virtualjaguar_pertitle_defaults=disabled \
+  --option virtualjaguar_true_color=<disabled|enabled> \
+  <--press ladder> --frames <N+1> --shot <N> \
+  --out-prefix /tmp/<label>/<name>
+```
+
+## Control: Cybermorph reproduces the shipped result
+
+`test/roms/private/ROMS/Cybermorph (1993).jag`, press ladder
+`200:a 400:a 600:a 900:a 1200:a`, shot frame 1400 (reaches the in-flight HUD
+scene, pods-remaining view):
+
+| | unique colors | changed pixels |
+|---|---|---|
+| off (`disabled`) | 303 | — |
+| on (`enabled`) | 498 | 30548 / 78240 = **39.04%** |
+
+This is the same magnitude as the shipped figure's caption (304 -> 450 unique
+colors, 45.9% of pixels, from a different captured frame/session) — close
+enough on an independently-scripted boot-to-gameplay run to confirm the
+capture pipeline genuinely detects true-color's effect when it exists, and
+that the headless framebuffer read path (see `CLAUDE.md`'s caveat) is not
+masking anything here.
+
+**Caution logged in the process:** the frame number alone is not enough to
+identify a scene. Frame 850 with *no* input at all lands on the closing
+credits screen (43 unique colors, of course 0% diff off vs on) — completely
+different from the frame 850 used for the shipped `cyber_off_850.png` /
+`cyber_on_850.png`, which was reached by starting a mission first. A
+capture recipe must record its full input ladder, not just a frame number.
+
+## Measured nulls
+
+All four options above held constant except `true_color`; ROM paths are
+under `test/roms/private/ROMS/`.
+
+### Alien vs Predator (1994).jag — 0.0000%, most thoroughly checked
+
+Press ladder from `docs/avp-renderer-analysis.md` §9 (the same recipe behind
+the existing `hires_ab_avp_*` site assets):
+`3300:a 3600:a 3900:a 4200:a 4500:a 5000:a`, shot frame 6000 (static corridor,
+facing a door).
+
+- Static corridor (frame 6000): 0 / 78240 changed, unique colors identical
+  (8701 == 8701).
+- Moving variant (`+ --press 5600:up:400`, same shot frame): 0 / 78240
+  changed, unique colors identical (4304 == 4304).
+- Full sweep, `--shot-every 100` across frames 100-6000 (61 sampled frames,
+  spanning the title screen, menu, static corridor, and the moving-into-door
+  scene): **maximum diff across all 61 frames was 0.0000%.**
+- Ruled out the video-mode hypothesis (RGB16 mode 3 has no chroma/intensity
+  split for true-color to refine, per the comment in `src/tom/tom.c`'s RGB16
+  hires renderer): probed `TOMGetVideoMode()` via `harness_dlsym` at the
+  captured frame — returns `0` (CRY), not `3`. So this is not an
+  RGB16-video-mode exclusion; the option is live and applicable, and still
+  produces zero change.
+
+AvP is the one row in titledb whose true-color entry the top-of-file comment
+says was independently checked against its own thresholds (not just fallen
+out of the blanket policy pass) — and it is also the one with the widest,
+most-varied sampling here, and it never showed a difference.
+
+### Missile Command 3D (1995).jag — 0.0000% at the sampled frame
+
+Press ladder `200:a 500:a 800:a 1100:a 1400:a`, shot frame 1400 — reaches
+"Original 3D mode" gameplay: mountains against a blue sky gradient, a strong
+visual banding candidate if true-color were reaching the displayed pixels
+here. 0 / 78240 changed pixels, unique colors identical (1880 == 1880).
+Video mode confirmed 0 (CRY). Single frame only — not swept like AvP.
+
+### Doom (World) EX.j64 — 0.0000% at the sampled frame
+
+No `--press` needed; the title autoplays its E1M1 attract demo. Shot frame
+1600 (in-level combat, matches the scene family already used for
+`hires_ab_doomex_*`). 0 / 78240 changed pixels, unique colors identical
+(525 == 525). Video mode confirmed 0 (CRY). Single frame only.
+
+### I-War (1995).jag — gameplay not reached, not a null
+
+Tried `200:a 500:a 800:a 1100:a 1400:a 1700:a` and a `--shot-every 200` sweep
+to frame 2400: landed on the ship-select screen (frame ~1000) and a
+"PREPARE FOR NODE ALPHA MATRIX" transition screen (frame ~1600), never
+in-flight gameplay. I-War's menu flow needs a different input sequence than
+the generic "mash `a`" ladder that worked for the other titles here. Not
+tested further this pass — report as unreached, not as a measured zero.
+
+## Texture replacement (#528 tier 1) — blocked, no pack exists
+
+Searched for an actual texture-replacement pack to pair a "before" capture
+with a real "after":
+
+- Repo tree: `find . -iname "*texpack*"` — no hits.
+- Private ROM tree: `find -L test/roms/private -iname "*texpack*" -o -iname "*texture*pack*"` — no hits.
+- Home directory: `find -L /Users/jmattiello -maxdepth 4 -iname "*texpack*"` — no hits.
+
+Only the mechanism exists: `src/tom/texdump.c` / `src/tom/texreplace.c`
+(implementation), `test/tools/test_texdump.c` / `test/tools/test_texreplace.c`
+(synthetic test fixtures, not real game art), `docs/texture-dump.md` (design
+doc). Per the task guide, authoring replacement art is explicitly out of
+scope — stopping here rather than fabricating a pack to screenshot.
+
+## Outcome
+
+No new `site/assets/*.png` were added and no `site/pages/*.html` changed.
+The only genuinely visible true-color pair remains the already-published
+Cybermorph one. This document exists so the next attempt does not have to
+re-derive the capture recipe or re-discover which titledb rows are
+heuristic-only versus actually verified.


### PR DESCRIPTION
Relates to #506 (part 2 only). **Needs hand-linking in the Development panel.**

## Outcome: no new site assets, and that is the correct result

Built a deterministic A/B capture pipeline on `hires_shot` — same ROM, same input, same frame, only `virtualjaguar_true_color` toggled, with `internal_resolution=1x`, `usefastblitter=disabled`, `pertitle_defaults=disabled` held constant — and validated it against the shipped Cybermorph pair (reproduced 39.04% pixels changed vs the shipped 45.9% on an independently scripted run).

| Title | Pixels changed |
|---|---|
| Cybermorph (1993) | **39.04%** — control, already published |
| Alien vs Predator | **0.0000%** (61-frame sweep, static + moving) |
| Missile Command 3D | **0.0000%** |
| Doom EX | **0.0000%** |

Ruled out the RGB16-video-mode explanation by probing `TOMGetVideoMode()` directly — mode 0 (CRY) at every sampled frame.

Nothing clears the "genuinely visible" bar the issue sets, so **no assets are added**. Per the issue's own rule, a documented null beats a padded showcase.

## Headline finding → filed as #551

`titledb.c`'s `true_color=enabled` heuristic (`shaded blits / frames >= 10`) does not predict a visible difference. AvP, Doom and MC3D all clear the threshold by wide margins and show zero change. Only Cybermorph was ever screenshot-verified. Not fixed here — `titledb.c` is out of scope for a no-code issue.

## Out of scope / not done

- **Videos** (Doom netplay, Ultra Vortek Voice Modem) need real screen-recording sessions — not attempted.
- **Texture-replacement before/after**: searched the repo, the private ROM tree and `$HOME`; no pack exists, only the mechanism and synthetic fixtures. Authoring art is out of scope.
- **I-War**: the input ladder never reached gameplay, so it is **not** counted as a measured null.

Recipe and all raw numbers are in `docs/true-color-ab-captures.md` so a future attempt does not re-derive them.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)