### PR TITLE
perf(tom): widen the BG line-buffer clear from byte to word stores

### DIFF
--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -1543,8 +1543,26 @@ void TOMExecHalfline(uint16_t halfline, bool render)
 
          // Clear line buffer with BG
          if (GET16(tomRam8, VMODE) & BGEN) // && (CRY or RGB16)...
-            for(i=0; i<720; i++)
-               *current_line_buffer++ = bgHI, *current_line_buffer++ = bgLO;
+         {
+            /* Widened from 1440 byte stores to 720 word stores (#569/P8).
+             * Write the first pixel byte-by-byte (same order as the loop
+             * this replaces: high byte, then low byte), then re-load it
+             * as a native 16-bit word and replicate that word the rest
+             * of the way. This is a raw RAM-to-RAM repeat, not an
+             * endian-corrected value, so it is safe on any host byte
+             * order -- see the paletteRAM16 comment in op.c for the same
+             * "OK for direct copies, not for endian-corrected data"
+             * pattern applied to this exact line buffer. */
+            uint16_t * current_line_buffer16 = (uint16_t *)current_line_buffer;
+            uint16_t bgPixel;
+
+            current_line_buffer[0] = bgHI;
+            current_line_buffer[1] = bgLO;
+            bgPixel = current_line_buffer16[0];
+
+            for (i = 1; i < 720; i++)
+               current_line_buffer16[i] = bgPixel;
+         }
 
          OPProcessList(halfline, render);
       }


### PR DESCRIPTION
Item **P8** (scoped) of the 2026-08 performance audit — tracking epic #569.

⚠️ **Needs a Development-panel link to #569.**

Pure host-cost reduction, byte-identical output on every host byte order.

## The problem

`TOMExecHalfline`'s BGEN line-buffer clear was 1440 individual byte stores per rendered halfline. On arm64/-O3 (Apple clang), the compiler already fully unrolls and auto-vectorizes this into NEON stores — nothing to fix there. But the actual **shipped x86-64 baseline** (no `-march`, matching this repo's default Linux/Windows config) compiles it to 8×-unrolled scalar `movb` pairs — 2880 individual byte stores. Confirmed by cross-compiling both the old and new forms for `x86_64-apple-darwin` and disassembling, not assumed from the local arm64 host.

## The fix

Widen to 720 word stores through a `uint16_t*`. Byte order is preserved by construction rather than composed: the first pixel is still written byte-by-byte (`bgHI` then `bgLO`, same order as before), then **re-read** as a native 16-bit word and that value is replicated — a pure byte-copy round-trip, not a shift-composed value, so it's correct on any host endianness without needing an endian branch. (The brief's own suggested "minimal form" snippet used a shift-composed value instead — independently confirmed in review to be a real byte-order bug on little-endian hosts. Not shipped.) Same pattern already used for this exact line buffer's `paletteRAM16` case in `src/tom/op.c`.

## Verification

- `bash scripts/c89-lint.sh` clean; full suite green.
- Byte-identical framebuffer + audio A/B (400 frames, Wolfenstein 3D + Alien vs Predator, both confirmed to keep BGEN continuously active through gameplay via instrumentation) vs. the pre-change binary.
- Reviewed independently: byte order traced manually through both writes, loop bounds checked for off-by-one (720 iterations from i=1, plus the explicit i=0 write, matches the original 1440-byte/720-word footprint exactly), and the `op.c` precedent claim verified to exist as stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)