### PR TITLE
docs(perf): 2026-08 performance audit — RISC idle-loop fast-forward is the lever

### DIFF
--- a/docs/perf-audit-2026-08.md
+++ b/docs/perf-audit-2026-08.md
@@ -1,0 +1,275 @@
+# Performance audit — 2026-08-22
+
+Why RPi 4 / Apple A10X run this core badly while they run N64/Saturn/PSX interpreters fine,
+and the prioritized, delegatable task list that falls out of it. Shorthand, LLM-oriented.
+Raw per-subsystem sub-agent reports (line-level detail, rejected ideas) live in
+[`perf-audit/`](perf-audit/); only items **verified by a second read or a measurement** are
+promoted here.
+
+## TL;DR
+
+1. **The DSP (and GPU) interpreters spend most of their budget interpreting idle loops.**
+   Frame-end PC sampling shows the DSP parked in a 3-5 instruction wait loop 90-99.7% of the
+   time on Iron Soldier / AvP / Doom, while executing its **full** 26.6 MHz cycle budget
+   (416k-590k opcodes/frame, every title). Nothing else can run inside a RISC slice and IRQs
+   are only delivered at slice entry, so these loops are fixed points for the rest of the
+   slice → a **cycle-exact fast-forward** is possible. DSP is 50-67% of frame time on
+   commercial titles (Iron Soldier 67%, AvP 63%); this is the single biggest lever and
+   needs no JIT. → **P1**
+2. **Linux/Android/RPi builds pay GOT/PLT for every global in the hot loops.** ELF targets
+   are `-fPIC` with only a link-time version script — no `-fvisibility=hidden`, no
+   `-fno-semantic-interposition`, no LTO (LTO exists only for `classic_armv7_a7`). GCC must
+   assume interposition, so `gpu_reg[..]`, the flags, `dsp_pc`, counters… are GOT-indirect
+   loads per emulated instruction and every `JaguarRead*` is a PLT call. `RETRO_API` already
+   carries `visibility("default")`, so hiding everything else needs no source change.
+   `jni/Android.mk` additionally inherits **none** of `Makefile`'s opt flags (no `-O3`; NDK
+   default `-O2 -fstack-protector-strong`). → **P2**
+3. A handful of genuinely dumb per-pixel / per-instruction costs that are mechanical to fix:
+   fast blitter does 3-6 full `JaguarRead*/Write*` dispatch calls per pixel although inline
+   RAM helpers already exist in the same file; `GPUReadLong` splits every DRAM long into two
+   `JaguarReadWord` calls; DSP `sh`/`sha` are 32-iteration loops (GPU versions are single
+   shifts); event scheduler does 4×32-slot double scans per event at ~2,000 events/frame;
+   68K runs a 3-call hook chain per instruction that costs 3× the 68K interpreter itself.
+   → **P3–P8**
+4. **AvP's titledb defaults (2x + true colour) cost ~30% of its frame on the host** — on an
+   A10X that is the difference between playable and not. → **P9**
+5. Threading: not worth it. 68K/GPU/DSP sync at sub-halfline granularity; the one clean
+   producer/consumer boundary (audio resample) is too small to pay for a thread. Don't.
+6. Already fine (don't re-propose): computed-goto dispatch (both RISCs), inlined delay
+   slots, frontend glue (zero frame copies, one audio batch, geometry only on change),
+   vjtrace compiled out of release, crash_detect 256-sample hash/frame, perf probes at slice
+   granularity, OP `O(N²)` (teardown-only, 0% of frame), TOM LUT-driven scanline render.
+
+## Evidence
+
+### Host profiles (macOS arm64, `sample`, 12 s each, release `-O3 -g`, fast blitter)
+
+Top-of-stack samples. States: `test/roms/private/states/iron_soldier_v104_f2400.state`,
+`Alien vs Predator (1994) corridor.state`.
+
+| symbol | Iron Soldier | AvP | jagniccc |
+| --- | ---: | ---: | ---: |
+| `DSPExec` + `dsp_executeOpcode` (loop + inlined handlers) | 5278 | 2684 | 4332 |
+| `dsp_opcode_jr` | **1303** | 539 | 920 |
+| `blitter_generic` | 653 | 706 | 505 |
+| `JaguarReadLong` / `JaguarWriteLong` / `JaguarWriteWord` | 584 / 275 / – | 181 / – / 80 | 353 / – / 158 |
+| `TOMExecHalfline` (hires render inlined) + `Shadow*` | 36 | **1655 + ~2000** | 87 |
+| `OPProcessFixedBitmap` / `OPProcessScaledBitmap` | 278 | 613 | 511 |
+| `GetTimeToNextEvent`+`SubtractEventTimes`+`HandleNextEvent` | 331 | 212 | 345 |
+| `NVMBiosHook`+`M68KInstructionHook`+`JaguarCDHLEHook` | **310** | – | 310 |
+| `m68k_execute` | 103 | – | 150 |
+| `GPUExec` + `executeOpcode` | 30 | 366 | 403 |
+
+### Frame-end PC histogram (TEST_EXPORTS build, 1200 frames, `dsp_pc`/`gpu_pc` read after each `retro_run`)
+
+| title | top DSP PC | share | loop (decoded from DSP RAM) | shape |
+| --- | --- | ---: | --- | --- |
+| Iron Soldier | `$F1B128-12C` | 99.7% | `cmp r28,r2 ; movefa r21,r2 ; jr EQ,-3 ; (ds) addqt #1,r0` | poll alt-bank reg written by I2S ISR |
+| AvP | `$F1B130-134` | 74% | same driver, same loop | same |
+| Doom | `$F1B092-09C` | 90% | `movei #a,r2 ; load (r2),r1 ; or r1,r1 ; jr EQ,-6 ; (ds) nop` | poll RAM word |
+| jagniccc (GPU) | `$F03042/44` | 73% | `cmpq #0,r0 ; jr NE,-2 ; (ds) load (r15),r0` | poll 68K mailbox |
+| AvP (GPU) | `$F03118` | 80% | `jr $ ; nop` | pure spin (GPU mostly halted here, cheap) |
+
+`dsp_exec_opcode_count`/frame: IS 590k, AvP 532k, Doom 461k, niccc 417k — i.e. the DSP
+always consumes its whole slice budget (≈443k cycles/frame; delay-slot instructions are not
+charged by the outer loop, which is why opcodes > cycles).
+
+Slice structure (`src/core/jaguar.c:1683-1752`): one scheduler step per event; EVENT_JERRY
+has `JERRYI2SCallback` (~735/field) + `DSPSampleCallback` (~800/field), EVENT_MAIN has
+`HalflineCallback` (524/field) → ~2,000 slices/frame of ~550 RISC cycles each. IRQs are
+dispatched in `DSPExec`/`GPUExec` at slice entry only (`dsp.c:1070-1100`, `gpu.c:1466`;
+plus the in-loop `IMASKCleared` re-check, which only fires after the ISR's own `store`).
+
+## Task list
+
+Columns: impact on frame time (measured where stated, else estimate), risk, effort, who.
+"sonnet" = mechanical with the spec below + existing tests; "opus" = needs design.
+Every task: branch off `libretro/develop`, C89, `make TEST_EXPORTS=1 test`, acid gate,
+`test/tools/ir_ab.sh --ref libretro/develop HEAD` for the Ir delta (load-insensitive), and
+a RetroArch smoke. Audio/DSP tasks: BOTH `test_audio_clipping` AND `test_audio_presence`.
+
+### P1 — RISC idle-loop fast-forward (DSP first, then GPU) — HIGH (est. 30-50% of frame on commercial titles) — risk MED — effort L — **opus (design), sonnet (port to GPU)**
+
+Files: `src/jerry/dsp.c` (`DSPExec` ~1070-1160, `dsp_opcode_jr` 1397, `dsp_opcode_jump`),
+`src/tom/gpu.c` (`GPUExec` 1429-1570, `gpu_opcode_jr/jump` 1794-1880).
+
+Mechanism (must stay bit-exact — same cycles charged, same register/flag end state,
+`dsp_exec_opcode_count` advanced by the skipped instruction count so `crash_detect`'s wedge
+test (`crash_detect.c:452-482`) still sees progress):
+
+- Detect a *taken backward* `jr` (offset in [-8, -1]) — optionally `jump` to a nearby PC.
+- Candidate body = instructions from target to the `jr` inclusive + its delay slot. Admit
+  only: ALU/cmp/btst/move/moveq/movei/movefa/moveta/nop, `addq/addqt/subq/subqt`, and
+  **loads whose effective address is plain RAM** (DSP/GPU local RAM or `<0x200000` DRAM),
+  never a register-space address (`$F00000-$F1FFFF` minus local RAM — reads there have side
+  effects / change without an instruction). Reject any store, any `jump`/`jr` other than the
+  loop branch, `load_r14/15`-relative with a register-space base, `mmult/imacn/div` etc.
+- Fixed-point test: snapshot (active bank regs, flags) at the loop head; run one
+  iteration; snapshot again; run another; if delta(iter2) == delta(iter1) for every register
+  and flags identical and the branch was taken both times → affine extrapolation: with
+  `n = (cycles_remaining / loop_cost) - 1`, apply `reg += n*delta` for the delta registers,
+  `cycles -= n*loop_cost`, `opcode_count += n*len`, then fall through and let the last partial
+  iteration run normally. (The Iron Soldier loop has `addqt #1,r0` in the delay slot — a
+  monotonic counter — which is why "identical state" alone is not enough.)
+- `loop_cost` must be exactly what the interpreter charges per iteration today: sum of
+  `*_opcode_cycles[]` for the charged instructions + any `bus_stall`; the inlined delay slot
+  is *not* charged by the outer loop (see `gpu.c:1815-1822` comment). Safest: measure it from
+  the two probe iterations (`cycles_before - cycles_after`) rather than recomputing.
+- Gate OFF when `vjs.gpuPipelineTiming`/DSP pipeline timing is on, when `busArbiter.enabled`
+  (`dram_timing`), when `riscClockScalePct != 100`, and under `VJ_TRACE` PCHIST — those
+  paths have per-instruction state the extrapolation would have to model. Stock settings
+  are the ones the Pi/A10X users run.
+- Exit conditions are automatic: the ISR (delivered at the next slice entry) changes the
+  polled register/memory, so the next fixed-point probe fails and normal execution resumes.
+  A 68K/GPU/OP write to the polled RAM happens between slices for the same reason.
+- Savestates: no new state (detection is re-derived every slice). Determinism: identical
+  by construction; verify with `test/tools/ir_ab.sh` (Ir will DROP) plus framebuffer+audio
+  A/B over ≥8,000 frames on Iron Soldier / AvP / Doom / Wolf3D / Tempest 2000 / Skyhammer
+  using the existing A/B sweep tooling (`docs/profiling.md`, memory
+  `project_fb_ab_sweep_tooling`). Acceptance = byte-identical framebuffer + audio streams
+  with the feature on vs off.
+- Measure with `test/tools/test_benchmark` on the three states above; expected DSP time to
+  drop by the idle fraction (ISR is ~100-300 cycles of a ~550-cycle slice).
+- Prototype order: (1) `jr $ ; nop` and register-only loops (covers IS/AvP and the whole
+  Atari sound-driver family), (2) RAM-poll loops (Doom, niccc GPU mailbox), (3) port to GPU.
+
+Also note: `dsp_releaseTimeSlice_flag` / `DSPReleaseTimeslice` are write-only dead code
+(`dsp.c:792/811/824`) — not a hook to build on.
+
+### P2 — ELF build flags: visibility / interposition / LTO / Android opt — HIGH for Pi+Android (unmeasured; A/B it) — risk LOW-MED — effort S (flags) + M (validate) — **sonnet**
+
+Files: `Makefile` (unix block ~193, rpi blocks ~320-410, `Makefile.common:158-165`),
+`jni/Android.mk`, `link.T`, `link-test.T`, `exports.list`.
+
+- Add `-fno-semantic-interposition` (GCC; clang no-op) to all ELF `-fPIC` targets — safe
+  first cut, zero source change.
+- Add `-fvisibility=hidden` for `!TEST_EXPORTS` builds (the white-box test ABI dlsyms
+  internals via `link-test.T`, so keep test builds default-visibility, or introduce a
+  `VJ_TEST_EXPORT` attribute later). `retro_*` stay exported via `RETRO_API`.
+  `scripts/build-id.sh` / `test/tools/simd_matrix_check.sh` already assert build identity —
+  extend the matrix with a `readelf`/`nm -D` row so a hidden-visibility regression is
+  caught like #516 was.
+- LTO (`-flto`) on `unix`/`rpi*`: flip, run acid + `make TEST_EXPORTS=1 test` + device
+  smoke; LTO can surface latent C89 UB. Measure with `ir_ab.sh 'OPT…' 'OPT… LTO=1'` — Ir
+  may rise while wall time drops; wall-clock A/B/B/A on the Pi is the verdict.
+- `jni/Android.mk`: `COREFLAGS` currently `-DINLINE=inline -D__LIBRETRO__ $(INCFLAGS)
+  $(BLITTER_SIMD_DEFINE)` — add `-O3 -DNDEBUG -fvisibility=hidden -fno-stack-protector
+  -fomit-frame-pointer` (LOCAL_CFLAGS win over NDK defaults; verify with `ndk-build V=1`).
+- Darwin targets are unaffected (two-level namespace → `dso_local`), which is why the
+  A10X needs P1/P3+ rather than this.
+- Optional later: PGO (`-fprofile-generate/-use`) — `make benchmark` is a deterministic
+  training workload; needs a corpus + staleness guard; design first.
+
+### P3 — Fast blitter per-pixel dispatch — MED-HIGH of blitter time (blitter = 5-17% of frame) — risk LOW — effort S-M — **sonnet**
+
+`src/tom/blitter.c`: `READ_PIXEL_*`/`WRITE_PIXEL_*`/`READ_ZDATA_16`/`WRITE_ZDATA_16`/
+`READ_RDATA_*` macros (264-345) call `JaguarRead*/Write*` (5-7 range compares, cross-TU call)
+3-6× per pixel inside `blitter_generic` (553-1158). `blitter_read_byte/word/long` /
+`blitter_write_*` (60-140, `BLITTER_ALWAYS_INLINE`, `<0x200000` fast path + identical
+fallback) already exist and are used only by the accurate engine (≥2167). Route the macros
+through them. Gate: `test/tools/test_blitter_compare` (fast vs accurate, 0 divergent) +
+framebuffer A/B. Bundle: cache `REG(A1_FLAGS)`/`REG(A2_FLAGS)` in locals before the pixel
+loop (re-read 30+ times per pixel, loop-invariant: no `blitter_ram` write until 1152-1154);
+make `blitter_generic` `static`. Later (needs design, L): hoist the ~20 loop-invariant
+command-bit branches out of the per-pixel loop by specialising the common shapes (the
+accurate engine's "COLLAPSED INNER LOOP — PATTERN FILL" at ~2500 is the template); add
+`PERF_COUNTER`s to the fast engine first so shapes are chosen by measurement.
+
+### P4 — `GPUReadLong` DRAM fallback — MED of GPU LOAD cost — risk ~0 — effort S — **sonnet**
+
+`src/tom/gpu.c:885`: `return (JaguarReadWord(offset, who) << 16) | JaguarReadWord(offset + 2, who);`
+→ `return JaguarReadLong(offset, who);` (`jaguar.c:1122` has the one-check `GET32` fast path
+and an identical two-word fallback; `DSPReadLong` and `GPUWriteLong` already do this).
+`loadp` pays it twice. Byte-identical. While there: delete the dead `gpu_opcode[64]`
+function-pointer table (`gpu.c:524`, only use is `#if 0` at 1509 — keeps 64 out-of-line
+handler copies alive), make `gpu_opcode_cycles[64]`/`gpu_convert_zero[32]` `static const`
+(`gpu.c:512/653`), and consider turning the malloc'd `branch_condition_table`
+(`gpu.c:656`, shared with dsp.c) into a `static const` baked table (verify byte-identical).
+
+### P5 — DSP `sh`/`sha` 32-iteration loops — MED (depends on SH frequency in sound drivers) — risk ~0 — effort S — **sonnet**
+
+`src/jerry/dsp.c:1999-2030` (`sha`), `2039-2073` (`sh`): `while (shift) { _Rn <<= 1; … }`.
+Port the GPU versions verbatim (`gpu.c` `gpu_opcode_sh` 2668, `gpu_opcode_sha` 2641: single
+native shift with the `>=32` guard). Flags/carry semantics must match the loop exactly
+(C = bit shifted out first). Audio test pair required.
+
+### P6 — Event scheduler O(32) double scans — MED (~3-4% measured on host) — risk LOW-MED — effort S-M — **sonnet**
+
+`src/core/event.c`: two 32-slot lists, `GetTimeToNextEvent` ×2 + `SubtractEventTimes` +
+`HandleNextEvent` each scan all 32 per scheduler step, ~2,000 steps/frame, `double` math.
+(a) keep live events packed (swap-remove) so scans are O(live≈5-8); (b) cache
+next-event time per list and only rescan on insert/remove; (c) `SubtractEventTimes` →
+a per-list time base (subtract once, not per slot). Savestate format (`EventStateSave/Load`
+307-393) serialises by position + callback id — keep it stable or bump with the next
+version. Also consider merging `JERRYI2SCallback` and `DSPSampleCallback` cadences if they
+are the same period (halves JERRY steps) — check `dac.c:329/371` vs `jerry.c:383` first.
+
+### P7 — 68K per-instruction hook chain — LOW-MED (~3% measured on Iron Soldier / niccc) — risk LOW — effort S — **sonnet**
+
+`src/core/jaguar.c:364-410` `M68KInstructionHook` runs per 68K instruction
+(`m68kinterface.c:203`): traceback ring store + `JaguarCDHLEHook()` + `NVMBiosHook()` +
+strategy hook — three cross-TU calls that each immediately reject. Measured: the three hooks
+(310 samples) cost 3× `m68k_execute` (103). Fix: one precomputed `m68kHookPCs` fast
+reject — e.g. a global `uint32_t hookMask` / small sorted range table rebuilt whenever
+`hle_active`, `jaguarMemTrackInserted`, or `bootConfig.strategy` change, and check it inline
+before any call; keep the traceback ring store (cheap, needed by crash reports) or make it
+`startM68KTracing`-gated too if the PC ring is only read on crash.
+
+### P8 — Minor mechanical — LOW each — **sonnet**, bundle with neighbours
+
+- `tom.c:1541-1547` BG line-buffer clear: 1440 byte stores → 720 16-bit stores / `memset`
+  when hi==lo (only when BGEN set; check codegen first — may already vectorise).
+- `libretro.c:2879-2901, 2951-2973`: 24 unconditional `input_state_cb(KEYBOARD)` numpad
+  fallbacks per frame — gate on a keyboard being present.
+- `jlink.c:666-682`: `clock_gettime` per frame with netlink off — skip when disabled.
+- `dsp.c:2140-3097`: ~960 lines of dead second interpreter (`DSP_add`…`DSPOpcode[]`,
+  `DSPExecP/P2/Comp` prototypes without bodies) — zero runtime cost; cleanup PR only,
+  touches savestate layout (`pipeline[]`/`scoreboard[]` still serialised) → version bump.
+
+### P9 — Enhancement defaults vs. host capability — HIGH for AvP/Doom on slow hosts — risk LOW — effort S-M — **sonnet** (policy decision: user)
+
+`src/core/titledb.c:122-135` turns on `internal_resolution=2x` + `true_color` for AvP
+(Doom likewise per memory). Host profile: `TOMExecHalfline` (hires render inlined) +
+`Shadow*` ≈ 30% of AvP's frame. Options: (a) a core option "enhancement profile:
+auto/quality/performance" where `auto` disables titledb enhancements on platforms with
+`HAVE_NEON` 32-bit / `rpi*` / when `retro_run` overruns the frame budget for N frames;
+(b) make the hires path cheaper (`tom.c:916-1021` per-subpixel shadow-tag lookups). Do (a)
+first — it is a few lines and recovers ~30% on the exact titles people test.
+
+### Not recommended / rejected (so nobody re-spends the tokens)
+
+- Threading (DSP thread, OP pipelining, framebuffer-convert thread, audio thread) —
+  sub-halfline sync; `GPUSyncToM68K` fires on ordinary mailbox polls; conversion *is* the
+  render; audio resample is too small. See `perf-audit/bus-frame.md` §7.
+- 68K JIT / core swap — 0.7-2.6% of frame; licence issues (prior decision).
+- `-Ofast`/`-ffast-math` — #517 (determinism).
+- Flag packing / lazy flags in the RISC interpreters — deliberate, commented rationale; not
+  the bottleneck (idle loops are).
+- Caching `gpu_reg` bank pointer in a local — it legitimately changes mid-slice (STORE to
+  G_FLAGS).
+- DSP/GPU `div` 32-iteration loops — likely load-bearing for bit-exact 16.16 semantics
+  (SCPCD comment); JTRM check before touching.
+- OP `OPObjectExists` O(N²) — teardown-only; the #123 "~1%" was wrong.
+
+## Measurement recipes
+
+- Host hot-function profile (attribution only, load-insensitive enough):
+  `make RELEASE_DEBUG_INFO=1` → `test/tools/test_benchmark <dylib> <rom> 6000 --warmup 60
+  --blitter fast --load-state <state> & sample $! 12 -file out.txt` → read "Sort by top of
+  stack". Per-commit deltas: `test/tools/ir_ab.sh --ref libretro/develop HEAD` (cachegrind
+  Ir, zero-variance; Ir can rise while wall time falls for inlining/unrolling changes).
+- Frame-end RISC PC histogram (idle-loop finder): build `TEST_EXPORTS=1`, dlsym
+  `dsp_pc`/`gpu_pc`/`JaguarReadWord` and sample after each `retro_run` (the harness used
+  for this audit was a 40-line patch of `test/tools/test_benchmark.c`; worth landing as
+  `test/tools/risc_pc_histogram.c` next to `m68k_pc_histogram.c`).
+- On-device: the `RETRO_ENVIRONMENT_GET_PERF_INTERFACE` counters (`device_perf.sh`,
+  `rpi_perf.sh`) give the **subsystem** split only (8 brackets, no stacks) — run first to
+  confirm the ordering on the A10X (#509's unmet exit criterion; iPad Pro 2 = A10X). For
+  **function/line** attribution use Instruments Time Profiler: `make platform=ios-arm64
+  RELEASE_DEBUG_INFO=1` keeps `-O3 -g`; nothing in `code-sign-cores.sh` or the RetroArch
+  Xcode project strips (`COPY_PHASE_STRIP=NO`, no `STRIP_INSTALLED_PRODUCT`); the
+  `RetroArch iOS Release` scheme's ProfileAction already builds Release; `dsymutil` the dylib
+  so Instruments matches by UUID; Product ▸ Profile ▸ Time Profiler, Invert Call Tree +
+  Flatten Recursion. Scriptable via `xctrace record --template 'Time Profiler' --device
+  <udid> --attach RetroArch --time-limit 30s`. Full recipe: `perf-audit/device-profiling.md`.
+  Gap worth filling: a `device_perf.sh profile` subcommand wrapping `xctrace`.

--- a/docs/perf-audit/blitter.md
+++ b/docs/perf-audit/blitter.md
@@ -1,0 +1,423 @@
+> Raw sub-agent audit output (2026-08-22, read-only, sonnet). Line numbers refer to
+> `libretro/develop` @ 5f898da. Verified items are promoted to [`../perf-audit-2026-08.md`](../perf-audit-2026-08.md);
+> treat anything here that is NOT in that file as unverified.
+
+# Blitter performance audit (read-only) — src/tom/blitter.c et al.
+
+Repo: virtualjaguar-libretro, worktree alien-predator-save-state-ad621b
+Scope: `blitter_generic` (fast, default engine), `BlitterMidsummer2` (accurate,
+opt-in), `blitter_mmio.c`, `blit_memo.c`, `blitter_simd_*.c`, memory-access
+helpers. No edits made; no build run.
+
+## Executive summary
+
+The fast blitter (`blitter_generic`, `src/tom/blitter.c:553-1158`) is the
+default engine and the one 95%+ of games use. It has **not** received the
+memory-access fast-path optimization that already exists in this file and is
+used only by the accurate engine: `blitter_read_byte/word/long` and
+`blitter_write_byte/word/long` (`blitter.c:60-140`, explicitly commented
+"~98% of blitter memory accesses target main RAM... avoiding the full address
+dispatch... for the common case"). `blitter_generic`'s `READ_PIXEL` /
+`WRITE_PIXEL` / `READ_RDATA` / `WRITE_ZDATA` macros call `JaguarReadByte` /
+`JaguarReadWord` / `JaguarReadLong` / `JaguarWrite*` directly — real,
+non-inlined, cross-TU function calls with a multi-branch address-space
+dispatch chain — for every one of the 3-6 memory ops per pixel. This is
+Finding 1, and it's a mechanical, low-risk fix.
+
+Finding 2, also mechanical: `REG(A1_FLAGS)` / `REG(A2_FLAGS)` (4 byte-array
+reads + shifts each) are evaluated 30+ times in the `blitter_generic` inner
+loop body via macro call sites, even though both registers are invariant for
+the entire blit (nothing writes `blitter_ram` between `blitter_blit()`'s
+setup and its final `WREG` after the loop). Caching them in two locals
+before the outer loop and passing those locals to the macros removes all of
+that redundant work.
+
+Finding 3 (bigger, needs design): the inner loop's `if` cascade
+(`DSTEN`, `DCOMPEN|BCOMPEN`, `CLIPA1`, `PATDSEL`/`ADDDSEL`/LFU, `GOURD`,
+`SRCSHADE`, shadow-fb hooks...) all gate on `cmd`/mode bits that are constant
+for the whole blit, but there are too many of them for the compiler to fully
+loop-unswitch (2^N combinations), so most are real per-pixel branches. A
+template-by-macro specialization (like the accurate engine's own "collapsed
+inner loop" pattern, see Finding 7) that decodes the mode once per blit and
+dispatches to a handful of specialized inner-loop bodies (copy, copy+key,
+Gouraud, LFU) would remove this.
+
+The accurate engine (`BlitterMidsummer2`) is a literal cycle-by-cycle
+FDSYNC-cascade simulation of the Oberon gate netlist and is already
+heavily tuned where it's been profiled: `ADDARRAY`/`ADD16SAT` are
+`BLITTER_ALWAYS_INLINE`-forced and NEON/SSE2-vectorized
+(`blitter_simd_neon.h`/`_sse2.c`) per the comment "ADDARRAY at 1910 samples,
+... the single largest leaf in the entire emulator" (`blitter.c:1477-1479`).
+Row-offset (`addrgen_ya`) caching is already done (`blitter.c:2455-2457`),
+and a "COLLAPSED INNER LOOP — PATTERN FILL" fast path already collapses the
+2-cycle-per-pixel state machine into 1 iteration for the pure-pattern-fill
+command shape (`blitter.c:2500-2506`). This confirms the MEMORY.md note
+"state-machine collapse... remaining" is half-done: the next candidate is
+the plain textured SRCEN+DSTEN copy shape (no GOURD/pattern), likely AvP's
+actual hot path, which still runs the full multi-cycle FSM.
+
+None of the fast engine's SIMD helpers are used by `blitter_generic` at all
+— NEON/SSE2 code only accelerates `BlitterMidsummer2`. The fast engine is
+scalar top to bottom. This is expected given it's a true per-pixel scalar
+loop (no 4-lane phrase batching the way the accurate engine's ADDARRAY is),
+so "add SIMD to the fast path" would require restructuring to a phrase-batch
+model — out of scope for a quick win.
+
+---
+
+## Findings
+
+### F1 — `blitter_generic` bypasses the existing RAM fast-path helpers [HIGH / S-M / LOW-risk / mechanical]
+
+**Where:** `src/tom/blitter.c:264-345` (`READ_PIXEL_*`, `READ_RDATA_*`,
+`WRITE_PIXEL_*`, `READ_ZDATA_16`, `WRITE_ZDATA_16` macros used throughout
+`blitter_generic`, `553-1158`) all call `JaguarReadByte`/`JaguarReadWord`/
+`JaguarReadLong`/`JaguarWriteByte`/`JaguarWriteWord`/`JaguarWriteLong`
+directly (defined `src/core/jaguar.c:954-1170`).
+
+**What:** These are out-of-line, non-`static` functions in a different
+translation unit (`jaguar.c`), so (absent LTO — see below) every call is a
+real call/return, and each does: mask, `VJT_WATCH_RD/WR` check (cheap, a
+global-int guard), `blitMemoRecording`/`blitMemoMode` check (cheap), then an
+`if/else if` chain over 5-7 address ranges (RAM, ROM, CD, jagMemSpace, TOM,
+JERRY, unknown) before reaching `jaguarMainRAM[]` for the ~98% RAM case.
+
+Meanwhile `blitter_read_byte/word/long` and `blitter_write_byte/word/long`
+(`blitter.c:60-140`) already exist, are `BLITTER_ALWAYS_INLINE`, and do
+exactly "check `addr < 0x200000`, touch `jaguarMainRAM[]` directly, else
+fall back to the full `Jaguar*` call" — but per
+`grep -n "blitter_read_byte\|blitter_write_byte" blitter.c` (confirmed by
+direct read), every call site of these helpers is inside `BlitterMidsummer2`
+(lines 1469, 2629-3006, and more, all ≥2167) — **zero** call sites are inside
+`blitter_generic` (553-1158).
+
+**Why it costs on an in-order ARM core (Pi4/A10X):** a mispredicted or even
+correctly-predicted indirect-free direct call still pays call/return
+overhead, register spill/fill around the call (these functions clobber
+plenty), and the full range-check chain (5-7 compares) instead of the
+single compare the existing fast-path helper already does. This runs 3-6
+times per pixel (source read, optional src-Z, dest read, optional dest-Z,
+write, optional Z-write, plus the `PATTERNDATA`/`DSTDATA`/`DSTZ`/`SRCZINT`
+register-source reads which also route through `READ_RDATA` → same
+`JaguarRead*` path when SRCEN/DSTEN are off). Given the blitter is already
+measured at 5-17% of frame time (task context) with a scalar per-pixel loop
+doing this multiple times per pixel, this dispatch/call overhead is a
+meaningful fraction of that.
+
+Whether LTO can already inline this away: `Makefile:219` shows `-flto=4
+-fwhole-program` is enabled **only** for `platform=classic_armv7_a7`. The
+`rpi*`/`rpi*_64`/`unix`/`ios`/`tvos` targets that the task calls out
+(RPi4, A10X) do **not** enable LTO (checked `Makefile:320-410`, no `-flto`
+in the `rpi*` or generic-ARM blocks), so on those targets `blitter.c` and
+`jaguar.c` are separate objects and the compiler cannot inline
+`JaguarReadByte` etc. into `blitter_generic` regardless of function
+attributes on the callee.
+
+**Proposed change:** route `blitter_generic`'s pixel/Z/register reads and
+writes through `blitter_read_byte/word/long` / `blitter_write_*` the same
+way `BlitterMidsummer2` already does — i.e. change the `READ_PIXEL_n`/
+`WRITE_PIXEL_n`/`READ_ZDATA_16`/`WRITE_ZDATA_16` macros (and the
+`READ_RDATA_n` register-source macros, which fall back to `JaguarRead*` only
+when `SRCEN`/`DSTEN` are off — less hot but same principle) to call the
+`blitter_*` helpers instead of `Jaguar*` directly. This is a drop-in
+replacement (same signature shape: `addr` in, value out) confined to this
+file's macros.
+
+**Risk:** LOW for pixel-exactness — the fast-path helpers replicate
+`JaguarRead*`/`JaguarWrite*`'s exact RAM-path semantics (mask, byte-swap,
+`blitMemoRecording`/`blitMemoMode` hooks) for the `<0x200000` case and fall
+back to the identical full dispatch otherwise; behavior for cart-ROM/TOM/
+JERRY-mapped blit sources (rare but real, e.g. reading OP display list
+data) is unchanged since those still fall through to `JaguarRead*`. Gate
+with `test/tools/test_blitter_compare` (fast-vs-accurate) plus the acid
+suite before merging — should be a no-op on output, pure timing win.
+Savestates unaffected (no new state).
+
+**Effort:** S-M. Mechanical macro edit, but touches ~10 macros used
+pervasively — a cheap model (sonnet) can do this correctly given clear
+instructions to mirror `BlitterMidsummer2`'s existing usage pattern, then a
+human/stronger pass should verify `test_blitter_compare` and the audio/video
+acid tests are unaffected (they should be, since the RAM path is byte-
+identical).
+
+---
+
+### F2 — `REG(A1_FLAGS)`/`REG(A2_FLAGS)` recomputed 30+ times per pixel [MED-HIGH / S / LOW-risk / mechanical]
+
+**Where:** `src/tom/blitter.c:553-1055` (the `blitter_generic` inner loop
+body). Confirmed by direct count: `REG(A1_FLAGS)` appears 19 times and
+`REG(A2_FLAGS)` 17 times as literal macro-call text within that span (not
+all execute on every pixel — depends on which branch — but the simplest
+"opaque pixel copy" path alone hits `READ_PIXEL(a2, REG(A2_FLAGS))` (src),
+either `READ_PIXEL(a1, REG(A1_FLAGS))` or `READ_RDATA(DSTDATA, a1,
+REG(A1_FLAGS), ...)` (dst), and `WRITE_PIXEL(a1, REG(A1_FLAGS), writedata)`
+— **3 REG() evaluations minimum per pixel**, more with Z/compare/shadow
+paths active).
+
+**Why it costs:** `REG(A)` (`blitter.c:180-181`) is
+`((blitter_ram[A]<<24)|(blitter_ram[A+1]<<16)|(blitter_ram[A+2]<<8)|blitter_ram[A+3])`
+— 4 independent byte loads (defeats word-load coalescing since it's byte-by-
+byte from a `uint8_t[]`) plus 3 shifts and 3 ORs, repeated for a value that
+cannot change during `blitter_generic` (verified: no `WREG`/`blitter_ram[]`
+write occurs between the top of the function and the final register
+writeback at `blitter.c:1152-1154`, i.e. after the loop). On an in-order
+core this is ~7-10 extra instructions per call site, several call sites per
+pixel, for a value that's loop-invariant.
+
+**Proposed change:** at the top of `blitter_generic` (after the existing
+`bppSrc` computation, `blitter.c:556`), add
+`uint32_t a1Flags = REG(A1_FLAGS), a2Flags = REG(A2_FLAGS);` and replace
+every `REG(A1_FLAGS)`/`REG(A2_FLAGS)` inside the loop body with the locals.
+Mechanical `sed`-style replacement confined to lines 557-1055.
+
+**Risk:** LOW — provably invariant (verified above), pure textual
+substitution, `test_blitter_compare` + acid should be unaffected (bit-
+identical results, faster).
+
+**Effort:** S. Good candidate for a cheap model to do as a mechanical
+find/replace, with a human spot-check that no `WREG(A1_FLAGS,...)` or
+`WREG(A2_FLAGS,...)` was missed inside the loop (there isn't one, confirmed
+above, but worth a final grep before merging).
+
+---
+
+### F3 — `blitter_generic` inner-loop mode decode is not hoisted out of the loop [MED-HIGH impact / L effort / MED risk / needs design]
+
+**Where:** `src/tom/blitter.c:574-908` (main inner `while (inner_loop--)`
+body).
+
+**What:** ~20 command-bit tests (`SRCEN`, `SRCENZ`, `SRCENX`, `DSTEN`,
+`DSTENZ`, `GOURZ`, `Z_OP_INF/EQU/SUP`, `DCOMPEN`, `BCOMPEN`, `CMPDST`,
+`CLIPA1`, `PATDSEL`, `ADDDSEL`, `TOPBEN`, `TOPNEN`, `LFU_NAN/NA/AN/A`,
+`GOURD`, `SRCSHADE`, plus `shadowFBActive`/`shadowHiresActive`) gate nested
+`if`s inside the per-pixel loop. Each test itself is cheap (`cmd & CONST`
+against a register-resident local — confirmed at `blitter.c:206-240`), but
+`cmd` and the shadow globals don't change during the loop, so all ~20
+branches are 100% predictable after the first iteration (branch
+misprediction is NOT the cost here — `__builtin_expect` would not help).
+The cost is pure **instruction count**: the CPU still executes and retires
+every compare+branch every pixel, and because there are too many for the
+compiler to profitably loop-unswitch into 2^20 specialized loop bodies, it
+does not do this automatically (confirmed: no `static`/specialization
+scaffolding exists for `blitter_generic` today — it's a single monolithic
+function, unlike `BlitterMidsummer2` which already has a hand-written
+collapsed variant for one command shape, see F7).
+
+**Proposed change:** decode the handful of *actually common* command shapes
+once per blit in `blitter_blit()` (opaque copy, copy+colour-key, Gouraud
+fill, LFU-only) and dispatch to specialized inner-loop functions/macro
+expansions for each, falling back to the current fully-general loop for
+anything else — the same "collapse the common case, keep the general
+path as fallback" pattern the accurate engine (F7) already uses.
+
+**Risk:** MED — this is a real logic restructuring, not a mechanical
+transform; must preserve exact semantics (including the DCOMPEN/PATTERNDATA
+colour-key fix documented at `blitter.c:648-657`, the ADDDSEL saturating-add
+path, and the shadow-framebuffer hi-res hooks). Gate hard on
+`test_blitter_compare` (fast-vs-accurate divergence) AND full acid suite;
+this is exactly the kind of change that could silently regress an edge
+case a specific game depends on (Hover Strike's BCOMPEN kludge at
+`blitter.c:563-568` is a warning sign that this loop has game-specific
+landmines). Savestates unaffected.
+
+**Effort:** L, needs design (which command shapes are common enough to
+special-case — would benefit from instrumenting `blitter_generic` first,
+see the Observability Gap note below). Not a mechanical task for a cheap
+model; needs a reviewer familiar with the blitter semantics.
+
+---
+
+### F4 — Per-pixel address computation redoes `y*width*(1+pitch)` even when y is loop-constant [MED impact / L effort / MED risk / needs design]
+
+**Where:** `PIXEL_OFFSET_16`/`_8`/`_32`/etc, `blitter.c:270-286`, e.g.
+`PIXEL_OFFSET_16(a)` =
+`(((((uint32_t)a##_y>>16)*a##_width)+((...x...)&~3))*(1+a##_pitch)+(...))`.
+
+**What:** every `READ_PIXEL`/`WRITE_PIXEL`/`READ_ZDATA`/`WRITE_ZDATA` call
+recomputes the full row-offset formula (2 multiplies) from scratch, even
+though for the overwhelmingly common axis-aligned blit (`a1_yadd`/`a2_yadd`
+== 0 within a row) `y` — and therefore the row base — does not change across
+the inner loop; only the x term does.
+
+**Why it costs:** 2 integer multiplies per pixel per address computed (up
+to 2-4 addresses/pixel). Modern in-order ARM cores do integer multiply in
+1-3 cycles, so this is a smaller cost than F1/F2/F3, but it's paid
+unconditionally regardless of blit shape.
+
+**Proposed change:** track a running row-base address incrementally,
+recomputed only when y actually changes (i.e. once per outer-loop
+iteration, or once per pixel only for diagonal/scaled blits where y does
+change every pixel). This is the "O(width*height) that could be O(height)"
+case flagged in the task.
+
+**Risk:** MED — must handle A2's mask-wrap (`a2_mask_x`/`a2_mask_y`),
+phrase-mode alignment, and the 1bpp/2bpp/4bpp sub-byte bit-shift terms
+correctly; a subtly wrong incremental-address scheme is exactly the class
+of bug `test_blitter_compare` exists to catch, but only if the accurate
+engine takes the same address on the same inputs (it uses its own
+`ADDRGEN`, so this is an independent implementation — good for defense in
+depth, but means a shared bug wouldn't be caught by comparison alone;
+rely on acid + real-game verification (Battle Sphere Gold, Val d'Isere,
+AvP) too.
+
+**Effort:** L, needs design. Lower priority than F1-F3 given the smaller
+per-pixel cost (multiply vs. function-call-plus-dispatch-chain), but worth
+scoping if F1-F3 don't fully close the gap.
+
+**Note:** `PIXEL_OFFSET_1`/`_2`/`_4` (`blitter.c:264-268`) additionally do a
+**division** (`a##_width / 8`, `/4`, `/2`) per pixel for sub-byte pixel
+sizes. 1/2/4bpp blits are comparatively rare (mostly font/CLUT work), so
+this is LOW tier on its own, but if F4 is tackled, hoisting the width/N
+division alongside the row-address caching is free.
+
+---
+
+### F5 — `blitter_generic` is not `static`, preventing whole-function inlining/specialization [LOW impact / S effort / LOW risk / mechanical]
+
+**Where:** `src/tom/blitter.c:553`, `void blitter_generic(uint32_t cmd)`.
+
+**What:** `blitter_generic` has exactly one call site
+(`blitter_blit()`, same TU, `blitter.c:1380`) and is not declared or used
+anywhere else (`grep -rn blitter_generic` across `src/` and `test/` turns up
+only that one call plus comments/docs). It is not `static`.
+
+**Proposed change:** mark it `static void blitter_generic(uint32_t cmd)`.
+This lets the compiler consider inlining it into `blitter_blit`, enables
+better whole-function DCE/analysis, and costs nothing.
+
+**Risk:** LOW — no external references exist. Trivial to verify with grep
+before merging.
+
+**Effort:** S, purely mechanical, safe for a cheap model to apply alongside
+F1/F2.
+
+---
+
+### F6 — `blit_memo` / memo-hook overhead when memoization is OFF [confirmed cheap — no action needed]
+
+**Where:** `BlitMemoLaunch()` (`blit_memo.c:628-693`), guarded reads/writes
+in `blitter_read_*`/`blitter_write_*` and `JaguarRead*`/`JaguarWrite*` via
+`blitMemoRecording`/`blitMemoMode` globals.
+
+**Finding:** `BlitMemoLaunch()` returns immediately (`if (!blitMemoMode)
+return 0`, `blit_memo.c:635`) when memo is off (the default,
+`blitMemoMode = BLIT_MEMO_OFF` at `blit_memo.c:126`), and every per-pixel
+hook site (`blitter.c:65,78,93,105,120,138` and the equivalents in
+`jaguar.c`) is a single global-int compare before the (skipped) hash/record
+work. This is already cheap and not a target for optimization — confirms
+task item 4's concern was not realized in this codebase.
+
+---
+
+### F7 — Accurate engine (`BlitterMidsummer2`) is a genuine cycle-accurate FDSYNC simulation; most of its cost is load-bearing [context, secondary per task priority]
+
+**Where:** `src/tom/blitter.c:2167-4041`.
+
+**What:** this function literally simulates the Oberon ASIC's flip-flop
+state machine one *hardware clock cycle* per `while(true)` loop iteration
+(the `idle`/`inner`/`a1update`/`a2update`/`init_if`/... boolean cascade at
+`blitter.c:2299-2410` is a direct transcription of FDSYNC next-state logic,
+per the file's own header comment about the Oberon ASIC nets). For a
+config that needs N hardware cycles per pixel, this loop runs N iterations
+per pixel. This is why it's ~34% of frame time on AvP vs. 5-17% for the
+scalar-but-decode-heavy fast engine — it's doing categorically more work
+(cycle-accurate vs. result-accurate).
+
+**Already-done optimizations found (do not re-propose these):**
+- `ADDARRAY`/`ADD16SAT` are `BLITTER_ALWAYS_INLINE` and route through
+  `blitter_simd_add16sat_x4` (NEON: `blitter_simd_neon.h:161-307`; also
+  SSE2/scalar variants), explicitly profiled ("ADDARRAY at 1910 samples...
+  single largest leaf", `blitter.c:1477-1479`).
+- Row-offset caching: `a1_ya_cached`/`a2_ya_cached` computed once per inner-
+  loop entry, not per pixel (`blitter.c:2455-2457`, comment "Precompute
+  y*width row offsets (invariant when y unchanged)").
+- Address-decode constants (`a1_xconst`/`a2_xconst`) and `srcshift`
+  precomputed once per inner-loop entry (`blitter.c:2459-2469, 2471-2489`).
+- A hand-written "COLLAPSED INNER LOOP — PATTERN FILL" fast path
+  (`blitter.c:2500-2506` and following) that detects the pure-pattern-fill
+  command shape (`PATDSEL` set, no `SRCEN`/`SRCENX`/`DSTEN`/`DSTENZ`/
+  `DSTWRZ`/`GOURD`/`GOURZ`/`SRCSHADE`/`ADDDSEL`/`BCOMPEN`/`DCOMPEN`,
+  `zmode==0`) and runs 1 iteration/pixel instead of the state machine's 2,
+  doing the same `ADDRGEN`/mask/`DATA`/write/step work directly. This
+  confirms and partially resolves the "state-machine collapse... remaining"
+  item noted in project memory (`project_blitter_optimization_status.md`).
+
+**What's still open (matches "remaining" in memory notes, not re-audited in
+depth per task priority):** only the pattern-fill shape has a collapsed
+path. The plain textured-copy shape (`SRCEN`+`DSTEN`, no `GOURD`, i.e. a
+straightforward source-to-dest blit with Z/compare off) — very plausibly
+AvP's actual per-triangle texture-blit hot path — still runs the full
+multi-cycle FSM. Extending the collapse pattern to that shape is the next
+highest-value target in this engine, per the existing code's own precedent,
+but is a genuinely large, design-level undertaking (state-machine analysis
++ correctness proof against `test_blitter_compare`), not something to
+attempt mechanically. Flagged here for prioritization, not detailed further
+per the task's "keep secondary" instruction.
+
+---
+
+### F8 — SIMD coverage: NEON/SSE2 accelerate only the accurate engine; fast engine is 100% scalar [informational — no action recommended]
+
+**Where:** `blitter_simd_neon.h`/`blitter_simd_sse2.c`/`blitter_simd_scalar.c`
+provide `blitter_simd_lfu`, `blitter_simd_dcomp`, `blitter_simd_zcomp`,
+`blitter_simd_byte_merge`, `blitter_simd_add16sat_x4`. All 7 call sites for
+these (`blitter.c:1619,1790,1826,1892,2147,2148`) sit inside
+`BlitterMidsummer2`'s helper functions (`1393-2166` range, called from
+within `2167-4041`). `blitter_generic` calls none of them — it processes one
+pixel at a time with scalar C, so there's no natural 4-lane batch to
+vectorize without restructuring to a phrase-batched model (an F3/F4-class
+redesign, not a SIMD bolt-on). Not recommending action here; noting it so a
+"why doesn't the fast blitter use NEON" question doesn't come up as a
+surprise later.
+
+**NEON target selection** (task item 5): confirmed correct after PR #562/
+issue #560 — `Makefile.common:154-163` selects NEON for `HAVE_NEON=1`
+(set for `rpi2`-`rpi5` 32-bit, `Makefile:407-429`), for `ios-arm64`/
+`tvos-arm64` explicitly, and for any `ARCH` of `aarch64`/`arm64` (which
+covers `rpi*_64` via `Makefile:391-392` setting `ARCH = aarch64`, and
+generic `arm64`/`aarch64` platforms via `Makefile:333-338`). No new finding
+here — this was the subject of the prior #560 fix and looks complete for
+the targets this task named (Pi4, A10X/iOS).
+
+---
+
+## Observability gap (not a runtime-perf finding, but blocks verifying the above)
+
+`PERF_COUNTER`/`PERF_INC` instrumentation (`blitter_calls`, `blitter_outer`,
+`blitter_inner`, `blitter_inner_io`, `blitter_inner_idle`,
+`blitter_phrase_reads`, `blitter_phrase_writes`, declared `blitter.c:163-
+170`) is **only** incremented inside `BlitterMidsummer2`
+(`blitter.c:2169,2299,2566,2868,3086`) — `blitter_generic`, the default
+engine, increments none of them. `test/tools/blitter_budget_probe.c`
+explicitly documents this (`test/tools/blitter_budget_probe.c:48-56`:
+"PERF_INC(blitter_calls) exists only in blitter_generic()" — that comment
+is itself stale/wrong; it's actually only in `BlitterMidsummer2` — and "a
+run that leaves the blitter on fast reports 0 blits"). Net effect: there is
+currently no in-tree way to get a per-command-shape breakdown of where the
+5-17% fast-blitter frame-time budget actually goes without switching to the
+(much slower, differently-shaped) accurate engine first. If F3's "which
+command shapes are common enough to special-case" question needs answering
+empirically, adding `PERF_INC`/lightweight shape-bucket counters to
+`blitter_generic` first would be a cheap, low-risk prerequisite (S effort,
+mechanical, mirrors the existing `PERF_COUNTER` pattern).
+
+---
+
+## Priority ranking
+
+1. **F1** (bypass RAM fast-path helpers) — HIGH impact, S-M effort, LOW risk.
+   Do first; mechanical; a cheap model can execute it correctly with a
+   pointer to `BlitterMidsummer2`'s existing usage as the template.
+2. **F2** (cache `REG(A1_FLAGS)`/`REG(A2_FLAGS)`) — MED-HIGH impact, S effort,
+   LOW risk. Do alongside F1 in the same PR; trivially mechanical.
+3. **F5** (`static` on `blitter_generic`) — LOW impact, S effort, LOW risk.
+   Free, bundle with F1/F2.
+4. **Observability gap fix** — prerequisite for F3, cheap, do before F3.
+5. **F3** (specialize inner loop per command shape) — MED-HIGH impact, L
+   effort, MED risk. Needs design + real measurement (see observability
+   gap) to pick which shapes to special-case; not mechanical.
+6. **F4** (incremental row address) — MED impact, L effort, MED risk. Lower
+   priority than F3 given smaller per-op cost (multiply vs. call/dispatch).
+7. **F7** (extend accurate-engine collapse to textured-copy shape) — real
+   opportunity but explicitly secondary per task scope; large, needs design.
+8. F6, F8 — informational, no action.

--- a/docs/perf-audit/build-68k.md
+++ b/docs/perf-audit/build-68k.md
@@ -1,0 +1,389 @@
+> Raw sub-agent audit output (2026-08-22, read-only, sonnet). Line numbers refer to
+> `libretro/develop` @ 5f898da. Verified items are promoted to [`../perf-audit-2026-08.md`](../perf-audit-2026-08.md);
+> treat anything here that is NOT in that file as unverified.
+
+# Virtual Jaguar libretro — build-flag + 68K audit (read-only)
+
+Repo: `.claude/worktrees/alien-predator-save-state-ad621b`. All line numbers verified by
+direct `Read`/`grep` against `Makefile` (2649 lines), `Makefile.common` (272 lines),
+`link.T`, `link-test.T`, `exports.list`, `jni/Android.mk`, `jni/Application.mk`,
+`libretro-common/include/libretro.h`, `libretro.c`, `src/core/jaguar.c`,
+`src/m68000/m68kinterface.c`, `src/core/vjtrace.h`, `src/core/vjag_memory.h`.
+
+**File-structure correction that matters for the Android finding below**: the whole
+platform-selection `ifeq` chain (unix / classic_armv7_a7 / osx / ios / tvos / rpi* /
+arm64-generic / consoles / msvc, and all `fpic`/`SHARED`/`GC_STYLE`/`OPT_LEVEL`/`WARNINGS`
+assembly) lives in **`Makefile`**, lines ~193–975. **`Makefile.common`** (272 lines) only
+holds `SOURCES_C`/`SOURCES_CXX` and the `BLITTER_SIMD_SRC` NEON/SSE2 selection logic —
+it carries zero optimization-flag logic. `jni/Android.mk` includes only `Makefile.common`,
+never `Makefile`. This is load-bearing for Finding A2.
+
+---
+
+## PART A — build / compiler-flag audit
+
+### A1. HYPOTHESIS CONFIRMED — ELF/GNU-ld targets are `-fPIC` with no compile-time
+non-interposition signal; the version script is a link-time-only mechanism
+
+**Evidence:**
+- `Makefile:201` (unix), `:214` (classic_armv7_a7), `:337` (arm64/aarch64 generic),
+  `:376` (rpi0..rpi5_64), `:769` (Windows/MinGW fallback) all set
+  `SHARED := -shared -Wl,--no-undefined -Wl,--version-script=$(LINK_SCRIPT)`.
+  `jni/Android.mk:62` does the Android-equivalent: `LOCAL_LDFLAGS := -Wl,-version-script=$(CORE_DIR)/link.T`.
+- `link.T` (17 lines) / `link-test.T` (117 lines): GNU `--version-script` syntax,
+  `global: retro_*; local: *;` in production mode. `exports.list` (13 lines) is the
+  Mach-O mirror (`_retro_*`) via `-exported_symbols_list` (`Makefile.common` doesn't
+  carry this; it's `MACHO_EXPORTS_FLAGS` at `Makefile:166`).
+- Grepped the entire `Makefile` + `Makefile.common` + `jni/Android.mk` for
+  `-fvisibility`, `-flto`/`-fwhole-program`, `-fno-semantic-interposition`, `-fno-plt`:
+  **zero hits** on any ELF/GNU-ld platform block (unix, rpi0–rpi5_64, arm64/aarch64
+  generic, generic `armv*`, Android). The only `-flto=4 -fwhole-program` in the whole
+  tree is `classic_armv7_a7` (`Makefile:219`), which is a separate, self-contained
+  recipe (see A1b below).
+- Confirmed `RETRO_API` in `libretro-common/include/libretro.h:63-83` already expands to
+  `__attribute__((__visibility__("default")))` on non-Windows GCC≥4/Clang. `libretro.c:4`
+  `#include <libretro.h>` pulls that declaration in before every `retro_*` definition
+  (e.g. `libretro.c:4949 void retro_init(void)`), so the attribute is already inherited
+  by the definitions — **no source change needed** to keep `retro_*` exported if
+  `-fvisibility=hidden` were added globally.
+
+**Why this costs real cycles:** under `-fPIC` without `-fvisibility=hidden` or
+`-fno-semantic-interposition`, GCC/Clang must, at compile time (per-.o, with no
+knowledge of the eventual link), assume any non-`static` global function or object
+*could* be interposed by another definition at dynamic-link time (classic ELF/System V
+symbol preemption semantics — this is independent of what the linker later does with
+`--version-script`, because the version script is invisible to the compiler driver).
+The compiler therefore routes:
+- every call to a non-`static` cross-TU function through the PLT (indirect, through
+  `.got.plt`), and
+- every access to a non-`static` global object through a GOT-indirect load (`@GOTPCREL`
+  on x86_64, `:got:`/`:got_lo12:` on AArch64),
+even for calls/accesses that will end up 100% internal to the `.so` after linking with
+`link.T`. `src/tom/gpu.h:4`, `src/jerry/dsp.h:2`, `src/core/jaguar.h:13`,
+`src/jerry/jerry.h:2`, `src/tom/tom.h:9` (37 `extern` globals across the hottest headers
+alone, not counting functions) are exactly the kind of cross-TU state the interpreter's
+per-instruction hot loops touch — GPU/DSP register file access, `jaguarMainRAM`,
+`busArbiter`, etc.
+
+I could not build a Linux `.so` in this read-only session to produce an `objdump -d`
+diff proving the exact GOT/PLT instruction counts (no `make` allowed, and the only
+prebuilt artifact in the tree is the macOS `.dylib`, whose ld64/two-level-namespace
+codegen story is materially different from ELF's — Mach-O does not default to the same
+symbol-preemption assumption, so the dylib's `nm` output, 2423 local `t`/`d`/`b`/`s` vs.
+46 global `T`, is NOT evidence either way for this ELF-specific claim). The mechanism
+itself is standard, well-documented GCC/Clang behavior (see `-fno-semantic-interposition`
+in the GCC manual and Ulrich Drepper's "How To Write Shared Libraries" §2.2), and the
+Makefile-side evidence (zero mitigating flags on every ELF platform block, confirmed by
+direct grep) is unambiguous, so I'm reporting this as **structurally confirmed, cycle-
+count unverified**.
+
+**Proposed change (two independent, stackable options):**
+
+1. **`-fno-semantic-interposition`** — add to `FLAGS` for all non-MSVC platforms
+   (near `Makefile:874`, alongside the existing `-fomit-frame-pointer -fno-common`).
+   Zero interaction with `TEST_EXPORTS`/`link-test.T`: it changes codegen assumptions
+   only, not ELF visibility/binding, so `dlsym` into the wide test ABI is unaffected.
+   Safe with the existing version-script setup (this is literally GCC's documented
+   sanctioned pairing: version-script-hidden internals + `-fno-semantic-interposition`
+   to let the compiler act on that fact). **Effort: S. Risk: LOW. Impact: MED–HIGH
+   (unmeasured). Mechanical — sonnet can do this**, but the resulting binary needs an
+   A/B on real ARM hardware (RPi4/Android) per `test/tools/opt_ab.sh`/`rpi_perf.sh`
+   before claiming a win, same protocol as #515/#516/#517.
+
+2. **`-fvisibility=hidden`**, gated so it does not fight `TEST_EXPORTS`:
+   ```
+   ifeq ($(TEST_EXPORTS),1)
+      LINK_SCRIPT := link-test.T
+      ...
+   else
+      LINK_SCRIPT := link.T
+      MACHO_EXPORTS := exports.list
+      CFLAGS  += -fvisibility=hidden
+      CXXFLAGS += -fvisibility=hidden   # SOURCES_CXX is empty in this tree, but harmless
+   endif
+   ```
+   at `Makefile.common`... **correction**: this ifeq actually lives in `Makefile.common`
+   itself at lines 158-165 (the `TEST_EXPORTS`/`LINK_SCRIPT` block is one of the few
+   things in `Makefile.common` that isn't `SOURCES_*`) — verified directly. Since
+   hidden visibility is a compile-time ELF/Mach-O symbol-table property (stronger than
+   the version script — a hidden symbol never reaches `.dynsym` regardless of what
+   `link.T` says), it must stay OFF whenever `link-test.T`'s wide ABI (`DSP*`, `GPU*`,
+   `m68k_*`, `jaguarMainRAM`, `regs`, `vjs`, ~80 more patterns, see `link-test.T:12-117`)
+   needs those symbols to actually land in `.dynsym` for the test harnesses' `dlsym()`
+   calls — which is exactly the gating shown above. **This does NOT need per-symbol
+   `VJ_TEST_EXPORT` attribute annotations** — gating the single `-fvisibility=hidden`
+   flag on `TEST_EXPORTS` is sufficient, because in the `TEST_EXPORTS=1` branch every
+   symbol keeps its default (exported) visibility exactly as today. **Effort: M**
+   (needs verification that no other file already relies on being able to `dlsym`
+   something outside the `retro_*`/test-ABI set in the *production* build — grep for
+   any `dlopen`/`dlsym` self-use inside `libretro.c` and `src/**` first; I didn't find
+   one, but a design-review pass is warranted since this changes what `.dynsym` exports
+   on the *default* `make` target). **Risk: LOW-MED** (the coexistence design is sound
+   but touches `Makefile.common`'s core `TEST_EXPORTS` branch — a place the repo's own
+   comments (`Makefile.common:174-191`, `Makefile:1008-1075`) flag as historically
+   fragile / stale-.o-hazard-prone). **Needs design review, not purely mechanical** —
+   sonnet can draft it but a human/opus pass should confirm the `TEST_EXPORTS` gating
+   doesn't interact with `BUILD_AXES` in a way that reintroduces #457-class staleness
+   (it shouldn't — `TEST_EXPORTS` is already in `BUILD_AXES` at `Makefile:184-186`, so
+   flipping it already forces the full-object flush that would also recompile with/
+   without `-fvisibility=hidden` correctly — but this deserves an explicit check, not
+   an assumption).
+
+Do these together, or `-fno-semantic-interposition` alone first as the lower-risk,
+zero-coexistence-hazard step. Neither has been touched by #560/#562/#567 (those were
+SIMD-selection and per-SoC `-mcpu`/`-O3` fixes, a completely different axis).
+
+### A1b. `classic_armv7_a7` already gets most of this benefit via LTO, and no other
+platform does
+
+`Makefile:219` (`CFLAGS += -flto=4 -fwhole-program -fuse-linker-plugin ...`) means GCC's
+IPA at LTO time already privatizes any symbol not visible from outside the linked
+program image — `-fwhole-program`'s documented effect — while still respecting the
+`default`-visibility attribute `RETRO_API` puts on `retro_*`, so that target likely
+already avoids most of the GOT/PLT tax described in A1, incidentally, as a side effect
+of a flag added for code-size reasons (`Makefile:919-926` discusses the size win, not
+this angle — so this exact benefit appears to be unrecognized/undocumented even for the
+one platform that already has it). This is worth a one-line comment addition, not a
+functional change. **Effort: S. Risk: none (docs only).**
+
+### A2. CONFIRMED — Android (`jni/Android.mk`) inherits **none** of the project's
+optimization flags: no `-O3`/`OPT_LEVEL`, no `-DNDEBUG`, no `-fomit-frame-pointer`,
+no `-fno-common`, no `WARNINGS` block
+
+**Evidence:** `jni/Android.mk:35` does `include $(CORE_DIR)/Makefile.common`, never
+`include $(CORE_DIR)/Makefile`. As established above, all `OPT_LEVEL`/`-DNDEBUG`/
+`-fomit-frame-pointer`/`-fno-common`/`WARNINGS`/`FLAGS`/`CFLAGS` assembly (`Makefile:1-975`)
+lives in `Makefile`, not `Makefile.common`. `jni/Android.mk:41` builds `COREFLAGS` from
+scratch: `-DINLINE="inline" -D__LIBRETRO__ $(INCFLAGS) $(BLITTER_SIMD_DEFINE)` — four
+things, none of which are an optimization level, `NDEBUG`, or any of the other flags
+this audit was asked to check. `jni/Application.mk` (2 lines) sets only `APP_ABI := all`
+— no `APP_OPTIM`, no `APP_CFLAGS`. So the Android build's `-O` level, whether `assert()`
+compiles to a no-op, frame-pointer/common-symbol behavior, and every `-W` choice are
+**entirely delegated to ndk-build's own toolchain defaults**, which the project makes
+no attempt to pin or verify. (I did not find `assert()` calls in the hot interpreter
+files — `grep -rn "assert(" src/tom/gpu.c src/jerry/dsp.c src/core/jaguar.c src/m68000/*.c`
+returned 0 hits, and `assert.h` is only pulled in via `src/m68000/sysdeps.h` — so the
+missing `-DNDEBUG` is likely low-consequence today, but it's one more implicit
+dependency on toolchain defaults that the rest of this Makefile goes out of its way to
+pin explicitly, e.g. `Makefile:70-99`'s whole `OPT_O3_PLATFORMS` mechanism exists
+*because* an implicit "last -O wins" default silently regressed `classic_armv7_a7` for
+years — issue #516, `Makefile:74`.)
+
+**Proposed change:** add an explicit, pinned optimization block to `jni/Android.mk`
+mirroring `Makefile`'s non-MSVC release branch — at minimum
+`-O3 -DNDEBUG -fomit-frame-pointer -fno-common` appended to `COREFLAGS`, plus
+per-ABI `-mcpu`/`-march` tuning analogous to the RPi table in
+`docs/agent/build.md:27-33` (e.g. `armeabi-v7a` → a NEON-capable Cortex baseline,
+`arm64-v8a` → generic `-march=armv8-a`, since unlike RPi, an Android ABI name does not
+identify silicon exactly — this needs the same care `docs/agent/build.md:37-44` gives
+the RPi 32-vs-64-bit `-mfpu`/`-mfloat-abi` split, i.e. don't blindly copy an RPi row
+onto an ABI that isn't that exact core). **Effort: S–M. Risk: LOW** (this is strictly
+additive — nothing currently sets these flags for Android, so there's no "last flag
+wins" conflict to navigate). **Impact: uncertain-but-plausible MED-HIGH** — I can't
+verify what `ndk-build`'s implicit default optimization level actually resolves to for
+release mode without invoking `ndk-build` (out of scope here), so treat the impact
+tier as an estimate, not a measurement; verify with `ndk-build V=1` dry output or
+equivalent before/after, then A/B on-device. **Mechanical enough for sonnet** to draft,
+but the per-ABI `-march` choice needs a design pass (same caution as the RPi table).
+
+### A3. `-Wno-strict-aliasing` is a *warning suppression*, not `-fno-strict-aliasing`
+— no live issue here, but flag it so nobody "fixes" a non-problem
+
+`Makefile:959` (`WARNINGS` block) has `-Wno-strict-aliasing` but **no** `-fno-strict-
+aliasing` anywhere in the tree (grepped `Makefile`+`Makefile.common`+`jni/Android.mk`,
+one hit total, the `-W` form). `-fstrict-aliasing` therefore stays at its `-O2`/`-O3`
+default (enabled) on every platform. This means the type-based-alias optimization
+*is* active; the codebase evidently has (or had) some type-punning that triggers the
+GCC warning, and the project chose to silence the warning rather than either fix the
+punning or disable the optimization — the more aggressive (and more dangerous) of the
+two options was correctly avoided. **No action needed; this closes off a plausible-
+looking but incorrect "dumb win."**
+
+### A4. `-DNDEBUG` / asserts — confirmed disabled in release on every non-Android,
+non-MSVC-debug platform
+
+`Makefile:828` (`FLAGS += $(OPT_LEVEL) -DNDEBUG`, the non-DEBUG/non-MSVC branch) and
+`Makefile:825-826` (MSVC branch, same). `assert()` is essentially unused in the hot path
+(see A2 above) so this is low-consequence either way, but it is correctly wired for
+every platform driven through `Makefile` — only Android (A2) misses it.
+
+### A5. PGO is structurally feasible; not attempted; the benchmark harness already
+gives a deterministic profiling workload
+
+`Makefile:2460-2482` (`benchmark:` target) drives `test/tools/test_benchmark` against
+`test/roms/jagniccc.j64` with **fixed** `BENCH_FRAMES=900`, `BENCH_WARMUP=300`,
+`BENCH_BLITTER=fast` — `Makefile.common`'s comment block above it (in `Makefile`,
+`:2412-2463`, not `Makefile.common` — corrected location) documents this ROM as "the
+only public ROM that exercises GPU, DSP, blitter and 68K in real proportion" and that
+warmup is load-bearing because `jagniccc` sits in BIOS boot for the first ~90 frames.
+This is exactly the deterministic, representative workload a two-pass
+`-fprofile-generate` / `-fprofile-use` PGO build wants. No `-fprofile-generate`/`-use`
+flags exist anywhere in the tree today (grepped, zero hits) and there is no
+`make pgo`-style target.
+
+**Proposed change:** a new `pgo` make target: (1) build with `-fprofile-generate`,
+(2) run `make benchmark` (or a small corpus of 2-3 ROMs spanning cart/CD/GPU-heavy/
+DSP-heavy, to avoid over-fitting the profile to one title), (3) rebuild with
+`-fprofile-use -fprofile-correction`, discarding the `.gcda` files from the release
+artifact. **Determinism note, addressed proactively because this codebase is unusually
+touchy about it (#400, #479, #517):** PGO does not itself introduce any run-to-run
+nondeterminism — it only changes which optimization decisions the compiler makes
+*ahead of time*, baked into the binary at build time; it has no runtime/floating-point-
+mode implications like `-Ofast`/`-ffast-math` did, so it does not reopen the #517 class
+of hazard. What it *does* require: profile data goes stale as the interpreter tables
+(`cpuemu.c`, `cputbl.h`) or hot loops change, so a stale profile silently regresses
+rather than erroring — this needs either CI regenerating profile data on every release
+tag, or an explicit staleness check. **Effort: M (new build-system machinery + corpus
+selection + staleness guard). Risk: MED (build complexity, not correctness — PGO
+binaries are still fully deterministic at runtime). Impact: MED-HIGH, unmeasured — PGO
+typically nets 5-15% on branch-heavy dispatch code like this interpreter, but that's a
+generic prior, not a measurement of this codebase.** This needs a design pass (which
+ROMs go in the training corpus, where `.gcda` artifacts live, how staleness is
+detected) before a mechanical implementation — **not sonnet-alone**, needs the same
+kind of protocol rigor #515/#517 already established for this repo.
+
+### A6. `-O3` rollout is essentially complete; nothing left here
+
+`Makefile:70-98` (`OPT_O3_PLATFORMS`) already covers `unix osx win ios-arm64 ios9
+tvos-arm64` plus all nine `rpi*` names (issue #516/#567, already merged per git log:
+`6624ef1 perf(build): per-SoC -mcpu and -O3 for every Raspberry Pi target`,
+`048f233 fix(test): make the tuning probe independent of the calling make's flags`).
+The generic `arm64`/`aarch64` platform block (`Makefile:334-339`) and the generic
+`armv*` block (`Makefile:417-430`) are **not** in `OPT_O3_PLATFORMS`, so they build at
+the `-O2` fallback (`Makefile:97`) — this is a real gap (a distro packaging a generic
+`platform=arm64` build gets `-O2`, not `-O3`) but it's a narrow one: every *named*
+concrete target (rpi*, ios, tvos, osx, unix, win) already has it, and the generic
+`arm64`/`armv*` blocks exist specifically as an escape hatch for unidentified silicon
+(see `Makefile:328-333`'s own comment about issue #560), where `-mcpu` tuning is
+deliberately withheld for the same "don't guess the SoC" reason `docs/agent/build.md`
+gives. Adding these two names to `OPT_O3_PLATFORMS` is a **one-line, S-effort, LOW-risk**
+follow-up (same measurement-transfers-by-ISA-family argument `Makefile:38-39` already
+uses to justify `osx`/`ios-arm64`/`tvos-arm64` from a single macOS arm64 measurement) —
+flagging it since the prompt asked specifically about missing `-O3`, but noting it's
+minor compared to A1/A2/A5. **Impact: LOW (narrow platform surface). Mechanical —
+sonnet can do this.**
+
+### A7. `-fno-stack-protector` / unwind-table trimming: only `classic_armv7_a7` has it
+
+`Makefile:221,223` (`-fno-stack-protector -fomit-frame-pointer` /
+`-fno-unwind-tables -fno-asynchronous-unwind-tables`) are `classic_armv7_a7`-only.
+`-fomit-frame-pointer` is separately applied globally (`Makefile:874`), but stack-
+protector and unwind-table trimming are not. **This is a real but genuinely double-
+edged tradeoff, not a pure "dumb win"**: stack-protector canaries are one of the few
+runtime mitigations standing between a maliciously crafted ROM/savestate that overflows
+a fixed-size buffer somewhere in the C emulation code and actual exploitation — removing
+it project-wide trades a small, unmeasured perf gain for a real (if narrow) hardening
+regression on a codebase that parses untrusted game data. **Recommend: do not blanket-
+apply; if pursued, scope it to the RPi/embedded targets only (where the security model
+is already "trusted single-user device," matching why `classic_armv7_a7` — an embedded
+console-clone target — already has it) and leave `unix`/`osx`/`android`/`ios` alone.**
+**Effort: S. Risk: MED (security tradeoff, needs an explicit decision, not silent).
+Impact: LOW-MED, unmeasured.**
+
+### A8. No `-DDEBUG`/logging leakage found in release
+
+Grepped for stray debug macros: only `DEBUG_PRESENTATION` (`Makefile:979-982`, opt-in,
+off by default) and `BLITTER_TRACE`/`BENCH_PROFILE`/`VJ_TRACE` (all opt-in via their own
+`=1` flags, already gated correctly per `Makefile.common:123-165`). `VJT_WATCH_RD`
+(`src/core/vjtrace.h:323` vs `:342`) compiles to a true no-op
+(`do { } while (0)`) when `VJ_TRACE` is undefined, i.e., in every production build —
+verified directly, this is not a hidden per-access cost in the shipped binary. **No
+action needed.**
+
+---
+
+## PART B — 68K core (brief, per profiles showing 0.7-2.6% of frame time)
+
+1. **Memory access: direct C dispatch via a chain of address-range `if`/`else if`
+   comparisons, not a jump table, not function-pointer-per-access.**
+   `src/core/jaguar.c:500` (`m68k_read_memory_8`), `:548` (`_16`), `:595` (`_32`) each
+   do `address &= 0x00FFFFFF;` then a linear chain: main RAM (`0x000000-0x1FFFFF`)
+   checked **first** (the hottest case), then cart ROM (`0x800000-0xDFFEFF`), then
+   CD/TOM/JERRY/unknown. `m68kinterface.h:86-93` declares these as plain
+   `unsigned int m68k_read_memory_N(unsigned int)` — ordinary extern functions, called
+   directly from `inlines.h:85`'s `get_iword` macro, not through a vtable. This is
+   fine and standard for a UAE-derived core; RAM-resident code (the common case) is a
+   single range check away.
+
+2. **Instruction fetch fast path:** `inlines.h:85` `get_iword(o)` is literally
+   `m68k_read_memory_16(regs.pc + (o))` — every fetch re-enters the full read-dispatch
+   chain above (address mask + `M68K_BUS_CHARGE` + `M68KGPURAMSyncRead` + range check),
+   there is no separate "instruction fetch from a cached RAM/ROM pointer" fast path
+   distinct from data reads. Given the 0.7-2.6% frame-time budget this is very unlikely
+   to matter, but if it were ever revisited: a direct-pointer fast path for PC known to
+   be inside `jaguarMainRAM`/`jaguarMainROM` (recomputed only on branches, not every
+   fetch) is the standard UAE/Musashi optimization for this — **not proposing it**, out
+   of scope per the brief ("keep this brief," "no JIT/no core swap"), but noting it's
+   the one structural thing that *would* matter if 68K's frame-time share ever grew
+   (e.g. from a bug fix that makes more code path through this table).
+
+3. **`m68k_execute` per-instruction overhead** (`src/m68000/m68kinterface.c:144-216`):
+   each iteration does: one `regs.spcflags & SPCFLAG_DEBUGGER` check, one
+   `checkForIRQToHandle` check, one `regs.intLevel > regs.intmask &&
+   TOMIRQRequestActive()` check, a computed dispatch `(*cpuFunctionTable[opcode])(opcode)`,
+   and a plain 32-bit subtraction (`regs.remainingCycles -= cycles`, both `int32_t` —
+   **no 64-bit division anywhere in this loop**, confirmed by reading the full function
+   body). This is about as lean as a table-dispatch interpreter loop gets; nothing
+   "silly" here. IRQ is polled via cheap flag checks, not re-derived every instruction
+   from scratch.
+
+4. **`cpuFunctionTable[opcode]` dispatch** — confirmed, this is a plain indirect call
+   through a 65536-entry function-pointer table (`src/m68000/cpustbl.c`, machine-
+   generated), exactly what the brief said to treat as "fine." Linker dead-code
+   elimination for the unused second table (`op_smalltbl_4_ff`, "fast" but never bound)
+   is already handled — `Makefile:877-940`'s whole `GC_STYLE` block exists specifically
+   for this (issue #321, already shipped).
+
+5. **No compile-unit-specific flag divergence for the 68K files.** Grepped `Makefile`
+   for any `m68000`/`cpuemu` special-casing outside the `#321` dead-code-elimination
+   comment: none. `src/m68000/cpu*.c` and `read*.c` are C89-lint-exempt
+   (`docs/agent/build.md:74-77`, `scripts/c89-lint.sh::skip_file`) but that's a *lint*
+   exemption, not a compiler-flag one — they compile through the same generic
+   `%.o: %.c` rule (`Makefile:998-999`) with the same `$(CFLAGS)` as every other file,
+   confirmed by reading that rule directly. No stray `-O0`/`-fno-*` applied only to
+   this directory.
+
+6. **One real per-access cost worth naming, not fixing:** `M68K_BUS_CHARGE`
+   (`src/core/jaguar.c:447-451`) calls `bus_arbiter_m68k_access()` — a real function
+   call — on every memory access when `busArbiter.enabled`, for DRAM-timing accuracy
+   (the #337 cycle-domain contract). This is a deliberate accuracy feature, already
+   investigated and exonerated as a stutter cause per project memory
+   (`project_bus_contention_merge_plan`), and is explicitly out of scope here (not a
+   "dumb win," it's a correctness/perf tradeoff already made on purpose). Not proposing
+   a change; noting it exists so it isn't rediscovered as if new.
+
+7. **`GET16`/`GET32`/`SET16`/`SET32`** (`src/core/vjag_memory.h:75-79`): byte-by-byte
+   shift/OR composition from a `uint8_t*`, e.g. `GET32(r,a) = ((r[a]<<24)|(r[a+1]<<16)|
+   (r[a+2]<<8)|r[a+3])`. This is the standard portable big-endian-from-byte-array
+   idiom; modern GCC/Clang at `-O2`+ generally recognize it as a byte-swap-load and fold
+   it to a single load+`bswap`/`rev` (this pattern is explicitly idiom-matched by both
+   compilers' tree optimizers), and `unsigned char*` accesses are exempt from strict-
+   aliasing concerns, so A3's finding doesn't interact with this. **Not flagging as an
+   issue** — I have no evidence it doesn't fold correctly, and 68K's frame-time share is
+   too small for this to be worth an unverified change. If it ever mattered, the way to
+   check is `objdump -d` on `m68k_read_memory_32`'s ROM branch and see whether GCC
+   emitted a fused load+bswap or four separate byte loads+shifts — I did not do this
+   (no build allowed), so treat this item as "check before touching," not a finding.
+
+---
+
+## Summary of proposed changes by impact/effort
+
+| # | Change | Platforms | Impact | Effort | Risk | Who |
+|---|---|---|---|---|---|---|
+| A1-1 | `-fno-semantic-interposition` | unix, rpi*, arm64-generic, android, armv*-generic | MED-HIGH (unmeasured) | S | LOW | sonnet (mechanical), needs on-device A/B |
+| A1-2 | `-fvisibility=hidden` gated on `!TEST_EXPORTS` | same as above | MED-HIGH (unmeasured) | M | LOW-MED | design review, then sonnet |
+| A2 | Pin `-O3 -DNDEBUG -fomit-frame-pointer` (+per-ABI `-march`) in `jni/Android.mk` | android | MED-HIGH (estimate) | S-M | LOW | sonnet, ABI-tuning part needs review |
+| A5 | PGO via existing `make benchmark` harness | unix, rpi*, android (any GCC/Clang ELF target) | MED-HIGH (generic prior, unmeasured) | M | MED (build complexity) | needs design (corpus, staleness), not sonnet-alone |
+| A6 | Add generic `arm64`/`armv*` to `OPT_O3_PLATFORMS` | generic arm64/armv builds only | LOW (narrow surface) | S | LOW | sonnet |
+| A7 | `-fno-stack-protector`/unwind trimming, RPi-scoped only | rpi* only, deliberately not global | LOW-MED (unmeasured) | S | MED (security tradeoff — needs an explicit yes/no, not silent) | needs a decision, then sonnet |
+| A1b | Doc comment: classic_armv7_a7's existing LTO already gets most of A1's benefit | docs only | n/a | S | none | sonnet |
+
+Nothing in Part B is being proposed — the 68K interpreter's dispatch, memory-access
+chain, and per-instruction loop are all structurally sound for a table-dispatch
+interpreter, and its 0.7-2.6% frame-time share means even a real inefficiency there
+wouldn't move the needle versus GPU/DSP/blitter work. Already-shipped/decided-against
+items **not** re-proposed here: `-ffast-math`/`-Ofast` globally (#517, rejected,
+measured ~0%), SIMD/NEON selection (#560/#562, fixed), per-SoC `-mcpu`/`-O3` for named
+RPi targets (#567, merged), linker dead-code elimination for the unused 68K "fast" table
+(#321, shipped), `-Wno-strict-aliasing` "fix" (A3 above — not a real issue).

--- a/docs/perf-audit/bus-frame.md
+++ b/docs/perf-audit/bus-frame.md
@@ -1,0 +1,348 @@
+> Raw sub-agent audit output (2026-08-22, read-only, sonnet). Line numbers refer to
+> `libretro/develop` @ 5f898da. Verified items are promoted to [`../perf-audit-2026-08.md`](../perf-audit-2026-08.md);
+> treat anything here that is NOT in that file as unverified.
+
+# Read-only perf audit: bus/memory-map, event scheduler, frame loop, TOM, OP
+
+Scope: src/core/jaguar.c, src/core/event.c, src/core/bus_arbiter.{c,h}, src/core/vjag_memory.h,
+src/core/perf_iface.h, src/core/crash_detect.c, src/core/vjtrace.h, src/tom/tom.c, src/tom/op.c,
+src/m68000/m68kinterface.c (only the instruction-hook call site). Repo:
+virtualjaguar-libretro, worktree `.claude/worktrees/alien-predator-save-state-ad621b`, branch
+`perf/560-rpi-soc-tuning`. All findings are grounded in lines actually read; no edits made.
+
+A large amount of this territory has already been investigated by concurrent/prior sessions today
+(per claude-mem observations attached to these files) — #540/PR#542 (M68KInstructionHook register
+capture), #520 (interpreter dispatch/context threading ruled out), #517 (fast-math FP audit),
+#560/PR#562/PR#567 (RPi SIMD + per-SoC -mcpu/-O3, the branch this worktree is on). I've tried not to
+re-propose that work; where I re-examined something already covered I say so and give the delta.
+
+---
+
+## 1. Memory dispatch (bus decode)
+
+**Structure is already good.** Both the UAE-facing fast path (`m68k_read/write_memory_{8,16,32}`,
+jaguar.c:500-921) and the general-purpose path (`JaguarRead/WriteByte/Word/Long`, jaguar.c:954-1181)
+are plain if/else ladders (no jump table, no page table), but the ladders are already ordered
+correctly: main RAM ($0-$1FFFFF) is checked first in every one of the 6 functions, cart ROM
+($800000+) second. That's the right order — RAM and ROM dominate 68K traffic (instruction fetch +
+stack + most data). No reordering opportunity found.
+
+**Finding 1.1 — bus dispatch functions are all extern/non-static, and only one build target gets
+LTO.** `JaguarReadByte/Word/Long`, `JaguarWriteByte/Word/Long` (jaguar.c:954,988,1020,1074,1122,1147)
+and `m68k_read/write_memory_*` (jaguar.c:500-921) are called from every other subsystem
+(src/tom/tom.c, src/tom/op.c via `OPLoadPhrase`/`OPStorePhrase`, src/tom/gpu.c, src/jerry/dsp.c,
+src/jerry/jerry.c, blitter, CD/CDROM) as ordinary extern C functions. Grep of Makefile: only the
+`classic_armv7_a7` target sets `-flto=4 -fwhole-program -fuse-linker-plugin` (Makefile:219,
+comment at 920-924 confirms LTO measurably shrinks that target's binary, "22.7% on non-LTO ld64").
+None of the `rpi*` targets (the ones just tuned in PR #567 on this very branch), the generic Linux
+`unix` target, tvOS/iOS, or Android set LTO. That means on every non-classic_armv7_a7 target, the
+hottest cross-cutting functions in the whole emulator — the ones every processor's every memory
+access funnels through — cannot be inlined at their call sites; every access pays a real
+non-inlined call (and on ARM, argument marshalling + branch-and-link + return) on top of whatever
+work the function does.
+- Why it costs on in-order ARM: no speculative/OoO execution to hide call latency; a mispredicted
+  or even correctly-predicted BL/BLR still costs pipeline bubbles the compiler could have removed
+  by inlining a 10-branch if-ladder into the caller (which itself typically already knows or can
+  narrow the address range, e.g. OP phrase fetches are almost always RAM).
+- Proposed change: enable `-flto` (or GCC's `-flto=N -fuse-linker-plugin`) on the rpi* targets and
+  the generic unix/Linux target, matching what classic_armv7_a7 already does. Needs a full
+  `make TEST_EXPORTS=1 test` + acid pass afterward (LTO can expose latent C89 UB / missing
+  `extern`/visibility issues that never bit non-LTO builds) and a binary-size/build-time check.
+- Impact: MED-HIGH, unsure without measurement — these are the single most-called functions in the
+  core, so even a few cycles/call compounds across millions of calls/sec, but the actual win
+  depends heavily on how much the compiler can already do at each call site.
+- Risk: LOW-MED for the compiler flag itself (pure codegen), but MED to validate — LTO can surface
+  ODR/visibility bugs that were previously masked.
+- Effort: S to flip the flag, M to validate (needs the acid suite + a real RetroArch smoke test on
+  device, not just host).
+- Sonnet-doable for the flag flip + build verification; a human/Opus call is needed only if LTO
+  regresses correctness and someone has to bisect which TU triggered it.
+
+**Finding 1.2 — `M68K_BUS_CHARGE` / `bus_arbiter_m68k_access` per-access cost is real but opt-in
+only, so default-path impact is ~zero.** jaguar.c:447-451 gates the whole dram_timing charge on
+`busArbiter.enabled`, which defaults to 0 (`bus_arbiter_init`, bus_arbiter.c:65) and is only turned
+on by the `virtualjaguar_dram_timing` core option. When on, every 68K access pays a real
+non-inlined call into `bus_arbiter_m68k_access` (bus_arbiter.c:136-185: a handful of range
+compares in `bus_arbiter_dram_cost` plus carry arithmetic) on top of the base bus dispatch. Not a
+new finding to act on — already correctly gated, and the model itself is already documented as
+"contention_scale... settable only via VJ_DRAM_SCALE... while the correct physical cost... is
+being pinned down" (bus_arbiter.h:113-117), i.e. known WIP. No action recommended; flagging only
+because the task asked for the per-access cost. Impact: LOW (opt-in, off by default). 
+
+**Finding 1.3 — `M68KGPURAMSyncRead`/`M68KGPURAMSync` do 2 range checks on every 68K read/write.**
+jaguar.c:483-498 and 671-681. Cheap (2 compares, static function, almost certainly inlined into
+its 6 call sites even without LTO since it's same-TU), correctly structured to early-exit before
+touching GPU/DSP state on the overwhelming majority of accesses that don't touch RISC-local RAM.
+No change proposed — this is the mailbox-handshake mechanism from issues #406/#456/#138 and is
+already minimal for what it does.
+
+---
+
+## 2. Event scheduler (src/core/event.c) — the real find in this section
+
+**Finding 2.1 — two 32-slot linear-scan event lists, touched 3-4x per dispatched event, dispatched
+~1,500-2,500+ times per field.** `EVENT_LIST_SIZE` is 32 (event.c:22), duplicated into
+`eventList[32]` (EVENT_MAIN) and `eventListJERRY[32]` (EVENT_JERRY). Every iteration of
+`JaguarExecuteNew`'s `do {} while(!frameDone)` loop (jaguar.c:1683-1752) calls:
+  - `GetTimeToNextEvent(EVENT_MAIN)` — scans all 32 slots (event.c:172-179)
+  - `GetTimeToNextEvent(EVENT_JERRY)` — scans all 32 slots (event.c:185-192)
+  - `SubtractEventTimes(timeDelta, <other list>)` — scans all 32 slots, unconditional subtract,
+    no `valid` check by design (event.c:242-255, comment at 210-211/228-229 explains the tradeoff)
+  - `HandleNextEvent(<chosen list>)` — scans all 32 slots to decrement (event.c:199-239), then
+    dispatches one callback
+  That's 4×32 = 128 struct-element touches per outer-loop iteration, not counting the callback
+  itself. Re-arming a callback (`SetCallbackTime`, event.c:74-112) adds an early-exit linear scan
+  for a free slot on top, called once per dispatched event.
+- How many outer-loop iterations per field: each iteration corresponds to exactly one dispatched
+  event, so the count is the sum of all EVENT_MAIN + EVENT_JERRY callback firings per field.
+  Confirmed from callers: `HalflineCallback` re-arms itself every `JaguarGetHalflinePeriodUs()`
+  (jaguar.c:1358, ~63.6us NTSC) → 524/field on EVENT_MAIN. On EVENT_JERRY,
+  `JERRYI2SCallback` re-arms at `22.675737` us fixed (src/jerry/jerry.c:383) → ~735/field, and
+  `DSPSampleCallback` re-arms at the I2S sample period (src/jerry/dac.c:329, comment at dac.c:23-24
+  says "fires at 48 kHz") → ~800/field, plus JERRYPIT1/2 and UART when a game uses them. Total is
+  in the range of ~1,500-2,000+ event dispatches per field for a title doing audio, i.e. roughly
+  190,000-256,000 struct-element touches per field just in scheduler bookkeeping, before any
+  emulation work happens.
+- Why it costs on in-order ARM: `struct Event` is `{bool, int, double, void(*)(void)}`, likely
+  24 bytes with padding — a linear scan through contiguous memory is cache-friendly, but the
+  stride between the `double` fields defeats simple auto-vectorization (non-unit stride gather),
+  so this is very likely a plain scalar loop: load-compare-branch or load-subtract-store per slot,
+  32 times, 4 times, ~2000 times/field. On a Cortex-A7/A53-class in-order core with no branch
+  predictor depth to spare, ~2000 × 128 = ~256,000 branchy scalar iterations/field is a
+  non-trivial, currently-unmeasured tax that scales with the EVENT_LIST_SIZE constant rather than
+  with the number of *actually active* events (typically well under 10 at once).
+- Proposed change (pick one, ascending effort): (a) cheapest — track `numberOfEvents` per-list
+  (the code already has a combined `numberOfEvents` at event.c:48, just needs splitting) and give
+  `SubtractEventTimes`/`HandleNextEvent`'s "touch every slot" loops an early-exit once they've
+  processed `numberOfEvents` valid ones — helps only if valid slots cluster near the front, which
+  they mostly will if `SetCallbackTime` is changed to fill low indices preferentially (it already
+  does, since it scans from 0). (b) proper fix — replace the two 32-slot arrays with a compact
+  packed array of only the live events (swap-remove on completion) so the scan length equals the
+  actual active-event count (typically 3-8), not 32. (c) most invasive — a small binary
+  min-heap keyed on eventTime, turning `GetTimeToNextEvent` into O(1) and insert/remove into
+  O(log n); probably overkill at n<10.
+- Impact: MED, genuinely unsure without a profile — the work per element is small, but the
+  iteration count (thousands/field × 128) is large enough that I'd want this measured (e.g. via
+  the existing BENCH_PROFILE perf counters, or wall-clock A/B) before calling it HIGH or LOW.
+  This is the single largest *unexamined* candidate this audit turned up.
+- Risk: LOW-MED for (a)/(b) — pure refactor of an already-isolated module with existing savestate
+  serialization (`EventStateSave/Load`, event.c:307-393) that would need to keep working
+  (compaction changes slot *indices*, which the callback-ID-based savestate format
+  (event.c:271-304) is actually robust to, since it doesn't serialize slot identity semantics
+  beyond array position — would need care but the format already tolerates reordering since it
+  saves/restores by position, not by a stable ID other than the callback pointer). (c) is MED risk
+  (a heap is easy to get subtly wrong, and savestate format would need a bigger rework).
+- Effort: S for (a), M for (b), M-L for (c).
+- Sonnet-doable for (a)/(b) with a clear spec and the existing `test/` savestate/event tests as a
+  correctness gate; (c) would benefit from a design pass first.
+
+---
+
+## 3. Frame loop (`JaguarExecuteNew`, jaguar.c:1683-1752)
+
+Already well-shaped: one event-driven `do/while`, GPU/DSP slice budgets handed out once per
+iteration (`GPUBeginSlice`/`DSPBeginSlice`), `M68KExecuteWithStalls` runs the 68K, `GPUExec`/
+`DSPExec` run only the slice remainder not already consumed inline via `GPUSyncToM68K`/
+`DSPSyncToM68K`. No redundant per-halfline work found beyond what's already discussed in §2 (the
+loop's *iteration count* is the cost, not extra work inside each iteration). `PERF_INC`/`PERF_ADD`
+(perf_counters.h) are BENCH_PROFILE-only (compiled out in shipping builds) — confirmed by their
+use pattern matching other PERF_COUNTER sites; not re-verified against the header since it's out
+of scope, but no evidence of a stray always-on counter in this loop.
+
+**Finding 3.1 — `HalflineCallback` (jaguar.c:1272-1359) does 2 TOM register round-trips
+(`TOMReadWord`, `TOMWriteWord`) plus a full `TOMExecHalfline` call on every halfline, including the
+odd ones that do nothing but light-gun bookkeeping.** This is correct/expected — VC has to advance
+every halfline per JTRM, and `TOMExecHalfline` already early-returns after `TOMLightgunHalfline`
+for odd halflines (tom.c:1519-1520, see §4). Not flagging as a problem; noting I checked it because
+the task asked "anything done per-halfline that could be per-frame" and the answer here is no —
+VC/HC advancement and the OP's even/odd gating are genuinely per-halfline hardware behavior.
+
+**Finding 3.2 — `GPUSyncToM68K`/`DSPSyncToM68K` early-out is a single flag check.**
+`GPUSyncToM68K` (src/tom/gpu.c:1393-1401) returns immediately if `!GPU_RUNNING || halted ||
+gpu_in_exec` before doing any of the cycle-domain math. Combined with the 2-range-check gate at the
+call site (Finding 1.3), a 68K access that doesn't touch GPU/DSP RAM and a halted GPU/DSP both cost
+only a few branches. This matches the task's ask ("cheap early-out before any bookkeeping") — yes,
+it already has one. No action proposed.
+
+---
+
+## 4. TOM video (src/tom/tom.c)
+
+**Already table-driven, not computed per pixel.** `CRY16ToRGB32[0x10000]`, `RGB16ToRGB32[0x10000]`,
+`MIX16ToRGB32[0x10000]` (tom.c:463-465) are filled once in `TOMFillLookupTables` (tom.c:622-649,
+called once from `TOMInit`, tom.c:1616-1621) and every scanline renderer
+(`tom_render_16bpp_cry_scanline` etc., tom.c:787-1382) does a straight LUT index per pixel — no
+per-pixel arithmetic conversion, no per-pixel function call in the 1x path. `TOMExecHalfline`
+(tom.c:1469-1613) is a single early-return for odd halflines (line 1519-1520) before any OP/render
+work, which is the correct place for that gate.
+
+**Finding 4.1 — line-buffer BG clear is a byte-at-a-time loop, only when BGEN is set.**
+tom.c:1541-1547:
+```c
+uint8_t * current_line_buffer = (uint8_t *)&tomRam8[0x1800];
+uint8_t bgHI = tomRam8[BG], bgLO = tomRam8[BG + 1];
+if (GET16(tomRam8, VMODE) & BGEN)
+   for(i=0; i<720; i++)
+      *current_line_buffer++ = bgHI, *current_line_buffer++ = bgLO;
+```
+1440 individual byte stores, run once per *rendered* halfline (i.e. once per output scanline, up
+to ~240-256/field for a typical display area) whenever the title has BGEN set in VMODE.
+- Why it costs: byte stores instead of a widened (16-bit pattern) or `memset`-style fill; on a
+  simple in-order core this is still just a tight store loop the compiler *may* auto-vectorize
+  (constant trip count, no aliasing hazard since bgHI/bgLO are locals) — I did not verify the
+  actual generated code, so I can't say whether this is already free.
+- Proposed change: replace with a 16-bit store loop (`SET16` per iteration, 720 iterations instead
+  of 1440 byte stores) or, when `bgHI == bgLO`, a plain `memset`. Mechanical, low-risk.
+- Impact: LOW-MED, unsure — only fires when BGEN is set (not all titles use it) and only 1440
+  bytes/line; worth a quick compiler-explorer/objdump check before spending effort here, since a
+  modern `-O3 -mcpu=...` build may already turn this into a wide store.
+- Risk: LOW (pure output-identical rewrite, no semantic change if `bgHI`/`bgLO` composition into a
+  16-bit store matches the existing byte order — needs a byte-order check since the code writes
+  hi then lo explicitly, i.e. it's already big-endian-explicit, not a `SET16` macro call, so the
+  replacement must preserve that exact byte order).
+- Effort: S. Sonnet-doable mechanically, with the acid/framebuffer A/B tests as the correctness
+  gate (must be pixel-identical to the byte-loop version).
+
+**Finding 4.2 — hi-res (Nx) renderers are separate, gated code paths (`shadowHiresActive`), not
+touched by 1x users.** Confirmed by reading `tom_render_16bpp_cry_scanline_hires` (tom.c:916-1021):
+the extra per-subpixel work (shadow tag lookups, `replActive` hoisted out per the comment at
+tom.c:930-933) only runs when the hi-res enhancement is on. Not a default-path finding; no action.
+
+---
+
+## 5. Object Processor (src/tom/op.c)
+
+**Finding 5.1 — `OPObjectExists`/`OPDiscoverObjects` O(N²) is NOT a per-frame cost; it runs once,
+at emulator teardown.** op.c:319-331 (`OPObjectExists`, linear search, comment at line 323
+"Yes, we really do a linear search, every time") is only called from `OPDiscoverObjects`
+(op.c:334-369), whose only caller is `OPDone()` (op.c:310-316), whose only caller is `TOMDone()`
+(tom.c:1627), which is called once from `JaguarDone()` (jaguar.c:1593-1601) at core shutdown —
+confirmed via `grep -rn OPDone\b` / `grep -rn OPDiscoverObjects\b` across `src/`, only hits in
+op.c/op.h/tom.c. **This corrects the framing in the task brief and (per source comments) issue
+#123: the O(N²) object-list walk is not "~1% of frame time," it is 0% of frame time — it never
+runs during gameplay at all.** No action needed; flagging so nobody re-optimizes a cold path.
+
+**Finding 5.2 — the per-halfline object-list walk (`OPProcessList`, op.c:476-776) is a straight
+switch on 5 object types, each O(1) plus one/two phrase fetches (`OPLoadPhrase` →
+`JaguarReadLong` ×2) per object.** No unexpected per-object overhead found: the loop is bounded by
+`OP_RUNAWAY_GUARD_OBJECTS` (op.c:479, 771-774) so a malformed/huge list can't run away. The
+`OBJECT_TYPE_GPU` case (op.c:654-698) genuinely does need to run the GPU inline (that's the
+documented #406/#354-adjacent hardware behavior — the OP halts until the GPU releases it) and
+already has a bounded guard (`OP_GPU_RELEASE_GUARD_CYCLES`) and an early-out for games that never
+enabled GPU IRQ3 (`GPUOPInterruptEnabled()`, op.c:685-686) so it doesn't burn cycles needlessly.
+No change proposed here.
+
+**Finding 5.3 — bitmap pixel loops (`OPProcessFixedBitmap`, op.c:780-1240; sampled the 8bpp case at
+op.c:1074-1126 and 16bpp at op.c:1127-1190+) are already function-call-free per pixel in the
+default (non-shadowfb/non-hires) path.** Transparency (`flagTRANS`) and read-modify-write
+(`flagRMW`) checks are per-pixel branches (unavoidable — they're genuinely per-pixel hardware
+state), but the actual write is a direct store or a `BLEND_Y`/`BLEND_CR` macro (LUT-backed,
+`op_blend_y[0x10000]`/`op_blend_cr[0x10000]`, op.c:67-68), not a function call.
+`ShadowFBLineFromRAM`/`ShadowHiresLineFromRAM` (op.c:1168-1180) are called per-pixel but only when
+`shadowFBActive`/`shadowHiresActive` — both off by default, so the stock path never pays for them.
+No action proposed; this matches the pattern already established in tom.c (LUTs, hoisted flags).
+
+---
+
+## 6. crash_detect.c / vjtrace.c / perf_iface.h — release-build cost
+
+**Finding 6.1 — `vjtrace` is fully compiled out of shipping builds.** `VJT_WATCH_RD`/`VJT_WATCH_WR`/
+`VJT_EMIT` are `do {} while(0)` unless `VJ_TRACE` is defined (src/core/vjtrace.h:321-323 vs
+340-342), and `VJ_TRACE` is only added to `CFLAGS` when `TEST_EXPORTS=1` (Makefile:158-165) — i.e.
+only `make test`, never a normal `make` or a RetroArch-shipped core. Every `VJT_WATCH_*` call site
+sprinkled through jaguar.c's memory dispatch (§1) costs literally zero instructions in a release
+build. Confirmed, not previously stated as fact in this file's own header comment ("body is
+entirely #ifdef'd out, so there is zero cost" — vjtrace.h:6) but I verified the Makefile gating
+myself rather than trusting the comment. No action needed.
+
+**Finding 6.2 — `crash_detect` defaults to ON (`virtualjaguar_crash_detect` = "enabled" in
+libretro_core_options.h:226) and runs once per *frame* (called from top-level `libretro.c:5548`,
+outside this audit's file scope but the call site is what determines "once/frame" vs "once/
+instruction"), not per instruction or per halfline.** Its cost is bounded and small:
+`fb_hash` (crash_detect.c:207-227) deliberately samples 256 evenly-spaced pixels
+("costs 256 ops per frame" per its own comment at line 208, verified against the loop at 221-225
+which steps by `total/256`), everything else in `CrashDetectFrameTick` (crash_detect.c:396+) is
+O(1) counter/threshold comparisons. Confirmed cheap; no action needed. This directly answers the
+task's question ("is it on by default and what does it cost") — yes/on, and ~256 ops + O(1)/frame.
+
+**Finding 6.3 — `perf_iface.h`'s ~2,000 probes/frame are already documented as negligible by the
+header's own design-rationale comment (lines 17-38), which I verified rather than took on faith**:
+off (`vjPerfActive==0`, RetroArch declines or has `perfcnt_enable` off) costs one
+predicted-not-taken branch per probe; on, it's a real indirect call/probe (~2,000/frame) but at
+"slice" granularity (once per halfline/blit/event-loop-step, never per instruction), which the
+comment itself calls "negligible." I found nothing in jaguar.c/tom.c/op.c that contradicts this —
+probe sites are all at function-entry/exit of frame-loop-shaped functions, not inner loops.
+
+---
+
+## 7. Threading feasibility (design assessment, not code-level findings)
+
+The architecture is fundamentally hard to parallelize safely because of how tightly the four
+"processors" are coupled *within* a single scheduler slice, not just at frame boundaries:
+
+- **(a) Audio mixing/resampling of already-produced DSP output.** This is the only candidate with
+  a genuinely decoupled producer/consumer shape already in the code: `DSPSampleCallback`/
+  `DACWordStrobe` (src/jerry/dac.c:213-330ish) capture I2S samples into a ring buffer
+  (`i2sRingL`/`i2sRingR`) during the interleaved event loop, and `DACPrepareFrame`/`SoundCallback`
+  (dac.c:332,376) do the linear-interpolation resample from ring to output buffer once per frame,
+  reading only already-finalized samples. **However**, the actual resample work is small (on the
+  order of a few hundred samples/frame of linear interpolation — cheap, memory-bound), and
+  `audio_batch_cb` is a frontend callback that the libretro API contract expects to be invoked
+  from the same thread as `retro_run` (RetroArch is not documented/tested to accept it from a
+  worker thread). Feasibility: the *compute* part could move to a worker thread that finishes
+  before the (still-synchronous) `audio_batch_cb` call, but the work is likely too small for the
+  thread-wake/join overhead to pay for itself on a weak in-order core. Verdict: technically safest
+  candidate, but LOW expected payoff — not recommended without a profile showing the resample loop
+  itself is actually hot (I doubt it is).
+- **(b) Framebuffer format conversion / hi-res upscaling on another thread.** Not separable as the
+  code is structured today: CRY/RGB16→XRGB8888 conversion happens *inline*, pixel-by-pixel, during
+  `TOMExecHalfline`'s scanline render (§4) — there is no distinct "raw Jaguar framebuffer" that
+  gets converted in a second pass; the conversion *is* the render. Making this threadable would
+  require restructuring TOM to render into an intermediate CRY/16bpp buffer and adding a real
+  post-process conversion pass, which is a bigger architecture change than "make an existing pass
+  threaded." Feasibility: MED-effort, MED risk (savestate/run-ahead correctness has to account for
+  a buffer that isn't XRGB8888-final at the point a state is captured); not something I'd recommend
+  without a separate design pass.
+- **(c) DSP on its own thread with lock-stepped sync.** Not recommended. `M68KGPURAMSyncRead`/
+  `M68KGPURAMSync` (jaguar.c:483-498, 671-681) force a synchronous GPU/DSP catch-up on *every* 68K
+  access that falls in GPU/DSP local RAM — which includes ordinary mailbox polling loops, i.e.
+  this can fire many times per halfline, not just at frame boundaries. Cross-thread synchronization
+  at that granularity (a mutex/futex signal potentially multiple times per halfline, ×524
+  halflines/field) would almost certainly cost more in wake/signal latency than serial execution
+  saves, on top of turning a currently-deterministic instruction-interleaved model into one where
+  determinism (needed for run-ahead and netplay-class savestate replay) depends on thread
+  scheduling order unless a full lock-step barrier is added at every sync point — which then is no
+  longer meaningfully "threaded" (all real work still serializes on the barrier). Verdict: not
+  feasible without a fundamentally different coupling model between 68K and DSP; out of scope for
+  an incremental change.
+- **(d) OP rendering pipelined against the next scanline.** `OPProcessList` writes the *current*
+  halfline's line buffer, which is then read by the scanline renderer later in the *same*
+  `TOMExecHalfline` call (tom.c:1549 write, 1587-1593 read) — no double-buffering exists today.
+  Complicating factor: `OPProcessList`'s `OBJECT_TYPE_GPU` case (op.c:654-698) runs the GPU inline
+  and mutates shared GPU state, so pipelining "OP for halfline N+1" against "TOM render of halfline
+  N" on separate threads would race on GPU state for any title using GPU objects (Primal Rage,
+  per the comment at op.c:660-673, is a real example). Feasibility: only safe for the no-GPU-object
+  common case, which would need runtime detection and a fallback to serial — MED-HIGH effort for
+  LOW clearly-demonstrated payoff (the OP/TOM per-halfline work is already cheap per §4/§5). Not
+  recommended.
+
+**Overall threading conclusion:** the emulator's determinism/accuracy model depends on fine-grained
+(sub-halfline) synchronous interleaving between 68K/GPU/DSP, which is the opposite of what's needed
+for cheap thread parallelism. The one clean producer/consumer boundary that exists (audio resample)
+doesn't have enough work in it to be worth the synchronization cost. I'd deprioritize threading
+entirely for this subsystem area and focus perf effort on the sequential-cost findings above
+(§1.1 LTO, §2 event scheduler) instead.
+
+---
+
+## Summary table
+
+| # | Finding | File:line | Impact | Risk | Effort | Sonnet-OK |
+|---|---|---|---|---|---|---|
+| 1.1 | Bus dispatch fns non-static, no LTO on rpi*/unix targets | jaguar.c:500-1181; Makefile:219 | MED-HIGH (unsure) | LOW-MED | S(flag)/M(validate) | Yes, w/ human sign-off on acid results |
+| 2.1 | Event scheduler O(32) linear scans ×4, ~1.5-2k dispatches/field | event.c:74-255; jaguar.c:1683-1752 | MED (unsure) | LOW-MED | S-M | Yes |
+| 4.1 | BG line-buffer clear is byte-at-a-time | tom.c:1541-1547 | LOW-MED (unsure) | LOW | S | Yes |
+| 1.2 | dram_timing per-access call | bus_arbiter.c:136-185 | LOW (opt-in, off by default) | n/a | n/a | n/a — no action |
+| 5.1 | OP O(N²) is a myth for perf purposes — teardown-only | op.c:319-369; tom.c:1627 | NONE | n/a | n/a | n/a — no action, just a correction |
+| 6.1-6.3 | vjtrace/crash_detect/perf_iface all already cheap by design | see §6 | NONE | n/a | n/a | n/a — no action |
+| 7 | Threading: only (a) audio is safe, and it's too small to bother; (b)-(d) unsafe or too invasive | design-level | — | — | — | — |

--- a/docs/perf-audit/device-profiling.md
+++ b/docs/perf-audit/device-profiling.md
@@ -1,0 +1,189 @@
+> Raw sub-agent audit output (2026-08-22, read-only, sonnet). Line numbers refer to
+> `libretro/develop` @ 5f898da. Verified items are promoted to [`../perf-audit-2026-08.md`](../perf-audit-2026-08.md);
+> treat anything here that is NOT in that file as unverified.
+
+# Audit: is the existing device-perf tooling enough to find hot FUNCTIONS on an A10X iPad, or do we need Instruments?
+
+Repo: `/Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro/.claude/worktrees/alien-predator-save-state-ad621b`
+RetroArch checkout: `/Users/jmattiello/Workspace/Provenance/RetroArch`
+Both read-only for this audit; nothing was built, edited, or deployed.
+
+---
+
+## 1. What the perf-counter path (`RETRO_ENVIRONMENT_GET_PERF_INTERFACE`) actually delivers
+
+**It is subsystem-level millisecond/tick totals only. It cannot attribute time to a function or a line, and it was never designed to.**
+
+Evidence:
+
+- `src/core/perf_iface.h` (lines 1-16, 89-99): 8 fixed slots (`VJP_M68K, VJP_GPU, VJP_DSP, VJP_GPU_SYNC, VJP_DSP_SYNC, VJP_OP, VJP_BLITTER, VJP_DAC`). Each slot brackets a whole *slice* — "one GPU execution span, every entry path", "one blit, whichever engine" — not a function or opcode. The header says outright: "every probe brackets a SLICE ... never an interpreter inner loop."
+- `src/core/perf_iface.c`: `VJPerfEnter`/`VJPerfLeave` just call the frontend's `perf_start`/`perf_stop` on a `struct retro_perf_counter`, i.e. two `clock`-style timestamps per span. No call-stack, no PC, no line info is captured — the counter is literally a name string + accumulated ticks + run count (`struct retro_perf_counter` in libretro.h).
+- `docs/profiling.md`, "The counters" table: 8 rows, one line each — `vj_gpu_exec` = "All GPU RISC execution, every entry path". You get "how much time GPU execution took in total", not "which opcode/branch in `GPUExec`/`executeOpcode` was expensive."
+
+So for the stated goal — hot **functions/lines** inside `GPUExec`/`executeOpcode` (`src/tom/gpu.c`), `DSPExec` (`src/jerry/dsp.c`), the blitter (`src/tom/blitter.c`), memory dispatch (`src/core/jaguar.c`) — the counter path answers "which of these ~8 buckets is expensive", not "which function/line inside the bucket". Getting finer would require adding new counter slots by hand for every candidate hot spot (the doc's "Adding a counter" section), which is a guess-and-recompile loop, not a profiler.
+
+**Known traps** (both documented in `docs/profiling.md` and re-stated verbatim as comments in `test/tools/device_perf.sh` lines ~17-45):
+
+1. **`perfcnt_enable` trap.** RetroArch's `runloop.c` always accepts registration (`vjPerfActive=1`), but gates `start`/`stop` and the final `perf_log()` behind its own `perfcnt_enable` setting. Off means every counter reads **zero**, indistinguishable from a broken core. `device_perf.sh cfg` exists solely to force `perfcnt_enable = "true"` into `retroarch.cfg` before capture.
+2. **Avg-not-total trap.** RetroArch's log format is `"[PERF] Avg (%s): %llu ticks, %llu runs.\n"` — an average, not a total. Ranking by the printed average inverts the real comparison (blitter: few, expensive calls; GPU: many, cheap ones — printed averages get the ranking backwards). `device_perf.sh report`'s awk parser explicitly multiplies `avg × runs` back into a total before ranking (`test/tools/device_perf.sh`, `cmd_report`).
+
+Two more caveats worth carrying forward: enabling counters costs ~2,000 extra indirect calls/frame (negligible per-slice but non-zero — don't compare counters-on vs counters-off for absolute speed), and the counters deliberately **overlap** (GPU cycles pulled inline into `vj_m68k_slice` via `GPUSyncToM68K`, and into `vj_op_halfline` via the Object Processor's inline GPU calls) — they are not a pie chart and `report`'s awk decomposes the nesting rather than summing it.
+
+**Can `device_perf.sh` target an iPad (iOS), not just tvOS?** Yes, iOS is a first-class, symmetric destination, not an afterthought:
+
+- `resolve_platform()` in `test/tools/device_perf.sh` (~line 96-113) has an explicit `ios|iOS` branch: `MK_PLATFORM=ios-arm64`, `DYLIB=virtualjaguar_libretro_ios.dylib`, `MODULES="$RA_DIR/pkg/apple/iOS/modules"`, `SCHEME="RetroArch iOS Release"`, `SDK=iphoneos`, `DEST_PLATFORM=iOS`.
+- `cmd_install`'s `xcodebuild -destination "platform=$DEST_PLATFORM,name=$DEVICE"` uses `DEST_PLATFORM` (the destination namespace `iOS`/`tvOS`), not the SDK name — a bug class this script explicitly guards against (see the comment in `resolve_platform`, and the sibling memory note `project_540...` / commit "fix(test): use the destination namespace, not the SDK name, for tvOS" in recent git log — same fix class applies symmetrically to iOS since it shares the same `resolve_platform` function).
+- `-d`/`--device` selection is device-name/UDID generic (`need_device()`), not platform-specific.
+- **Nothing obviously broken for iOS in the script text.** It is exercised in the codebase primarily through tvOS in the docs and the recent PR #563 (see `project_509_device_perf_capture` memory: "two SILENT RetroArch traps ... GPU RISC is ~74%, blitter ~17%; A10X still unavailable") — i.e., the iOS path is implemented but **the A10X capture itself has not actually been run yet** per that memory note. That's a "never exercised on the goal device" gap, not a code defect visible from reading the script.
+
+---
+
+## 2. What Instruments Time Profiler needs on device
+
+### (a) Core dylib
+
+- `make platform=ios-arm64 RELEASE_DEBUG_INFO=1` — confirmed this keeps **both** optimization and debug info:
+  - `Makefile` line ~91-97: for `platform=ios-arm64`, `OPT_LEVEL` defaults to `-O3` (it's in `OPT_O3_PLATFORMS`, Makefile line 70-71, "osx / ios-arm64 / ios9 / tvos-arm64 are that measurement plus the same clang and the same architecture", referencing the #515 macOS-arm64 -O3 measurement).
+  - `Makefile` line ~826-828 (`else: FLAGS += $(OPT_LEVEL) -DNDEBUG`) applies `-O3 -DNDEBUG` for the ios-arm64 release path.
+  - `Makefile` line ~833-841: `ifeq ($(RELEASE_DEBUG_INFO),1) ... FLAGS += -g` — appended on top, additively, with no `-O` override afterward. So the produced dylib is `-O3 -DNDEBUG -g`: optimized code with DWARF line/symbol info, i.e. exactly what Instruments needs for a representative-perf-but-symbolicated capture. (`-g` alone does not disable optimizations; it just keeps debug info describing the optimized code, with some inlining/variable-visibility loss that's normal for release-profiling and doesn't materially hurt function-level attribution.)
+  - The `ios-arm64` platform block itself (`Makefile` lines 278-290) sets `CC = cc -arch arm64 -isysroot $(IOSSDK)`, `MINVERSION = -miphoneos-version-min=8.0` (it's in the `ios9|ios-arm64` filter) — nothing there strips or alters debug info.
+  - **No `strip` or `dsymutil` call anywhere in `Makefile`** (grepped the whole file — the only hits are a comment about it and the unrelated `$(strip ...)` Make function). The core build produces a plain, unstripped `.dylib`; any stripping/dSYM generation is left entirely to downstream tooling.
+
+- **Is the dylib stripped later?** No, by neither of the two candidate steps:
+  - `pkg/apple/code-sign-cores.sh` (read in full) only runs `codesign --force --sign ...` over every `.dylib`/`.framework`/`.bundle` under `iOS/modules` or `tvOS/modules`. It does not strip symbols; codesigning a binary does not remove its symbol table or DWARF sections.
+  - `device_perf.sh cmd_install` calls `xcodebuild ... build` (not `archive`/`install`) on the `RetroArch_iOS13.xcodeproj` "RetroArch iOS Release" scheme. Xcode's copy/strip phase (`STRIP_INSTALLED_PRODUCT`, `DEPLOYMENT_POSTPROCESSING`) is **not set anywhere** in `project.pbxproj` for the RetroArch app target or at the project level (grepped the whole file: zero hits for `STRIP_INSTALLED_PRODUCT`, zero for `DEPLOYMENT_POSTPROCESSING`). Xcode's default is that `DEPLOYMENT_POSTPROCESSING` (which gates `STRIP_INSTALLED_PRODUCT`) only fires on an **install/archive** action, not a plain `build`/Run action — so a normal `xcodebuild build` or Xcode ▶ Run leaves the app's embedded frameworks/dylibs (including the injected core) unstripped. Corroborating: the project's own top-level Release config explicitly sets `COPY_PHASE_STRIP = NO` (`project.pbxproj` line 1888, in the project-level `96AFAE5316C1D4EA009DE44C /* Release */` config), and the RetroArch app target's own Release block (`9204BE2A1D319EF300BD49DB`) adds no override.
+  - The one `DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym"` hit in the whole `project.pbxproj` (line 1671) belongs to an unrelated helper target ("Rebuild assets.zip"), not the RetroArch app or the core. The app target has no explicit `DEBUG_INFORMATION_FORMAT`, so Xcode's built-in default applies (`dwarf-with-dsym` for Release configs on any reasonably modern Xcode) — meaning a Release build of the **app itself** does get a dSYM by default; the **core dylib**, built by our own `make`, does not, unless you explicitly run `dsymutil` on it (see recipe below).
+
+- **Can `dsymutil` produce a dSYM for the core, and will Instruments symbolicate it?** Yes to both, mechanically:
+  - `dsymutil path/to/virtualjaguar_libretro_ios.dylib -o virtualjaguar_libretro_ios.dylib.dSYM` builds the dSYM bundle straight from the unstripped, `-g`-built dylib's DWARF.
+  - Instruments/`xctrace symbolicate` matches purely by **Mach-O UUID** (`LC_UUID` load command), embedded at link time and identical between the shipped dylib and its dSYM as long as you don't rebuild/relink in between generating the two. As long as the dylib inside the `.app` bundle that's actually running on the iPad has the same UUID as the dSYM you hand Instruments (i.e., don't `make clean && make` again after `dsymutil` — that changes the UUID), Instruments resolves symbols for a `dlopen`'d dylib the same way it does for any other loaded image; there's nothing libretro/dlopen-specific that defeats this — Instruments/Time Profiler samples every loaded image in the target process, not just its main executable, and dSYM matching is opaque to how the image got mapped. Practical mechanism: put the dSYM in Xcode's "Symbols" search paths / next to the binary, or drag it onto the already-recorded trace.
+
+### (b) RetroArch app build for the actual profiling run
+
+- **Must it be Debug or Release?** Confirmed from the actual scheme file (`RetroArch_iOS13.xcodeproj/xcshareddata/xcschemes/RetroArch iOS Release.xcscheme`, read in full):
+  - `<ProfileAction buildConfiguration = "Release" ... >` — Xcode's Product ▶ Profile action on this scheme **always builds Release**, regardless of what the Run/Launch action is set to. This is exactly what you want: representative perf, not `-O0` debug-build numbers.
+  - `<LaunchAction buildConfiguration = "Release" ... selectedDebuggerIdentifier = "" ... runnableDebuggingMode = "0">` — even the normal Run action on this scheme launches Release with no debugger attached (`selectedDebuggerIdentifier=""`), so ordinary "Run" and "Profile" both give you Release-config, non-debugger-attached runs. Good: nothing about this scheme's config needs changing to get a valid profiling build.
+- **Does Release strip?** As established in 2(a): no — `COPY_PHASE_STRIP=NO` project-wide, no `STRIP_INSTALLED_PRODUCT`/`DEPLOYMENT_POSTPROCESSING` overrides, and Product ▶ Profile does a `build`-class action (via Instruments' own launch), not an archive/install, so the app and its embedded core dylib keep symbols.
+- **Does Instruments need the "Debug executable"/`get-task-allow` entitlement, i.e. a development-signed build on that device?** Yes, this is standard iOS/Xcode behavior (not something visible as a literal source line in this repo — none of the four `.entitlements` files under `pkg/apple/` (`RetroArch.entitlements`, `RetroArchAppStore.entitlements`, `RetroArchCg.entitlements`, `RetroArchiOS9.entitlements`) declare `get-task-allow` explicitly, because Xcode injects it automatically into the provisioning profile/signature at sign time whenever the app is signed with a **Development** (not Distribution/App Store/Ad Hoc/Enterprise) signing identity). Practically: the build must be run/installed to the iPad **from Xcode with your Apple Developer account's Development certificate** (which `device_perf.sh install` already does via `-allowProvisioningUpdates`, `DEVELOPMENT_TEAM = S32Z3HMYVQ` set on the tvOS extension target and `S32Z3HMYVQ`/`UK699V5ZS8` elsewhere in the project). A TestFlight/Ad-Hoc/enterprise-distributed build will refuse Instruments attach because it lacks `get-task-allow`.
+
+---
+
+## 3. Concrete step-by-step recipe
+
+### Build the symbolized core
+
+```bash
+cd /path/to/virtualjaguar-libretro
+# ios-arm64 SDK path resolves via xcodebuild, needs full Xcode (not CommandLineTools)
+make platform=ios-arm64 RELEASE_DEBUG_INFO=1 -j"$(getconf _NPROCESSORS_ONLN)"
+ls -la virtualjaguar_libretro_ios.dylib
+
+# dSYM from the freshly-built, still-unstripped dylib -- do this BEFORE
+# any further make/link touches the file, since dsymutil's match is by
+# Mach-O UUID and a relink changes it.
+dsymutil virtualjaguar_libretro_ios.dylib -o virtualjaguar_libretro_ios.dylib.dSYM
+```
+
+### Sign / inject into the RetroArch app
+
+```bash
+export VJ_RETROARCH_DIR=/Users/jmattiello/Workspace/Provenance/RetroArch
+test/tools/device_perf.sh doctor                 # confirm the iPad shows "connected" (not "unavailable")
+test/tools/device_perf.sh build   ios             # re-does the make above + build-identity assert
+test/tools/device_perf.sh install ios -d "<iPad name or UDID>"
+```
+`install` copies the dylib into `pkg/apple/iOS/modules`, runs `code-sign-cores.sh` (signing only, no stripping — see §2a), then `xcodebuild -scheme "RetroArch iOS Release" -destination "platform=iOS,name=<device>" build` to build+install the app itself.
+
+### Build + install RetroArch to the iPad from Xcode (equivalent, if doing it by hand instead of the script)
+
+1. Open `pkg/apple/RetroArch_iOS13.xcodeproj` in Xcode.
+2. Scheme selector (top bar): choose **"RetroArch iOS Release"**.
+3. Destination device selector: choose the physical iPad Pro (must show as trusted/connected, not "unavailable").
+4. **Product ▶ Profile** (⌘I) — this builds Release (per the scheme's `ProfileAction`, confirmed above), installs, and launches Instruments with a template picker.
+5. Choose the **Time Profiler** template.
+
+*Needs the user physically present*: unlocking/trusting the iPad the first time a Mac connects to it (an on-device "Trust This Computer?" tap), and starting/interacting with the actual gameplay in RetroArch once it launches under Instruments (loading the Jaguar ROM, navigating menus, playing). Everything else — build, sign, install, start/stop the trace — can be scripted or driven from Xcode without hands-on-device interaction.
+
+### Capture
+
+6. In Instruments' Time Profiler window, hit **Record** (red circle) if it didn't auto-start.
+7. On the iPad: load Virtual Jaguar core, load a ROM, play real gameplay for 20-30s (per the project's own guidance in `test/tools/device_perf.sh cmd_capture`: "not a menu, not an attract loop" — representativeness matters).
+8. Stop the recording (red square) in Instruments.
+
+### Read the results
+
+9. **Symbolication**: Instruments ▶ File ▶ Symbols (or the info panel) — point it at `virtualjaguar_libretro_ios.dylib.dSYM` if it isn't auto-found (Spotlight/dSYM search paths). Xcode auto-locates dSYMs it built itself (the app's own dSYM, via the default `dwarf-with-dsym` setting established in §2), but the **core's** dSYM was built by hand with the standalone `dsymutil` step, so may need manual pointing the first time.
+10. **Call Tree pane** (bottom of the Time Profiler track): checkboxes for
+    - **"Invert Call Tree"** — flips the tree root-first from leaves, surfacing the actual hot leaf functions (e.g. `GPUExec`, `BlitterMidsummer2`) at the top instead of burying them under `main`/event-loop frames.
+    - **"Hide System Libraries"** — cuts kernel/libsystem noise, leaves core + RetroArch frames.
+    - **"Flatten Recursion"** — merges recursive call frames of the same function so a deeply-recursive path doesn't fragment its time across many tree rows.
+11. Right-click any frame ▶ **"Show in Heaviest Stack Trace"** (or select the sample and open the detail/heaviest-stack view) to see the single most-expensive call path start to finish — the fastest way to find e.g. "`GPUExec` → `executeOpcode` case X → `JaguarReadByte`" as the actual expensive path rather than an aggregate bucket.
+12. Zoom into a time range in the track view to isolate one gameplay segment (e.g. a specific slow scene) instead of averaging the whole capture.
+
+### `xctrace` CLI alternative (scriptable, no GUI)
+
+Confirmed available on this Mac (`/usr/bin/xctrace`, part of Xcode command-line tools) and usable exactly as the user's spec suggests:
+
+```bash
+# Find the device UDID first
+xcrun xctrace list devices
+
+xcrun xctrace record --template "Time Profiler" \
+  --device <UDID> \
+  --attach RetroArch \
+  --time-limit 30s \
+  --output run.trace
+
+# Symbolicate against the core's manually-built dSYM (app's own dSYM is
+# usually auto-resolved from its build folder / Xcode's DerivedData index)
+xcrun xctrace symbolicate --input run.trace \
+  --dsym virtualjaguar_libretro_ios.dylib.dSYM
+
+# Export the call tree / heaviest stack to XML for offline/scripted reading
+xcrun xctrace export --input run.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="time-profile"]' \
+  --output run.xml
+```
+`--attach RetroArch` requires the app already running on the device with Instruments/`devicectl` trusting the Mac; `--device` accepts the UDID from `xctrace list devices` (same UDIDs `device_perf.sh doctor`'s `xcrun devicectl list devices` prints). The exact `--xpath` schema name for the call-tree table needs a one-time `xctrace export --input run.trace --toc` dry run against a real capture to confirm on this Xcode version — this is unverified against an actual trace since no build/deploy was performed for this audit.
+
+**Steps needing the user physically present**: initial device trust dialog; unlocking the iPad; interacting with RetroArch's UI (load core, load ROM, play). Build, sign, deploy, `xctrace record`/`export`, and reading the resulting file are all scriptable/headless once the device is trusted and awake.
+
+---
+
+## 4. Recommendation
+
+**Run both — they answer different questions and neither substitutes for the other.**
+
+- The perf-counter path (`device_perf.sh`) is the fast, low-friction first pass: no Xcode GUI interaction after initial setup, no dSYM juggling, gives the subsystem split (GPU RISC vs blitter vs 68K vs DSP vs OP vs DAC) on the actual A10X in a few minutes once the device is trusted. Its ceiling is exactly 8 fixed buckets at slice granularity — it will confirm *that* GPU execution dominates (matching the ~74% figure already recorded for #509 in project memory) but cannot say *where inside* `GPUExec`/`executeOpcode` the A10X specifically is slow (a particular opcode case, a branch misprediction, a specific memory-dispatch call pattern that only shows up on this chip's smaller cache/narrower OoO window).
+- Instruments Time Profiler on-device is the tool that actually answers the stated goal — hot **functions and lines**. It requires more one-time setup (symbolized build, dSYM, Xcode device trust, GUI interaction to invert/flatten the call tree) but is the only path in scope that gets to function/line granularity, and its "Heaviest Stack Trace" + inverted-call-tree views directly map onto `GPUExec`/`executeOpcode`, `DSPExec`, `blitter_generic`/`BlitterMidsummer2`, and the `JaguarRead*/JaguarWrite*` dispatch functions named in the task and in `docs/profiling.md`'s own "Hot paths to know" table.
+
+**Sequencing that costs the least device time**: run `device_perf.sh` first (cheap, confirms which of the 8 buckets to chase — almost certainly GPU per the #509 note), then go straight to Instruments and use "Invert Call Tree" + "Heaviest Stack Trace" filtered to just that subsystem's source files to find the actual hot functions/lines within it. This avoids wasting a profiling session broadly across all subsystems when the counters already narrow the target.
+
+### Gaps in the repo's scripts worth filling (not implemented — description only)
+
+`test/tools/rpi_perf.sh` has an automated `profile` subcommand (drives `perf_iface_witness`, a standalone one-file env-28 frontend, over ssh, with no GUI/config needed) that `device_perf.sh` has no counterpart for. That asymmetry is structural, not an oversight: iOS has no ad-hoc CLI execution outside an app bundle (no ssh-and-run-a-binary path the way Linux ARM has), so a `perf_iface_witness`-style standalone binary can't run there — `device_perf.sh capture` is necessarily "print manual steps for a human," and that's already what it does.
+
+A `device_perf.sh profile` subcommand that wraps `xctrace` (per §3's CLI recipe) would still be valuable to add, though, to close the gap on the *function-level* side rather than the counter side. It would need to:
+- Accept `-d/--device` consistent with the other subcommands, resolve to a UDID via `xcrun xctrace list devices` (parsed the same way `cmd_doctor` already parses `xcrun devicectl list devices`).
+- Require/verify the app is already running (or launch it itself via `devicectl device process launch`) before `xctrace record --attach`.
+- Take the core's dSYM path as a parameter (or auto-locate it next to the dylib built by `cmd_build`) and run `xctrace symbolicate` before `export`.
+- Emit a flattened/inverted call-tree text or JSON summary (mirroring `cmd_report`'s existing "print a table, don't just say 'trace saved'" pattern) — the exact `--xpath` schema for that would need to be pinned against a real captured trace first, which this read-only audit could not do.
+- Still need a human for the same two steps §3 lists (device trust, playing the game) — it would only remove the Xcode-GUI portion of the workflow, not the on-device interaction.
+
+---
+
+## Files read for this audit
+
+- `docs/profiling.md` (whole file)
+- `src/core/perf_iface.h`, `src/core/perf_iface.c`
+- `src/core/perf_counters.h` (head)
+- `test/tools/device_perf.sh` (whole file)
+- `test/tools/rpi_perf.sh` (doctor/profile sections)
+- `test/tools/perf_iface_witness.c` (header comment)
+- `Makefile` lines 1-100, 260-340, 800-870 (OPT_LEVEL, RELEASE_DEBUG_INFO, ios-arm64/ios9/tvos-arm64 blocks; grepped whole file for `strip`/`dsymutil`)
+- `scripts/build-id.sh` (whole file)
+- `/Users/jmattiello/Workspace/Provenance/RetroArch/pkg/apple/code-sign-cores.sh` (whole file)
+- `/Users/jmattiello/Workspace/Provenance/RetroArch/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj` (grepped for `DEBUG_INFORMATION_FORMAT`, `STRIP_INSTALLED_PRODUCT`, `COPY_PHASE_STRIP`, `DEPLOYMENT_POSTPROCESSING`; read app-target and project-level Release config blocks in full)
+- `/Users/jmattiello/Workspace/Provenance/RetroArch/pkg/apple/RetroArch_iOS13.xcodeproj/xcshareddata/xcschemes/RetroArch iOS Release.xcscheme` (whole file)
+- `/Users/jmattiello/Workspace/Provenance/RetroArch/pkg/apple/*.entitlements` (all four files)
+- `find /Users/jmattiello/Workspace/Provenance -maxdepth 4 -iname 'build_ios*'` — no results, no such script exists anywhere under Provenance/.

--- a/docs/perf-audit/dsp.md
+++ b/docs/perf-audit/dsp.md
@@ -1,0 +1,340 @@
+> Raw sub-agent audit output (2026-08-22, read-only, sonnet). Line numbers refer to
+> `libretro/develop` @ 5f898da. Verified items are promoted to [`../perf-audit-2026-08.md`](../perf-audit-2026-08.md);
+> treat anything here that is NOT in that file as unverified.
+
+# DSP subsystem perf audit — src/jerry/dsp.c, dac.c, jerry.c
+
+Read-only audit. No files modified. Repo:
+/Users/jmattiello/Workspace/Provenance/virtualjaguar-libretro/.claude/worktrees/alien-predator-save-state-ad621b
+
+Baseline confirmed from code (not assumed): dispatch is computed-goto
+(`dsp_executeOpcode`, dsp.c:1165-1264, `goto *dsp_dispatch[index]`), delay slots for
+JUMP/JR are inlined into `dsp_opcode_jump`/`dsp_opcode_jr` (dsp.c:1353-1430, comment
+explicitly says this replaced a recursive `DSPExec(1)` call). Do not re-propose either.
+
+---
+
+## Finding 1 — SH/SHA implemented as a 32-iteration bit-shift loop; hardware (and our own
+timing model) charges 1 cycle
+
+**File/line:** `dsp_opcode_sh` dsp.c:2039-2073, `dsp_opcode_sha` dsp.c:1999-2030.
+
+**What:** Both instructions shift by a *variable* amount (`RM`, sign gives direction,
+magnitude clamped to 32) via a `while (shift) { _Rn <<= 1; shift--; }` /
+`_Rn = (int32_t)_Rn >> 1` loop — up to 32 individual single-bit shifts per instruction.
+Contrast with `dsp_opcode_shlq`/`shrq`/`sharq` (dsp.c:1976-1998, 2031-2038), the
+*immediate*-shift variants, which already do a single native C `<<`/`>>` with no loop.
+
+**Why it costs on in-order ARM:** `dsp_opcode_cycles[]` (dsp.c:226-235, index 23=SH,
+26=SHA) charges these opcodes **1 cycle** — the same as ADD — because the real DSP has a
+barrel shifter (arbitrary shift in one cycle). Our interpreter instead burns up to 32
+host loop iterations (branch + shift + decrement each) to compute what a single native
+shift instruction gives for free. On an in-order core with no branch-heavy
+loop-unrolling wins, this is pure waste: emulated-cycle cost is already flat regardless
+of shift amount, so making the host implementation flat too is free correctness-neutral
+speedup. SH/SHA are common in audio-mixing/sample-scaling code, which is exactly the
+class of DSP program the cited titles run.
+
+**Proposed change:** replace both loops with clamped native shifts. For the
+left-shift branch (`sRm<0`): `_Rn = (shift >= 32) ? 0 : (_Rn << shift);` (shift==32 must
+stay special-cased — native `<<32` on a 32-bit type is UB). For the arithmetic
+right-shift branch: clamp `shift` to 31 instead of 32 (after 31 iterations of `>>1` on a
+32-bit signed value the result is already fully sign-extended, so 31 and 32 iterations
+produce an identical result) and do `_Rn = (int32_t)_Rn >> shift;` — this sidesteps the
+shift-by-32 UB case entirely while being bit-identical to the existing loop's output.
+Carry-flag computation is already taken from the *pre-shift* value in both functions
+(`dsp_flag_c=(_Rn&0x80000000)>>31` / `dsp_flag_c=_Rn&0x1`), so it is unaffected by this
+change.
+
+**Impact:** HIGH (uncertain exact %, but this is the single clearest "hardware says O(1),
+we implemented O(n)" mismatch in the file, and SH/SHA are common in mixer code).
+**Risk:** LOW — same numeric result, same emulated cycle cost (`dsp_opcode_cycles`
+unchanged), no savestate/ABI impact. Needs the shift==32 / clamp-to-31 edge cases gotten
+exactly right and a few unit vectors checked (shift=0,1,31,32,>32 both directions,
+negative and positive `_Rn`).
+**Effort:** S. **Suitable for sonnet** mechanically, but the edge-case proof (why 31 not
+32 for the arithmetic branch, why 32 needs a branch for the logical branch) should be
+verified by whoever reviews it — flag for a second pass rather than blind trust.
+
+---
+
+## Finding 2 — LOAD/STORE opcodes always pay a real, non-inlinable function call, even
+for the (very common) DSP-local-RAM case
+
+**File/line:** every `dsp_opcode_load*`/`store*` variant, e.g. `dsp_opcode_load`
+dsp.c:1667-1673, `dsp_opcode_store` dsp.c:1626-1633, `dsp_opcode_load_r14_indexed`
+dsp.c:1688-1694, `dsp_opcode_store_r14_indexed` dsp.c:1536-1543 — all call
+`DSPReadLong`/`DSPWriteLong` unconditionally. Only `loadb`/`loadw`/`storeb`/`storew`
+(dsp.c:1601-1660) have an inline range check before falling through to the same calls.
+
+`DSPReadLong`/`DSPWriteLong` (dsp.c:445-527, 686-847) are declared `extern`
+(non-`static`) in dsp.h:32,35 and are called from other translation units (m68k memory
+map, jerry.c register glue, etc.), so **they cannot be inlined into dsp.c without
+LTO**. Confirmed no LTO is enabled for `unix`, `rpi*`, `osx`, `ios-*`, `android` targets
+— grep of `Makefile` shows `-flto=4 -fwhole-program -fuse-linker-plugin` only on the
+`classic_armv7_a7` block (Makefile:219), gated to that one platform. The
+Raspberry Pi 4 / A10X targets this audit cares about build without LTO.
+
+**Why it costs:** Every LOAD/STORE (a large fraction of all DSP opcodes in mixer code)
+pays a full ABI call: argument marshalling, a real `call`/`bl`, and — critically — the
+compiler must assume the callee can touch any global, so it cannot keep `dsp_flag_z/n/c`,
+`dsp_pc`, the `dsp_reg` bank pointer, etc. in registers across the call; they get
+spilled before and reloaded after (see Finding 5). This compounds with the fact that the
+opcode *fetch* path in `DSPExec` (dsp.c:1137-1143) and the JUMP/JR delay-slot fetch
+(dsp.c:1374-1380, 1411-1417) **already** hand-inline exactly this fast path — proving the
+authors know the pattern is worth avoiding for fetch, but LOAD/STORE data access never
+got the same treatment.
+
+**Proposed change (two options, pick one):**
+(a) *Build-level, broad*: enable `-flto` for `unix`/`rpi*`/`osx` (at minimum `rpi*`,
+since that's the stated target) the same way `classic_armv7_a7` already does, and
+benchmark. Fixes this finding, Finding 5, and part of Finding 1's cousins (any other
+inlinable-but-cross-TU call) all at once. Also benefits the GPU core (`src/tom/gpu.c`)
+for free if it has the same shape — not audited here.
+(b) *Source-level, surgical*: add a `static inline` fast-path wrapper in dsp.c, used
+only by the LOAD/STORE opcode handlers, that open-codes the `offset >= DSP_WORK_RAM_BASE
+&& offset <= DSP_WORK_RAM_BASE+0x1FFF` check and the `GET32/SET32` on `dsp_ram_8`
+directly (mirroring dsp.c:1137-1143), falling back to the real `DSPReadLong`/
+`DSPWriteLong` for everything else. **Must not** silently drop the HLE side effects that
+already live inside `DSPReadWord`/`DSPReadLong`/`DSPWriteWord`/`DSPWriteLong` for
+addresses inside DSP local RAM: the sound-command auto-ack at `DSP_SOUND_CMD_BASE..END`
+(dsp.c:420-427, 453-489, documented "TODO(v2.3)" workaround) and the CDDA mailbox
+logging/snapshot at `$F1B270-$F1B277` (dsp.c:606-635, 674-686) are both *inside* the
+work-RAM range and must be replicated exactly, or reproduced by falling through to the
+real function whenever the offset lands in those sub-ranges.
+
+**Impact:** MED-HIGH for (a) (broad, touches every cross-TU call, not just this one);
+MED for (b) alone. **Risk:** (a) MED — LTO is a build-wide change, larger blast radius,
+needs a build-across-all-targets check and the per-target OPT_LEVEL/-mcpu discipline the
+repo just finished tuning (PR #567) respected; (b) MED — correctness risk is real and
+specific (the two side-effect windows above), needs careful review, not mechanical.
+**Effort:** (a) S to try, M to validate across targets; (b) M.
+**Not suitable for a cheap model alone** — the HLE side-effect carve-outs need a human
+(or a careful high-effort agent) to get right; a blind "hoist the array access" edit
+would reintroduce exactly the Wolf3D/CDDA regressions those TODOs were written to avoid.
+
+---
+
+## Finding 3 — No idle/spin-loop fast-forward for `jr`-to-self / tight poll loops
+
+**File/line:** `dsp_opcode_jr` dsp.c:1397-1430; slice sizing in
+`src/core/jaguar.c` `JaguarExecuteNew` (jaguar.c:1682-1750); `DSPExec` main loop
+dsp.c:1070-1160.
+
+**What exists already, so don't re-propose it:** the RISC slice handed to `DSPExec`
+(`riscCycles` in jaguar.c:1712-1716/1732-1736, via `DSPBeginSlice`/`DSPSliceRemaining`)
+is **already bounded to the time until the next scheduled event** (`GetTimeToNextEvent`
+against `EVENT_MAIN`/`EVENT_JERRY`, jaguar.c:1688-1690) — so "how many cycles can the DSP
+run before something external can change" is already a known, computed quantity every
+slice. The missing piece is *inside* that already-bounded slice: nothing detects that
+the DSP is burning its whole cycle budget on a 2-3 instruction poll (a `jr`-to-self or
+`load`+`cmp`+`jr` loop waiting on an I2S/timer IRQ flag) instead of doing useful work.
+`DSPHandleIRQsNP` (dsp.c:859-916) is only invoked when `IMASKCleared` — i.e. it's not a
+per-instruction poll cost, and there's no mechanism that recognizes "this instruction
+sequence has no externally-visible side effect and will keep re-executing until an IRQ
+fires" and jumps straight to slice-end.
+
+`DSPReleaseTimeslice`/`dsp_releaseTimeSlice_flag` (dsp.c:312, 340-343) look related but
+are **not** an idle-skip mechanism for this: it's set from a few `DSPWriteLong` control-
+register paths (dsp.c:792, 811, 824, when the 68K or DSP pokes `DSPINT0`/`CPUINT`) and
+then never read anywhere except the savestate blob (dsp.c:3131, 3191) — grep confirms zero
+other reads. It's effectively a **write-only dead flag** today (separate, tiny, LOW-impact
+cleanup note — not a hot-path cost since it's set only on rare control writes, not per
+instruction).
+
+**What would be required for a real idle-skip:** pattern-match a short basic block
+(1-4 instructions) reachable only through a backward branch, prove it has no
+observable side effect other than the branch condition itself (no STORE, no register
+write visible outside the loop, no MOVEQ/etc. feeding something read outside the loop),
+and if so, compute how many *whole* iterations fit in the remaining slice budget and
+skip straight to the last partial iteration, leaving `dsp_pc`/flags exactly as if every
+iteration had run. Given the slice is already event-bounded, the "next event" the loop
+is waiting on doesn't even need separate discovery — the loop is right up against the
+same deadline `DSPBeginSlice` already computed.
+
+**Impact:** Unknown but potentially the largest single lever given `dsp_opcode_jr` alone
+is 12-14% of profiled DSP time — but that number is the cost of *executing* the loop body
+including legitimate (non-spin) branches, not proof that most of it is idle spin; would
+need instrumentation to confirm what fraction of `jr` executions are in a provably-idle
+loop before investing here. **Risk:** HIGH — this is exactly the kind of change that can
+silently break IRQ-timing-sensitive titles (the repo's own history: SCLK IRQ deferral
+bug, DSA steal race, lost-wakeup CPUINT fix — all subtle DSP/IRQ-timing bugs from past
+work per project memory) and interacts with savestates (mid-loop state must stay
+faithfully resumable) and determinism. **Effort:** L. **Not suitable for a cheap model**
+— this needs careful design, a written plan, and A/B validation against real titles
+(Iron Soldier, AvP, Skyhammer) before it's safe to land; recommend a dedicated design doc
+and prototype behind a flag, not a direct PR.
+
+---
+
+## Finding 4 — Global flag/register-bank state forces spill/reload around every
+cross-TU call (ties Findings 1/2/5 together)
+
+**File/line:** `dsp_flag_z`, `dsp_flag_n`, `dsp_flag_c` (dsp.c:269, all `static`),
+`dsp_reg`/`dsp_alternate_reg` (dsp.c:270, `static` pointers re-pointed by
+`DSPUpdateRegisterBanks`, dsp.c:843-855), `dsp_pc` (dsp.c:259, **not** static — has
+external linkage per dsp.h — used by libretro-side debug/state code), `SET_ZN` macro
+(dsp.c:292) writes two of the three flag globals on almost every ALU opcode.
+
+**What:** Because `dsp_flag_z/n/c` and `dsp_reg` are plain (non-`volatile`) globals
+written by nearly all ~60 opcode handlers, and because those handlers are all inlined
+into one giant `dsp_executeOpcode`/`DSPExec` translation unit, the compiler *can* in
+principle keep them resident in registers across many consecutive non-memory-touching
+opcodes within a single `-O2`/`-O3` compile of dsp.c. That register residency breaks at
+every call the compiler can't see through — which, per Finding 2, is every LOAD/STORE
+opcode plus any DSP opcode that touches JERRY/TOM registers or main RAM
+(`JaguarReadByte`/`JaguarWriteByte` etc., also extern, also cross-TU). So the actual cost
+of this finding is not separable from Finding 2/LTO — fixing cross-TU call opacity (LTO,
+or hand-inlined fast paths) is what would let the compiler stop spilling these flags.
+
+**Impact:** folded into Finding 2's estimate; not independently actionable. **Risk/Effort:**
+n/a as a standalone item — listed for completeness so it isn't mistaken for a separate,
+smaller "just add `register` keywords" fix (that wouldn't help; the issue is
+alias-analysis across TU boundaries, not register allocation pressure within one
+function).
+
+---
+
+## Finding 5 — `dsp_opcode_div`: 32-iteration bit-serial loop — likely correctly modeling
+real hardware cost, not a clear win
+
+**File/line:** `dsp_opcode_div` dsp.c:1903-1932.
+
+**What:** Restoring-division-style loop, 32 iterations of shift/add/compare per DIV
+instruction, regardless of operand size. Unlike SH/SHA (Finding 1), `dsp_opcode_cycles`
+(dsp.c:226-235, index 21) charges **9 cycles** for DIV — the *only* non-1/2/3/4 entry in
+the whole table — strongly suggesting this reflects genuine bit-serial hardware
+division latency (JTRM should be checked before touching this, per repo hardware-
+accuracy rule; not done in this audit — flagging as unverified). Replacing the loop with
+native `/`/`%` would only save host cycles, not emulated cycles (timing is unaffected
+either way since `dsp_opcode_cycles[21]` is unchanged by the host implementation), so the
+only benefit is host wall-clock, and DIV is typically far rarer in audio-mixer code than
+ADD/MULT/SH.
+
+**Impact:** LOW-MED, uncertain — worth an instruction-frequency profile before
+investing (the existing per-title profiling data cited in the task didn't call out DIV
+specifically, unlike `jr`). **Risk:** MED — must reproduce the exact quotient/remainder
+semantics of the 16.16-mode branch (`dsp_div_control & 0x01`, dsp.c:1917-1919) and the
+divide-by-zero convention (`RN=0xFFFFFFFF`, `dsp_remain=0`, dsp.c:1908-1914) bit-exactly;
+a naive native `/`/`%` substitution is *not* obviously equivalent for the 16.16 fixed-
+point mode without deriving it by hand. **Effort:** M. Lower priority than Finding 1.
+
+---
+
+## Finding 6 — DSPExec / DSPHandleIRQs overhead per call: already lean
+
+Explicitly checked and **not** worth further work — no re-proposal needed:
+- `DSPExec`'s outer loop exits immediately when DSP is halted
+  (`while (cycles > 0 && DSP_RUNNING)`, dsp.c:1077, `DSP_RUNNING` = `dsp_control & 0x01`,
+  dsp.c:276) — cheap early-out already exists.
+- `DSPHandleIRQsNP` (dsp.c:859-916) is only called when `IMASKCleared &&
+  dspFlagsRetireDelay==0` (dsp.c:1095), not once per instruction; when nothing pending it
+  bails after a mask/bits computation (dsp.c:862, 880-887) — a handful of ALU ops, not a
+  loop, not a hot-path concern.
+- `VJT_PCHIST_DSP(dsp_pc)` (dsp.c:1088) compiles to a true no-op
+  (`#define VJT_PCHIST_DSP(pc) do {} while(0)`, vjtrace.h:344) unless `VJ_TRACE` is
+  defined, and `-DVJ_TRACE` is only added under `TEST_EXPORTS=1` (Makefile:161) — **never
+  in a release/shipped build**. Confirmed by direct read of both the macro and the
+  Makefile guard; do not re-propose gating this further.
+- `VJP_ENTER`/`VJP_LEAVE` around `DSPExec` (dsp.c:1075, 1157) are guarded by a single
+  runtime bool check (`if (vjPerfActive) ...`, perf_iface.h:133-134) — cheap, paid once
+  per `DSPExec` *call* (not per instruction), not worth touching.
+- No `crash_detect` calls anywhere in dsp.c's instruction loop (grep found only a
+  comment referencing the out-of-band watchdog, dsp.c:1119) — confirmed zero per-
+  instruction crash-detect cost.
+- `riscClockScalePct` is read once per `DSPSyncToM68K` call (dsp.c:1052), not per
+  instruction.
+
+These were all explicitly asked about in the brief; reporting them as **already fine**
+so they don't get re-investigated.
+
+---
+
+## Finding 7 — ~960 lines of dead code: a second, unreachable pipelined DSP interpreter
+
+**File/line:** dsp.c:2140 (`isLoadStore[]` table) through dsp.c:3097 (`DSP_xor`), plus
+the `PipelineStage`/`scoreboard`/`pipeline[4]`/`plPtr*` machinery declared at
+dsp.c:66-90, and `DSPExecP`/`DSPExecP2`/`DSPExecComp` prototypes at dsp.h:41-43.
+
+**What:** A complete second implementation of every DSP opcode (`DSP_add`, `DSP_jr`,
+`DSP_sh`, `DSP_mmult`, ... ~60 functions, all `INLINE static`, all named `DSP_*` as
+opposed to the live `dsp_opcode_*`), dispatched through a separate `DSPOpcode[64]`
+function-pointer table (dsp.c:2186), operating on the old 4-stage pipeline/scoreboard
+model (`pipeline[plPtrExec]`, `scoreboard[]`, etc.). Grepped the entire repo:
+`DSPOpcode[` is referenced only at its own definition (dsp.c:2186) and twice more, both
+*inside* `DSP_jr`/`DSP_jump`'s own bodies (dsp.c:2506, 2581) — i.e. it calls itself, not
+called from anywhere reachable. `DSPExecP`/`DSPExecP2`/`DSPExecComp` — the presumed old
+entry points for this engine — are declared in dsp.h but **have no function bodies
+anywhere in the repo** (grepped, zero matches beyond the three prototype lines) and have
+**zero callers** anywhere in the repo. This whole block is unreachable: not called at
+build time by anything, and half of its would-be entry points don't even exist as
+compiled functions.
+
+Note: `pipeline[]`, `scoreboard[]`, `plPtrFetch/Read/Exec/Write` are still written by
+`FlushDSPPipeline()` (dsp.c:2247-2258, called from dsp.c:827, 1005) and saved/loaded in
+the savestate blob (dsp.c: `STATE_SAVE_BUF`/`STATE_LOAD_BUF` for `pipeline`/`scoreboard`,
+near end of file) — so removing this isn't purely deletion-only; it touches the
+savestate format (per project convention, any savestate layout change needs a version
+bump, see project memory "Savestate version policy"). `IMASKCleared` is a real, live
+field saved in the same block — don't remove that one.
+
+**Impact:** Effectively zero runtime perf impact — dead code that's never called is
+never fetched into I-cache. The value here is code hygiene / reduced binary size /
+reduced maintenance surface (~30% of this file is unreachable), not frame-time. Flagging
+because it was encountered while reading every `dsp_opcode_*`/`DSP_*` function per the
+brief's instructions, and because someone reading `dsp_opcode_cycles[64]` next to
+`isLoadStore[65]` (note the off-by-one array size difference — another sign these are
+unrelated/stale) could easily mistake the dead table for load-bearing. **Risk:** LOW
+functionally (pure deletion of unreachable code) but touches savestate layout (version
+bump needed) — this is exactly the kind of "not really performance" item the repo's
+"no bundling into perf PRs" rule (project memory) says should be its own PR, not folded
+into a DSP perf change.
+**Effort:** S-M (mostly deletion, but needs the savestate version-bump ceremony).
+**Suitable for sonnet** as a separate, explicitly-scoped cleanup task — not this one.
+
+---
+
+## Finding 8 — DAC/audio (`src/jerry/dac.c`): already carefully tuned, low priority
+
+**File/line:** `DSPSampleCallback` dac.c:256-324, `DACCaptureSample` dac.c:213-231,
+`DACPrepareFrame` dac.c:332-368, `SoundCallback` dac.c:376-425.
+
+**What:** `DSPSampleCallback` runs once per *output* sample (~800/frame NTSC, ~48000/sec
+total) and does ~6 double-precision FP operations per call (linear interpolation between
+two ring-buffer samples, lag/resync tracking) — genuinely O(samples), genuinely float
+math, exactly what the brief asked to look for. However: (1) the volume is tiny relative
+to the DSP interpreter (48k calls/sec vs. millions of RISC instructions/sec), so this is
+very unlikely to be a measurable fraction of the 22-67% DSP frame-time figures cited —
+those are DSP-interpreter time, not DAC-mix time, and are almost certainly counted
+separately in the profiler; (2) this exact code was the subject of a recent, carefully
+reasoned fix (issue #393 lag-drift, referenced in the surrounding comments at dac.c:88-
+109, dac.c:279-294) — the double-precision arithmetic and resync thresholds are there on
+purpose to fix an audible bug, not an oversight. `DACCaptureSample` (dac.c:213-231,
+called at I2S word-strobe rate, not 48kHz) is pure integer/mask arithmetic — no finding.
+`SoundCallback`'s padding loop (dac.c:411-423) only runs for the rare short-frame
+hold case, not every frame.
+
+**Impact:** LOW, and this repo's own rule (`docs/agent/testing.md`,
+CLAUDE.md "Audio/DSP changes... MUST clear BOTH test_audio_clipping AND
+test_audio_presence") plus the project-memory record of this exact code's recent bug
+history make it a bad place to spend effort for uncertain gain. **Risk:** MED-HIGH for
+any change here specifically because of that history (i2s lag drift, word-strobe
+crackle — both previously-shipped regressions in this exact file per project memory).
+**Recommendation:** don't touch without first getting an actual profiler sample showing
+DAC/resample time as a measurable fraction of frame time; not indicated by the data in
+the brief. Not scoring this one with effort/who-can-do-it since it's a "don't" finding.
+
+---
+
+## Summary table
+
+| # | Finding | Impact | Risk | Effort | Model |
+|---|---|---|---|---|---|
+| 1 | SH/SHA bit-loop → native shift | HIGH | LOW | S | sonnet (+review) |
+| 2 | LOAD/STORE cross-TU call opacity (LTO or hand-inline fast path) | MED-HIGH | MED | S(a)/M(b) | needs careful design |
+| 3 | jr-spin idle-skip | unknown, possibly HIGH | HIGH | L | needs design doc, not mechanical |
+| 4 | Global flag spill (subsumed by #2) | — | — | — | — |
+| 5 | DIV 32-iter loop | LOW-MED, unverified | MED | M | needs JTRM check first |
+| 6 | DSPExec/IRQ overhead | already lean | — | — | no action |
+| 7 | ~960 lines dead pipelined-DSP code | ~0 perf, code hygiene | LOW (savestate version bump) | S-M | sonnet, separate PR |
+| 8 | DAC per-sample float math | LOW | MED-HIGH | — | don't, absent profiler evidence |

--- a/docs/perf-audit/frontend.md
+++ b/docs/perf-audit/frontend.md
@@ -1,0 +1,257 @@
+> Raw sub-agent audit output (2026-08-22, read-only, sonnet). Line numbers refer to
+> `libretro/develop` @ 5f898da. Verified items are promoted to [`../perf-audit-2026-08.md`](../perf-audit-2026-08.md);
+> treat anything here that is NOT in that file as unverified.
+
+# Frontend/Presentation-Path Performance Audit
+Scope: libretro.c glue, shadowfb, texreplace/texdump, DAC hand-off, titledb, input polling,
+crash_detect, perf_iface, vjtrace, netlink polling — everything in `retro_run()` outside the
+GPU/DSP/blitter/bus emulation core itself.
+
+Repo: virtualjaguar-libretro, worktree alien-predator-save-state-ad621b. Read-only audit, no
+edits made.
+
+## Headline conclusion
+
+This layer is already well-optimized. I could not find a full-frame copy, an unconditional
+per-pixel conversion, redundant geometry/variable-update calls, or a chunked audio hand-off.
+The video buffer TOM renders into IS the buffer handed to `video_cb` — zero extra copies. Audio
+is one `audio_batch_cb` call per frame with a fixed sample count. `check_variables()` and
+`SET_GEOMETRY` are both correctly edge-gated. Diagnostic/optional features (crash watchdog,
+texture dump, blit-memo, cheats, netlink) all short-circuit cheaply when off or idle.
+
+Net implication for the weak-ARM-host investigation: the frontend glue is very unlikely to be
+where RPi4/A10X frame time is going. The other agents' territory (GPU/DSP interpreters, blitter,
+bus) is the much more plausible place — consistent with existing perf_iface capture data already
+in project memory (GPU RISC ~74%, blitter ~17% of frame time on captured devices).
+
+---
+
+## 1. Video path: NO full-frame copy found (POSITIVE finding, not an action item)
+
+- `libretro.c:4678` — `JaguarSetScreenBuffer(videoBuffer)` is called once at init. TOM's scanline
+  renderer (`src/tom/tom.c`, out of this audit's scope) writes pixels directly into
+  `videoBuffer`.
+- `libretro.c:5550` — `video_cb(videoBuffer, game_width, game_height, game_width << 2)` hands
+  that SAME pointer straight to the frontend. No `memcpy`, no per-pixel conversion loop, no
+  intermediate staging buffer anywhere between TOM's render and `video_cb` in libretro.c.
+- `RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER` is not used — and doesn't need to be,
+  since there is already no extra copy to eliminate. Grepped `libretro.c` for
+  `GET_CURRENT_SOFTWARE_FRAMEBUFFER`: no hits.
+- Pitch is `game_width << 2` (4 bytes/pixel, XRGB8888), consistent with `JaguarSetScreenPitch`
+  called on geometry change (`libretro.c:5358`).
+- The only per-frame write to `videoBuffer` from libretro.c itself is the stale-tail-row
+  blanking block (`libretro.c:5492-5541`), which is conditionally gated (`written > 0 && written
+  < stock_height && ... <= MAX_BLANK_TAIL_ROWS && ...coverage...`) and bounded to at most 32 rows
+  when it fires at all (issue #178 fix, well-commented, not a steady-state cost). No action
+  needed.
+
+**Shadowfb / True Color**: `src/tom/shadowfb.h:1-25` documents that True Color pixel substitution
+happens INLINE inside TOM's CRY scanline renderer at read time (value-check against
+`shadowTag`), not as a separate post-frame merge pass over `videoBuffer`. There is therefore no
+"shadowfb merge" step to find in the frontend glue — it's architecturally already fused into the
+render, which is the efficient design. `shadowFBActive` (default: off, `virtualjaguar_true_color`
+defaults to `"disabled"`, `libretro_core_options.h:155`) gates all of it; with the option off this
+costs nothing beyond the option check.
+
+**Hi-res / Internal Resolution**: `virtualjaguar_internal_resolution` defaults to `"1x"`
+(`libretro_core_options.h:169`), so `shadowHiresN == 1` and the Nx surface is never allocated on
+a default install. `ShadowHiresFrameTick()` (`src/tom/shadowfb.c:644-669`) is called
+unconditionally every frame (`libretro.c:5465`) but is a single `hiresEpoch` increment plus an
+`if` — deliberately kept O(1) even at 1x per the comment there (the field had to become a pure
+frame-phase counter for issue #400 savestate-determinism reasons; verified in project memory
+`project_400_runahead_determinism`). No finding.
+
+## 2. Dynamic resolution / geometry: correctly change-gated
+
+- `libretro.c:5345` — the `SET_GEOMETRY` block only runs
+  `if ((tomWidth != videoWidth || tomHeight != videoHeight) && tomWidth > 0 && tomHeight > 0)`.
+  Confirmed this is the ONLY call site of `RETRO_ENVIRONMENT_SET_GEOMETRY` in `retro_run`; it is
+  not called every frame. No finding — already optimal.
+
+## 3. Audio hand-off: single fixed-size batch call, no chunking
+
+- `src/jerry/dac.c:425` — `audio_batch_cb((int16_t *)buffer, length / 2)` is called exactly once
+  per `SoundCallback()` invocation, which itself is called exactly once per `retro_run()`
+  (`libretro.c:5470`). `length` is fixed per field (`BUFNTSC`/`BUFPAL`), so this is one batch call
+  of ~800/960 sample-pairs per frame, not many small calls. No finding.
+- `DACPrepareFrame()` (`dac.c:332-374`) does a handful of `double` divisions/multiplications
+  (`frame_us`, `i2sStepScale`, etc.) once per frame — trivial cost, not a hot loop. Per-sample
+  resampling math (`DSPSampleCallback`, the I2S ring) is DSP/audio-engine territory, out of this
+  audit's frontend-glue scope, and is event-driven rather than looped once per frame here.
+
+## 4. Input polling
+
+- `libretro.c:2717` — `input_poll_cb()` is called exactly once per frame. Confirmed no other call
+  site in `retro_run`'s call graph.
+- Default config (`virtualjaguar_alt_inputs` defaults `"disabled"`,
+  `libretro_core_options.h:583`): the cheap path is taken —
+  `libretro.c:2731-2735`, 2 calls to `input_state_cb(player, RETRO_DEVICE_JOYPAD, 0,
+  RETRO_DEVICE_ID_JOYPAD_MASK)` when `libretro_supports_bitmasks` is true (virtually all modern
+  frontends including RetroArch). The more expensive per-button-bit fallback loop
+  (`libretro.c:2738-2744`, up to 13 calls x 2 players) only triggers on a frontend that lacks
+  bitmask support.
+- **Finding (LOW, informational)**: in the default (non-`enable_alt_inputs`) branch, libretro.c
+  unconditionally issues 24 `input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_*)` calls every
+  frame regardless of whether any keyboard is attached — 12 for player 0
+  (`libretro.c:2879-2901`: `RETROK_0..4`, `RETROK_5/6` folded into OR-expressions at 2889/2891,
+  `RETROK_7/8/9`, `RETROK_MINUS/EQUALS`) and 12 for player 1 (`libretro.c:2951-2973`, same shape
+  with `p,q,w,e,r,t,y,u,i,o,[,]`). These exist to give the numpad-digit shortcuts a keyboard
+  fallback even without `enable_alt_inputs`. Per the task brief, `input_state_cb` can be
+  comparatively expensive per call on some frontends (RetroArch routes it through its input
+  remap/driver layer). 24 extra calls/frame is a small absolute number — I estimate LOW impact,
+  likely sub-1% of frame time even on a weak host — but it is unconditional and not obviously
+  skippable without either (a) a "is a physical keyboard present" signal the libretro API doesn't
+  reliably expose, or (b) moving the fallback behind `enable_alt_inputs` as a behavior change
+  (risk: regresses existing keyboard-shortcut users). Effort: S (mechanical instrumentation to
+  measure/confirm) to M (any change bigger than measurement is a design decision, not mechanical
+  — do NOT hand this to a cheap model to "just fix"). Recommend: measure first before touching;
+  do not change without user sign-off given the behavior-visible risk.
+- `InputDevAnyAttached()` (`src/jerry/inputdev.c:283-286`) is an O(1) bitmask check
+  (`inputdev_attach_mask ? 1 : 0`), and the non-pad device loop at `libretro.c:3009` is gated
+  behind it — with no alternate devices configured (default) this is one branch, not a loop. No
+  finding.
+- Team Tap: `JoystickSetTeamTap`/`JoystickGetTeamTap` (`src/jerry/joystick.c`) only affect how the
+  Jaguar-side matrix decode routes reads; team-tap sockets 1-3 are NOT separately polled via
+  `input_state_cb` — the adapter emulation lives entirely on the emulated-bus side, reusing the
+  same `joypad0Buttons`/`joypad1Buttons` arrays already filled from the 2 polled ports. So Team
+  Tap does not add extra `input_state_cb` calls even when attached. No finding.
+- The per-frame `for (i = 0; i < JOYPAD_BUTTON_SLOTS; i++)` clear loop (`libretro.c:2726-2729`,
+  `JOYPAD_BUTTON_SLOTS = JOYPAD_SOCKETS * 21`) clears both port arrays unconditionally
+  (`src/jerry/joystick.h:61-63`) — on the order of ~168 bytes total, trivial. No finding.
+
+## 5. `check_variables()`: correctly update-gated
+
+- `libretro.c:5333-5334` —
+  `if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated) check_variables();`
+  This is the ONLY call site in `retro_run`. `check_variables()` (`libretro.c:2064`) is not called
+  every frame, only when RetroArch signals a variable actually changed. No finding.
+
+## 6. Dormant-feature costs — all confirmed cheap
+
+- **Crash-detect watchdog** (`src/core/crash_detect.c`): default option state is `"enabled"`
+  (`libretro_core_options.h:226`), so it runs on every default install, not opt-in. Cost per
+  frame when ON: `CrashDetectFrameTick()` (`crash_detect.c:396`) does a handful of O(1) PC/state
+  checks plus one call to `fb_hash()` (`crash_detect.c:211-227`), which is a **256-sample rolling
+  hash**, explicitly NOT a full-frame scan (`step = total/256` when `total > 256`) — the comment
+  at `crash_detect.c:207-208` states this is deliberate ("costs 256 ops per frame"). This is
+  genuinely cheap regardless of resolution (1x or Nx supersampled) since it's a fixed sample
+  count, not `O(w*h)`. When OFF (`cd_mode == CRASH_DETECT_OFF`), `CrashDetectFrameTick` returns at
+  `crash_detect.c:408`, one branch. No finding — already well-designed; flagging only because the
+  audit brief specifically asked about its default state and per-frame cost.
+- **vjtrace**: gated entirely behind `#ifdef VJ_TRACE` in `libretro.c:5301-5313`.
+  `VJ_TRACE` is only defined when `TEST_EXPORTS=1` (`Makefile:161`, inside the
+  `ifeq ($(TEST_EXPORTS),1)` block) — it is NOT compiled into a normal release build at all
+  (`make` without `TEST_EXPORTS=1` never defines it). No finding — confirms it costs literally
+  zero bytes of code in shipped builds.
+- **perf_iface / `vjPerfActive`**: `src/core/perf_iface.h:30-38` documents (and this audit
+  confirms by reading the header, no need to re-derive) that RetroArch accepts
+  `RETRO_ENVIRONMENT_GET_PERF_INTERFACE` unconditionally and registration is never gated, so
+  under ordinary RetroArch play `vjPerfActive` is 1 and every `VJP_ENTER`/`VJP_LEAVE` probe makes
+  a real (fast, returns-immediately) indirect call — "on the order of 2,000 per frame" per the
+  header's own comment. This is a whole-codebase number; this audit's scope only contains ONE
+  probe pair (`VJP_DAC` at `dac.c:339` and `dac.c:373`), so the frontend-glue contribution here is
+  2 calls/frame, negligible. The bulk of the 2,000 originates in GPU/DSP/blitter interpreter
+  loops, which are the other agents' scope, not this one. Already documented as an accepted
+  tradeoff in the source and in project memory (`project_509_device_perf_capture.md`) — not a new
+  finding, just confirming it's understood and out of this audit's actionable scope.
+- **Texture replace / dump**: `texDumpEnabled` gates `TexDumpFrame()` at the retro_run call site
+  itself (`libretro.c:5320-5321`), and `texReplaceEnabled`/`tr_tab == NULL` gates
+  `TexReplacePreBlit()` (`src/tom/texreplace.c:598-604`) at entry — both are off by default
+  (diagnostic/opt-in features) and cost one branch when off. `TexReplacePreBlit`/`PostBlit` are
+  invoked per-blit from the blitter, not per-frame from libretro.c, so their steady-state cost
+  when a pack IS loaded belongs to the blitter agent's scope, not this one.
+- **Cheats**: `cheat_apply_all()` (`libretro.c:5469`) → `cheat_list_apply()`
+  (`src/core/cheat.c:290-306`) iterates `list->count` entries (0 with no cheats set) and skips
+  disabled ones — no cost with no cheats active. No finding.
+- **Blit-memo**: `BlitMemoFrame()` gated by `blitMemoMode` at the call site
+  (`libretro.c:5316-5317`) — did not investigate its internals (blitter agent's scope) but the
+  call-site gate is correct.
+- **Netlink / JLink / UART polling**: `JLinkFrameTick()`, `JLinkPoll()`, `UARTPoll()`
+  (`libretro.c:5368-5370`) run **unconditionally every frame regardless of whether netlink is
+  enabled**. Traced each:
+  - `JLinkPoll()` (`src/jerry/jlink.c:392-413`): checks `jlinkMode` first; with the default
+    `JLINK_MODE_DISABLED` it hits neither the `NETPACKET` nor `TCP_*` branches and returns
+    immediately — no socket syscalls. Cheap.
+  - `JLinkFrameTick()` (`src/jerry/jlink.c:666-705`): calls `JLinkNowMs()` UNCONDITIONALLY (every
+    frame, even fully disabled) → `JLinkNowUsec()` → `clock_gettime(CLOCK_MONOTONIC, ...)` on
+    POSIX (`jlink.c:46-58`). This is a real kernel time query on every single frame regardless of
+    netlink state, though on Linux (including RPi) `clock_gettime(CLOCK_MONOTONIC)` is normally
+    vDSO-backed (no syscall trap), so the practical cost is a handful of nanoseconds — I could not
+    confirm vDSO support specifically on the target RPi kernels from static code alone. Then
+    checks `JLinkDiscActive()` (`src/jerry/jlink_discover.c:343-345`, an `discSock >= 0` check,
+    O(1)) and `jlinkDevice == JLINK_DEVICE_VOICEMODEM` (O(1)), then returns early at
+    `jlink.c:678-682` since `jlinkWaitEnabled` defaults off.
+  - `UARTPoll()` (`src/jerry/uart.c:325-328`) is just `UARTKickRx()`, did not chase further — one
+    call regardless.
+  **Verdict**: well-gated overall; the only unconditional real work is one `clock_gettime` call
+  per frame. LOW impact, almost certainly not measurable, but technically "cost when the feature
+  is off should be zero branches" is violated by one syscall/vDSO-call. Effort S if someone wants
+  to gate `JLinkNowMs()` behind `jlinkMode != JLINK_MODE_DISABLED || JLinkDiscActive()`, but I'd
+  call this not worth the risk/churn for the expected gain — flagging only because it's the one
+  place this scope found a feature-off frame calling into the OS clock unconditionally.
+
+## 7. Per-title DB: NOT consulted per frame
+
+- `grep -n "TitleDB" libretro.c` shows all call sites are in `check_variables()`'s option-default
+  resolution path (`libretro.c:1864-1887`, itself only reachable from
+  `check_variables()`, which is update-gated per item 5) and in `retro_load_game`/
+  `retro_unload_game`/`retro_deinit` (`libretro.c:4479-5208`, all load/unload-time, not per
+  frame). No finding — confirmed not a per-frame cost.
+
+## 8. Allocation / memset churn per frame
+
+- Grepped all `memcpy`/`memset` call sites in `libretro.c`. None are in `retro_run`'s call graph
+  except the conditional, bounded stale-tail-row blank (item 1) and the input-button-array clears
+  (item 4, ~168 bytes). All other `memcpy`/`memset` calls are at init/load/unload/state-save-load
+  time. No malloc/free/calloc found in `retro_run` or its direct callees within this audit's
+  scope. No finding.
+
+## 9. Apple platform build flags (frontend-adjacent, brief compiler-flag spot check only)
+
+- `Makefile:70` — `OPT_O3_PLATFORMS` includes `ios-arm64`, `tvos-arm64` (and `osx`), each getting
+  `-O3` per the measured +5.5% macOS arm64 result documented at `Makefile:30-45` (issue #515).
+  RPi targets (`rpi0`..`rpi5_64`) are also in this list — consistent with the already-merged
+  per-SoC tuning in `perf/560-rpi-soc-tuning` (this branch's own recent commits,
+  `project_rpi_soc_tuning.md`).
+- `Makefile.common:157` — `ifneq (,$(filter ios-arm64 tvos-arm64,$(platform)))` sets NEON for
+  those two platforms explicitly; `Makefile.common:164` further notes armv8+ implies NEON anyway.
+  So Apple arm64 targets get both `-O3` and NEON. No gap found in the subset I checked.
+- Did not do a full compiler-flag audit (explicitly another agent's job per the task brief) — did
+  not check `-flto`, `-fwhole-program` interaction on iOS/tvOS specifically, or
+  `-fomit-frame-pointer`/PGO opportunities. `Makefile:219` shows `-flto=4 -fwhole-program
+  -fuse-linker-plugin` is used somewhere (need the surrounding platform guard to know which
+  targets) — flagging as a pointer for the dedicated compiler-flags agent, not verified further
+  here.
+
+## 10. Compiler-hint opportunities in libretro.c hot paths
+
+- Did not find an obvious high-value `__builtin_expect`/`restrict` opportunity within this
+  scope's actual hot path, because there ISN'T a hot per-pixel/per-sample loop living in
+  libretro.c itself (confirmed above — TOM/DAC own those loops, and they're out of scope). The
+  only candidate branches are already on cold/rare paths (tail-blank mismatch, geometry change,
+  crash-detect log-rate-limited warnings) where a misprediction hint would not be measurable.
+
+---
+
+## Summary table
+
+| # | Item | File:line | Impact | Risk | Effort | Model |
+|---|------|-----------|--------|------|--------|-------|
+| 1 | Full-frame video copy | — | N/A (none found) | — | — | — |
+| 2 | Shadowfb per-frame merge | — | N/A (fused into scanline render, not a separate pass) | — | — | — |
+| 3 | Geometry set every frame | — | N/A (already change-gated) | — | — | — |
+| 4 | Audio chunking | dac.c:425 | N/A (single batch call already) | — | — | — |
+| 5 | Unconditional keyboard scan | libretro.c:2879-2901, 2951-2973 | LOW (24 calls/frame, default config) | MED if changed (visible behavior) | S to measure / M to change | measure: sonnet; change: needs design sign-off |
+| 6 | check_variables() cadence | libretro.c:5333-5334 | N/A (already update-gated) | — | — | — |
+| 7 | crash_detect fb_hash | crash_detect.c:211-227 | N/A (already sampled, 256 ops) | — | — | — |
+| 8 | vjtrace in release | libretro.c:5301 / Makefile:161 | N/A (compiled out unless TEST_EXPORTS=1) | — | — | — |
+| 9 | vjPerfActive ~2000 calls/frame | perf_iface.h:30-38 | Out of this scope's actionable area (only 2 calls here); known/accepted tradeoff | — | — | — |
+| 10 | Netlink clock_gettime when disabled | jlink.c:666-682, 81-89 | LOW (one clock query/frame, likely vDSO) | LOW | S | sonnet, but likely not worth it |
+| 11 | TitleDB per-frame | — | N/A (load-time/option-time only) | — | — | — |
+| 12 | Apple/RPi -O3 + NEON | Makefile:70, Makefile.common:157 | N/A (already present) | — | — | — |
+
+No HIGH or MED-tier actionable findings surfaced in this scope. The one candidate worth a second
+look (#5, unconditional keyboard polling) is LOW impact and its only real "fix" carries a
+user-visible behavior-change risk, so I recommend NOT touching it without explicit product
+direction, and instead pointing investigation time at the GPU/DSP/blitter/bus layers other agents
+are covering.

--- a/docs/perf-audit/gpu.md
+++ b/docs/perf-audit/gpu.md
@@ -1,0 +1,446 @@
+> Raw sub-agent audit output (2026-08-22, read-only, sonnet). Line numbers refer to
+> `libretro/develop` @ 5f898da. Verified items are promoted to [`../perf-audit-2026-08.md`](../perf-audit-2026-08.md);
+> treat anything here that is NOT in that file as unverified.
+
+# GPU RISC interpreter perf audit — src/tom/gpu.c (read-only)
+
+Scope read in full: `src/tom/gpu.c` (2766 lines), plus `src/core/jaguar.c` (memory
+dispatch), `src/core/jaguar.h`, `src/core/bus_arbiter.{h,c}`, `src/core/perf_iface.h`,
+`src/tom/op.c` (GPUExec call sites), `libretro_core_options.h` (option defaults),
+`libretro-common/include/retro_inline.h` (INLINE macro).
+
+Context established up front: `virtualjaguar_dram_timing` (`busArbiter.enabled`) and
+`virtualjaguar_gpu_pipeline_timing` (`vjs.gpuPipelineTiming`) both **default to
+"disabled"** (`libretro_core_options.h:275`, `:298`-ish). So the pipeline-timing model
+(`GPUPipeCheckUse`, `GPUPipeMemAccess`, lines 249-388) and the bus-arbiter DRAM charge
+(`GPU_EXT_ACCESS`, lines 62-66) are **not** on the profiled hot path that produced the
+24-74% GPU-time numbers in the brief — they're opt-in accuracy features. Existing
+comments (line 1432-1440, issue #532) show the team already did one round of
+"cache the global in a local for the exec loop" hardening for exactly this reason. Only
+one gap remains in that hardening (finding 3 below).
+
+---
+
+## Finding 1 — GPUReadLong's external-memory fallback bypasses JaguarReadLong's fast path
+
+**File:line:** `src/tom/gpu.c:885` (inside `GPUReadLong`, `src/tom/gpu.c:837`)
+
+```c
+return (JaguarReadWord(offset, who) << 16) | JaguarReadWord(offset + 2, who);
+```
+
+**What it is:** Every GPU 32-bit LOAD that misses GPU-local RAM and GPU control RAM
+(i.e. every load from main DRAM, cart ROM, TOM/JERRY registers — the common case for
+texture/display-list/blitter-parameter streaming) falls through to this line, which
+manually assembles a long out of **two separate `JaguarReadWord` calls**.
+
+Compare `JaguarWriteLong`'s external path, which GPU's own `GPUWriteLong` already uses
+correctly (`src/tom/gpu.c:1109`: `JaguarWriteLong(offset, data, who);` — a single call),
+and compare `JaguarReadLong` itself (`src/core/jaguar.c:1122`), which has a **fast path**
+for the common case:
+
+```c
+uint32_t JaguarReadLong(uint32_t offset, uint32_t who)
+{
+   uint32_t addr = offset & 0xFFFFFF;
+   if (busArbiter.enabled && who == OP) bus_arbiter_op_charge(1);
+   if (addr < 0x800000)
+   {
+      VJT_WATCH_RD(addr, 0, who);
+      if (blitMemoRecording) BlitMemoNoteRead(addr, 4);
+      return GET32(jaguarMainRAM, addr & 0x1FFFFF);      // src/core/jaguar.c:1122-1143
+   }
+   return (JaguarReadWord(offset, who) << 16) | JaguarReadWord(offset+2, who);
+}
+```
+
+`GPUReadLong`'s fallback (line 885) never calls `JaguarReadLong` at all — it reimplements
+the slow tail directly. The result: a GPU LOAD from main RAM pays **two** function calls
+instead of one, and each of those two `JaguarReadWord` calls independently repeats: an
+`offset &= 0xFFFFFF` mask, a `VJT_WATCH_RD` check, a `blitMemoRecording` check, and its
+own `if (offset < 0x800000) ... else if ...` range-check chain
+(`src/core/jaguar.c:988-1013`) — i.e. the range-check chain and the two watch/memo hooks
+are each paid *twice* per long, and `JaguarReadLong`'s single-comparison fast path
+(`addr < 0x800000`) is skipped entirely in favor of `JaguarReadWord`'s longer chain
+(main RAM / ROM / CD / E00000 mirror / TOM / JERRY / unknown) walked twice.
+
+**Why it costs on in-order ARM:** each `JaguarReadWord` call is opaque from
+`GPUReadLong`'s TU-local view once cross-TU (unless LTO devirtualizes/inlines both), so
+this is 2x the call/return overhead, 2x the branch-chain traversal, 2x the global-flag
+checks, on a core with no OoO to hide the extra latency. This is exercised by
+`gpu_opcode_load` (`src/tom/gpu.c:2311`, `GPU_PIPE_LOAD(RM); RN = GPUReadLong(RM &
+0xFFFFFFFC, GPU);`), `load_r14/r15_indexed`, `load_r14/r15_ri`, and doubly by `loadp`
+(`gpu_opcode_loadp`, line 2323 area — issues two `GPUReadLong` calls for one STOREP
+phrase, so the external case pays **4** `JaguarReadWord` calls where 2 `JaguarReadLong`
+calls would do).
+
+**Proposed change:** in `GPUReadLong`, replace the two-word fallback with a single call:
+
+```c
+return JaguarReadLong(offset, who);
+```
+
+This is a **pure refactor** — same final bytes for every address class, since
+`JaguarReadLong`'s own fallback for non-fast-path addresses (`addr >= 0x800000`) is
+*exactly* the same two-`JaguarReadWord` expression, byte for byte. No behavior change,
+only removes duplicated dispatch/hook work on the common (`addr < 0x800000`) case.
+
+**Impact:** HIGH (my best guess — LOAD is one of the most frequent GPU opcodes in
+texture/blit-heavy kernels, and this doubles call overhead on that exact path; can't
+quantify % without a profile run, but it's a genuine 2x-call-count-per-load regression
+relative to what's already sitting one call away).
+
+**Risk:** essentially zero — semantically identical output, does not touch flags, PC,
+savestates, or timing accounting (the `GPU_PIPE_LOAD`/`GPU_EXT_ACCESS` charge happens
+before this call, unaffected).
+
+**Effort:** S. Mechanical, one-line change plus a comment. A cheap model (sonnet) can do
+this safely; recommend running `test/tools/test_blitter_compare` and the general
+`make TEST_EXPORTS=1 test` suite afterward (GPU load-heavy paths: texture/Cinepak/blitter
+tests) since it's a hot, widely-exercised function.
+
+**No existing issue reference found** for this specific gap — `GPUWriteLong`'s use of
+`JaguarWriteLong` (the correct pattern) has no comment explaining why `GPUReadLong`
+doesn't mirror it; looks like an oversight, not a deliberate asymmetry.
+
+---
+
+## Finding 2 — `gpu_opcode[64]` function-pointer table is dead code, keeps 64 out-of-line copies alive
+
+**File:line:** `src/tom/gpu.c:524` (definition), used only at `src/tom/gpu.c:1509`
+inside `#if 0 ... #endif` (`src/tom/gpu.c:1508-1512`, confirmed the only other reference
+via `grep -rn "\bgpu_opcode\b\["`).
+
+```c
+void (*gpu_opcode[64])()=
+{
+    gpu_opcode_add, gpu_opcode_addc, ... // 64 entries
+};
+...
+#if 0
+      gpu_opcode[index]();
+#else
+       executeOpcode(index);
+#endif
+```
+
+**What it is:** a 64-entry function-pointer table built from every `gpu_opcode_*`
+handler, whose only consumer is compiled out (`#if 0`). Because the table takes the
+address of every handler, each `gpu_opcode_*` function (all declared `INLINE static`,
+i.e. a plain `inline`/`__inline__` hint per `retro_inline.h`, not `always_inline`) is
+forced to keep an out-of-line, addressable definition even though `executeOpcode`'s
+computed-goto dispatch (line 1583) is the only live call site and — being a single-use
+`static` function called from one place per label — should otherwise be a strong
+candidate for full inlining by GCC/Clang at `-O2`/`-O3`.
+
+**Why it costs on in-order ARM:** taking a function's address doesn't prevent inlining
+the call site, but it does force the compiler to also *emit* a standalone copy of every
+handler (up to 64 extra function bodies, some fairly large — `gpu_opcode_mmult`,
+`gpu_opcode_div`, `gpu_opcode_normi`). That's dead .text bloat that dilutes icache
+locality for the actual hot loop on cache-constrained cores (32KB L1-I on Cortex-A72,
+smaller/shared on A10X's efficiency-adjacent paths), and it's linked in unconditionally.
+
+**Proposed change:** delete the `gpu_opcode[64]` table and the `#if 0` dead branch;
+keep only the `executeOpcode(index)` call. (Alternatively, if some other reviewer wants
+disassembly tooling later, gate the table behind that build, but nothing else in the
+tree currently reads it — confirmed via `grep -rln gpu_opcode\\[`.)
+
+**Impact:** LOW-MED (icache-pressure argument is plausible but unmeasured; the dead
+table's own storage is trivially small — the win, if any, is in whether the compiler can
+now fully absorb the handler bodies into the goto targets and shrink hot .text, not in
+removing the table's own bytes).
+
+**Risk:** LOW — dead code with no reachable caller; a pure deletion.
+
+**Effort:** S, mechanical, sonnet-doable. Recompile and check binary size / confirm
+`make TEST_EXPORTS=1 test` still passes (no behavior can change since the deleted path
+never ran).
+
+---
+
+## Finding 3 — `GPU_PIPE_LOAD`/`GPU_PIPE_STORE` macros re-read the global `vjs.gpuPipelineTiming` from inside every load/store handler, missing the #532 caching
+
+**File:line:** `src/tom/gpu.c:393-402` (macro definitions), used inside ~15 opcode
+handlers (`gpu_opcode_load`, `_loadb`, `_loadw`, `_loadp`, `_load_r14/r15_indexed`,
+`_load_r14/r15_ri`, `_store`, `_storeb`, `_storew`, `_storep`,
+`_store_r14/r15_indexed`, `_store_r14/r15_ri`).
+
+```c
+#define GPU_PIPE_LOAD(addr) \
+   do { \
+      if (vjs.gpuPipelineTiming) GPUPipeMemAccess((addr), 1); \
+      else GPU_EXT_ACCESS(addr); \
+   } while (0)
+```
+
+**What it is:** `GPUExec` (line 1429) explicitly caches `vjs.gpuPipelineTiming` into a
+local `pipeTiming` "issue #532" specifically to avoid a per-instruction global reload
+across the opaque `executeOpcode` call (see the comment at line 1432-1440: *"executeOpcode()
+is an opaque call, so without these locals the compiler must assume the call clobbers
+both globals and reloads them on every emulated instruction"*). But that caching only
+covers the two direct uses inside `GPUExec`'s own loop body (`if (pipeTiming)
+GPUPipeCheckUse(index);` and the post-opcode accounting). The `GPU_PIPE_LOAD`/
+`GPU_PIPE_STORE` macros, expanded inside the individual `gpu_opcode_*` handlers, read
+`vjs.gpuPipelineTiming` directly — the #532 local never reaches them, so every load/store
+opcode still pays a fresh global load of `vjs.gpuPipelineTiming` (and, when
+`GPU_EXT_ACCESS` is taken, a second global load of `busArbiter.enabled`).
+
+**Why it costs on in-order ARM:** same shape of cost the #532 comment already diagnosed
+for the outer loop — a global field load per instruction that the compiler cannot hoist
+because `vjs` (settings struct) could in principle be touched by anything reachable from
+the call graph. In practice this is *one byte load* per load/store opcode (small), but
+it's the exact class of redundant work #532 set out to eliminate and missed.
+
+**Proposed change:** either (a) pass `pipeTiming` through as an explicit parameter to
+every load/store handler (invasive — 15 signature changes), or (b) the cheaper option:
+introduce a second file-scope variable, e.g. `static uint8_t gpu_pipeTiming_cached;` set
+once at the top of `GPUExec` alongside the existing `pipeTiming` local, and have the
+macros test that instead of `vjs.gpuPipelineTiming`. Since it's still a global read
+either way, (b) is a wash on its own merits and only "closes the doc gap" — **I'd
+recommend not spending effort here** unless profiling shows it matters; flagging mainly
+because it's the one loose end of an otherwise-completed optimization pass, and a future
+"finish #532" pass should know about it.
+
+**Impact:** LOW (single byte load, well predicted, likely single-cacheline-resident).
+
+**Risk:** LOW if touched (behavior-preserving), but not worth the diff churn for the
+likely payoff.
+
+**Effort:** S if pursued; recommend skipping.
+
+---
+
+## Finding 4 — `gpu_opcode_cycles[64]`, `gpu_convert_zero[32]` should be `static const`
+
+**File:line:** `src/tom/gpu.c:512` (`uint8_t gpu_opcode_cycles[64] = {all 1s}`),
+`src/tom/gpu.c:653` (`uint32_t gpu_convert_zero[32] = {32,1,2,...31}`).
+
+**What it is:** both tables are declared with external linkage and are mutable
+(non-`const`). Confirmed via `grep -rln` across the whole tree that neither symbol is
+referenced from any other `.c`/`.h` file (`gpu_opcode_cycles` gets one *comment*
+mention in `src/core/bus_arbiter.h:28`, not an actual reference; `gpu_convert_zero` has
+zero references outside `gpu.c`). Neither is declared in `gpu.h`. `gpu_opcode_cycles` is
+never written anywhere (grep confirms only reads at lines 1515, 1547, 1551, 1832,
+1833, 1879, 1880) — every entry is permanently 1.
+
+**Why it costs on in-order ARM:** because the compiler cannot prove (without whole-
+program/LTO visibility) that no other TU writes these arrays, it cannot constant-fold
+`gpu_opcode_cycles[index]` to the literal `1` even though that's always true, and it must
+treat the array as potentially-aliased, mutable global state rather than placing it in
+`.rodata` with the "never changes" guarantee that would let it fold `cycles -=
+gpu_opcode_cycles[index] + ...` into `cycles -= 1 + ...` at `-O2`/`-O3`. Also relevant to
+the branch-prediction/interlock table `gpu_pipe_flags`/`gpu_pipe_sets_flags` (lines
+203-215, 236-240) which **are** already correctly `static const uint8_t[64]` — so the
+project already knows the right pattern here; `gpu_opcode_cycles`/`gpu_convert_zero`
+just weren't updated to match.
+
+`gpu_convert_zero` is read on every `addq`/`subq`/`shrq`/`rorq`/`sharq`/indexed-load/
+indexed-store instruction (the "quick" immediate forms, some of the most common GPU
+opcodes in compiled Jaguar code per the JTRM's own registers score-boarding write-up).
+
+**Proposed change:**
+```c
+static const uint8_t gpu_opcode_cycles[64] = { ...same 64 ones... };
+static const uint32_t gpu_convert_zero[32] = { ...same values... };
+```
+Also fix the two call sites (`bus_arbiter.h`'s comment doesn't need a code change; it's
+prose). Verify `gpu_opcode_cycles` truly has no writers before applying (grep already
+done above; re-verify at patch time with `grep -n "gpu_opcode_cycles\[.*\] *="`).
+
+**Impact:** LOW (each is a small, cheap load already; the win is constant-folding
+`cycles -= gpu_opcode_cycles[index]` to `cycles -= 1`, saving one table load + add per
+instruction on the accounting path, and letting `gpu_convert_zero[IMM_1]` sit
+unambiguously in `.rodata`). Cumulatively low-single-digit-percent at most, but free.
+
+**Risk:** near zero — `static const` only tightens guarantees already true in practice;
+purely mechanical, no behavior change.
+
+**Effort:** S, sonnet-doable directly.
+
+---
+
+## Finding 5 — `branch_condition_table` is a heap-allocated pointer, adding one indirection to every conditional JUMP/JR
+
+**File:line:** `src/tom/gpu.c:656` (`uint8_t * branch_condition_table = 0;`),
+`src/tom/gpu.c:657` (`#define BRANCH_CONDITION(x) branch_condition_table[(x) +
+((jaguar_flags & 7) << 5)]`), built once by `build_branch_condition_table()`
+(`src/tom/gpu.c:751`, `malloc(32*8)`), used in `gpu_opcode_jump` (line 1794) and
+`gpu_opcode_jr` (line 1845) — i.e. on every taken-or-not conditional branch, one of the
+hottest opcode classes in compiled GPU code (loop back-edges, texture-loop counters).
+
+**What it is:** the 256-byte table is `malloc`'d once at startup and accessed through a
+global pointer, so `BRANCH_CONDITION(x)` costs a **pointer load + index** rather than a
+direct array index. It's shared with `src/jerry/dsp.c` (confirmed via grep — DSP defines
+its own copy of the macro against the same global), which is presumably why it's a
+pointer rather than a fixed array: whichever of GPU/DSP initializes first calls
+`build_branch_condition_table()` and both then read the same 256 bytes.
+
+**Why it costs on in-order ARM:** one extra load-use dependency (load the pointer, then
+load through it) versus a `static const uint8_t table[256]` baked into `.rodata` at
+compile time and indexed directly, on the single most latency-sensitive part of a
+mispredict-prone branch-condition computation.
+
+**Proposed change:** since the table's 256 entries are a pure function of `i`/`j` (see
+the nested loop at lines 762-773) and don't depend on any runtime config, it can be
+generated at compile time (a static `constexpr`-style array literal, computed offline
+once and pasted in, or built via X-macro) and declared
+`static const uint8_t branch_condition_table[256]` directly, eliminating both the
+`malloc`, the null-check-free-at-shutdown bookkeeping, and the pointer indirection.
+Because it's shared with `dsp.c`, this would need to move to a shared header (or be
+duplicated — 256 bytes is cheap to duplicate per-file if sharing the header is
+inconvenient) and touches two files, so it's a slightly larger change than the other
+findings here.
+
+**Impact:** MED (my best guess — every taken/not-taken branch pays this, and branches
+are extremely common in RISC loop bodies; the *removed* indirection is small in absolute
+cycles but the site is hot).
+
+**Risk:** LOW-MED — must verify the generated table is byte-identical to
+`build_branch_condition_table()`'s output (straightforward to check with a one-off test
+harness dump, or by keeping the runtime builder as a `#ifdef`-gated fallback/assertion
+during development) and that DSP's copy/reference is updated consistently so the two
+interpreters can't desync. Needs care, not a blind mechanical edit — recommend sonnet
+draft + a human/careful-model check of the generated table against
+`build_branch_condition_table()`'s current output before landing.
+
+**Effort:** M.
+
+---
+
+## Finding 6 — `gpu_opcode_div` is a 32-iteration bit-serial loop per DIV instruction
+
+**File:line:** `src/tom/gpu.c:2558` (`gpu_opcode_div`), loop at roughly line 2570-2580
+(`for(i=0; i<32; i++) { ... }` — restoring-division bit-serial algorithm, comment credits
+"SCPCD").
+
+**What it is:** every GPU `DIV` opcode runs an explicit 32-iteration loop, each iteration
+a data-dependent shift+conditional-add+shift chain (`r = (r<<1)|...; r += (sign?RM:-RM);
+q = (q<<1)|...`). This is a serial dependency chain with no cross-iteration ILP — on an
+in-order core each iteration is latency-bound, not throughput-bound.
+
+**Why it costs on in-order ARM:** ~32 sequential shift/add/compare steps versus a native
+32-bit hardware divide (`UDIV` on ARMv7-A/ARMv8, or an emulated `/`/`%` the compiler
+lowers efficiently) is a real, measurable per-instruction cost multiplier specifically on
+cores without deep OoO to overlap the chain — this is exactly the profile of the
+in-order/low-IPC hosts named in the brief (A10X, Cortex-A72).
+
+**Why I am NOT proposing a rewrite:** the comment ("Real algorithm, courtesy of SCPCD:
+NYAN!") and the 16.16-fixed-point pretreatment (`if (gpu_div_control & 0x01) q <<= 16, r
+= RN >> 16;`) strongly suggest this bit-serial form was chosen to match real hardware's
+extended-precision (48-bit effective dividend in the 16.16 case) and possibly its
+specific overflow/edge-case behavior bit-for-bit, which a native `/`/`%` would not
+necessarily reproduce (divide-by-zero, quotient overflow, the exact remainder on
+overflow). Given the repo's stated priority on hardware accuracy over cleverness (see
+CLAUDE.md's hardware-accuracy rules) and that I have not verified against JTRM/silicon
+whether the two paths are provably equivalent, I'm flagging this as a candidate, not a
+recommendation.
+
+**Impact:** MED, *if* DIV is common in profiled titles (perspective texture mapping /
+division-heavy render kernels use it); LOW if DIV is rare in practice. Can't tell without
+a per-opcode instruction histogram, which is outside this audit's read-only scope.
+
+**Risk:** HIGH — touches emulation correctness/hardware-accuracy directly; per this
+repo's CLAUDE.md rule, would need JTRM PDF verification (not source comments) before any
+change, and must not regress the acid-test suite's DIV coverage if any exists.
+
+**Effort:** M if attempted, and should NOT be done mechanically — needs a careful/senior
+pass with hardware-doc verification, not a cheap-model mechanical edit. Recommend: only
+pursue after profiling confirms DIV is actually hot in a real title; otherwise leave
+alone.
+
+---
+
+## Investigated, not recommended (already correct or unsafe to touch)
+
+- **`gpu_reg` double indirection (RM/RN macros, `#define RM gpu_reg[gpu_opcode_first_parameter]`,
+  line ~597-ish).** `gpu_reg` is a `static uint32_t *` pointing at bank 0 or bank 1,
+  re-pointed by `GPUUpdateRegisterBanks()`. I checked both call sites
+  (`src/tom/gpu.c:984`, inside `GPUWriteLong`'s `case 0x00` — i.e. a **GPU STORE to its
+  own G_FLAGS register**, which happens routinely in ISR epilogues toggling
+  IMASK/REGPAGE — and `src/tom/gpu.c:1180`, inside `GPUHandleIRQs`). Because a GPU STORE
+  instruction can flip the bank *mid-slice*, `gpu_reg` is **not** loop-invariant across
+  `GPUExec`'s instruction loop, so caching the pointer in a local across multiple
+  opcodes (the obvious "fix") is unsafe without an invalidation scheme tied to every
+  STORE-to-G_FLAGS. Not a good mechanical target; flagging as understood-and-rejected
+  rather than silent.
+
+- **Z/N/C flags as three separate byte globals** (`static uint8_t gpu_flag_z, gpu_flag_n,
+  gpu_flag_c;`, line ~586). There's an explicit in-code rationale at
+  `src/tom/gpu.c:582-585`: *"There is a distinct advantage to having these separated
+  out--there's no need to clear a bit before writing a result."* This is a deliberate,
+  documented design choice (RMW avoidance), not an oversight. I don't recommend packing
+  them into one flags word — that would reintroduce the clear-before-write cost the
+  comment explains was avoided, and three adjacent `uint8_t` globals likely already share
+  a cache line in practice (declared consecutively). Not flagging as a finding.
+
+- **`GPUHandleIRQs` cost when idle.** Called once per `GPUExec` invocation (not
+  per-instruction — confirmed by reading the full exec loop, lines 1429-1573: the call is
+  at line 1471, before the `while` loop, with no per-instruction re-check). Early-exits in
+  2-3 cheap comparisons (`!GPU_RUNNING`, `gpu_flags & IMASK`, `bits &= mask; if (!bits)
+  return;`) when nothing is pending. Not a hot-path concern.
+
+- **`VJP_ENTER`/`VJP_LEAVE` (perf_iface.h).** Per-`GPUExec`-call (slice granularity), not
+  per-instruction. The header's own design doc (`src/core/perf_iface.h:1-40`) explicitly
+  addresses this: "Every probe here brackets a SLICE ... never an interpreter inner
+  loop." Confirmed by reading the actual placement — correct as designed, not a finding.
+
+- **`VJT_PCHIST_GPU`, `crash_detect` hooks.** `VJT_PCHIST_GPU(gpu_pc)` (line 1483) is
+  inside `#ifdef VJ_TRACE`, compiled out in release/shipped builds. No `CrashDetect*`
+  call exists inside the instruction loop at all (only at `GPUWriteLong`'s G_PC/G_CTRL
+  write handlers, i.e. on GPU start/stop transitions, not per instruction). Not a
+  per-instruction cost in release builds.
+
+- **`GPU_PIPE_*` pipeline-timing model and `GPU_EXT_ACCESS`/dram-timing.** Both gated by
+  core options that **default to disabled** (`libretro_core_options.h`). Zero cost in the
+  default configuration beyond the two cheap global-bool checks addressed in Finding 3.
+  Not the source of the profiled 24-74% GPU-time hotspot under default settings.
+
+- **`executeOpcode`'s computed-goto dispatch.** Already computed-goto per the task brief;
+  confirmed unchanged and correctly structured (lines 1575-1730). GCC-only path with a
+  `switch` fallback for MSVC (lines 1730+). No further dispatch-level optimization
+  identified.
+
+- **`sqtable[32]` inside `gpu_opcode_cmpq`** (`src/tom/gpu.c:1966`) is a function-local
+  `static int32_t` array, never written — should technically be `static const int32_t`
+  too, but as a function-local static its initializer is already resolved at load time
+  with no per-call cost; this is a style nit, not a performance finding. Mentioned for
+  completeness, not worth a separate action.
+
+- **GPU-object OP release-guard loop** (`src/tom/op.c:674-690`,
+  `OP_GPU_RELEASE_GUARD_CYCLES=4000`, `OP_GPU_RELEASE_STEP_CYCLES=16`): repeatedly calls
+  `GPUExec(16)` in a polling loop when the OP hands a GPU-interrupt object to the GPU,
+  paying `GPUExec`'s fixed per-call overhead (VJP_ENTER/LEAVE, `GPUHandleIRQs`,
+  `vjs.gpuPipelineTiming`/`riscClockScalePct` reads) once per 16 GPU cycles of real work
+  in the worst case. This is title-specific (games that route objects through the GPU —
+  Primal Rage, Val d'Isere per project memory) rather than a universal hotspot, and the
+  fine polling granularity looks intentional (it's how `op_obf_written` timing is modeled
+  accurately — the loop normally exits after the first iteration or two once the GPU's
+  ISR responds, so the 4000/16=250 worst case is rare). Flagging as understood, not
+  proposing a change without evidence a real title hits the worst case.
+
+- **`JaguarWriteLong`'s per-call CDDA-DIAG debug comparison** (`src/core/jaguar.c:1163`,
+  `if (addr == 0xF1B274 && data != 0) LOG_DBG(...)`) — a single cheap, well-predicted
+  compare paid on every long write (68K, GPU, DSP alike), explicitly marked in its own
+  comment as leftover debug instrumentation to "remove... when resolved" (Primal Rage
+  CDDA investigation). Out of gpu.c's scope (shared file, not GPU-specific), LOW impact,
+  and already self-documented as scheduled for removal — not raising as a new finding,
+  just noting it's there and already tracked in spirit.
+
+---
+
+## Summary table
+
+| # | Finding | Impact | Risk | Effort | Model |
+|---|---|---|---|---|---|
+| 1 | `GPUReadLong` external fallback → use `JaguarReadLong` | HIGH | ~none | S | sonnet |
+| 2 | Delete dead `gpu_opcode[64]` table + `#if 0` block | LOW-MED | LOW | S | sonnet |
+| 3 | `GPU_PIPE_LOAD/STORE` re-reads `vjs.gpuPipelineTiming` | LOW | LOW | S | skip (not worth it) |
+| 4 | `gpu_opcode_cycles`/`gpu_convert_zero` → `static const` | LOW | ~none | S | sonnet |
+| 5 | `branch_condition_table` malloc'd pointer → static const array | MED | LOW-MED | M | careful/verify |
+| 6 | `gpu_opcode_div` 32-iter bit-serial loop | MED (unverified) | HIGH | M | senior + JTRM check |
+
+Recommended order if pursuing: **1 → 4 → 2** (cheap, safe, mechanical, do all three
+together and re-run `make TEST_EXPORTS=1 test` + `test/tools/test_blitter_compare`), then
+consider profiling to see if 5 or 6 are worth the larger effort — I would not spend
+effort on 5/6 without an instruction-frequency profile confirming JUMP/JR/DIV density in
+the titles that show the worst A10X/Pi4 numbers.

--- a/test/tools/risc_pc_histogram.c
+++ b/test/tools/risc_pc_histogram.c
@@ -1,0 +1,761 @@
+/* test/tools/risc_pc_histogram.c -- where are the GPU and DSP parked at
+ * the end of each frame?
+ *
+ * test_benchmark.c plus a frame-end sampler: after every retro_run() it
+ * reads dsp_pc / gpu_pc (TEST_EXPORTS wide ABI) and at the end prints the
+ * hottest PCs with the surrounding instructions decoded from RISC RAM
+ * (via JaguarReadWord), plus dsp_exec_opcode_count per frame.  A RISC
+ * that is idling shows 90%+ of its samples in a 2-5 instruction jr loop;
+ * this is how the idle-loop finding in docs/perf-audit-2026-08.md was made.
+ *
+ * Needs a TEST_EXPORTS=1 core (the dsp_, gpu_ and Jaguar symbols are
+ * hidden otherwise, and the sampler then prints "sampler: symbols not
+ * exported" and nothing else).
+ *
+ * Build:
+ *   make TEST_EXPORTS=1
+ *   cc -O2 -Wall -std=c99 -I. -I./libretro-common/include \
+ *      -o test/tools/risc_pc_histogram test/tools/risc_pc_histogram.c
+ * Run (same arguments as test_benchmark):
+ *   test/tools/risc_pc_histogram ./virtualjaguar_libretro.dylib rom.jag 1200 \
+ *      --warmup 30 --blitter fast --load-state state.state
+ *
+ * ---- original test_benchmark.c header follows ----
+ */
+/* Headless benchmark tool: loads core via dlopen, runs N frames, and
+   reports wall-clock timing (total, FPS, ms/frame).
+
+   Usage: test_benchmark <core.dylib> <rom_file> [num_frames]
+          [--blitter fast|accurate] [--warmup N] [--load-srm file]
+*/
+#include <stdio.h>
+#include <stdint.h>
+/* ---- frame-end RISC PC sampler ---- */
+#define PCH_N 4096
+typedef uint16_t (*read_word_fn)(uint32_t addr, uint32_t who);
+static read_word_fn g_rd;
+static uint32_t *g_dsp_pc, *g_gpu_pc, *g_dsp_cnt;
+static uint32_t hd_pc[PCH_N], hd_n[PCH_N], hg_pc[PCH_N], hg_n[PCH_N];
+static int hd_c, hg_c;
+
+static const char *risc_opname[64] = {
+   "add", "addc", "addq", "addqt", "sub", "subc", "subq", "subqt",
+   "neg", "and", "or", "xor", "not", "btst", "bset", "bclr",
+   "mult", "imult", "imultn", "resmac", "imacn", "div", "abs", "sh",
+   "shlq", "shrq", "sha", "sharq", "ror", "rorq", "cmp", "cmpq",
+   "sat8", "sat16", "move", "moveq", "moveta", "movefa", "movei", "loadb",
+   "loadw", "load", "loadp", "load_r14i", "load_r15i", "storeb", "storew", "store",
+   "storep", "store_r14i", "store_r15i", "move_pc", "jump", "jr", "mmult", "mtoi",
+   "normi", "nop", "load_r14ri", "load_r15ri", "store_r14ri", "store_r15ri", "sat24", "pack"
+};
+
+static void hist_add(uint32_t *pcs, uint32_t *ns, int *c, uint32_t pc)
+{
+   int i;
+   for (i = 0; i < *c; i++)
+   {
+      if (pcs[i] == pc)
+      {
+         ns[i]++;
+         return;
+      }
+   }
+   if (*c < PCH_N)
+   {
+      pcs[*c] = pc;
+      ns[*c] = 1;
+      (*c)++;
+   }
+}
+
+static void hist_dump(const char *tag, uint32_t *pcs, uint32_t *ns, int c,
+                      uint32_t base, uint32_t size, int total)
+{
+   int i, k;
+   printf("\n=== %s PC histogram (frame-end samples, %d) ===\n", tag, total);
+   for (k = 0; k < 8; k++)
+   {
+      int best = -1;
+      for (i = 0; i < c; i++)
+         if (ns[i] && (best < 0 || ns[i] > ns[best]))
+            best = i;
+      if (best < 0)
+         break;
+      printf("  %08X  %5u (%.1f%%)", pcs[best], ns[best], 100.0 * ns[best] / total);
+      if (g_rd && pcs[best] >= base && pcs[best] < base + size)
+      {
+         uint32_t off = pcs[best] - base;
+         int j, lo = (int)off - 16;
+         if (lo < 0)
+            lo = 0;
+         printf("   code @%08X:", base + lo);
+         for (j = lo; j < (int)off + 12 && j + 1 < (int)size; j += 2)
+         {
+            uint16_t op = g_rd(base + j, 0);
+            printf(" %s%s(%u,%u)", (j == (int)off) ? "*" : "",
+                   risc_opname[op >> 10], (op >> 5) & 31, op & 31);
+         }
+      }
+      printf("\n");
+      ns[best] = 0;
+   }
+}
+/* ---- end sampler ---- */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#else
+#include <time.h>
+#endif
+
+#include <libretro.h>
+
+/* Function pointers loaded from the core */
+static void (*pretro_set_environment)(retro_environment_t);
+static void (*pretro_set_video_refresh)(retro_video_refresh_t);
+static void (*pretro_set_audio_sample)(retro_audio_sample_t);
+static void (*pretro_set_audio_sample_batch)(retro_audio_sample_batch_t);
+static void (*pretro_set_input_poll)(retro_input_poll_t);
+static void (*pretro_set_input_state)(retro_input_state_t);
+static void (*pretro_init)(void);
+static void (*pretro_deinit)(void);
+static bool (*pretro_load_game)(const struct retro_game_info *);
+static void (*pretro_run)(void);
+static void (*pretro_unload_game)(void);
+static void *(*pretro_get_memory_data)(unsigned);
+static size_t (*pretro_get_memory_size)(unsigned);
+static size_t (*pretro_serialize_size)(void);
+static bool (*pretro_unserialize)(const void *, size_t);
+/* Optional: only present when the core was built with BENCH_PROFILE=1. */
+static void (*pperf_counters_dump)(FILE *);
+static unsigned long long *(*pperf_counters_find)(const char *);
+
+/* Options state */
+static int bios_option_set = 0;
+static const char *blitter_value = "enabled"; /* default: fast blitter */
+
+/* High-resolution timer helpers */
+#ifdef __APPLE__
+static mach_timebase_info_data_t timebase_info;
+
+static uint64_t timer_now(void)
+{
+   return mach_absolute_time();
+}
+
+static double timer_elapsed_sec(uint64_t start, uint64_t end)
+{
+   uint64_t elapsed = end - start;
+   if (timebase_info.denom == 0)
+      mach_timebase_info(&timebase_info);
+   /* Convert to nanoseconds, then seconds */
+   return (double)elapsed * (double)timebase_info.numer / (double)timebase_info.denom / 1e9;
+}
+#else
+static uint64_t timer_now(void)
+{
+   struct timespec ts;
+   clock_gettime(CLOCK_MONOTONIC, &ts);
+   return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+static double timer_elapsed_sec(uint64_t start, uint64_t end)
+{
+   return (double)(end - start) / 1e9;
+}
+#endif
+
+static void log_printf(enum retro_log_level level, const char *fmt, ...)
+{
+   va_list ap;
+   const char *lvl_str = "???";
+   switch (level) {
+      case RETRO_LOG_DEBUG: lvl_str = "DBG"; break;
+      case RETRO_LOG_INFO:  lvl_str = "INF"; break;
+      case RETRO_LOG_WARN:  lvl_str = "WRN"; break;
+      case RETRO_LOG_ERROR: lvl_str = "ERR"; break;
+      default: break;
+   }
+   fprintf(stderr, "[%s] ", lvl_str);
+   va_start(ap, fmt);
+   vfprintf(stderr, fmt, ap);
+   va_end(ap);
+}
+
+static bool environment_cb(unsigned cmd, void *data)
+{
+   switch (cmd)
+   {
+      case RETRO_ENVIRONMENT_GET_LOG_INTERFACE:
+      {
+         struct retro_log_callback *cb = (struct retro_log_callback *)data;
+         cb->log = log_printf;
+         return true;
+      }
+      case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+         return true;
+      case RETRO_ENVIRONMENT_GET_VARIABLE:
+      {
+         struct retro_variable *var = (struct retro_variable *)data;
+         if (strcmp(var->key, "virtualjaguar_bios") == 0)
+         {
+            var->value = "enabled";
+            bios_option_set = 1;
+            return true;
+         }
+         if (strcmp(var->key, "virtualjaguar_pal") == 0)
+         {
+            var->value = "disabled";
+            return true;
+         }
+         if (strcmp(var->key, "virtualjaguar_usefastblitter") == 0)
+         {
+            var->value = blitter_value;
+            return true;
+         }
+         var->value = NULL;
+         return false;
+      }
+      case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE:
+      {
+         bool *updated = (bool *)data;
+         *updated = false;
+         return true;
+      }
+      case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+      case RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS:
+      case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
+      case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK:
+         return true;
+      case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
+      {
+         unsigned *version = (unsigned *)data;
+         *version = 2;
+         return true;
+      }
+      case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS:
+         return true;
+      case RETRO_ENVIRONMENT_GET_INPUT_BITMASKS:
+         return false;
+      case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+         *(const char **)data = "test/roms/private";
+         return true;
+      case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+         *(const char **)data = "/tmp";
+         return true;
+      default:
+         return false;
+   }
+}
+
+static void video_refresh(const void *data, unsigned width, unsigned height, size_t pitch)
+{
+   (void)data; (void)width; (void)height; (void)pitch;
+}
+
+static void audio_sample(int16_t left, int16_t right)
+{
+   (void)left; (void)right;
+}
+
+static size_t audio_sample_batch(const int16_t *data, size_t frames)
+{
+   (void)data;
+   return frames;
+}
+
+static void input_poll(void) {}
+static int16_t input_state(unsigned port, unsigned device, unsigned index, unsigned id)
+{
+   (void)port; (void)device; (void)index; (void)id;
+   return 0;
+}
+
+static void print_usage(const char *progname)
+{
+   fprintf(stderr,
+      "Usage: %s <core.dylib> <rom_file> [num_frames]\n"
+      "       [--blitter fast|accurate] [--warmup N] [--load-srm file]\n"
+      "       [--load-state file]\n"
+      "\n"
+      "Options:\n"
+      "  num_frames           Number of frames to benchmark (default: 300)\n"
+      "  --blitter fast       Use fast blitter (default)\n"
+      "  --blitter accurate   Use accurate (Midsummer2) blitter\n"
+      "  --warmup N           Run N warmup frames before timing\n"
+      "  --load-srm file      Load EEPROM save data from file\n"
+      "  --load-state file    Load a save state into the core after retro_load_game.\n"
+      "                       Accepts raw retro_serialize() payloads or RetroArch\n"
+      "                       RASTATE container files (the MEM chunk is extracted).\n",
+      progname);
+}
+
+int main(int argc, char **argv)
+{
+   void *handle;
+   const char *core_path;
+   const char *rom_path;
+   const char *srm_load_path = NULL;
+   const char *state_load_path = NULL;
+   struct retro_game_info info;
+   FILE *f;
+   long fsize;
+   int i;
+   int num_frames = 300;
+   int warmup_frames = 0;
+   uint64_t t_start, t_end;
+   double elapsed, fps, ms_per_frame;
+
+   if (argc < 3)
+   {
+      print_usage(argv[0]);
+      return 1;
+   }
+
+   core_path = argv[1];
+   rom_path = argv[2];
+
+   /* Parse optional arguments */
+   for (i = 3; i < argc; i++)
+   {
+      if (strcmp(argv[i], "--blitter") == 0 && i + 1 < argc)
+      {
+         const char *mode = argv[++i];
+         if (strcmp(mode, "fast") == 0)
+            blitter_value = "enabled";
+         else if (strcmp(mode, "accurate") == 0)
+            blitter_value = "disabled";
+         else
+         {
+            fprintf(stderr, "Unknown blitter mode: %s (use 'fast' or 'accurate')\n", mode);
+            return 1;
+         }
+      }
+      else if (strcmp(argv[i], "--warmup") == 0 && i + 1 < argc)
+         warmup_frames = atoi(argv[++i]);
+      else if (strcmp(argv[i], "--load-srm") == 0 && i + 1 < argc)
+         srm_load_path = argv[++i];
+      else if (strcmp(argv[i], "--load-state") == 0 && i + 1 < argc)
+         state_load_path = argv[++i];
+      else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0)
+      {
+         print_usage(argv[0]);
+         return 0;
+      }
+      else
+         num_frames = atoi(argv[i]);
+   }
+
+   if (num_frames <= 0)
+   {
+      fprintf(stderr, "ERROR: num_frames must be a positive integer (got %d)\n", num_frames);
+      return 1;
+   }
+   if (warmup_frames < 0)
+   {
+      fprintf(stderr, "ERROR: --warmup must be >= 0 (got %d)\n", warmup_frames);
+      return 1;
+   }
+
+#ifdef __APPLE__
+   /* Initialize timebase for mach_absolute_time conversion */
+   mach_timebase_info(&timebase_info);
+#endif
+
+   /* Load ROM */
+   f = fopen(rom_path, "rb");
+   if (!f)
+   {
+      fprintf(stderr, "Cannot open ROM: %s\n", rom_path);
+      return 1;
+   }
+   fseek(f, 0, SEEK_END);
+   fsize = ftell(f);
+   fseek(f, 0, SEEK_SET);
+   info.data = malloc(fsize);
+   info.size = fsize;
+   info.path = rom_path;
+   info.meta = NULL;
+   if (fread((void *)info.data, 1, fsize, f) != (size_t)fsize)
+   {
+      fprintf(stderr, "Failed to read ROM\n");
+      fclose(f);
+      return 1;
+   }
+   fclose(f);
+
+   /* Load core */
+   handle = dlopen(core_path, RTLD_LAZY);
+   if (!handle)
+   {
+      fprintf(stderr, "dlopen failed: %s\n", dlerror());
+      free((void *)info.data);
+      return 1;
+   }
+
+#define LOAD_SYM(sym) do { \
+   p##sym = dlsym(handle, #sym); \
+   if (!p##sym) { fprintf(stderr, "Missing symbol: " #sym "\n"); return 1; } \
+} while(0)
+
+   LOAD_SYM(retro_set_environment);
+   LOAD_SYM(retro_set_video_refresh);
+   LOAD_SYM(retro_set_audio_sample);
+   LOAD_SYM(retro_set_audio_sample_batch);
+   LOAD_SYM(retro_set_input_poll);
+   LOAD_SYM(retro_set_input_state);
+   LOAD_SYM(retro_init);
+   LOAD_SYM(retro_deinit);
+   LOAD_SYM(retro_load_game);
+   LOAD_SYM(retro_run);
+   LOAD_SYM(retro_unload_game);
+   LOAD_SYM(retro_get_memory_data);
+   LOAD_SYM(retro_get_memory_size);
+   LOAD_SYM(retro_serialize_size);
+   LOAD_SYM(retro_unserialize);
+
+   /* Optional perf-counter access; absent unless built with BENCH_PROFILE=1. */
+   pperf_counters_dump = dlsym(handle, "perf_counters_dump");
+   g_dsp_pc  = dlsym(handle, "dsp_pc");
+   g_gpu_pc  = dlsym(handle, "gpu_pc");
+   g_dsp_cnt = dlsym(handle, "dsp_exec_opcode_count");
+   g_rd      = (read_word_fn)dlsym(handle, "JaguarReadWord");
+   if (!g_dsp_pc || !g_gpu_pc)
+      fprintf(stderr, "sampler: symbols not exported -- build the core with TEST_EXPORTS=1\n");
+   pperf_counters_find = dlsym(handle, "perf_counters_find");
+
+   pretro_set_environment(environment_cb);
+   pretro_set_video_refresh(video_refresh);
+   pretro_set_audio_sample(audio_sample);
+   pretro_set_audio_sample_batch(audio_sample_batch);
+   pretro_set_input_poll(input_poll);
+   pretro_set_input_state(input_state);
+
+   pretro_init();
+
+   fprintf(stderr, "--- Benchmark configuration ---\n");
+   fprintf(stderr, "  Core:    %s\n", core_path);
+   fprintf(stderr, "  ROM:     %s\n", rom_path);
+   fprintf(stderr, "  Blitter: %s\n",
+           strcmp(blitter_value, "enabled") == 0 ? "fast" : "accurate");
+   fprintf(stderr, "  BIOS:    %s\n", bios_option_set ? "enabled" : "enabled (pending)");
+   fprintf(stderr, "  Warmup:  %d frames\n", warmup_frames);
+   fprintf(stderr, "  Measure: %d frames\n", num_frames);
+   fprintf(stderr, "---\n");
+
+   if (!pretro_load_game(&info))
+   {
+      fprintf(stderr, "retro_load_game failed!\n");
+      free((void *)info.data);
+      dlclose(handle);
+      return 1;
+   }
+
+   /* Load SRM (EEPROM save) if provided */
+   if (srm_load_path)
+   {
+      void *save_data = pretro_get_memory_data(0);
+      size_t save_size = pretro_get_memory_size(0);
+      if (save_data && save_size > 0)
+      {
+         FILE *sf = fopen(srm_load_path, "rb");
+         if (sf)
+         {
+            size_t srm_size;
+            fseek(sf, 0, SEEK_END);
+            srm_size = (size_t)ftell(sf);
+            fseek(sf, 0, SEEK_SET);
+            if (srm_size <= save_size)
+            {
+               if (fread(save_data, 1, srm_size, sf) == srm_size)
+                  fprintf(stderr, "--- Loaded SRM from %s (%zu bytes into %zu) ---\n",
+                          srm_load_path, srm_size, save_size);
+            }
+            fclose(sf);
+         }
+         else
+            fprintf(stderr, "WARNING: Cannot open SRM file: %s\n", srm_load_path);
+      }
+      else
+         fprintf(stderr, "WARNING: Core reports no SAVE_RAM area\n");
+   }
+
+   /* Load save state if provided.  Accepts both raw retro_serialize()
+    * payloads and RetroArch RASTATE container files (extracts the
+    * MEM chunk).  See https://github.com/libretro/RetroArch on the
+    * RASTATE format. */
+   if (state_load_path)
+   {
+      FILE *stf = NULL;
+      long st_total = 0;
+      uint8_t *st_buf = NULL;
+      const uint8_t *payload = NULL;
+      size_t payload_size = 0;
+      size_t expected;
+      const char *state_err = NULL;
+
+      stf = fopen(state_load_path, "rb");
+      if (!stf)
+      {
+         state_err = "cannot open state file";
+         goto state_fail;
+      }
+      if (fseek(stf, 0, SEEK_END) != 0)
+      {
+         state_err = "fseek to end failed";
+         goto state_fail;
+      }
+      st_total = ftell(stf);
+      if (st_total <= 0)
+      {
+         state_err = "ftell failed or empty state file";
+         goto state_fail;
+      }
+      if (fseek(stf, 0, SEEK_SET) != 0)
+      {
+         state_err = "fseek to start failed";
+         goto state_fail;
+      }
+      st_buf = (uint8_t *)malloc((size_t)st_total);
+      if (!st_buf)
+      {
+         state_err = "malloc failed for state buffer";
+         goto state_fail;
+      }
+      if (fread(st_buf, 1, (size_t)st_total, stf) != (size_t)st_total)
+      {
+         state_err = "short read on state file";
+         goto state_fail;
+      }
+      fclose(stf);
+      stf = NULL;
+      payload = st_buf;
+      payload_size = (size_t)st_total;
+      /* RASTATE container? "RASTATE" + 1 version byte, then chunks. */
+      if (st_total >= 16 && memcmp(st_buf, "RASTATE", 7) == 0)
+      {
+         const uint8_t *p = st_buf + 8;       /* past magic+version */
+         const uint8_t *end = st_buf + st_total;
+         int found = 0;
+         /* Each chunk: 4-byte type + 4-byte LE size + payload. */
+         while (p + 8 <= end)
+         {
+            uint32_t chunk_size = (uint32_t)p[4] | ((uint32_t)p[5] << 8)
+                               | ((uint32_t)p[6] << 16) | ((uint32_t)p[7] << 24);
+            /* Bounds-check the declared chunk size against the buffer. */
+            if (chunk_size > (uint32_t)(end - (p + 8)))
+            {
+               state_err = "RASTATE chunk size overruns buffer";
+               goto state_fail;
+            }
+            if (memcmp(p, "MEM ", 4) == 0)
+            {
+               payload = p + 8;
+               payload_size = chunk_size;
+               found = 1;
+               break;
+            }
+            p += 8 + chunk_size;
+         }
+         if (!found)
+         {
+            state_err = "no MEM chunk in RASTATE file";
+            goto state_fail;
+         }
+         fprintf(stderr, "--- RASTATE: extracted MEM chunk (%zu bytes) ---\n", payload_size);
+      }
+      expected = pretro_serialize_size();
+      fprintf(stderr, "--- State payload: %zu bytes (core expects %zu) ---\n",
+              payload_size, expected);
+      if (!pretro_unserialize(payload, payload_size))
+      {
+         state_err = "retro_unserialize failed";
+         goto state_fail;
+      }
+      fprintf(stderr, "--- State loaded from %s ---\n", state_load_path);
+      free(st_buf);
+      st_buf = NULL;
+
+      if (0)
+      {
+state_fail:
+         fprintf(stderr, "ERROR: %s: %s\n",
+                 state_err ? state_err : "state load error",
+                 state_load_path);
+         if (stf) fclose(stf);
+         if (st_buf) free(st_buf);
+         pretro_unload_game();
+         pretro_deinit();
+         free((void *)info.data);
+         dlclose(handle);
+         return 1;
+      }
+   }
+
+   /* Run warmup frames (not timed) */
+   if (warmup_frames > 0)
+   {
+      fprintf(stderr, "--- Running %d warmup frames ---\n", warmup_frames);
+      for (i = 0; i < warmup_frames; i++)
+         pretro_run();
+      fprintf(stderr, "--- Warmup complete ---\n");
+   }
+
+   /* Timed run with per-frame samples to expose variance.  Audio
+    * dropouts in real frontends are caused by *worst-case* frames
+    * exceeding the 16.6 ms (60 Hz) budget, not by the average. */
+   {
+      double *frame_ms = (double *)malloc((size_t)num_frames * sizeof(double));
+      unsigned long long *blit_calls_at_frame = (unsigned long long *)malloc((size_t)num_frames * sizeof(unsigned long long));
+      unsigned long long *blit_inner_at_frame = (unsigned long long *)malloc((size_t)num_frames * sizeof(unsigned long long));
+      double frame_budget_ms = 1000.0 / 60.0;
+      int over_budget = 0;
+      double max_ms = 0.0;
+      double p50_ms = 0.0, p99_ms = 0.0, p999_ms = 0.0;
+      unsigned long long *blit_calls_ctr = pperf_counters_find ? pperf_counters_find("blitter_calls") : NULL;
+      unsigned long long *blit_inner_ctr = pperf_counters_find ? pperf_counters_find("blitter_inner") : NULL;
+      unsigned long long blit_calls_prev = blit_calls_ctr ? *blit_calls_ctr : 0;
+      unsigned long long blit_inner_prev = blit_inner_ctr ? *blit_inner_ctr : 0;
+
+      if (!frame_ms || !blit_calls_at_frame || !blit_inner_at_frame)
+      {
+         fprintf(stderr, "ERROR: malloc failed for per-frame timing\n");
+         pretro_unload_game(); pretro_deinit();
+         free((void *)info.data); dlclose(handle);
+         return 1;
+      }
+
+      fprintf(stderr, "--- Benchmarking %d frames ---\n", num_frames);
+      t_start = timer_now();
+
+      for (i = 0; i < num_frames; i++)
+      {
+         uint64_t f0 = timer_now();
+         uint64_t f1;
+         pretro_run();
+         f1 = timer_now();
+         if (g_dsp_pc)
+            hist_add(hd_pc, hd_n, &hd_c, *g_dsp_pc);
+         if (g_gpu_pc)
+            hist_add(hg_pc, hg_n, &hg_c, *g_gpu_pc);
+         frame_ms[i] = timer_elapsed_sec(f0, f1) * 1000.0;
+         if (blit_calls_ctr) {
+            blit_calls_at_frame[i] = *blit_calls_ctr - blit_calls_prev;
+            blit_calls_prev = *blit_calls_ctr;
+         } else blit_calls_at_frame[i] = 0;
+         if (blit_inner_ctr) {
+            blit_inner_at_frame[i] = *blit_inner_ctr - blit_inner_prev;
+            blit_inner_prev = *blit_inner_ctr;
+         } else blit_inner_at_frame[i] = 0;
+      }
+
+      t_end = timer_now();
+
+      elapsed = timer_elapsed_sec(t_start, t_end);
+      fps = (double)num_frames / elapsed;
+      ms_per_frame = (elapsed * 1000.0) / (double)num_frames;
+
+      /* Quicksort copy so the original order is preserved for any
+       * later analysis (currently we don't print it, but cheap). */
+      {
+         double *sorted = (double *)malloc((size_t)num_frames * sizeof(double));
+         int j;
+         if (sorted)
+         {
+            memcpy(sorted, frame_ms, (size_t)num_frames * sizeof(double));
+            /* Insertion sort (small N typical). */
+            for (i = 1; i < num_frames; i++)
+            {
+               double key = sorted[i];
+               j = i - 1;
+               while (j >= 0 && sorted[j] > key) { sorted[j + 1] = sorted[j]; j--; }
+               sorted[j + 1] = key;
+            }
+            p50_ms  = sorted[(int)((double)num_frames * 0.50)];
+            p99_ms  = sorted[(int)((double)num_frames * 0.99)];
+            p999_ms = sorted[(int)((double)num_frames * 0.999)];
+            max_ms  = sorted[num_frames - 1];
+            free(sorted);
+         }
+      }
+      for (i = 0; i < num_frames; i++)
+         if (frame_ms[i] > frame_budget_ms) over_budget++;
+
+      /* Print results */
+      printf("\n=== BENCHMARK RESULTS ===\n");
+      printf("Blitter mode:    %s\n",
+             strcmp(blitter_value, "enabled") == 0 ? "fast" : "accurate");
+      printf("Frames measured: %d\n", num_frames);
+      printf("Warmup frames:   %d\n", warmup_frames);
+      printf("Total time:      %.3f s\n", elapsed);
+      printf("Frames/sec:      %.2f\n", fps);
+      printf("Time/frame avg:  %.3f ms\n", ms_per_frame);
+      printf("Time/frame p50:  %.3f ms\n", p50_ms);
+      printf("Time/frame p99:  %.3f ms\n", p99_ms);
+      printf("Time/frame p999: %.3f ms\n", p999_ms);
+      printf("Time/frame max:  %.3f ms\n", max_ms);
+      printf("Over 16.67 ms:   %d / %d frames (%.2f%%)\n",
+             over_budget, num_frames, 100.0 * over_budget / num_frames);
+      printf("=========================\n");
+      hist_dump("DSP", hd_pc, hd_n, hd_c, 0xF1B000, 0x2000, num_frames);
+      hist_dump("GPU", hg_pc, hg_n, hg_c, 0xF03000, 0x1000, num_frames);
+      if (g_dsp_cnt)
+         printf("dsp_exec_opcode_count total=%u (%.0f/frame incl. warmup)\n",
+                *g_dsp_cnt, (double)*g_dsp_cnt / (num_frames + warmup_frames));
+
+      /* If we have per-frame blitter counters, dump the slowest frames
+       * so we can correlate blit volume with frame-time spikes. */
+      if (over_budget > 0 && blit_calls_ctr) {
+         int j;
+         double avg_calls = 0.0, avg_inner = 0.0;
+         double slow_calls = 0.0, slow_inner = 0.0;
+         int slow_n = 0;
+         printf("\n--- Worst frames (>16.67ms) -----------------------------\n");
+         printf("  idx  frame_ms  blit_calls  blit_inner_iter\n");
+         for (j = 0; j < num_frames; j++) {
+            avg_calls += blit_calls_at_frame[j];
+            avg_inner += blit_inner_at_frame[j];
+            if (frame_ms[j] > frame_budget_ms) {
+               slow_calls += blit_calls_at_frame[j];
+               slow_inner += blit_inner_at_frame[j];
+               slow_n++;
+               if (slow_n <= 12)
+                  printf("  %4d  %7.2f   %10llu   %15llu\n",
+                         j, frame_ms[j],
+                         blit_calls_at_frame[j],
+                         blit_inner_at_frame[j]);
+            }
+         }
+         printf("---\n");
+         printf("Avg per frame (all):    blits=%.0f  inner_iter=%.0f\n",
+                avg_calls / num_frames, avg_inner / num_frames);
+         if (slow_n > 0)
+            printf("Avg per frame (slow):   blits=%.0f  inner_iter=%.0f  (%dx, %dx vs avg)\n",
+                   slow_calls / slow_n, slow_inner / slow_n,
+                   (int)((slow_calls / slow_n) / (avg_calls / num_frames + 1e-9)),
+                   (int)((slow_inner / slow_n) / (avg_inner / num_frames + 1e-9)));
+         printf("=========================================================\n");
+      }
+
+      free(frame_ms);
+      free(blit_calls_at_frame);
+      free(blit_inner_at_frame);
+   }
+
+   if (pperf_counters_dump)
+      pperf_counters_dump(stderr);
+
+   pretro_unload_game();
+   pretro_deinit();
+   free((void *)info.data);
+   dlclose(handle);
+
+   return 0;
+}


### PR DESCRIPTION
Tracking epic: #569 (link in the Development panel by hand — `Closes` keywords don't link on this repo).

## What

- `docs/perf-audit-2026-08.md` — the prioritized, delegatable task list (P1–P9) with evidence, per-task spec, acceptance gates and model-tier routing (sonnet = mechanical, opus = design).
- `docs/perf-audit/*.md` — raw read-only sub-agent reports per subsystem (GPU, DSP, blitter, bus/frame loop, frontend, build/68K, device profiling). Only items re-verified or measured are promoted into the main doc; the header of each file says so.
- `test/tools/risc_pc_histogram.c` — `test_benchmark.c` + a frame-end `dsp_pc`/`gpu_pc` sampler with RISC-RAM decode (TEST_EXPORTS build). This is the measurement behind the headline finding. C89-lint clean, builds with the documented `cc` line, smoke-run on jagniccc / Iron Soldier / AvP / Doom.

## Headline

The DSP (and GPU) interpreters burn their **full** cycle budget interpreting 2–5 instruction idle/poll loops: 99.7% (Iron Soldier), 90% (Doom), 74% (AvP) of frame-end DSP PCs sit in the sound driver's `cmp/movefa/jr` or a `load/or/jr` mailbox poll, at 416k–590k DSP opcodes per frame. Nothing else can run inside a RISC slice and IRQs are delivered at slice entry only, so a **cycle-exact fast-forward** (affine register extrapolation over a proven fixed-point loop body) is possible — no JIT, bit-identical output. DSP is 50–67% of frame time on commercial titles → P1.

Other verified dumb costs: ELF targets have no `-fvisibility=hidden` / `-fno-semantic-interposition` / LTO (GOT load per global per emulated instruction on the Pi), `jni/Android.mk` inherits none of `Makefile`'s opt flags, the fast blitter makes 3–6 full `JaguarRead*/Write*` dispatch calls per pixel while inline RAM helpers already exist in the file, `GPUReadLong` splits DRAM longs into two `JaguarReadWord` calls, DSP `sh`/`sha` are 32-iteration loops (GPU versions are single shifts), the event scheduler scans 4×32 slots per event at ~2,000 events/frame, the 68K per-instruction hook chain costs 3× the 68K interpreter, and AvP's titledb 2x+true-colour defaults cost ~30% of its frame.

Docs-only + one test tool; no emulation code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)