### PR TITLE
perf(build): hide internal symbols, drop semantic interposition, give Android its opt flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -954,14 +954,30 @@ endif
 # $(LINK_SCRIPT) (link.T / link-test.T), so nothing outside libretro.c's
 # retro_* functions is meant to be interposable at all.
 #
-# GC_STYLE=gnu (set above, per platform block) already identifies
-# exactly the ELF/GNU-ld matrix -- unix, qnx, rpi*, generic
-# arm64/aarch64, generic armv* -- as opposed to GC_STYLE=macho (Apple
-# ld64's two-level namespace already resolves same-image symbols
-# directly, so this is a Linux/Pi/Android win, not a macOS one) or
-# unset (STATIC_LINKING=1 archive targets, MSVC/Xbox, Solaris ld,
-# theos_ios, and classic_armv7_a7, which opts into its own bespoke
-# -flto=4 -fwhole-program pipeline in its platform block above instead).
+# GC_STYLE=gnu (set above, per platform block) identifies every target
+# that links through GNU ld with a --version-script, which is a
+# slightly WIDER set than "ELF": unix, qnx, rpi*, generic
+# arm64/aarch64, generic armv* are the real ELF/GNU-ld matrix this
+# block exists for, but the native `win` (MinGW) block also sets
+# GC_STYLE=gnu -- purely because MinGW's ld honours --version-script
+# and --gc-sections too, not because its output is ELF. `win`'s TARGET
+# is a PE/COFF .dll, and libretro.h's RETRO_API expands to
+# __attribute__((__dllexport__)) there (see libretro.h's RETRO_API
+# definition), not the visibility attribute -- so this block's whole
+# rationale (GOT/PLT indirection from ELF-style interposition,
+# RETRO_API surviving -fvisibility=hidden via inherited visibility)
+# does not apply to it, and `win` IS built in CI
+# (c-cpp.yml's MSYS2 job, release.yml). It is therefore excluded
+# outright, the same way `theos_ios` is excluded from the
+# --gc-sections block just above for an analogous "GC_STYLE says gnu
+# but the platform isn't the thing this flag is for" reason.
+#
+# GC_STYLE=macho (Apple ld64's two-level namespace already resolves
+# same-image symbols directly, so this is a Linux/Pi/Android win, not
+# a macOS one) and unset (STATIC_LINKING=1 archive targets, MSVC/Xbox,
+# Solaris ld, theos_ios, and classic_armv7_a7, which opts into its own
+# bespoke -flto=4 -fwhole-program pipeline in its platform block above
+# instead) are excluded by the outer ifeq itself.
 #
 # -fno-semantic-interposition is added UNGUARDED for the platforms this
 # repo actually builds and tests (unix, rpi*, generic arm64/aarch64,
@@ -969,11 +985,12 @@ endif
 # compile" probe anywhere (checked), GCC has accepted the flag since
 # 5.1 (2015), and Clang accepts and silently ignores it, so every
 # toolchain on those rows clears that bar. `qnx` is excluded from just
-# this one flag: nothing in .github/workflows/ or .gitlab-ci.yml builds
-# it (checked), so its toolchain floor is unverified, and QNX SDP 6.x's
-# qcc wraps a gcc old enough (4.x) that the flag can hard-error rather
-# than no-op there. -fvisibility=hidden has no such floor (GCC >= 4.0)
-# and stays on for qnx.
+# this one flag (but keeps -fvisibility=hidden and LTO=1 below): nothing
+# in .github/workflows/ or .gitlab-ci.yml builds it (checked), so its
+# toolchain floor is unverified, and QNX SDP 6.x's qcc wraps a gcc old
+# enough (4.x) that the flag can hard-error rather than no-op there.
+# -fvisibility=hidden has no such floor (GCC >= 4.0) and stays on for
+# qnx. `win` gets neither flag at all -- see above.
 #
 # -fvisibility=hidden is added for non-TEST_EXPORTS builds only.
 # TEST_EXPORTS=1 is the wide white-box test ABI: the harnesses dlsym()
@@ -993,6 +1010,7 @@ endif
 #
 # Neither flag is an -O, so neither can trip issue #516.
 ifeq ($(GC_STYLE),gnu)
+ifneq ($(platform),win)
    ifneq ($(platform),qnx)
       FLAGS += -fno-semantic-interposition
    endif
@@ -1004,11 +1022,13 @@ ifeq ($(GC_STYLE),gnu)
    # A/B on real Pi hardware first (test/tools/rpi_perf.sh exists for
    # exactly that), same caution as the -O3 rollout above (#515/#516).
    # `make LTO=1` (add `platform=rpi4_64` etc.) appends -flto to both
-   # the compile and link lines for every GC_STYLE=gnu target.
+   # the compile and link lines for every GC_STYLE=gnu target except
+   # `win` (see above).
    ifeq ($(LTO),1)
       FLAGS   += -flto
       LDFLAGS += -flto
    endif
+endif
 endif
 # ----------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ MACHO_EXPORTS_FLAGS := -Wl,-exported_symbols_list,$(MACHO_EXPORTS)
 # CFLAGS contains -DINLINE="inline".
 BUILD_AXES := TEST_EXPORTS BENCH_PROFILE DEBUG BLITTER_TRACE COVERAGE \
               RELEASE_DEBUG_INFO DEBUG_PRESENTATION STATIC_LINKING platform \
-              OPT_LEVEL
+              OPT_LEVEL LTO
 BUILD_CONFIG := $(strip $(foreach v,$(BUILD_AXES),$(v)=$($(v))))
 BUILD_CONFIG_STAMP := .build-config
 # Superseded .link-mode, which tracked TEST_EXPORTS alone; removed by the
@@ -938,6 +938,79 @@ ifneq ($(platform),theos_ios)
    endif
 endif
 endif
+
+# ----------------------------------------------------------------
+# ELF visibility / symbol interposition (issue #569).
+#
+# GCC assumes symbol interposition per translation unit unless told
+# otherwise: every cross-file global in the hot interpreter loops
+# (gpu_reg, dsp_pc, the flag/counter externs the 68K/GPU/DSP headers
+# share) gets reloaded through the GOT, and every cross-file call
+# (JaguarReadLong &c.) goes through the PLT, because in principle a
+# symbol could be overridden by something loaded earlier in the
+# process. That is a real possibility for a handful of libc entry
+# points and essentially never true of this project's own internals --
+# the whole exported surface is already pinned to a fixed set by
+# $(LINK_SCRIPT) (link.T / link-test.T), so nothing outside libretro.c's
+# retro_* functions is meant to be interposable at all.
+#
+# GC_STYLE=gnu (set above, per platform block) already identifies
+# exactly the ELF/GNU-ld matrix -- unix, qnx, rpi*, generic
+# arm64/aarch64, generic armv* -- as opposed to GC_STYLE=macho (Apple
+# ld64's two-level namespace already resolves same-image symbols
+# directly, so this is a Linux/Pi/Android win, not a macOS one) or
+# unset (STATIC_LINKING=1 archive targets, MSVC/Xbox, Solaris ld,
+# theos_ios, and classic_armv7_a7, which opts into its own bespoke
+# -flto=4 -fwhole-program pipeline in its platform block above instead).
+#
+# -fno-semantic-interposition is added UNGUARDED for the platforms this
+# repo actually builds and tests (unix, rpi*, generic arm64/aarch64,
+# generic armv*): this Makefile has no cc-option-style "does this flag
+# compile" probe anywhere (checked), GCC has accepted the flag since
+# 5.1 (2015), and Clang accepts and silently ignores it, so every
+# toolchain on those rows clears that bar. `qnx` is excluded from just
+# this one flag: nothing in .github/workflows/ or .gitlab-ci.yml builds
+# it (checked), so its toolchain floor is unverified, and QNX SDP 6.x's
+# qcc wraps a gcc old enough (4.x) that the flag can hard-error rather
+# than no-op there. -fvisibility=hidden has no such floor (GCC >= 4.0)
+# and stays on for qnx.
+#
+# -fvisibility=hidden is added for non-TEST_EXPORTS builds only.
+# TEST_EXPORTS=1 is the wide white-box test ABI: the harnesses dlsym()
+# internal symbols (see link-test.T / exports-test.list above), which
+# hiding at compile time would break even though the version script
+# still lists them. retro_* itself is unaffected either way -- every
+# entry point in libretro.c is declared RETRO_API in libretro.h, which
+# expands (libretro-common/include/libretro.h) to
+# __attribute__((visibility("default"))) on non-Windows GCC/Clang >= 4,
+# and a visibility attribute already present on an earlier declaration
+# governs the later definition regardless of -fvisibility's default.
+# Verified empirically at the .o level (see task report): retro_init
+# stays "external" under -fvisibility=hidden while an ordinary global
+# like videoBuffer drops to "private external" (ELF STV_HIDDEN's
+# Mach-O equivalent) -- the flag works, and RETRO_API is what exempts
+# retro_*.
+#
+# Neither flag is an -O, so neither can trip issue #516.
+ifeq ($(GC_STYLE),gnu)
+   ifneq ($(platform),qnx)
+      FLAGS += -fno-semantic-interposition
+   endif
+   ifneq ($(TEST_EXPORTS),1)
+      FLAGS += -fvisibility=hidden
+   endif
+
+   # Opt-in LTO (issue #569). Deliberately NOT default-on -- it wants an
+   # A/B on real Pi hardware first (test/tools/rpi_perf.sh exists for
+   # exactly that), same caution as the -O3 rollout above (#515/#516).
+   # `make LTO=1` (add `platform=rpi4_64` etc.) appends -flto to both
+   # the compile and link lines for every GC_STYLE=gnu target.
+   ifeq ($(LTO),1)
+      FLAGS   += -flto
+      LDFLAGS += -flto
+   endif
+endif
+# ----------------------------------------------------------------
 
 LDFLAGS += $(fpic) $(SHARED)
 FLAGS += $(fpic)

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -88,7 +88,8 @@ when it differs it deletes the library **and every object** before building. Bot
 full rebuild per flip (~21s at `-j8` without ccache).
 
 Stamp covers **every** compile-affecting switch (`BUILD_AXES`: `TEST_EXPORTS BENCH_PROFILE
-DEBUG BLITTER_TRACE COVERAGE RELEASE_DEBUG_INFO DEBUG_PRESENTATION STATIC_LINKING platform`).
+DEBUG BLITTER_TRACE COVERAGE RELEASE_DEBUG_INFO DEBUG_PRESENTATION STATIC_LINKING platform
+OPT_LEVEL LTO`).
 **Adding a new CFLAGS-affecting switch means adding it to that list** — forgetting = silent
 chimera binary, not a build error. It stamps variable *names*, not `$(CFLAGS)` (`DEBUG=1`
 injects a per-second `-DBUILD_TIMESTAMP`, so stamping flags would flush every build).
@@ -105,6 +106,52 @@ the stamp tracked `TEST_EXPORTS` alone → `make DEBUG=1` after a release recomp
 (a "debug build" that was all `-O2`, no debug info); toggling `BENCH_PROFILE` recompiled nothing
 so `timing_probe` reported `timing_halfline_callbacks counter not found` (reads as broken tool,
 not ignored flag). `VJ_EXPECT_BUILD` can't catch either — git rev is identical across the flip.
+
+## ELF visibility / interposition / LTO (issue #569)
+
+Every ELF/GNU-ld release build (`unix`, `rpi*`, generic `arm64`/`aarch64`/`armv*`, Android
+via `jni/Android.mk`) now compiles with `-fno-semantic-interposition` and, for
+non-`TEST_EXPORTS` builds, `-fvisibility=hidden`. Mach-O targets (`osx`, `ios*`, `tvos*`)
+are untouched — Apple ld64's two-level namespace already resolves same-image symbols
+directly, so GCC's ELF-only interposition assumption never applied there. Gated on
+`GC_STYLE=gnu` in the `Makefile` (the same variable that already marks exactly the
+GNU-ld targets for `--gc-sections`), so no new platform list to keep in sync.
+`qnx` also has `GC_STYLE=gnu` and keeps `-fvisibility=hidden` (GCC ≥ 4.0), but is
+excluded from `-fno-semantic-interposition` (needs GCC ≥ 5.1): no CI or buildbot job
+builds `qnx` in this repo, so its toolchain floor is unverified, and QNX SDP 6.x's `qcc`
+is known to wrap an old enough GCC that the flag can hard-error instead of no-op.
+
+- **Why:** without these flags, GCC treats every cross-file global (`gpu_reg`, `dsp_pc`,
+  the flag/counter externs the hot interpreter headers share) and every cross-file call
+  (`JaguarReadLong` &c.) as potentially interposable, forcing GOT/PLT indirection per
+  emulated instruction. This project already pins its entire exported surface via
+  `$(LINK_SCRIPT)` (`link.T`/`link-test.T`), so nothing outside `libretro.c`'s `retro_*`
+  functions is meant to be interposable in the first place.
+- **`TEST_EXPORTS` is exempt from `-fvisibility=hidden`:** the white-box harnesses
+  `dlsym()` internal symbols (see Test ABI section above); hiding them at compile time
+  would break that even though the version script still lists them.
+  `-fno-semantic-interposition` still applies under `TEST_EXPORTS=1` — it only affects
+  codegen, not the symbol table.
+- **`retro_*` stays exported under `-fvisibility=hidden`:** `libretro.h` declares every
+  entry point `RETRO_API`, which expands to
+  `__attribute__((visibility("default")))` on non-Windows GCC/Clang ≥ 4. A visibility
+  attribute already present on an earlier declaration governs the later definition, so
+  `libretro.c`'s definitions (which never repeat `RETRO_API`) inherit it from the header
+  they include.
+- **`LTO=1` opt-in knob:** `make LTO=1` (combine with `platform=` as usual) appends
+  `-flto` to both compile and link lines for every `GC_STYLE=gnu` target. Deliberately
+  **not** default-on — it needs an A/B on real Pi hardware first
+  (`test/tools/rpi_perf.sh`), the same caution the `-O3` rollout used (#515/#516).
+  `classic_armv7_a7` is unaffected either way: it already runs its own
+  `-flto=4 -fwhole-program` pipeline in its platform block, independent of this knob.
+  `LTO` is in `BUILD_AXES` since it changes object content.
+- **Android (`jni/Android.mk`):** `ndk-build` never includes `Makefile`, only
+  `Makefile.common`, so it inherited none of the desktop optimisation flags. `COREFLAGS`
+  now also carries `-O3 -DNDEBUG -fvisibility=hidden -fno-stack-protector
+  -fomit-frame-pointer -fno-semantic-interposition` by hand.
+- **Issue #516 does not apply here:** neither `-fvisibility=hidden` nor
+  `-fno-semantic-interposition` is an `-O`, so neither can silently shift a platform's
+  resolved optimisation level.
 
 ## Build-identity guard (stale-binary protection)
 

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -114,12 +114,22 @@ via `jni/Android.mk`) now compiles with `-fno-semantic-interposition` and, for
 non-`TEST_EXPORTS` builds, `-fvisibility=hidden`. Mach-O targets (`osx`, `ios*`, `tvos*`)
 are untouched — Apple ld64's two-level namespace already resolves same-image symbols
 directly, so GCC's ELF-only interposition assumption never applied there. Gated on
-`GC_STYLE=gnu` in the `Makefile` (the same variable that already marks exactly the
-GNU-ld targets for `--gc-sections`), so no new platform list to keep in sync.
-`qnx` also has `GC_STYLE=gnu` and keeps `-fvisibility=hidden` (GCC ≥ 4.0), but is
-excluded from `-fno-semantic-interposition` (needs GCC ≥ 5.1): no CI or buildbot job
-builds `qnx` in this repo, so its toolchain floor is unverified, and QNX SDP 6.x's `qcc`
-is known to wrap an old enough GCC that the flag can hard-error instead of no-op.
+`GC_STYLE=gnu` in the `Makefile`, the same variable that already marks the GNU-ld targets
+for `--gc-sections` — but `GC_STYLE=gnu` is a slightly *wider* set than "ELF", so two
+platforms are explicitly carved back out:
+
+- **`qnx`** also has `GC_STYLE=gnu` and keeps `-fvisibility=hidden` (GCC ≥ 4.0), but is
+  excluded from `-fno-semantic-interposition` (needs GCC ≥ 5.1): no CI or buildbot job
+  builds `qnx` in this repo, so its toolchain floor is unverified, and QNX SDP 6.x's `qcc`
+  is known to wrap an old enough GCC that the flag can hard-error instead of no-op.
+- **`win`** (native MinGW) also sets `GC_STYLE=gnu` purely because MinGW's `ld` honours
+  `--version-script`/`--gc-sections` too — not because its output is ELF. `win`'s `TARGET`
+  is a PE/COFF `.dll`, and `libretro.h`'s `RETRO_API` expands to
+  `__attribute__((__dllexport__))` there, not the visibility attribute, so this whole
+  block's rationale (ELF-style GOT/PLT interposition, `RETRO_API` surviving
+  `-fvisibility=hidden` via inherited visibility) doesn't apply — and `win` *is* built in
+  CI (`c-cpp.yml`'s MSYS2 job, `release.yml`). It is excluded outright from all three of
+  `-fno-semantic-interposition`, `-fvisibility=hidden`, and the `LTO=1` knob below.
 
 - **Why:** without these flags, GCC treats every cross-file global (`gpu_reg`, `dsp_pc`,
   the flag/counter externs the hot interpreter headers share) and every cross-file call
@@ -139,8 +149,8 @@ is known to wrap an old enough GCC that the flag can hard-error instead of no-op
   `libretro.c`'s definitions (which never repeat `RETRO_API`) inherit it from the header
   they include.
 - **`LTO=1` opt-in knob:** `make LTO=1` (combine with `platform=` as usual) appends
-  `-flto` to both compile and link lines for every `GC_STYLE=gnu` target. Deliberately
-  **not** default-on — it needs an A/B on real Pi hardware first
+  `-flto` to both compile and link lines for every `GC_STYLE=gnu` target except `win`
+  (see above). Deliberately **not** default-on — it needs an A/B on real Pi hardware first
   (`test/tools/rpi_perf.sh`), the same caution the `-O3` rollout used (#515/#516).
   `classic_armv7_a7` is unaffected either way: it already runs its own
   `-flto=4 -fwhole-program` pipeline in its platform block, independent of this knob.

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -38,7 +38,20 @@ include $(CORE_DIR)/Makefile.common
 # arch .c compiles. Without it blitter.c falls back to the scalar inline
 # set -- which links fine against the neon/sse2 vtable and just runs
 # slower, so nothing would catch its absence at build time.
-COREFLAGS := -DINLINE="inline" -D__LIBRETRO__ $(INCFLAGS) $(BLITTER_SIMD_DEFINE)
+#
+# -O3 -DNDEBUG -fvisibility=hidden -fno-stack-protector
+# -fomit-frame-pointer -fno-semantic-interposition: the release
+# optimisation/visibility flags from the desktop Makefile (issue #569),
+# added by hand because ndk-build never includes Makefile -- only
+# Makefile.common -- so without this line Android inherited none of
+# them and built at whatever default APP_OPTIM/-O ndk-build picks.
+# LOCAL_LDFLAGS below already pins the production link.T version
+# script, same as every other ELF target; -fvisibility=hidden is safe
+# alongside it because libretro.h declares every retro_* entry point
+# RETRO_API (visibility("default")), so those symbols stay exported.
+COREFLAGS := -DINLINE="inline" -D__LIBRETRO__ $(INCFLAGS) $(BLITTER_SIMD_DEFINE) \
+             -O3 -DNDEBUG -fvisibility=hidden -fno-stack-protector \
+             -fomit-frame-pointer -fno-semantic-interposition
 
 # libretro.c includes the generated src/core/version.h.  Generate it
 # at parse time -- ndk-build doesn't go through the project Makefile,

--- a/test/tools/simd_matrix_check.sh
+++ b/test/tools/simd_matrix_check.sh
@@ -318,6 +318,11 @@ expect_vis unix     no  yes TEST_EXPORTS=1
 expect_vis rpi4_64  no  yes TEST_EXPORTS=1
 # Mach-O is GC_STYLE=macho, not gnu -- neither flag belongs there.
 expect_vis osx      no  no
+# win (native MinGW) is GC_STYLE=gnu too, but that is a --version-script
+# convenience, not an ELF signal: TARGET is a PE/COFF .dll and RETRO_API
+# there expands to __attribute__((__dllexport__)), not the visibility
+# attribute, so it is explicitly excluded from both flags in the Makefile.
+expect_vis win       no  no
 
 echo
 if [ "$fail" -ne 0 ]; then

--- a/test/tools/simd_matrix_check.sh
+++ b/test/tools/simd_matrix_check.sh
@@ -263,6 +263,63 @@ expect_tune tvos-arm64 -O3 - no
 expect_tune vita       -O2 - no
 
 echo
+
+# --- ELF visibility / interposition (issue #569) ----------------------------
+# -fno-semantic-interposition and -fvisibility=hidden must reach every
+# GC_STYLE=gnu release CFLAGS; -fvisibility=hidden must vanish under
+# TEST_EXPORTS=1 (the white-box harnesses dlsym() internal symbols), while
+# -fno-semantic-interposition -- codegen-only, no symbol-table effect -- stays
+# on regardless. Mach-O (osx) must get neither: ld64's two-level namespace
+# never had the interposition assumption to begin with.
+#
+# expect_vis <platform> <expect-hidden:yes|no> <expect-interposition:yes|no> [extra make vars...]
+expect_vis() {
+   local plat="$1" want_hidden="$2" want_interp="$3"; shift 3
+   local got cflags has_hidden has_interp label
+
+   checked=$((checked + 1))
+   label="$plat${1:+ $1}"
+   got="$(dump "$plat" "$@")"
+   cflags="$(printf '%s' "$got" | sed -n 's/.*CFLAGS=//p')"
+
+   if [ -z "$cflags" ]; then
+      printf 'FAIL  %-42s could not read CFLAGS\n' "$label"; fail=$((fail + 1)); return
+   fi
+
+   has_hidden="$(printf '%s' "$cflags" | tr ' ' '\n' | grep -cE '^-fvisibility=hidden$')"
+   has_interp="$(printf '%s' "$cflags" | tr ' ' '\n' | grep -cE '^-fno-semantic-interposition$')"
+
+   if [ "$want_hidden" = yes ] && [ "$has_hidden" -eq 0 ]; then
+      printf 'FAIL  %-42s missing -fvisibility=hidden\n' "$label"; fail=$((fail + 1)); return
+   fi
+   if [ "$want_hidden" = no ] && [ "$has_hidden" -ne 0 ]; then
+      printf 'FAIL  %-42s unexpectedly has -fvisibility=hidden (breaks TEST_EXPORTS dlsym)\n' "$label"
+      fail=$((fail + 1)); return
+   fi
+   if [ "$want_interp" = yes ] && [ "$has_interp" -eq 0 ]; then
+      printf 'FAIL  %-42s missing -fno-semantic-interposition\n' "$label"; fail=$((fail + 1)); return
+   fi
+   if [ "$want_interp" = no ] && [ "$has_interp" -ne 0 ]; then
+      printf 'FAIL  %-42s unexpectedly has -fno-semantic-interposition\n' "$label"
+      fail=$((fail + 1)); return
+   fi
+
+   [ "$VERBOSE" = 1 ] && printf 'ok    %-42s hidden=%s interp=%s\n' "$label" "$want_hidden" "$want_interp"
+   return 0
+}
+
+echo "simd_matrix_check: ELF visibility / interposition (issue #569)"
+expect_vis unix     yes yes
+expect_vis rpi4_64  yes yes
+expect_vis rpi1     yes yes
+expect_vis arm64    yes yes
+# TEST_EXPORTS=1: -fvisibility=hidden must disappear, interposition stays.
+expect_vis unix     no  yes TEST_EXPORTS=1
+expect_vis rpi4_64  no  yes TEST_EXPORTS=1
+# Mach-O is GC_STYLE=macho, not gnu -- neither flag belongs there.
+expect_vis osx      no  no
+
+echo
 if [ "$fail" -ne 0 ]; then
    echo "simd_matrix_check: FAILED ($fail of $checked rows)"
    exit 1


### PR DESCRIPTION
Item **P2** of the 2026-08 performance audit — tracking epic #569, method and evidence in `docs/perf-audit-2026-08.md`.

⚠️ **Needs a Development-panel link to #569** (keywords do nothing on PRs targeting `develop`, per `pr-issue-link.yml`).

Build-flag change only — **no source touched, no emulation behaviour changes**.

## The problem

Every ELF/GNU-ld target (`unix`, `rpi0`–`rpi5_64`, generic `arm64`/`armv*`, Android) is built `-fPIC` with only a link-time version script (`link.T`) — there is no `-fvisibility=hidden`, no `-fno-semantic-interposition`, and no LTO except on `classic_armv7_a7`. GCC must therefore assume every symbol can be interposed at link time: cross-file globals in the hot interpreter loops (`gpu_reg`, the flags, `dsp_pc`, counters — 37+ externs in the hottest headers alone) become GOT-indirect loads per emulated instruction, and cross-file calls (`JaguarReadLong` and friends) go through the PLT. `RETRO_API` (`libretro-common/include/libretro.h`) already tags every `retro_*` entry point with `visibility("default")`, so hiding everything else needs no source change. Separately, `jni/Android.mk` includes only `Makefile.common`, never `Makefile`, so Android inherited none of the release optimisation flags (no `-O3`, NDK default `-O2 -fstack-protector-strong`).

## The change

- `-fno-semantic-interposition` on every `GC_STYLE=gnu` target except `qnx` (excluded — nothing in this repo's CI/buildbot builds or tests it, and its toolchain floor is unverified) and `win` (excluded — native MinGW targets PE/COFF, not ELF; `RETRO_API` there already expands to `__attribute__((__dllexport__))`, not the visibility attribute, so none of this block's rationale applies, and it's CI-built so an untested flag there is a real risk, not a theoretical one).
- `-fvisibility=hidden` for `!TEST_EXPORTS` builds only — the white-box test harnesses `dlsym` internal symbols via `link-test.T`/`exports-test.list`, so `TEST_EXPORTS=1` builds keep default visibility. `retro_*` stays exported everywhere via `RETRO_API`.
- An opt-in `LTO=1` knob (same `GC_STYLE=gnu` scope, same `qnx`/`win` exclusions) — deliberately **not** default-on. LTO can surface latent C89 UB and this repo's own history (#515/#516) says flag changes need a real-hardware A/B before shipping by default; `test/tools/rpi_perf.sh` exists for exactly that follow-up.
- `jni/Android.mk`: `COREFLAGS` gains `-O3 -DNDEBUG -fvisibility=hidden -fno-stack-protector -fomit-frame-pointer -fno-semantic-interposition`, with a comment explaining why (Android.mk doesn't include Makefile, so it never inherited these).
- `test/tools/simd_matrix_check.sh` gained assertion rows for the new flags per platform (following the file's existing row format and `env -u MAKEFLAGS` isolation), including a regression guard that `win` gets neither new flag.
- `docs/agent/build.md` documents what shipped, why `TEST_EXPORTS` is exempt, and both carve-outs.

## Verification

- **The exact hazard this repo has been bitten by (#516: a stray flag silently not applying, or a platform's last `-O` changing) was checked directly**, not just argued: resolved compile-line dumps (`make -n`) for `unix`, `unix TEST_EXPORTS=1`, `qnx`, `rpi4_64`, and `win` all confirmed to get exactly the intended flag set — `win` gets neither new flag, `qnx` gets visibility but not interposition, `TEST_EXPORTS=1` keeps interposition but drops visibility, every real ELF target gets both. No platform's last `-O` changed (grep-verified: no `-O` token exists anywhere in the new block).
- **`win` scope creep was caught in review, not shipped.** `win` also sets `GC_STYLE := gnu` (for `--version-script`/`--gc-sections` reasons, unrelated to being ELF) and is CI-built (`c-cpp.yml`, `release.yml`), so the first draft of this change silently applied both flags there. Task review caught it; fixed and independently re-verified across five platform dumps in a scoped re-review.
- **`-fvisibility=hidden` doesn't break the test ABI.** Release dylib exports exactly **46** `retro_*` symbols before and after. `TEST_EXPORTS=1` dylib exports **633** symbols including internals (`_dsp_pc` and friends) — the wide white-box ABI survives. Proved at the `.o` level with `nm -m`: `RETRO_API`-tagged symbols stay `external` under `-fvisibility=hidden` while an ordinary global drops to `private external` (the Mach-O equivalent of `STV_HIDDEN`) — demonstrating the mechanism, not just citing GCC docs.
- Full suite (`make TEST_EXPORTS=1 test`): every group `0 failed` (49 result groups), `simd_matrix_check: OK (42 rows)`, `scripts/c89-lint.sh` clean.

## Disclosed, not hidden

- **Android NDK ordering is asserted, not demonstrated** — no local NDK exists to run `ndk-build` in this environment. The reasoning (`LOCAL_CFLAGS` is appended after `TARGET_CFLAGS` on the ndk-build compile line, so it wins) is standard, documented NDK behaviour, but the first real exercise of this is `release.yml`'s `android-*` matrix on this PR.
- **`qnx`'s partial exclusion** (loses interposition, keeps visibility) is a judgment call from general QNX/`qcc` toolchain knowledge — nothing in this repo builds or tests `qnx`.

**No speed number claimed from this host** — see the audit doc's measurement recipes for the Pi/A10X path, and `LTO=1` is explicitly staged for that A/B rather than defaulted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)