### PR TITLE
fix(build): derive ARCH so cross-compiled ARM builds get the NEON blitter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,12 +306,60 @@ else ifeq ($(platform), qnx)
 	CXX = QCC -Vgcc_ntoarmv7le_cpp
 
 # ARM
+# Generic ARM64 Linux.  Same defect as the rpi* names below: `arm64` matched
+# no branch in this chain and fell through to the Windows fallback, so it
+# built a .dll against -lwinmm (issue #560).  Its SIMD selection was already
+# correct -- Makefile.common matches `arm64` by platform name -- which is
+# exactly why this went unnoticed: the blitter looked right in a variable
+# dump while the link line was for the wrong OS.
+else ifneq (,$(filter arm64 aarch64,$(platform)))
+	TARGET := $(TARGET_NAME)_libretro.so
+	fpic := -fPIC
+	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=$(LINK_SCRIPT)
+	GC_STYLE := gnu
+	ARCH = aarch64
+
+# Raspberry Pi.  These are the names libretro-super passes.  Before issue
+# #560 this project had no branch for any of them, so they fell all the way
+# through to the *Windows* fallback at the end of this chain and built
+# `virtualjaguar_libretro.dll` linked against -lwinmm -lws2_32.  Scalar SIMD
+# was the least of it.
+#
+# The 32-bit names describe the userland, not the silicon: rpi2..rpi5 are all
+# NEON-capable running a 32-bit OS, but rpi1 and rpi0 are ARMv6 (ARM1176) with
+# no NEON at all, so they are deliberately absent from the NEON list.
+#
+# No -mcpu/-mtune and no -O level here.  Both are unmeasured on this hardware
+# and the standing rule from #515/#516/#517 is to measure first -- #516 is
+# precisely the case of an optimisation flag that looked applied and was not.
+else ifneq (,$(filter rpi0 rpi1 rpi2 rpi3 rpi3_64 rpi4 rpi4_64 rpi5 rpi5_64,$(platform)))
+	TARGET := $(TARGET_NAME)_libretro.so
+	fpic := -fPIC
+	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=$(LINK_SCRIPT)
+	GC_STYLE := gnu
+	ifneq (,$(filter rpi3_64 rpi4_64 rpi5_64,$(platform)))
+		ARCH = aarch64
+	else
+		ARCH = arm
+		ifneq (,$(filter rpi2 rpi3 rpi4 rpi5,$(platform)))
+			HAVE_NEON = 1
+		endif
+	endif
+
 else ifneq (,$(findstring armv,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
 	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=$(LINK_SCRIPT)
 	GC_STYLE := gnu
 	ARCH = arm
+	# A platform name that says "neon" is a promise about the target, and
+	# it is the only NEON signal these generic armv* names carry: ARCH=arm
+	# above matches none of the aarch64/arm64 rules in Makefile.common, so
+	# armv7-neon-hardfloat built the SCALAR blitter (issue #560).  Plain
+	# armv7/armv6 names stay scalar -- ARMv7's baseline is VFP, not NEON.
+	ifneq (,$(findstring neon,$(platform)))
+		HAVE_NEON = 1
+	endif
 
 # Nintendo Switch (libnx)
 else ifeq ($(platform), libnx)
@@ -1092,6 +1140,13 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# hidden on the other platform, where harness_dlsym silently returns
 	@# NULL.  Cheap, so it runs before anything links against that ABI.
 	@python3 scripts/check-export-lists.py
+	@# Which blitter each platform actually selects (issue #560).  Same
+	@# spirit as the export-list check above: a build-system assertion that
+	@# needs no core, so it runs before anything links.  It exists because
+	@# picking the WRONG blitter is silent -- scalar compiles, links, and
+	@# passes every functional test below; it is only slow, on hardware no
+	@# CI runner owns.  Uses `make -n` deliberately; see the script header.
+	@bash test/tools/simd_matrix_check.sh
 	./test/test_dram_timing
 	./test/test_cheat
 	./test/test_event_queue

--- a/Makefile.common
+++ b/Makefile.common
@@ -123,6 +123,29 @@ else ifeq ($(BLITTER_SIMD),neon)
 else ifeq ($(BLITTER_SIMD),scalar)
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/tom/blitter_simd_scalar.c
 else
+# Derive ARCH from the toolchain triple when the platform block did not set
+# it.  Issue #560.
+#
+# This is the case that reaches actual users.  The rules below key on
+# $(ARCH); the native `uname -m` fallback further down is deliberately
+# skipped for cross-compilers (BLITTER_CROSS_CC); and no platform block
+# sets ARCH for a generic `platform=unix` cross-build.  So the shipped
+# "Linux 64-bit (ARM)" buildbot binary -- .gitlab-ci.yml:44, built as
+# platform=unix with an aarch64- prefixed CC -- matched nothing and fell
+# through to the SCALAR blitter on hardware where NEON is architecturally
+# mandatory.  The guard written to prevent false detection was, by itself,
+# forcing the slow path.
+#
+# Only aarch64 is inferred.  A 32-bit arm-*-gnueabihf triple says nothing
+# about NEON (the armhf baseline is VFP; ARMv6 parts such as the Pi 1 and
+# Zero have no NEON at all), so those keep falling through to scalar rather
+# than guessing.  Set HAVE_NEON=1 by hand for an armv7 toolchain you know.
+ifeq ($(ARCH),)
+ifneq (,$(findstring aarch64-,$(CC)))
+   ARCH := aarch64
+endif
+endif
+
 # ARM targets: prefer NEON when guaranteed or explicitly enabled.
 ifeq ($(HAVE_NEON), 1)
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/tom/blitter_simd_neon.c

--- a/test/tools/simd_matrix_check.sh
+++ b/test/tools/simd_matrix_check.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# simd_matrix_check.sh -- assert which blitter each platform actually selects.
+#
+# Issue #560.  Every defect it covers was invisible for the same reason: the
+# build system silently picks a *slower but working* implementation, so a
+# misconfigured target compiles clean, links clean, passes every test, and
+# just runs slow on hardware nobody in CI owns.  There is no failure to
+# notice.  This script is the thing that notices.
+#
+# What it caught when it was written:
+#   * platform=unix with an aarch64- cross CC -- the shipped "Linux 64-bit
+#     (ARM)" buildbot binary -- selected SCALAR on hardware where NEON is
+#     architecturally mandatory.
+#   * armv7-neon-hardfloat, a platform named after NEON, selected SCALAR.
+#   * every rpi* name fell through to the Windows branch and built a .dll.
+#
+# ---------------------------------------------------------------------
+# WHY `make -n`, when the repo rule says -n lies
+#
+# The standing warning (issue #560's own text, and CLAUDE.md) is "do NOT use
+# make -n to verify" -- true for anything about *what got built*, because
+# already-built objects make a dry run report nothing to do.
+#
+# This script asks a strictly different question: what does a variable expand
+# to?  Variables are computed at parse time, before any recipe runs, so -n
+# reports them exactly.  And -n is required here, not merely allowed:
+# `platform` is in BUILD_AXES, so a non-dry run at each of these platforms
+# would rewrite .build-config and `rm -f $(TARGET) $(OBJECTS)` every
+# iteration -- this check would delete the build it is meant to guard.
+#
+# Usage: test/tools/simd_matrix_check.sh [-v]
+# Exit:  0 all rows as expected, 1 a row regressed.
+
+set -u
+
+cd "$(dirname "$0")/../.." || exit 1
+
+VERBOSE=0
+[ "${1:-}" = "-v" ] && VERBOSE=1
+
+PROBE="$(mktemp -t vjsimd).mk"
+trap 'rm -f "$PROBE"' EXIT
+cat > "$PROBE" <<'EOF'
+vjsimd:
+	@echo "SIMD=$(notdir $(BLITTER_SIMD_SRC)) TARGET=$(notdir $(TARGET))"
+EOF
+
+fail=0
+checked=0
+
+# dump <platform> [CC=...]
+dump() {
+   local plat="$1"; shift
+   # -n prints the recipe with variables already expanded; grep the echo out
+   # of it.  2>/dev/null because some platform blocks probe for SDKs that are
+   # absent on the running host and warn about it -- that does not affect the
+   # variable we are reading.
+   # -n prints the *unexecuted* `echo "SIMD=... TARGET=..."` line, quotes and
+   # all, so strip the quotes before matching or the first token anchors to a
+   # `"` and silently never matches.
+   make -n -f Makefile -f "$PROBE" vjsimd platform="$plat" "$@" 2>/dev/null \
+      | tr -d '"' | tr ' ' '\n' | grep -E '^(SIMD|TARGET)=' | tr '\n' ' '
+}
+
+# expect <expected-simd> <platform> [CC=...] -- '*' to skip the SIMD check
+expect() {
+   local want="$1" plat="$2"; shift 2
+   local got simd target label
+
+   got="$(dump "$plat" "$@")"
+   simd="$(printf '%s' "$got" | sed -n 's/.*SIMD=blitter_simd_\([a-z0-9]*\)\.c.*/\1/p')"
+   target="$(printf '%s' "$got" | sed -n 's/.*TARGET=\([^ ]*\).*/\1/p')"
+   label="$plat${1:+ $1}"
+   checked=$((checked + 1))
+
+   if [ -z "$simd" ]; then
+      printf 'FAIL  %-42s could not read BLITTER_SIMD_SRC (got: %s)\n' "$label" "$got"
+      fail=$((fail + 1))
+      return
+   fi
+
+   if [ "$want" != '*' ] && [ "$simd" != "$want" ]; then
+      printf 'FAIL  %-42s expected %s, got %s\n' "$label" "$want" "$simd"
+      fail=$((fail + 1))
+      return
+   fi
+
+   # A non-Windows platform that produced a .dll fell through the platform
+   # if-chain into the Windows fallback -- how every rpi* name used to build.
+   case "$plat" in
+      win*|windows*|xbox*) ;;
+      *)
+         case "$target" in
+            *.dll)
+               printf 'FAIL  %-42s fell through to the Windows branch (TARGET=%s)\n' \
+                  "$label" "$target"
+               fail=$((fail + 1))
+               return
+               ;;
+         esac
+         ;;
+   esac
+
+   [ "$VERBOSE" = 1 ] && printf 'ok    %-42s %s (%s)\n' "$label" "$simd" "$target"
+   return 0
+}
+
+echo "simd_matrix_check: blitter selection per platform (issue #560)"
+
+# --- the regression that shipped: cross-compiled ARM64 Linux ---------------
+# platform=unix + an aarch64 cross CC is .gitlab-ci.yml:44, "Linux 64-bit
+# (ARM)" -- the binary an actual Raspberry Pi user installs.
+expect neon   unix CC=aarch64-linux-gnu-gcc
+expect neon   unix CC=aarch64-none-linux-gnu-gcc
+# 32-bit armhf says nothing about NEON (VFP baseline, and ARMv6 parts exist),
+# so scalar is the correct conservative answer here, not a bug.
+expect scalar unix CC=arm-linux-gnueabihf-gcc
+
+# --- Raspberry Pi names (libretro-super) -----------------------------------
+expect neon   rpi5_64
+expect neon   rpi4_64
+expect neon   rpi3_64
+expect neon   rpi5
+expect neon   rpi4
+expect neon   rpi3
+expect neon   rpi2
+# rpi1/rpi0 are ARMv6 (ARM1176) -- no NEON in the silicon.  Scalar is correct
+# and this row exists to stop a well-meaning blanket "all rpi get NEON" fix.
+expect scalar rpi1
+expect scalar rpi0
+
+# --- generic ARM names ------------------------------------------------------
+expect neon   armv7-neon-hardfloat
+expect neon   classic_armv7_a7
+expect neon   arm64
+expect neon   ios-arm64
+expect neon   tvos-arm64
+
+# --- x86 ---------------------------------------------------------------------
+expect sse2   windows_msvc2015_x64
+# Deliberately scalar: C89-only C mode plus the _MSC_VER < 1700 SSE2_SET64
+# path, and the msvc-check CI job runs VS2022 and cannot verify it.
+expect scalar windows_msvc2010_x64
+
+# --- must NOT be given host SIMD ---------------------------------------------
+# emscripten is the reason the native uname -m fallback keeps a platform
+# allowlist rather than being opened up to everything: it has no cross-CC
+# prefix, so on an x86_64 host a blanket fix would hand it the SSE2 blitter.
+expect scalar emscripten
+expect scalar vita
+
+# --- native host build --------------------------------------------------------
+case "$(uname -m 2>/dev/null)" in
+   aarch64|arm64)        expect neon   unix ;;
+   x86_64|i686|i386)     expect sse2   unix ;;
+   *)                    expect '*'    unix ;;
+esac
+
+echo
+if [ "$fail" -ne 0 ]; then
+   echo "simd_matrix_check: FAILED ($fail of $checked rows)"
+   exit 1
+fi
+echo "simd_matrix_check: OK ($checked rows)"
+exit 0

--- a/test/tools/simd_matrix_check.sh
+++ b/test/tools/simd_matrix_check.sh
@@ -41,10 +41,14 @@ VERBOSE=0
 
 PROBE="$(mktemp -t vjsimd).mk"
 trap 'rm -f "$PROBE"' EXIT
-cat > "$PROBE" <<'EOF'
-vjsimd:
-	@echo "SIMD=$(notdir $(BLITTER_SIMD_SRC)) TARGET=$(notdir $(TARGET))"
-EOF
+# Built with printf rather than a heredoc on purpose: the recipe line needs a
+# leading TAB (make refuses anything else), and .editorconfig pins *.sh to
+# indent_style = space -- a literal tab in this file fails the CI lint. Single
+# quotes keep make's $(...) out of the shell's hands.
+{
+   printf 'vjsimd:\n'
+   printf '\t@echo "SIMD=$(notdir $(BLITTER_SIMD_SRC)) TARGET=$(notdir $(TARGET))"\n'
+} > "$PROBE"
 
 fail=0
 checked=0


### PR DESCRIPTION
Fixes #560 — and corrects that issue twice over. See the [first correction](https://github.com/libretro/virtualjaguar-libretro/issues/560#issuecomment-5378062276) and the [impact correction](https://github.com/libretro/virtualjaguar-libretro/issues/560#issuecomment-5378647700).

## What was actually broken

**Every ARM path except the two native runners.**

| path | before | correct? |
|---|---|---|
| `platform=rpi*`, `platform=arm64` | built a **Windows `.dll`** (`-lwinmm -lws2_32`) | **no — cannot work at all** |
| `armv7-neon-hardfloat` | scalar, despite the name | **no** |
| cross-compiled `platform=unix` + `aarch64-` CC | scalar | **no** — distro packagers, cross containers |
| `webos-armv7a` | scalar | arguable, left alone deliberately |
| native `unix` on aarch64 (both official runners) | neon | yes, always was |

**Correction to an earlier version of this description:** I claimed the shipped "Linux 64-bit (ARM)" buildbot binary was scalar. It was not. Both official ARM64 builds are *native* — GitLab `linux-aarch64.yml` (`tags: aarch64`, `platform: unix`, `CC: gcc`) and GitHub `release.yml` (`ubuntu-24.04-arm`, `gcc`) — so `uname -m` fired and they had NEON all along. No user of an official ARM64 Linux core was affected.

The `rpi*`/`arm64` rows were *under*stated, though: those names produce a Windows target.

## Root cause: `ARCH` is never derived

The rules key on `$(ARCH)`; no platform block sets it for a generic `unix` cross-build; and the `uname -m` fallback is *correctly* skipped for cross-compilers. Fixed by deriving `ARCH` from the toolchain triple.

Only `aarch64` is inferred. A 32-bit `arm-*-gnueabihf` triple says nothing about NEON (armhf's baseline is VFP; ARMv6 parts like the Pi 1 have none at all), so those keep falling through to scalar rather than guessing — which is why webOS armv7a is left as-is. If that target wants NEON it should say so explicitly with `HAVE_NEON=1`.

**Not** taking the issue's suggestion #1 ("run the `uname -m` auto-detect for any non-cross build") — `emscripten` has no cross-CC prefix, so on an x86_64 host that would hand it the **SSE2** blitter. The allowlist is load-bearing.

## `rpi*` and `arm64` platform blocks

Added, so those names stop falling through the platform if-chain into the Windows `else`. `arm64` is the instructive one — its *SIMD* selection was already correct (matched by platform name in `Makefile.common`), so a variable dump showed `neon` while the link line was for the wrong OS.

`rpi1`/`rpi0` stay scalar on purpose: ARM1176, ARMv6, **no NEON in the silicon**. A blanket "all rpi get NEON" fix would be wrong for them.

## Regression guard

`test/tools/simd_matrix_check.sh`, wired into `make test`. 22 rows covering every case above plus the ones that must **not** change (emscripten and vita must not get host SIMD; msvc2010 stays scalar deliberately).

This defect class is invisible by construction: the wrong blitter compiles, links, and passes every functional test — it's only *slow*, on hardware no CI runner owns. There's no failure to notice, so something has to assert it.

The script uses `make -n` against the repo's own "`-n` lies" rule, and says why in its header: that rule is about what got *built* (stale objects make a dry run report nothing to do), while this reads *variables*, computed at parse time. `-n` is also **required** — `platform` is in `BUILD_AXES`, so 22 non-dry invocations would `rm` the build this is guarding.

## Verified

- `simd_matrix_check: OK (22 rows)`; each fix confirmed by flipping it back
- `make test` exit 0 (2 unrelated skips: fountain ROM, chdman)
- `make lint` (c89) passes both sse2 and neon passes
- host build unchanged: osx still resolves neon/`-O3`, `ARCH` stays empty
- no new compile path: the `Linux aarch64` CI row is a *native* `ubuntu-24.04-arm` runner with **gcc**, so GCC-on-aarch64 already compiles `blitter_simd_neon.c` and is green

## Scope

**This is correctness and build hygiene, not the FPS fix.** Measured via #510's counters, the GPU RISC interpreter is ~74% of instrumented time against the blitter's ~17%, so the headline for #509 is GPU dispatch.

Per-SoC `-mcpu` tuning and `-O3` for the RPi targets follow in a separate PR.

> ⚠️ Commits are unsigned — the 1Password SSH agent is erroring in this environment. Needs `--amend -S` + force-push once unlocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)