### PR TITLE
fix(pacing): declare getloadavg() on glibc — develop is red without this

### DIFF
--- a/test/test_frontend_pacing.c
+++ b/test/test_frontend_pacing.c
@@ -131,6 +131,17 @@
  * flag to tune, because there is nothing left for a flag to tune.
  */
 
+/* getloadavg() is a BSD extension.  glibc declares it in <stdlib.h>, but
+ * hides it under -std=c99, which defines __STRICT_ANSI__ -- so this must be
+ * defined BEFORE any include or the declaration never appears and the call
+ * compiles as implicit-int (a hard error under Clang's C99+).  macOS declares
+ * it unconditionally, which is why this only ever broke on Linux CI.
+ * _BSD_SOURCE covers glibc older than 2.19. */
+#ifdef __linux__
+#define _DEFAULT_SOURCE 1
+#define _BSD_SOURCE 1
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -143,8 +154,9 @@
 #ifdef __linux__
 #include <unistd.h>
 #endif
-/* getloadavg() (POSIX-ish; Linux glibc and macOS both declare it in
- * <stdlib.h>, already included above) backs the load/core diagnostic.  It
+/* getloadavg() (a BSD extension; declared in <stdlib.h>, already included
+ * above -- on glibc only because of the _DEFAULT_SOURCE define at the top of
+ * this file, see the comment there) backs the load/core diagnostic.  It
  * also needs sysconf() for the core count, which unistd.h provides on Linux
  * above; widen that to macOS too rather than duplicating the include guard
  * per platform. */


### PR DESCRIPTION
**develop is currently red.** PR #555 merged before its follow-up fix landed on the branch, so `test/test_frontend_pacing.c` on develop calls `getloadavg()` with no feature-test macro.

Two jobs fail on develop and will fail on every PR branched from it:

```
test/test_frontend_pacing.c:264:9: error: call to undeclared function 'getloadavg';
ISO C99 and later do not support implicit function declarations
[-Wimplicit-function-declaration]
```

- `build-Linux x86_64 (Clang)`
- `AddressSanitizer + UndefinedBehaviorSanitizer`

## Cause

`getloadavg()` is a BSD extension. glibc *does* declare it in `<stdlib.h>` — as the comment in that file said — but hides it under `-std=c99`, which defines `__STRICT_ANSI__`. macOS declares it unconditionally, so the call compiled fine locally and only ever broke on Linux CI.

## Fix

Define `_DEFAULT_SOURCE` (plus `_BSD_SOURCE` for glibc older than 2.19) **before any include**, guarded to `__linux__` since macOS needs neither. Also corrected the stale comment that claimed `<stdlib.h>` alone was sufficient.

## Verification

```
cc -std=c99 -Wall -Wextra -Werror=implicit-function-declaration -c
  test/test_frontend_pacing.c   -> compiles clean
scripts/c89-lint.sh              -> passed
```

No behaviour change — the load/core reading still gates nothing, per #421's diagnostics-only decision.

Relates to #421. **Needs hand-linking in the Development panel.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)