### PR TITLE
perf(blitter): route the fast engine's pixel access through the inline RAM helpers

### DIFF
--- a/src/tom/blitter.c
+++ b/src/tom/blitter.c
@@ -263,29 +263,29 @@ PERF_COUNTER(blitter_phrase_writes);
 // 1 bpp pixel read
 #define PIXEL_SHIFT_1(a)      (((~a##_x) >> 16) & 7)
 #define PIXEL_OFFSET_1(a)     (((((uint32_t)a##_y >> 16) * a##_width / 8) + (((uint32_t)a##_x >> 19) & ~7)) * (1 + a##_pitch) + (((uint32_t)a##_x >> 19) & 7))
-#define READ_PIXEL_1(a)       ((JaguarReadByte(a##_addr+PIXEL_OFFSET_1(a), BLITTER) >> PIXEL_SHIFT_1(a)) & 0x01)
+#define READ_PIXEL_1(a)       ((blitter_read_byte(a##_addr+PIXEL_OFFSET_1(a)) >> PIXEL_SHIFT_1(a)) & 0x01)
 
 // 2 bpp pixel read
 #define PIXEL_SHIFT_2(a)      (((~a##_x) >> 15) & 6)
 #define PIXEL_OFFSET_2(a)     (((((uint32_t)a##_y >> 16) * a##_width / 4) + (((uint32_t)a##_x >> 18) & ~7)) * (1 + a##_pitch) + (((uint32_t)a##_x >> 18) & 7))
-#define READ_PIXEL_2(a)       ((JaguarReadByte(a##_addr+PIXEL_OFFSET_2(a), BLITTER) >> PIXEL_SHIFT_2(a)) & 0x03)
+#define READ_PIXEL_2(a)       ((blitter_read_byte(a##_addr+PIXEL_OFFSET_2(a)) >> PIXEL_SHIFT_2(a)) & 0x03)
 
 // 4 bpp pixel read
 #define PIXEL_SHIFT_4(a)      (((~a##_x) >> 14) & 4)
 #define PIXEL_OFFSET_4(a)     (((((uint32_t)a##_y >> 16) * (a##_width/2)) + (((uint32_t)a##_x >> 17) & ~7)) * (1 + a##_pitch) + (((uint32_t)a##_x >> 17) & 7))
-#define READ_PIXEL_4(a)       ((JaguarReadByte(a##_addr+PIXEL_OFFSET_4(a), BLITTER) >> PIXEL_SHIFT_4(a)) & 0x0f)
+#define READ_PIXEL_4(a)       ((blitter_read_byte(a##_addr+PIXEL_OFFSET_4(a)) >> PIXEL_SHIFT_4(a)) & 0x0f)
 
 // 8 bpp pixel read
 #define PIXEL_OFFSET_8(a)     (((((uint32_t)a##_y >> 16) * a##_width) + (((uint32_t)a##_x >> 16) & ~7)) * (1 + a##_pitch) + (((uint32_t)a##_x >> 16) & 7))
-#define READ_PIXEL_8(a)       (JaguarReadByte(a##_addr+PIXEL_OFFSET_8(a), BLITTER))
+#define READ_PIXEL_8(a)       (blitter_read_byte(a##_addr+PIXEL_OFFSET_8(a)))
 
 // 16 bpp pixel read
 #define PIXEL_OFFSET_16(a)    (((((uint32_t)a##_y >> 16) * a##_width) + (((uint32_t)a##_x >> 16) & ~3)) * (1 + a##_pitch) + (((uint32_t)a##_x >> 16) & 3))
-#define READ_PIXEL_16(a)       (JaguarReadWord(a##_addr+(PIXEL_OFFSET_16(a)<<1), BLITTER))
+#define READ_PIXEL_16(a)       (blitter_read_word(a##_addr+(PIXEL_OFFSET_16(a)<<1)))
 
 // 32 bpp pixel read
 #define PIXEL_OFFSET_32(a)    (((((uint32_t)a##_y >> 16) * a##_width) + (((uint32_t)a##_x >> 16) & ~1)) * (1 + a##_pitch) + (((uint32_t)a##_x >> 16) & 1))
-#define READ_PIXEL_32(a)      (JaguarReadLong(a##_addr+(PIXEL_OFFSET_32(a)<<2), BLITTER))
+#define READ_PIXEL_32(a)      (blitter_read_long(a##_addr+(PIXEL_OFFSET_32(a)<<2)))
 
 // pixel read
 #define READ_PIXEL(a,f) (\
@@ -298,13 +298,13 @@ PERF_COUNTER(blitter_phrase_writes);
 
 // 16 bpp z data read
 #define ZDATA_OFFSET_16(a)     (PIXEL_OFFSET_16(a) + a##_zoffs * 4)
-#define READ_ZDATA_16(a)       (JaguarReadWord(a##_addr+(ZDATA_OFFSET_16(a)<<1), BLITTER))
+#define READ_ZDATA_16(a)       (blitter_read_word(a##_addr+(ZDATA_OFFSET_16(a)<<1)))
 
 // z data read
 #define READ_ZDATA(a,f) (READ_ZDATA_16(a))
 
 // 16 bpp z data write
-#define WRITE_ZDATA_16(a,d)     {  JaguarWriteWord(a##_addr+(ZDATA_OFFSET_16(a)<<1), d, BLITTER); }
+#define WRITE_ZDATA_16(a,d)     {  blitter_write_word(a##_addr+(ZDATA_OFFSET_16(a)<<1), d); }
 
 // z data write
 #define WRITE_ZDATA(a,f,d) WRITE_ZDATA_16(a,d);
@@ -364,22 +364,22 @@ PERF_COUNTER(blitter_phrase_writes);
 	 (((f>>3)&0x07) == 5) ? (READ_RDATA_32(r,a,p)) : 0)
 
 // 1 bpp pixel write
-#define WRITE_PIXEL_1(a,d)       { JaguarWriteByte(a##_addr+PIXEL_OFFSET_1(a), (JaguarReadByte(a##_addr+PIXEL_OFFSET_1(a), BLITTER)&(~(0x01 << PIXEL_SHIFT_1(a))))|(d<<PIXEL_SHIFT_1(a)), BLITTER); }
+#define WRITE_PIXEL_1(a,d)       { blitter_write_byte(a##_addr+PIXEL_OFFSET_1(a), (blitter_read_byte(a##_addr+PIXEL_OFFSET_1(a))&(~(0x01 << PIXEL_SHIFT_1(a))))|(d<<PIXEL_SHIFT_1(a))); }
 
 // 2 bpp pixel write
-#define WRITE_PIXEL_2(a,d)       { JaguarWriteByte(a##_addr+PIXEL_OFFSET_2(a), (JaguarReadByte(a##_addr+PIXEL_OFFSET_2(a), BLITTER)&(~(0x03 << PIXEL_SHIFT_2(a))))|(d<<PIXEL_SHIFT_2(a)), BLITTER); }
+#define WRITE_PIXEL_2(a,d)       { blitter_write_byte(a##_addr+PIXEL_OFFSET_2(a), (blitter_read_byte(a##_addr+PIXEL_OFFSET_2(a))&(~(0x03 << PIXEL_SHIFT_2(a))))|(d<<PIXEL_SHIFT_2(a))); }
 
 // 4 bpp pixel write
-#define WRITE_PIXEL_4(a,d)       { JaguarWriteByte(a##_addr+PIXEL_OFFSET_4(a), (JaguarReadByte(a##_addr+PIXEL_OFFSET_4(a), BLITTER)&(~(0x0f << PIXEL_SHIFT_4(a))))|(d<<PIXEL_SHIFT_4(a)), BLITTER); }
+#define WRITE_PIXEL_4(a,d)       { blitter_write_byte(a##_addr+PIXEL_OFFSET_4(a), (blitter_read_byte(a##_addr+PIXEL_OFFSET_4(a))&(~(0x0f << PIXEL_SHIFT_4(a))))|(d<<PIXEL_SHIFT_4(a))); }
 
 // 8 bpp pixel write
-#define WRITE_PIXEL_8(a,d)       { JaguarWriteByte(a##_addr+PIXEL_OFFSET_8(a), d, BLITTER); }
+#define WRITE_PIXEL_8(a,d)       { blitter_write_byte(a##_addr+PIXEL_OFFSET_8(a), d); }
 
 // 16 bpp pixel write
-#define WRITE_PIXEL_16(a,d)     {  JaguarWriteWord(a##_addr+(PIXEL_OFFSET_16(a)<<1), d, BLITTER); }
+#define WRITE_PIXEL_16(a,d)     {  blitter_write_word(a##_addr+(PIXEL_OFFSET_16(a)<<1), d); }
 
 // 32 bpp pixel write
-#define WRITE_PIXEL_32(a,d)		{ JaguarWriteLong(a##_addr+(PIXEL_OFFSET_32(a)<<2), d, BLITTER); }
+#define WRITE_PIXEL_32(a,d)		{ blitter_write_long(a##_addr+(PIXEL_OFFSET_32(a)<<2), d); }
 
 // pixel write
 #define WRITE_PIXEL(a,f,d) {\
@@ -550,10 +550,19 @@ static void shadow_hires_sub_fast(shadowfb_sub *out, uint32_t cmd,
 // to optimize the blitter, then we may revisit it in the future...
 
 // Generic blit handler
-void blitter_generic(uint32_t cmd)
+static void blitter_generic(uint32_t cmd)
 {
    uint32_t srcdata, srczdata, dstdata, dstzdata, writedata, inhibit;
-   uint32_t bppSrc = (DSTA2 ? 1 << ((REG(A1_FLAGS) >> 3) & 0x07) : 1 << ((REG(A2_FLAGS) >> 3) & 0x07));
+   /* A1_FLAGS/A2_FLAGS are re-derived from blitter_ram on every textual
+    * use below (4 byte loads + shifts via the REG() macro).  Nothing in
+    * this function writes blitter_ram until the WREG() calls after the
+    * pixel loop -- the loop only mutates locals (a1_x/a1_y/a2_x/a2_y,
+    * gd_i/gd_c, z_i, colour_index, bitPos), never blitter_ram itself --
+    * so both registers are loop-invariant; hoist them once here instead
+    * of re-reading ~19 and ~17 times. */
+   uint32_t a1_flags = REG(A1_FLAGS);
+   uint32_t a2_flags = REG(A2_FLAGS);
+   uint32_t bppSrc = (DSTA2 ? 1 << ((a1_flags >> 3) & 0x07) : 1 << ((a2_flags >> 3) & 0x07));
 
    while (outer_loop--)
    {
@@ -579,37 +588,37 @@ void blitter_generic(uint32_t cmd)
             //				if (SRCEN)
             if (SRCEN || SRCENX)	// Not sure if this is correct... (seems to be...!)
             {
-               srcdata = READ_PIXEL(a2, REG(A2_FLAGS));
+               srcdata = READ_PIXEL(a2, a2_flags);
 
                if (SRCENZ)
-                  srczdata = READ_ZDATA(a2, REG(A2_FLAGS));
+                  srczdata = READ_ZDATA(a2, a2_flags);
                else if (cmd & 0x0001C020)	// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
-                  srczdata = READ_RDATA(SRCZINT, a2, REG(A2_FLAGS), a2_phrase_mode);
+                  srczdata = READ_RDATA(SRCZINT, a2, a2_flags, a2_phrase_mode);
             }
             else	// Use SRCDATA register...
             {
-               srcdata = READ_RDATA(SRCDATA, a2, REG(A2_FLAGS), a2_phrase_mode);
+               srcdata = READ_RDATA(SRCDATA, a2, a2_flags, a2_phrase_mode);
 
                if (cmd & 0x0001C020)		// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
-                  srczdata = READ_RDATA(SRCZINT, a2, REG(A2_FLAGS), a2_phrase_mode);
+                  srczdata = READ_RDATA(SRCZINT, a2, a2_flags, a2_phrase_mode);
             }
 
             // load dst data and Z
             if (DSTEN)
             {
-               dstdata = READ_PIXEL(a1, REG(A1_FLAGS));
+               dstdata = READ_PIXEL(a1, a1_flags);
 
                if (DSTENZ)
-                  dstzdata = READ_ZDATA(a1, REG(A1_FLAGS));
+                  dstzdata = READ_ZDATA(a1, a1_flags);
                else
-                  dstzdata = READ_RDATA(DSTZ, a1, REG(A1_FLAGS), a1_phrase_mode);
+                  dstzdata = READ_RDATA(DSTZ, a1, a1_flags, a1_phrase_mode);
             }
             else
             {
-               dstdata = READ_RDATA(DSTDATA, a1, REG(A1_FLAGS), a1_phrase_mode);
+               dstdata = READ_RDATA(DSTDATA, a1, a1_flags, a1_phrase_mode);
 
                if (DSTENZ)
-                  dstzdata = READ_RDATA(DSTZ, a1, REG(A1_FLAGS), a1_phrase_mode);
+                  dstzdata = READ_RDATA(DSTZ, a1, a1_flags, a1_phrase_mode);
             }
 
             if (GOURZ)
@@ -657,14 +666,14 @@ void blitter_generic(uint32_t cmd)
                      if (srcdata == 0)
                         inhibit = 1;
                   }
-                  else if (srcdata == 0 || srcdata == READ_RDATA(PATTERNDATA, a2, REG(A2_FLAGS), a2_phrase_mode))
+                  else if (srcdata == 0 || srcdata == READ_RDATA(PATTERNDATA, a2, a2_flags, a2_phrase_mode))
                      inhibit = 1;
                }
                else
                {
                   // compare destination pixel with pattern pixel
-                  if (dstdata == READ_RDATA(PATTERNDATA, a1, REG(A1_FLAGS), a1_phrase_mode))
-                     //						if (dstdata != READ_RDATA(PATTERNDATA, a1, REG(A1_FLAGS), a1_phrase_mode))
+                  if (dstdata == READ_RDATA(PATTERNDATA, a1, a1_flags, a1_phrase_mode))
+                     //						if (dstdata != READ_RDATA(PATTERNDATA, a1, a1_flags, a1_phrase_mode))
                      inhibit = 1;
                }
             }
@@ -690,7 +699,7 @@ void blitter_generic(uint32_t cmd)
                if (PATDSEL)
                {
                   // use pattern data for write data
-                  writedata = READ_RDATA(PATTERNDATA, a1, REG(A1_FLAGS), a1_phrase_mode);
+                  writedata = READ_RDATA(PATTERNDATA, a1, a1_flags, a1_phrase_mode);
                }
                else if (ADDDSEL)
                {
@@ -759,9 +768,9 @@ void blitter_generic(uint32_t cmd)
                //				if (/*a1_phrase_mode || BKGWREN ||*/ !inhibit)
             {
                // write to the destination
-               WRITE_PIXEL(a1, REG(A1_FLAGS), writedata);
+               WRITE_PIXEL(a1, a1_flags, writedata);
                if (DSTWRZ)
-                  WRITE_ZDATA(a1, REG(A1_FLAGS), srczdata);
+                  WRITE_ZDATA(a1, a1_flags, srczdata);
 
                /* True-color shadow store (see shadowfb.h): record the
                 * full-precision intensity for gouraud / intensity-shade
@@ -774,7 +783,7 @@ void blitter_generic(uint32_t cmd)
                 * all blit content reaches the Nx surface (design
                 * section 4). */
                if ((shadowFBActive || shadowHiresActive)
-                     && (((REG(A1_FLAGS) >> 3) & 0x07) == 4))
+                     && (((a1_flags >> 3) & 0x07) == 4))
                {
                   uint16_t sfb_frac = 0;
                   if (!inhibit && (GOURD || SRCSHADE))
@@ -810,33 +819,33 @@ void blitter_generic(uint32_t cmd)
             // load src data and Z
             if (SRCEN)
             {
-               srcdata = READ_PIXEL(a1, REG(A1_FLAGS));
+               srcdata = READ_PIXEL(a1, a1_flags);
                if (SRCENZ)
-                  srczdata = READ_ZDATA(a1, REG(A1_FLAGS));
+                  srczdata = READ_ZDATA(a1, a1_flags);
                else if (cmd & 0x0001C020)	// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
-                  srczdata = READ_RDATA(SRCZINT, a1, REG(A1_FLAGS), a1_phrase_mode);
+                  srczdata = READ_RDATA(SRCZINT, a1, a1_flags, a1_phrase_mode);
             }
             else
             {
-               srcdata = READ_RDATA(SRCDATA, a1, REG(A1_FLAGS), a1_phrase_mode);
+               srcdata = READ_RDATA(SRCDATA, a1, a1_flags, a1_phrase_mode);
                if (cmd & 0x001C020)	// PATDSEL | TOPBEN | TOPNEN | DSTWRZ
-                  srczdata = READ_RDATA(SRCZINT, a1, REG(A1_FLAGS), a1_phrase_mode);
+                  srczdata = READ_RDATA(SRCZINT, a1, a1_flags, a1_phrase_mode);
             }
 
             // load dst data and Z
             if (DSTEN)
             {
-               dstdata = READ_PIXEL(a2, REG(A2_FLAGS));
+               dstdata = READ_PIXEL(a2, a2_flags);
                if (DSTENZ)
-                  dstzdata = READ_ZDATA(a2, REG(A2_FLAGS));
+                  dstzdata = READ_ZDATA(a2, a2_flags);
                else
-                  dstzdata = READ_RDATA(DSTZ, a2, REG(A2_FLAGS), a2_phrase_mode);
+                  dstzdata = READ_RDATA(DSTZ, a2, a2_flags, a2_phrase_mode);
             }
             else
             {
-               dstdata = READ_RDATA(DSTDATA, a2, REG(A2_FLAGS), a2_phrase_mode);
+               dstdata = READ_RDATA(DSTDATA, a2, a2_flags, a2_phrase_mode);
                if (DSTENZ)
-                  dstzdata = READ_RDATA(DSTZ, a2, REG(A2_FLAGS), a2_phrase_mode);
+                  dstzdata = READ_RDATA(DSTZ, a2, a2_flags, a2_phrase_mode);
             }
 
             if (GOURZ)
@@ -867,12 +876,12 @@ void blitter_generic(uint32_t cmd)
                      if (srcdata == 0)
                         inhibit = 1;
                   }
-                  else if (srcdata == 0 || srcdata == READ_RDATA(PATTERNDATA, a1, REG(A1_FLAGS), a1_phrase_mode))
+                  else if (srcdata == 0 || srcdata == READ_RDATA(PATTERNDATA, a1, a1_flags, a1_phrase_mode))
                      inhibit = 1;
                }
                else
                {
-                  if (dstdata == READ_RDATA(PATTERNDATA, a2, REG(A2_FLAGS), a2_phrase_mode))
+                  if (dstdata == READ_RDATA(PATTERNDATA, a2, a2_flags, a2_phrase_mode))
                      inhibit = 1;
                }
             }
@@ -889,7 +898,7 @@ void blitter_generic(uint32_t cmd)
                if (PATDSEL)
                {
                   // use pattern data for write data
-                  writedata = READ_RDATA(PATTERNDATA, a2, REG(A2_FLAGS), a2_phrase_mode);
+                  writedata = READ_RDATA(PATTERNDATA, a2, a2_flags, a2_phrase_mode);
                }
                else if (ADDDSEL)
                {
@@ -939,15 +948,15 @@ void blitter_generic(uint32_t cmd)
 
             if (/*a2_phrase_mode || */BKGWREN || !inhibit)
             {
-               WRITE_PIXEL(a2, REG(A2_FLAGS), writedata);
+               WRITE_PIXEL(a2, a2_flags, writedata);
 
                if (DSTWRZ)
-                  WRITE_ZDATA(a2, REG(A2_FLAGS), srczdata);
+                  WRITE_ZDATA(a2, a2_flags, srczdata);
 
                /* True-color + hi-res shadow stores, A2-destination twin
                 * of the A1 branch above (see shadowfb.h). */
                if ((shadowFBActive || shadowHiresActive)
-                     && (((REG(A2_FLAGS) >> 3) & 0x07) == 4))
+                     && (((a2_flags >> 3) & 0x07) == 4))
                {
                   uint16_t sfb_frac = 0;
                   if (!inhibit && (GOURD || SRCSHADE))
@@ -977,7 +986,7 @@ void blitter_generic(uint32_t cmd)
                      int sh2 = 0;
                      shadowfb_sub sblk[4];
                      if (shadowHiresN == 2 && !inhibit && SRCEN && !BCOMPEN
-                           && (((REG(A1_FLAGS) >> 3) & 0x07) == 4)
+                           && (((a1_flags >> 3) & 0x07) == 4)
                            && (SRCSHADE || (!GOURD && !PATDSEL)))
                      {
                         int32_t hx = 0, hy = 0, vx = 0, vy = 0;


### PR DESCRIPTION
Item **P3** of the 2026-08 performance audit — tracking epic #569, method and evidence in `docs/perf-audit-2026-08.md`.

⚠️ **Needs a Development-panel link to #569** (keywords do nothing on PRs targeting `develop`, per `pr-issue-link.yml`).

Pure host-cost reduction. **No emulation behaviour changes** — output must be, and is verified to be, pixel-identical.

## The problem

`blitter_generic` — the **default** ("fast") blitter engine — read and wrote every pixel through `JaguarReadByte/Word/Long` / `JaguarWriteByte/Word/Long`: out-of-line, cross-TU calls that each re-walk a 5-7-range address ladder, 3-6 times per pixel. Meanwhile `blitter_read_byte/word/long` / `blitter_write_byte/word/long` already existed in the same file — a `<0x200000` direct-array fast path with an identical `Jaguar*` fallback for everything else — but were used only by the accurate engine (`BlitterMidsummer2`). No LTO on the affected platforms (Pi/Linux/Android — see #572), so the compiler could not close this gap on its own.

## The change

Routes `blitter_generic`'s `READ_PIXEL_*`/`WRITE_PIXEL_*`/`READ_ZDATA_16`/`WRITE_ZDATA_16` macros through the existing `blitter_read_*`/`blitter_write_*` helpers instead of `Jaguar*` directly. `READ_RDATA_*` (register-source reads) was left untouched — it already goes through `REG()`, direct `blitter_ram[]` access, never a `Jaguar*` call. Also: hoisted `REG(A1_FLAGS)`/`REG(A2_FLAGS)` into locals before the pixel loop (re-derived 30+ times per pixel, provably loop-invariant — nothing writes those registers until after the loop), and made `blitter_generic` `static` (one call site, not referenced by any test-ABI export list).

**One documented, proven-unreachable boundary case.** `blitter_read_long`/`blitter_write_long`/`blitter_write_word`'s RAM fast paths mask each byte independently (matching `Jaguar*`'s own behaviour), while... actually the two ARE identical in masking for every address the fast blitter can generate — the divergence is against a different case (see the PR discussion / task report for the full derivation, independently re-derived by the reviewer from `SET32`/`GET32` and the phrase-alignment invariant): blit source/dest addresses (`A1_BASE`/`A2_BASE`) are masked `& 0xFFFFFFF8` once in `blitter_blit` before `blitter_generic` ever runs and never mutated inside it, so every pixel/Z address the loop generates is `a_addr + {2k, 4m}` — a residue class that provably never lands in the one boundary window (`[0x1FFFFD, 0x1FFFFF]`) where the helper and `Jaguar*` would disagree. Flagged rather than silently relied on; a follow-up comment at the masking site (linking back to this invariant) is worth adding if that code is ever touched.

## Verification

- **`test/tools/test_blitter_compare` (fast vs accurate): 0 divergences across 591,684 total blits** — `yarc.j64` (133,750), `jagniccc.j64` (132,428), Alien vs Predator (132,378), Iron Soldier (193,128).
- **Framebuffer + audio digests byte-identical, stock vs patched, over 600 frames on all four ROMs** — with a **positive control**: the digest tool was proven to actually detect a deliberately-corrupted build of the changed code path, not just pass by construction.
- Full suite (`make TEST_EXPORTS=1 test`) green; `bash scripts/c89-lint.sh src/tom/blitter.c` clean.
- Reviewed independently: every changed macro checked individually against its `Jaguar*` counterpart (not just one representative), the boundary-unreachability proof re-derived from source rather than trusted, and the `A1_FLAGS`/`A2_FLAGS` hoist confirmed safe by grepping every `blitter_ram` write inside the function body.

**No speed number claimed from this host** — load average 30-375+ throughout; a real measurement needs the Pi or the A10X (see the audit doc's recipes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)