### PR TITLE
chore: back-merge master into develop (legacy MSVC fixes)

### DIFF
--- a/deps/libchdr/src/libchdr_chd.c
+++ b/deps/libchdr/src/libchdr_chd.c
@@ -495,7 +495,8 @@ static CHDR_INLINE void put_bigendian_uint48(uint8_t *base, uint64_t value)
 
 static CHDR_INLINE uint32_t get_bigendian_uint32_t(const uint8_t *base)
 {
-	return (base[0] << 24) | (base[1] << 16) | (base[2] << 8) | base[3];
+	return ((uint32_t)base[0] << 24) | ((uint32_t)base[1] << 16) |
+			((uint32_t)base[2] << 8) | (uint32_t)base[3];
 }
 
 /*-------------------------------------------------

--- a/deps/libchdr/src/libchdr_chd.c
+++ b/deps/libchdr/src/libchdr_chd.c
@@ -1554,6 +1554,7 @@ static chd_error header_read(chd_file *chd)
 	};
 
 	uint8_t rawheader[CHD_MAX_HEADER_SIZE];
+	chd_header *header;
 
 	/* punt if NULL */
 	if (chd == NULL)
@@ -1572,7 +1573,7 @@ static chd_error header_read(chd_file *chd)
 		return CHDERR_INVALID_DATA;
 
 	/* extract the direct data */
-	chd_header *header = &chd->header;
+	header = &chd->header;
 	memset(header, 0, sizeof(*header));
 	header->length  = get_bigendian_uint32_t(&rawheader[8]);
 	header->version = get_bigendian_uint32_t(&rawheader[12]);

--- a/deps/libchdr/unity.c
+++ b/deps/libchdr/unity.c
@@ -35,6 +35,22 @@
 #include "deps/miniz-3.1.1/miniz.c"
 #include "deps/zstd-1.5.7/zstddeclib.c"
 
+/* snprintf shim for MSVC < 2015 (buildbot msvc05/10): libchdr_chd.c uses
+ * snprintf for the V1/V2 hard-disk metadata string, and those CRTs ship
+ * only _snprintf. Declared here rather than in the vendored sources so
+ * `src/` stays byte-identical to the upstream pin.
+ *
+ * Deliberately NOT `#include <compat/msvc.h>`: that header defines
+ * SIZE_MAX as _UI32_MAX when it is not already set, and dr_flac.h --
+ * pulled in by libchdr_flac.c below -- derives DRFLAC_SIZE_MAX from
+ * SIZE_MAX. On x64 that would quietly narrow it to 32 bits. Take the
+ * one declaration this TU needs and nothing else. */
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#include <stddef.h>
+int c99_snprintf_retro__(char *s, size_t len, const char *format, ...);
+#define snprintf c99_snprintf_retro__
+#endif
+
 #include "src/libchdr_bitstream.c"
 #include "src/libchdr_cdrom.c"
 #include "src/libchdr_chd.c"

--- a/src/tom/texdump.c
+++ b/src/tom/texdump.c
@@ -39,6 +39,8 @@
 
 #include "texdump.h"
 
+#include <compat/msvc.h>  /* snprintf shim for MSVC < 2015 (buildbot msvc05/10) */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/tom/texreplace.c
+++ b/src/tom/texreplace.c
@@ -43,6 +43,8 @@
 
 #include "texreplace.h"
 
+#include <compat/msvc.h>  /* snprintf shim for MSVC < 2015 (buildbot msvc05/10) */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
GitFlow step 8, missed after the v3.4.0 hotfixes.

Three legacy-MSVC fixes landed on `master` on 2026-08-21 and were never back-merged:
`b8409ec`, `294f3c2`, `8c758ff`.

Until this lands, **every branch cut from `develop` — including the next release
branch — reintroduces the legacy-MSVC breakage.** The GitLab buildbot is the only
CI that builds msvc05/msvc10, and it builds `master` only, so `develop` has no
signal at all on this.

Clean merge: 4 files, 24 insertions, no conflicts.

- `deps/libchdr/unity.c`, `deps/libchdr/src/libchdr_chd.c` — `snprintf` shim for pre-2015 MSVC
- `src/tom/texdump.c`, `src/tom/texreplace.c` — same class

No functional change on any platform that already compiled.

Labelled `no-issue`: this is release-process hygiene, not a tracked defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)