### PR TITLE
fix(pacing): declare getloadavg() on glibc via _DEFAULT_SOURCE

### DIFF
--- a/test/test_frontend_pacing.c
+++ b/test/test_frontend_pacing.c
@@ -131,6 +131,17 @@
  * flag to tune, because there is nothing left for a flag to tune.
  */
 
+/* getloadavg() is a BSD extension.  glibc declares it in <stdlib.h>, but
+ * hides it under -std=c99, which defines __STRICT_ANSI__ -- so this must be
+ * defined BEFORE any include or the declaration never appears and the call
+ * compiles as implicit-int (a hard error under Clang's C99+).  macOS declares
+ * it unconditionally, which is why this only ever broke on Linux CI.
+ * _BSD_SOURCE covers glibc older than 2.19. */
+#ifdef __linux__
+#define _DEFAULT_SOURCE 1
+#define _BSD_SOURCE 1
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -143,8 +154,9 @@
 #ifdef __linux__
 #include <unistd.h>
 #endif
-/* getloadavg() (POSIX-ish; Linux glibc and macOS both declare it in
- * <stdlib.h>, already included above) backs the load/core diagnostic.  It
+/* getloadavg() (a BSD extension; declared in <stdlib.h>, already included
+ * above -- on glibc only because of the _DEFAULT_SOURCE define at the top of
+ * this file, see the comment there) backs the load/core diagnostic.  It
  * also needs sysconf() for the core count, which unistd.h provides on Linux
  * above; widen that to macOS too rather than duplicating the include guard
  * per platform. */


### PR DESCRIPTION
build-Linux x86_64 (Clang) and the ASan/UBSan job both failed on:

  test/test_frontend_pacing.c:264:9: error: call to undeclared function
  'getloadavg'; ISO C99 and later do not support implicit function
  declarations [-Wimplicit-function-declaration]

getloadavg() is a BSD extension.  glibc does declare it in <stdlib.h>, as the comment in this file said -- but hides it under -std=c99, which defines __STRICT_ANSI__.  macOS declares it unconditionally, so the call compiled locally and only ever broke on Linux CI.

Define _DEFAULT_SOURCE (plus _BSD_SOURCE for glibc older than 2.19) before any include, guarded to __linux__ since macOS needs neither.  Corrected the stale comment that claimed <stdlib.h> alone was sufficient.

Verified with the flag class that failed:
  cc -std=c99 -Wall -Wextra -Werror=implicit-function-declaration -c
    -> compiles clean
  scripts/c89-lint.sh -> passed

No behaviour change: the diagnostic still gates nothing.

<!--
Thanks for the PR!  This repo uses a GitFlow-style integration
branch: please target `develop` (the default for new feature work).
Use `master` only for hotfixes from `hotfix/*` or release branches
from `release/*`.
-->

## Summary

<!-- 1-3 sentences: what changed and why. -->

## Test plan

<!-- How did you verify this?  Build commands run, tests added, manual
checks against a ROM, etc.  CI green is necessary but not sufficient. -->

- [ ] `make -j$(getconf _NPROCESSORS_ONLN)` builds clean on host
- [ ] `make test` passes (or N/A — explain why)
- [ ] `bash scripts/c89-lint.sh` passes (no mid-block declarations)

## Branch base

- [ ] **Base is `develop`** (the integration branch)
- [ ] OR base is `master` *and* this is a `hotfix/*` or `release/*` branch
