### PR TITLE
perf(dsp): fast-forward provably idle RISC loops within a slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ tools/jagcd/jagcd-chd-check
 tools/jagcd/chdman
 tools/jagcd/*.exe
 test/tools/blit_memo_verify
+test/tools/dsp_idle_ab
+test/tools/dsp_idle_probe_falsify
 test/tools/i2s_lag_probe
 test/tools/test_memory_map
 test/tools/test_op_gpu_object

--- a/Makefile
+++ b/Makefile
@@ -1212,7 +1212,7 @@ clean:
 		test/test_biosdb test/test_cart_bios_loader \
 		test/test_titledb test/test_titlehook test/tools/test_hook_gate \
 		test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace test/tools/i2s_lag_probe \
-		test/tools/dsp_idle_probe_falsify \
+		test/tools/dsp_idle_probe_falsify test/tools/dsp_idle_ab \
 		test/tools/joymatrix_identity test/tools/teamtap_ports \
 		test/tools/teamtap_rom_probe test/tools/mouse_decode_test \
 		test/tools/rotary_decode_test test/tools/analog_decode_test \

--- a/Makefile
+++ b/Makefile
@@ -1212,6 +1212,7 @@ clean:
 		test/test_biosdb test/test_cart_bios_loader \
 		test/test_titledb test/test_titlehook test/tools/test_hook_gate \
 		test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace test/tools/i2s_lag_probe \
+		test/tools/dsp_idle_probe_falsify \
 		test/tools/joymatrix_identity test/tools/teamtap_ports \
 		test/tools/teamtap_rom_probe test/tools/mouse_decode_test \
 		test/tools/rotary_decode_test test/tools/analog_decode_test \
@@ -1276,6 +1277,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_framebuffer_integrity test/test_state_compat \
 		test/test_frontend_pacing test/test_jgd \
 		test/tools/test_runahead_determinism test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace \
+		test/tools/dsp_idle_probe_falsify \
 		test/test_butch_cd test/test_bios_config test/test_boot_config \
 		test/test_cart_format test/test_cart_needs_bios test/test_cart_bios_loader \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_chd test/test_chd_unit test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda test/test_cd_synth_subq \
@@ -1569,6 +1571,12 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# every STATE_SAVE_BUF; yarc.j64 is in-tree so this never skips, and
 	@# a real music-on title is used when the private corpus is present.
 	./test/tools/test_runahead_determinism ./$(TARGET) test/roms/yarc.j64 --quiet
+	@# DSP idle-loop fast-forward (#569): the admission rule must reject a
+	@# compound period that hides an undecoded store behind a not-taken jr
+	@# plus a jump back to the loop head -- and must still fire on a
+	@# genuinely idle loop, so a silently-disabled feature cannot pass.
+	@# Hand-assembles both shapes into DSP RAM; needs no ROM but yarc.
+	./test/tools/dsp_idle_probe_falsify ./$(TARGET) test/roms/yarc.j64 --quiet
 	@# Texture dump mode (issue #369): identity-contract freeze vs the
 	@# committed golden list, determinism, fast/accurate engine
 	@# independence, machine inertness (fb hashes + savestate digests
@@ -2349,6 +2357,22 @@ test/tools/test_wedge_spin: test/tools/test_wedge_spin.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_wedge_spin.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
+
+test/tools/dsp_idle_probe_falsify: test/tools/dsp_idle_probe_falsify.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/dsp_idle_probe_falsify.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
+
+# Not built by `test`: an A/B measurement harness, not an assertion.  See
+# the header comment for how to drive an option sweep with it.
+test/tools/dsp_idle_ab: test/tools/dsp_idle_ab.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/dsp_idle_ab.c \
 		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 

--- a/libretro.c
+++ b/libretro.c
@@ -2254,19 +2254,24 @@ static void check_variables(void)
    }
 
    /* DSP idle-loop fast-forward (issue #569).  Bit-exact by
-    * construction -- see the safety theorem in src/jerry/dsp.c -- and on
-    * by default: the corpus A/B (Iron Soldier, AvP, Doom, Wolfenstein
-    * 3D, Tempest 2000, jagniccc, yarc, plus the CD titles Primal Rage
-    * and Battle Morph) came back byte-identical on framebuffer, audio
-    * and periodic savestate digest with it off vs on.  DSPExec re-checks the interacting options (dram
-    * timing, pipeline timing, clock scale, blit memo) itself, so the
-    * order the option loop reads them in does not matter. */
+    * construction -- see the safety theorem in src/jerry/dsp.c -- and
+    * the corpus A/B (Iron Soldier, AvP, Doom, Wolfenstein 3D, Tempest
+    * 2000, jagniccc, yarc, plus the CD titles Primal Rage and Battle
+    * Morph) is byte-identical on framebuffer, audio and periodic
+    * savestate digest with it off vs on.  It still ships OFF for one
+    * release cycle: the failure mode if an untested title does slip
+    * through is a silent audio/video divergence nobody can attribute,
+    * against a speed win a user can opt into with one toggle -- an
+    * asymmetry a nine-title corpus does not settle for a ~200-title
+    * library.  DSPExec re-checks the interacting options (dram timing,
+    * pipeline timing, clock scale, blit memo) itself, so the order the
+    * option loop reads them in does not matter. */
    var.key = "virtualjaguar_risc_idle_skip";
    var.value = NULL;
    if (get_variable_pertitle(&var) && var.value)
-      vjs.riscIdleSkip = (strcmp(var.value, "disabled") != 0);
+      vjs.riscIdleSkip = (strcmp(var.value, "enabled") == 0);
    else
-      vjs.riscIdleSkip = true;
+      vjs.riscIdleSkip = false;
 
    /* DRAM timing: enabled/disabled only, covering BOTH halves of the
     * symmetric self-cost model (GPU stalls in gpu.c, 68K wait-states

--- a/libretro.c
+++ b/libretro.c
@@ -2253,6 +2253,21 @@ static void check_variables(void)
          GPUPipeTimingReset();
    }
 
+   /* DSP idle-loop fast-forward (issue #569).  Bit-exact by
+    * construction -- see the safety theorem in src/jerry/dsp.c -- and on
+    * by default: the corpus A/B (Iron Soldier, AvP, Doom, Wolfenstein
+    * 3D, Tempest 2000, jagniccc, yarc, plus the CD titles Primal Rage
+    * and Battle Morph) came back byte-identical on framebuffer, audio
+    * and periodic savestate digest with it off vs on.  DSPExec re-checks the interacting options (dram
+    * timing, pipeline timing, clock scale, blit memo) itself, so the
+    * order the option loop reads them in does not matter. */
+   var.key = "virtualjaguar_risc_idle_skip";
+   var.value = NULL;
+   if (get_variable_pertitle(&var) && var.value)
+      vjs.riscIdleSkip = (strcmp(var.value, "disabled") != 0);
+   else
+      vjs.riscIdleSkip = true;
+
    /* DRAM timing: enabled/disabled only, covering BOTH halves of the
     * symmetric self-cost model (GPU stalls in gpu.c, 68K wait-states
     * in jaguar.c).  The calibration scale is deliberately NOT a core

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -265,15 +265,15 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_risc_idle_skip",
       "DSP Idle-Loop Fast-Forward",
       NULL,
-      "Skip provably redundant iterations when the DSP is parked in a wait loop. Commercial titles leave the DSP spinning in a 3-5 instruction poll for most of every frame while it still interprets its full cycle budget; this fast-forwards those iterations instead. Bit-exact by construction, not an approximation: the registers, flags, cycles charged and instruction count all end up exactly where interpreting them would have left them, so save states, run-ahead and netplay are unaffected. Turned off automatically when DRAM timing, GPU pipeline timing, a non-stock RISC clock scale or blit memoization is in use.",
+      "Speed-up: skip provably redundant iterations when the DSP is parked in a wait loop. Commercial titles leave the DSP spinning in a 3-5 instruction poll for most of every frame while it still interprets its full cycle budget; this fast-forwards those iterations instead, cutting DSP interpretation by 66-87% on the titles measured. Bit-exact by construction, not an approximation: the registers, flags, cycles charged and instruction count all end up exactly where interpreting them would have left them, so save states, run-ahead and netplay are unaffected. New in this release and off by default while the compatibility corpus grows -- if a title looks or sounds wrong with it on, turn it off and please report it. Ignored automatically when DRAM timing, GPU pipeline timing, a non-stock RISC clock scale or blit memoization is in use.",
       NULL,
       "timing",
       {
-         { "enabled",  NULL },
          { "disabled", NULL },
+         { "enabled",  NULL },
          { NULL, NULL },
       },
-      "enabled"
+      "disabled"
    },
    {
       "virtualjaguar_dram_timing",

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -262,6 +262,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "1x"
    },
    {
+      "virtualjaguar_risc_idle_skip",
+      "DSP Idle-Loop Fast-Forward",
+      NULL,
+      "Skip provably redundant iterations when the DSP is parked in a wait loop. Commercial titles leave the DSP spinning in a 3-5 instruction poll for most of every frame while it still interprets its full cycle budget; this fast-forwards those iterations instead. Bit-exact by construction, not an approximation: the registers, flags, cycles charged and instruction count all end up exactly where interpreting them would have left them, so save states, run-ahead and netplay are unaffected. Turned off automatically when DRAM timing, GPU pipeline timing, a non-stock RISC clock scale or blit memoization is in use.",
+      NULL,
+      "timing",
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
       "virtualjaguar_dram_timing",
       "DRAM Timing (Experimental)",
       NULL,

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -45,6 +45,14 @@ struct VJSettings
 	 * src/cd/jagcd_hle.c). */
 	uint32_t cdReadSpeed;
 
+	/* Cycle-exact DSP idle-loop fast-forward (issue #569, perf audit P1).
+	 * Skips provably redundant iterations of a wait loop inside one RISC
+	 * slice; bit-exact by construction (see the safety theorem in
+	 * src/jerry/dsp.c).  Added after the existing scalars, never before
+	 * them: test/test_hle_bios.c redeclares VJSettings with only the
+	 * first three fields and resolves it via dlsym. */
+	bool riscIdleSkip;
+
 	char jagBootPath[MAX_PATH];
 	char CDBootPath[MAX_PATH];
 	char alpineROMPath[MAX_PATH];

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -29,6 +29,8 @@
 #include "m68000/m68kinterface.h"
 #include "settings.h"
 #include "tom.h"
+#include "blit_memo.h"
+#include "bus_arbiter.h"
 #include "../core/vjtrace.h"
 #include "perf_iface.h"
 
@@ -1065,10 +1067,674 @@ void DSPSyncToM68K(void)
 	VJP_LEAVE(VJP_DSP_SYNC);
 }
 
+/* ==================================================================
+ * Cycle-exact idle-loop fast-forward   (issue #569, perf audit P1)
+ * ==================================================================
+ *
+ * Commercial titles park the DSP in a 3-5 instruction wait loop for
+ * 74-99.7% of every frame while it still burns its whole 26.6 MHz
+ * budget interpreting that loop (docs/perf-audit-2026-08.md, P1).  This
+ * skips the provably redundant iterations.  It is NOT an approximation:
+ * the registers, the flags, the PC, the cycles charged and
+ * dsp_exec_opcode_count all end up exactly where the interpreter would
+ * have left them.  Run-ahead, netplay and savestates depend on that.
+ *
+ * ---- SAFETY THEOREM (verified against this tree, not assumed) -------
+ *
+ * (Line numbers below are pre-patch, i.e. as of the parent commit, so
+ * they line up with the file this block was written against.)
+ *
+ * (1) Nothing else in the machine executes inside one DSPExec() call.
+ *     The slice budget is "time until the next scheduled event":
+ *     JaguarExecuteNew() (src/core/jaguar.c:1683-1752) computes
+ *     GetTimeToNextEvent(), runs the 68K and the GPU, then calls
+ *     DSPExec(DSPSliceRemaining()); SubtractEventTimes() and
+ *     HandleNextEvent() only run AFTER DSPExec returns.  The OP runs
+ *     from a halfline event, i.e. also outside.  DSPSyncToM68K()
+ *     (dsp.c:1045-1066) is a different, EARLIER DSPExec call with its
+ *     own budget, not a re-entry -- it bails on dsp_in_exec.
+ *
+ * (2) No DSP interrupt can be dispatched mid-call for an admitted body.
+ *     NOTE: unlike GPUExec, DSPExec has no slice-entry DSPHandleIRQs
+ *     call at all.  The only in-loop dispatch is the
+ *     `IMASKCleared && dspFlagsRetireDelay == 0` re-check at the top of
+ *     DSPExec's loop below, and IMASKCleared is set only by a
+ *     store to D_FLAGS (dsp.c:698) -- which the admission rule excludes.
+ *     The other entry point, DSPSetIRQLine -> DSPHandleIRQsNP
+ *     (dsp.c:925-935), is only ever reached from event callbacks, i.e.
+ *     between slices, per (1).  The probe additionally requires
+ *     IMASKCleared == false and dspFlagsRetireDelay == 0, so neither
+ *     the pending-IRQ path nor the D_FLAGS retire countdown is live.
+ *
+ * (3) The register banks cannot move.  dsp_reg / dsp_alternate_reg are
+ *     repointed only by DSPUpdateRegisterBanks(), reachable from a
+ *     D_FLAGS write (dsp.c:756) or from taking an interrupt
+ *     (dsp.c:911) -- both excluded by (2).  The probe records the bank
+ *     pointer at the first snapshot and re-checks it at the third.
+ *
+ * (4) DSP-side reads are pure.  The HLE sound-engine auto-ack in
+ *     DSPReadWord/DSPReadLong (dsp.c:423/484) and the DSPGO poll
+ *     auto-clear (dsp.c:526) are all gated `who == M68K`.  Reads of
+ *     main DRAM take JaguarReadLong's `addr < 0x800000` fast path
+ *     (src/core/jaguar.c:1131-1141) whose only side effects are
+ *     VJT_WATCH_RD (compiled out unless VJ_TRACE) and BlitMemoNoteRead
+ *     (gated on blitMemoRecording); both are hard gates below.
+ *     busArbiter is charged there only for `who == OP`.
+ *
+ * Therefore: if a loop body performs no store and reads only plain RAM,
+ * every value it reads is constant for the remainder of the call, and
+ * one iteration is a pure function of (register file, flags).
+ *
+ * ---- ADMISSION RULE ------------------------------------------------
+ *
+ * Candidate: a TAKEN backward (or self-targeting) `jr` whose target is
+ * at most 8 words behind, with the whole body inside DSP local RAM.
+ * Body = target .. jr inclusive, plus the inlined delay-slot
+ * instruction.  Static decode (register-independent) requires:
+ *   - every opcode on the whitelist below (no store of any kind, no
+ *     accumulator/latency opcode, no second branch);
+ *   - the decode walk lands exactly on the jr, so the body really is
+ *     straight-line (movei carries a 32-bit immediate, i.e. 3 words);
+ *   - no movei in the delay slot (its immediate would be fetched from
+ *     past the branch).
+ * Register-dependent checks are deliberately deferred to the third
+ * snapshot: control can enter a loop body part-way through, so at the
+ * first snapshot a register written only in the early part of the body
+ * may still hold pre-loop garbage, and a load EA computed from it would
+ * be meaningless.  After two complete iterations the head state is
+ * steady-state and the checks are authoritative.
+ *
+ * ---- FIXED-POINT PROOF ---------------------------------------------
+ *
+ * Snapshots S0/S1/S2 are taken at the loop head (immediately after the
+ * taken jr's delay slot) on three consecutive arrivals, driven from
+ * DSPExec's own loop -- the probe iterations are ordinary interpreted
+ * execution, so no semantics are duplicated anywhere.  Extrapolate only
+ * when all of:
+ *   - the branch was taken all three times and landed on the same head
+ *     from the same jr (a different loop appearing mid-probe aborts it);
+ *   - elementwise S2-S1 == S1-S0 across BOTH register banks;
+ *   - dsp_flag_z/n/c identical in S0, S1 and S2;
+ *   - the measured cycle cost of iteration 1 equals iteration 2 (taken
+ *     as the delta of `cycles`, never recomputed from
+ *     dsp_opcode_cycles[] -- the inlined delay slot is not charged);
+ *   - likewise the measured dsp_exec_opcode_count delta;
+ *   - every register with a NONZERO per-iteration delta is read and
+ *     written only by an addqt/subqt whose destination is that same
+ *     register.
+ *
+ * That last rule is what makes the branch unable to flip.  It is
+ * strictly stronger than "the last flag-setting instruction reads only
+ * zero-delta registers": addqt/subqt are the only admitted opcodes that
+ * write no flags (dsp_opcode_addqt/subqt above), so any flag-setting
+ * instruction is forced to read zero-delta operands, AND so is every
+ * load base and every shift/rotate count.  Proof that the loop is then
+ * affine forever: memory is constant by the theorem, so with all
+ * zero-delta registers holding their S1 values and the flags holding
+ * their S1 values, every instruction that does not touch a counter
+ * register recomputes exactly the iteration-1 result -- hence flags and
+ * zero-delta registers stay put -- while each counter register is only
+ * ever incremented by a constant.  So iteration k's state is
+ * S1 + (k-1)*delta for all k, and the branch condition never changes.
+ *
+ * Then n = (cycles_remaining / cost) - 1 (always leave one full
+ * iteration to execute normally), reg += n*delta, cycles -= n*cost,
+ * dsp_exec_opcode_count += n*opcodes (crash_detect's wedge predicate
+ * reads that counter -- src/core/crash_detect.c:470-482 -- so a skipped
+ * loop must still look like progress).  Flags and PC are already
+ * correct by construction.  Nothing else is touched.
+ *
+ * Exit is automatic: the I2S/timer callback that eventually changes the
+ * polled location runs between slices, the next probe fails, and normal
+ * interpretation resumes.  No savestate impact -- every byte of probe
+ * state is re-derived from scratch inside each DSPExec call.
+ */
+
+/* Longest body accepted, in 16-bit words (jr offset range [-8,-1]). */
+#define DSP_IDLE_MAX_BODY	8
+/* Body instruction slots: <= 7 before the jr, plus the delay slot. */
+#define DSP_IDLE_MAX_INSN	10
+/* Per-slice reject memo: without it a loop that fails the fixed-point
+ * test would be re-probed every three iterations for the whole slice. */
+#define DSP_IDLE_MEMO		16
+
+/* Effective addresses we will admit for a load: DSP local SRAM (the
+ * range DSPReadLong itself serves out of dsp_ram_8 -- $F1B000-$F1CFFF,
+ * note this is the full 8K, not the $F1BFFF the task brief quoted) or
+ * main DRAM below the 2 MB aperture, where JaguarReadLong is a plain
+ * GET32 of jaguarMainRAM. */
+#define DSP_IDLE_EA_OK(ea) \
+	(((ea) >= DSP_WORK_RAM_BASE && (ea) <= DSP_WORK_RAM_BASE + 0x1FFF) \
+	 || ((ea) < 0x200000))
+
+#define DSP_IDLE_FETCH(a) \
+	((uint16_t)(((uint16_t)dsp_ram_8[(a) - DSP_WORK_RAM_BASE] << 8) \
+	            | (uint16_t)dsp_ram_8[(a) - DSP_WORK_RAM_BASE + 1]))
+
+/* Option gate (libretro `virtualjaguar_risc_idle_skip`) lives in vjs. */
+/* Diagnostics: counted only on the cold probe path, never per opcode. */
+uint32_t dsp_idle_skip_fires   = 0;		/* successful extrapolations */
+uint32_t dsp_idle_skip_rejects = 0;		/* candidate loops turned down */
+uint32_t dsp_idle_skip_iters   = 0;		/* iterations actually skipped */
+uint32_t dsp_idle_skip_opcodes = 0;		/* opcodes NOT interpreted -- the
+										 * honest, host-independent measure:
+										 * dsp_exec_opcode_count is advanced
+										 * over a skip on purpose, so it does
+										 * NOT show the saving. */
+
+static int       idleProbeStage;		/* 0 = none, 1 = have S0, 2 = have S1 */
+static uint32_t  idleProbeHead;
+static uint32_t  idleProbeJr;
+static uint32_t *idleProbeBank;			/* dsp_reg at S0 -- see theorem (3) */
+static int32_t   idleProbeCyc0, idleProbeCyc1;
+static uint32_t  idleProbeOpc0, idleProbeOpc1;
+static uint32_t  idleProbeS0[64], idleProbeS1[64];
+static uint8_t   idleProbeFz0, idleProbeFn0, idleProbeFc0;
+static uint8_t   idleProbeFz1, idleProbeFn1, idleProbeFc1;
+
+static uint8_t   idleBodyIdx[DSP_IDLE_MAX_INSN];
+static uint8_t   idleBodyP1[DSP_IDLE_MAX_INSN];
+static uint8_t   idleBodyP2[DSP_IDLE_MAX_INSN];
+static uint32_t  idleBodyImm[DSP_IDLE_MAX_INSN];
+static int       idleBodyCount;
+
+static uint32_t  idleMemoHead[DSP_IDLE_MEMO];
+static uint32_t  idleMemoJr[DSP_IDLE_MEMO];
+static int       idleMemoCount;
+static int       idleMemoNext;
+
+/* Opcode whitelist.  Admit only what has been reasoned about; anything
+ * absent is rejected, including every store (45/46/47/49/50/60/61), the
+ * accumulator and long-latency opcodes (16-21, 23, 26, 54-56, 63, 32)
+ * and both branches (52/53 -- the loop's own jr is handled separately).
+ * sat32s (42) is rejected because it reads dsp_acc, which the snapshot
+ * does not model; sat16s (33) is a pure RN->RN saturate and is admitted.
+ * mirror (48) and move_pc (51) are pure too but are left out to keep the
+ * whitelist to opcodes the audit actually observed in wait loops. */
+static int dsp_idle_op_admitted(uint32_t idx)
+{
+	switch (idx)
+	{
+	case  0: case  1: case  2: case  3:		/* add addc addq addqt */
+	case  4: case  5: case  6: case  7:		/* sub subc subq subqt */
+	case  8: case  9: case 10: case 11:		/* neg and or xor */
+	case 12: case 13: case 14: case 15:		/* not btst bset bclr */
+	case 22:								/* abs */
+	case 24: case 25: case 27:				/* shlq shrq sharq */
+	case 28: case 29:						/* ror rorq */
+	case 30: case 31:						/* cmp cmpq */
+	case 33:								/* sat16s */
+	case 34: case 35: case 36: case 37:		/* move moveq moveta movefa */
+	case 38:								/* movei */
+	case 39: case 40: case 41:				/* loadb loadw load */
+	case 43: case 44:						/* load_r14/15_indexed */
+	case 57:								/* nop */
+	case 58: case 59:						/* load_r14/15_ri */
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+/* Register operands of an admitted opcode, as indices into the 64-entry
+ * snapshot (0..31 = dsp_reg_bank_0, 32..63 = dsp_reg_bank_1).  `cur` is
+ * the base of the bank dsp_reg points at, `alt` the other one -- the
+ * bank split matters: moveta writes ALTERNATE_RN and movefa reads
+ * ALTERNATE_RM, which is exactly what Iron Soldier's wait loop polls.
+ * *dst is -1 when the instruction writes no register. */
+static int dsp_idle_operands(uint32_t idx, uint32_t p1, uint32_t p2,
+                             int cur, int alt, int *src, int *nsrc, int *dst)
+{
+	*nsrc = 0;
+	*dst  = -1;
+
+	switch (idx)
+	{
+	case  0: case  1: case  4: case  5:		/* add addc sub subc */
+	case  9: case 10: case 11:				/* and or xor */
+	case 28:								/* ror  (RM = count) */
+		src[(*nsrc)++] = cur + (int)p1;
+		src[(*nsrc)++] = cur + (int)p2;
+		*dst = cur + (int)p2;
+		return 1;
+	case 30:								/* cmp -- flags only */
+		src[(*nsrc)++] = cur + (int)p1;
+		src[(*nsrc)++] = cur + (int)p2;
+		return 1;
+	case  2: case  3: case  6: case  7:		/* addq addqt subq subqt */
+	case  8: case 12: case 14: case 15:		/* neg not bset bclr */
+	case 22: case 24: case 25: case 27:		/* abs shlq shrq sharq */
+	case 29: case 33:						/* rorq sat16s */
+		src[(*nsrc)++] = cur + (int)p2;
+		*dst = cur + (int)p2;
+		return 1;
+	case 13: case 31:						/* btst cmpq -- flags only */
+		src[(*nsrc)++] = cur + (int)p2;
+		return 1;
+	case 34:								/* move   RN = RM */
+	case 39: case 40: case 41:				/* loadb loadw load: RM = base */
+		src[(*nsrc)++] = cur + (int)p1;
+		*dst = cur + (int)p2;
+		return 1;
+	case 35: case 38:						/* moveq / movei -- immediate */
+		*dst = cur + (int)p2;
+		return 1;
+	case 36:								/* moveta  ALT_RN = RM */
+		src[(*nsrc)++] = cur + (int)p1;
+		*dst = alt + (int)p2;
+		return 1;
+	case 37:								/* movefa  RN = ALT_RM */
+		src[(*nsrc)++] = alt + (int)p1;
+		*dst = cur + (int)p2;
+		return 1;
+	case 43:								/* load_r14_indexed */
+		src[(*nsrc)++] = cur + 14;
+		*dst = cur + (int)p2;
+		return 1;
+	case 44:								/* load_r15_indexed */
+		src[(*nsrc)++] = cur + 15;
+		*dst = cur + (int)p2;
+		return 1;
+	case 58:								/* load_r14_ri */
+		src[(*nsrc)++] = cur + 14;
+		src[(*nsrc)++] = cur + (int)p1;
+		*dst = cur + (int)p2;
+		return 1;
+	case 59:								/* load_r15_ri */
+		src[(*nsrc)++] = cur + 15;
+		src[(*nsrc)++] = cur + (int)p1;
+		*dst = cur + (int)p2;
+		return 1;
+	case 57:								/* nop */
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+static int dsp_idle_memo_hit(uint32_t head, uint32_t jr)
+{
+	int i;
+
+	for (i = 0; i < idleMemoCount; i++)
+		if (idleMemoHead[i] == head && idleMemoJr[i] == jr)
+			return 1;
+	return 0;
+}
+
+static void dsp_idle_memo_reject(uint32_t head, uint32_t jr)
+{
+	if (dsp_idle_memo_hit(head, jr))
+		return;
+	idleMemoHead[idleMemoNext] = head;
+	idleMemoJr[idleMemoNext]   = jr;
+	idleMemoNext = (idleMemoNext + 1) % DSP_IDLE_MEMO;
+	if (idleMemoCount < DSP_IDLE_MEMO)
+		idleMemoCount++;
+	dsp_idle_skip_rejects++;
+}
+
+/* Register-independent decode of target..jr plus the delay slot. */
+static int dsp_idle_decode(uint32_t head, uint32_t jrAddr)
+{
+	uint32_t pc = head;
+	uint16_t op;
+	uint32_t idx;
+	int n = 0;
+
+	idleBodyCount = 0;
+
+	while (pc < jrAddr)
+	{
+		if (n >= DSP_IDLE_MAX_BODY)
+			return 0;
+		op  = DSP_IDLE_FETCH(pc);
+		idx = (uint32_t)(op >> 10);
+		if (!dsp_idle_op_admitted(idx))
+			return 0;
+		idleBodyIdx[n] = (uint8_t)idx;
+		idleBodyP1[n]  = (uint8_t)((op >> 5) & 0x1F);
+		idleBodyP2[n]  = (uint8_t)(op & 0x1F);
+		idleBodyImm[n] = 0;
+		if (idx == 38)						/* movei: opcode + LSW + MSW */
+		{
+			if (pc + 6 > jrAddr)			/* immediate would overrun the jr */
+				return 0;
+			idleBodyImm[n] = (uint32_t)DSP_IDLE_FETCH(pc + 2)
+			               | ((uint32_t)DSP_IDLE_FETCH(pc + 4) << 16);
+			pc += 6;
+		}
+		else
+			pc += 2;
+		n++;
+	}
+
+	if (pc != jrAddr)						/* decode fell out of step */
+		return 0;
+
+	/* The inlined delay slot at jr+2 runs on every iteration too.  A
+	 * movei there would fetch its immediate from past the branch, so
+	 * reject it rather than model it. */
+	op  = DSP_IDLE_FETCH(jrAddr + 2);
+	idx = (uint32_t)(op >> 10);
+	if (idx == 38 || !dsp_idle_op_admitted(idx))
+		return 0;
+	idleBodyIdx[n] = (uint8_t)idx;
+	idleBodyP1[n]  = (uint8_t)((op >> 5) & 0x1F);
+	idleBodyP2[n]  = (uint8_t)(op & 0x1F);
+	idleBodyImm[n] = 0;
+	n++;
+
+	idleBodyCount = n;
+	return 1;
+}
+
+/* Register-dependent half of the admission rule, run at S2 where the
+ * head state is provably steady.  Walks the body tracking each
+ * register's known value so a load base written earlier in the same body
+ * (Doom's `movei #addr,r2 ; load (r2),r1`) resolves to the address the
+ * load will really use, not to whatever the head snapshot held. */
+static int dsp_idle_check_body(const uint32_t *delta, int cur, int alt)
+{
+	uint32_t kval[64];
+	uint8_t  kok[64];
+	int src[3];
+	int nsrc, dst, s, j, i;
+	uint32_t idx, p1, p2, ea;
+
+	for (i = 0; i < 32; i++)
+	{
+		kval[i]      = dsp_reg_bank_0[i];
+		kval[32 + i] = dsp_reg_bank_1[i];
+		kok[i]       = 1;
+		kok[32 + i]  = 1;
+	}
+
+	for (j = 0; j < idleBodyCount; j++)
+	{
+		idx = idleBodyIdx[j];
+		p1  = idleBodyP1[j];
+		p2  = idleBodyP2[j];
+
+		if (!dsp_idle_operands(idx, p1, p2, cur, alt, src, &nsrc, &dst))
+			return 0;
+
+		/* A register whose per-iteration delta is nonzero is a pure
+		 * counter: it may only be read, and only be written, by an
+		 * addqt/subqt targeting itself.  Those two are the only
+		 * admitted opcodes that touch no flag, so this forbids a
+		 * growing value from reaching a compare, a load address, a
+		 * shift count or anything else. */
+		for (s = 0; s < nsrc; s++)
+			if (delta[src[s]] != 0
+			    && !((idx == 3 || idx == 7) && src[s] == dst))
+				return 0;
+		if (dst >= 0 && delta[dst] != 0 && !(idx == 3 || idx == 7))
+			return 0;
+
+		/* Loads: the effective address must be provably plain RAM. */
+		switch (idx)
+		{
+		case 39:							/* loadb */
+		case 40:							/* loadw */
+			/* Outside local RAM these divert to JaguarReadByte /
+			 * JaguarReadWord, whose full TOM/JERRY decode is not
+			 * audited here; inside it they degenerate to a pure
+			 * DSPReadLong of the containing long. */
+			if (!kok[cur + (int)p1])
+				return 0;
+			ea = kval[cur + (int)p1];
+			if (!(ea >= DSP_WORK_RAM_BASE && ea <= DSP_WORK_RAM_BASE + 0x1FFF))
+				return 0;
+			break;
+		case 41:							/* load */
+			if (!kok[cur + (int)p1])
+				return 0;
+			ea = kval[cur + (int)p1] & 0xFFFFFFFC;
+			if (!DSP_IDLE_EA_OK(ea))
+				return 0;
+			break;
+		case 43:							/* load_r14_indexed */
+			if (!kok[cur + 14])
+				return 0;
+			ea = (kval[cur + 14] & 0xFFFFFFFC)
+			   + (dsp_convert_zero[p1] << 2);
+			if (!DSP_IDLE_EA_OK(ea))
+				return 0;
+			break;
+		case 44:							/* load_r15_indexed */
+			if (!kok[cur + 15])
+				return 0;
+			ea = (kval[cur + 15] & 0xFFFFFFFC)
+			   + (dsp_convert_zero[p1] << 2);
+			if (!DSP_IDLE_EA_OK(ea))
+				return 0;
+			break;
+		case 58:							/* load_r14_ri */
+			if (!kok[cur + 14] || !kok[cur + (int)p1])
+				return 0;
+			ea = (kval[cur + 14] + kval[cur + (int)p1]) & 0xFFFFFFFC;
+			if (!DSP_IDLE_EA_OK(ea))
+				return 0;
+			break;
+		case 59:							/* load_r15_ri */
+			if (!kok[cur + 15] || !kok[cur + (int)p1])
+				return 0;
+			ea = (kval[cur + 15] + kval[cur + (int)p1]) & 0xFFFFFFFC;
+			if (!DSP_IDLE_EA_OK(ea))
+				return 0;
+			break;
+		default:
+			break;
+		}
+
+		/* Propagate what we can still prove about the destination. */
+		if (dst >= 0)
+		{
+			switch (idx)
+			{
+			case 38:						/* movei -- 32-bit immediate */
+				kval[dst] = idleBodyImm[j];
+				kok[dst]  = 1;
+				break;
+			case 35:						/* moveq -- RN = IMM_1 */
+				kval[dst] = p1;
+				kok[dst]  = 1;
+				break;
+			case 34: case 36: case 37:		/* move / moveta / movefa */
+				kval[dst] = kval[src[0]];
+				kok[dst]  = kok[src[0]];
+				break;
+			default:
+				kok[dst] = 0;
+				break;
+			}
+		}
+	}
+
+	return 1;
+}
+
+static void dsp_idle_snapshot(uint32_t *s)
+{
+	memcpy(s,      dsp_reg_bank_0, 32 * sizeof(uint32_t));
+	memcpy(s + 32, dsp_reg_bank_1, 32 * sizeof(uint32_t));
+}
+
+/* Give up on an in-flight probe.  When the loop that displaced it is a
+ * different one, memo the abandoned loop: otherwise two interleaved
+ * loops could restart each other forever without either reaching S2. */
+static void dsp_idle_probe_abandon(uint32_t head, uint32_t jr)
+{
+	if (idleProbeStage != 0
+	    && (idleProbeHead != head || idleProbeJr != jr))
+		dsp_idle_memo_reject(idleProbeHead, idleProbeJr);
+	idleProbeStage = 0;
+}
+
+/* Called from DSPExec immediately after a taken backward/self `jr`, with
+ * dsp_pc already at the loop head and the delay slot already executed.
+ * Returns the (possibly advanced) cycle budget. */
+static int32_t DSPIdleLoopProbe(int32_t cycles, uint32_t head, uint32_t jrAddr)
+{
+	uint32_t delta[64];
+	int32_t  cost, n;
+	uint32_t opcost;
+	int      cur, alt, i;
+
+	/* Whole body -- including the delay slot and its trailing byte --
+	 * must sit in DSP local SRAM, so every fetch is a pure dsp_ram_8
+	 * read and the PC-escape check in DSPExec is a no-op for it. */
+	if (head < DSP_WORK_RAM_BASE
+	    || jrAddr + 3 > DSP_WORK_RAM_BASE + 0x1FFF)
+	{
+		dsp_idle_probe_abandon(head, jrAddr);
+		return cycles;
+	}
+
+	/* Theorem (2): a pending IMASK clear or an un-retired D_FLAGS store
+	 * means interrupt state is in flight; do not extrapolate over it.
+	 * Both are transient (DSPExec dispatches the pending IRQ on its very
+	 * next iteration), so this is a reset, not a permanent reject. */
+	if (IMASKCleared || dspFlagsRetireDelay)
+	{
+		dsp_idle_probe_abandon(head, jrAddr);
+		return cycles;
+	}
+
+	/* A different loop showed up mid-probe.  Only then -- calling this
+	 * unconditionally would reset the probe of the loop we are actually
+	 * in the middle of measuring, and nothing would ever reach S2. */
+	if (idleProbeStage != 0
+	    && (idleProbeHead != head || idleProbeJr != jrAddr))
+		dsp_idle_probe_abandon(head, jrAddr);
+
+	if (dsp_idle_memo_hit(head, jrAddr))
+		return cycles;
+
+	if (idleProbeStage == 0)
+	{
+		if (!dsp_idle_decode(head, jrAddr))
+		{
+			dsp_idle_memo_reject(head, jrAddr);
+			return cycles;
+		}
+		dsp_idle_snapshot(idleProbeS0);
+		idleProbeFz0   = dsp_flag_z;
+		idleProbeFn0   = dsp_flag_n;
+		idleProbeFc0   = dsp_flag_c;
+		idleProbeCyc0  = cycles;
+		idleProbeOpc0  = dsp_exec_opcode_count;
+		idleProbeHead  = head;
+		idleProbeJr    = jrAddr;
+		idleProbeBank  = dsp_reg;
+		idleProbeStage = 1;
+		return cycles;
+	}
+
+	if (idleProbeStage == 1)
+	{
+		dsp_idle_snapshot(idleProbeS1);
+		idleProbeFz1   = dsp_flag_z;
+		idleProbeFn1   = dsp_flag_n;
+		idleProbeFc1   = dsp_flag_c;
+		idleProbeCyc1  = cycles;
+		idleProbeOpc1  = dsp_exec_opcode_count;
+		idleProbeStage = 2;
+		return cycles;
+	}
+
+	/* Stage 2: the live machine state is S2. */
+	idleProbeStage = 0;
+
+	/* Flags must have been identical at all THREE loop heads.  Comparing
+	 * only S0 against S2 would admit a two-iteration oscillation whose
+	 * third iteration behaves like neither probe. */
+	if (idleProbeFz1 != idleProbeFz0 || idleProbeFn1 != idleProbeFn0
+	    || idleProbeFc1 != idleProbeFc0
+	    || dsp_flag_z != idleProbeFz0 || dsp_flag_n != idleProbeFn0
+	    || dsp_flag_c != idleProbeFc0)
+	{
+		dsp_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+
+	/* Theorem (3): the bank pointers must not have moved. */
+	if (dsp_reg != idleProbeBank)
+	{
+		dsp_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+
+	/* Cost and opcode count measured, never recomputed: the inlined
+	 * delay slot is not charged by DSPExec's own `cycles -=`. */
+	cost = idleProbeCyc0 - idleProbeCyc1;
+	if (cost <= 0 || (idleProbeCyc1 - cycles) != cost)
+	{
+		dsp_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+	opcost = idleProbeOpc1 - idleProbeOpc0;
+	if (opcost == 0 || (dsp_exec_opcode_count - idleProbeOpc1) != opcost)
+	{
+		dsp_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+
+	/* Per-iteration register delta must be constant across both probes. */
+	for (i = 0; i < 32; i++)
+	{
+		delta[i]      = idleProbeS1[i] - idleProbeS0[i];
+		delta[32 + i] = idleProbeS1[32 + i] - idleProbeS0[32 + i];
+		if (dsp_reg_bank_0[i] - idleProbeS1[i] != delta[i])
+		{
+			dsp_idle_memo_reject(head, jrAddr);
+			return cycles;
+		}
+		if (dsp_reg_bank_1[i] - idleProbeS1[32 + i] != delta[32 + i])
+		{
+			dsp_idle_memo_reject(head, jrAddr);
+			return cycles;
+		}
+	}
+
+	cur = (dsp_reg == dsp_reg_bank_0) ? 0 : 32;
+	alt = 32 - cur;
+
+	if (!dsp_idle_check_body(delta, cur, alt))
+	{
+		dsp_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+
+	/* Always leave one full iteration to execute normally. */
+	n = (cycles / cost) - 1;
+	if (n <= 0)
+		return cycles;
+
+	for (i = 0; i < 32; i++)
+	{
+		if (delta[i])
+			dsp_reg_bank_0[i] += (uint32_t)n * delta[i];
+		if (delta[32 + i])
+			dsp_reg_bank_1[i] += (uint32_t)n * delta[32 + i];
+	}
+	cycles -= n * cost;
+	dsp_exec_opcode_count += (uint32_t)n * opcost;
+
+	dsp_idle_skip_fires++;
+	dsp_idle_skip_iters   += (uint32_t)n;
+	dsp_idle_skip_opcodes += (uint32_t)n * opcost;
+
+	return cycles;
+}
+
 /* DSP execution core */
 
 void DSPExec(int32_t cycles)
 {
+	int idleSkipActive;
+
 #ifdef DSP_SINGLE_STEPPING
 	if (dsp_control & 0x18)
 	{
@@ -1082,10 +1748,59 @@ void DSPExec(int32_t cycles)
 	dsp_releaseTimeSlice_flag = 0;
 	dsp_in_exec++;
 
+	/* Idle-loop fast-forward gates (issue #569).  Every one of these adds
+	 * per-instruction state the affine extrapolation does not model, so
+	 * any of them turns the whole thing off:
+	 *   - vjs.riscIdleSkip: the user-facing core option itself;
+	 *   - blitMemoMode / blitMemoRecording: the JaguarRead and JaguarWrite
+	 *     families note reads and writes for the memo (blit_memo.h:64-65,
+	 *     src/core/jaguar.c:1139), and skipping loads would change what
+	 *     the memo records;
+	 *   - riscClockScalePct != 100: the slice budget is rescaled per
+	 *     slice, so "cycles remaining" is no longer the same currency the
+	 *     measured per-iteration cost was charged in;
+	 *   - busArbiter.enabled (the dram_timing option): bus occupancy is
+	 *     accounted per access.  Belt-and-braces here -- dsp.c never
+	 *     touches busArbiter and JaguarReadLong charges it only for
+	 *     `who == OP` -- but a DSP-side arbiter charge added later must
+	 *     not silently invalidate this;
+	 *   - vjs.gpuPipelineTiming: the DSP has no pipeline-timing mode of
+	 *     its own (DSPExecP/DSPExecP2 are declared in dsp.h but never
+	 *     called), and this is the only pipeline-timing switch the
+	 *     frontend exposes -- a user who turns it on has asked for
+	 *     accuracy over speed, so honour it for the DSP too;
+	 *   - DSP_CTRL single-step / single-go: the slice is one instruction;
+	 *   - vjtrace armed or a memory watch installed (VJ_TRACE builds
+	 *     only): VJT_PCHIST_DSP in this loop and VJT_WATCH_RD on the
+	 *     DRAM read path are per-instruction / per-read side effects.
+	 *     This has to be a RUNTIME check, not `#ifdef VJ_TRACE`: the
+	 *     whole test ABI is built with -DVJ_TRACE (Makefile:158-161),
+	 *     so a compile-time gate would make every headless harness --
+	 *     including the A/B that proves this exact -- silently measure
+	 *     a disabled feature.  Both flags default off, so the cost is
+	 *     two loads per slice on trace builds and nothing at all on
+	 *     release builds. */
+	idleSkipActive = vjs.riscIdleSkip
+	              && !blitMemoMode && !blitMemoRecording
+	              && riscClockScalePct == 100
+	              && !busArbiter.enabled
+	              && !vjs.gpuPipelineTiming
+	              && !(dsp_control & 0x18);
+#ifdef VJ_TRACE
+	if (vjtrace_armed || vjtrace_nwatch)
+		idleSkipActive = 0;
+#endif
+	/* Probe + reject memo are re-derived from scratch every call, so
+	 * nothing here reaches a savestate and nothing survives a slice. */
+	idleProbeStage = 0;
+	idleMemoCount  = 0;
+	idleMemoNext   = 0;
+
 	while (cycles > 0 && DSP_RUNNING)
 	{
       uint16_t opcode;
       uint32_t index;
+      uint32_t pcThis;
 #ifdef VJ_TRACE
       VJT_PCHIST_DSP(dsp_pc);
 #endif
@@ -1134,6 +1849,8 @@ void DSPExec(int32_t cycles)
 			break;
 		}
 
+		pcThis = dsp_pc;
+
 		if (dsp_pc >= DSP_WORK_RAM_BASE && dsp_pc < DSP_WORK_RAM_BASE + 0x2000)
 		{
 			uint32_t off = dsp_pc - DSP_WORK_RAM_BASE;
@@ -1148,6 +1865,14 @@ void DSPExec(int32_t cycles)
 		dsp_exec_opcode_count++;
 		dsp_executeOpcode(index);
 		cycles -= dsp_opcode_cycles[index];
+
+		/* Idle-loop fast-forward (issue #569).  A taken `jr` that landed
+		 * on or behind its own address, at most 8 words back, is the only
+		 * candidate; the unsigned difference rejects a not-taken jr
+		 * (pc = pcThis + 2) and every forward branch in one compare. */
+		if (idleSkipActive && index == 53
+		    && (uint32_t)(pcThis - dsp_pc) <= 14)
+			cycles = DSPIdleLoopProbe(cycles, dsp_pc, pcThis);
 
 		/* Age out a D_FLAGS store once the instruction that was already
 		 * behind it in the pipeline has run (see DSPWriteLong, D_FLAGS

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -1291,6 +1291,11 @@ static int dsp_idle_op_admitted(uint32_t idx)
 	case 57:								/* nop */
 	case 58: case 59:						/* load_r14/15_ri */
 		return 1;
+	/* 52 (jump) and 53 (jr) are deliberately absent: excluding every
+	 * PC-modifying opcode but the loop-closing jr itself is load-bearing
+	 * for the executed-path check below (idleBodyCount forces exactly
+	 * one route from head to jrAddr), not only for the store-freedom
+	 * this whitelist was originally written to guarantee. */
 	default:
 		return 0;
 	}
@@ -1716,10 +1721,12 @@ static int32_t DSPIdleLoopProbe(int32_t cycles, uint32_t head, uint32_t jrAddr)
 	 * (I2S LTXD/RTXD, a blitter command, a latch clear) is exactly the
 	 * silent divergence this whole design exists to prevent.
 	 *
-	 * dsp_exec_opcode_count is incremented in precisely three places --
+	 * dsp_exec_opcode_count is incremented in three reachable places --
 	 * DSPExec's main loop, and the inlined delay slots in
-	 * dsp_opcode_jump and dsp_opcode_jr -- so one traversal of a
-	 * branch-free admitted body charges, deterministically:
+	 * dsp_opcode_jump and dsp_opcode_jr (a fourth site exists in the
+	 * pipelined DSP_jr, but that executor is dead code -- DSPExecP/
+	 * DSPExecP2 are declared and never defined) -- so one traversal of
+	 * a branch-free admitted body charges, deterministically:
 	 *
 	 *     (idleBodyCount - 1)   body instructions before the jr
 	 *   + 1                     the loop-closing jr itself

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -1113,8 +1113,12 @@ void DSPSyncToM68K(void)
  *     pointer at the first snapshot and re-checks it at the third.
  *
  * (4) DSP-side reads are pure.  The HLE sound-engine auto-ack in
- *     DSPReadWord/DSPReadLong (dsp.c:423/484) and the DSPGO poll
- *     auto-clear (dsp.c:526) are all gated `who == M68K`.  Reads of
+ *     DSPReadWord/DSPReadLong (dsp.c:423/484) are gated `who == M68K`.
+ *     The DSPGO poll auto-clear (dsp.c:526) tests `who == M68K` on the
+ *     clearing branch but resets dspgo_poll_count on its `else`, so a
+ *     DSP-side read of $F1A114 would touch that counter -- unreachable
+ *     here, because the load-EA rule admits DSP local SRAM and DRAM
+ *     only, never DSP_CONTROL_RAM_BASE.  Reads of
  *     main DRAM take JaguarReadLong's `addr < 0x800000` fast path
  *     (src/core/jaguar.c:1131-1141) whose only side effects are
  *     VJT_WATCH_RD (compiled out unless VJ_TRACE) and BlitMemoNoteRead
@@ -1124,6 +1128,16 @@ void DSPSyncToM68K(void)
  * Therefore: if a loop body performs no store and reads only plain RAM,
  * every value it reads is constant for the remainder of the call, and
  * one iteration is a pure function of (register file, flags).
+ *
+ * NOTE the premise is about the instructions the machine ACTUALLY
+ * executed between two arrivals at the loop head, not about the ones the
+ * decoder walked.  Those are not the same thing for free: the probe is
+ * only hooked on a taken backward jr, so a not-taken jr, a `jump` or
+ * plain fall-through can carry execution back to `head` without the
+ * probe ever seeing it.  The opcode-count identity in the proof below
+ * (opcost == idleBodyCount + 1) is what closes that gap; without it a
+ * compound period containing an undecoded store could satisfy every
+ * other condition here.
  *
  * ---- ADMISSION RULE ------------------------------------------------
  *
@@ -1159,6 +1173,10 @@ void DSPSyncToM68K(void)
  *     as the delta of `cycles`, never recomputed from
  *     dsp_opcode_cycles[] -- the inlined delay slot is not charged);
  *   - likewise the measured dsp_exec_opcode_count delta;
+ *   - that measured opcode delta equals idleBodyCount + 1 EXACTLY, which
+ *     is the count only a straight-line traversal of the decoded body
+ *     can produce -- this is the executed-path check, see the comment at
+ *     the test itself;
  *   - every register with a NONZERO per-iteration delta is read and
  *     written only by an addqt/subqt whose destination is that same
  *     register.
@@ -1190,7 +1208,9 @@ void DSPSyncToM68K(void)
  * state is re-derived from scratch inside each DSPExec call.
  */
 
-/* Longest body accepted, in 16-bit words (jr offset range [-8,-1]). */
+/* Longest body accepted, in 16-bit words (jr offset range [-8,-1]).
+ * Belt-and-braces only: the caller's `pcThis - dsp_pc <= 14` filter
+ * already caps [head, jr) at 7 words, so this bound never binds. */
 #define DSP_IDLE_MAX_BODY	8
 /* Body instruction slots: <= 7 before the jr, plus the delay slot. */
 #define DSP_IDLE_MAX_INSN	10
@@ -1681,6 +1701,43 @@ static int32_t DSPIdleLoopProbe(int32_t cycles, uint32_t head, uint32_t jrAddr)
 		return cycles;
 	}
 
+	/* EXECUTED-PATH CHECK.  Everything above pins what the *decoded* body
+	 * would do; this is what pins that the machine actually walked it.
+	 *
+	 * The probe only fires on a TAKEN backward jr, so an arrival at the
+	 * loop head says nothing about how the previous arrival got here: a
+	 * NOT-taken jr, a `jump`, or fall-through all reach `head` without
+	 * ever entering this function.  A compound period that happens to
+	 * have the same net register/flag effect -- e.g. a counter that
+	 * cycles 2 -> 1 (taken) -> 0 (not taken) -> a fall-through path that
+	 * resets it, containing an undecoded `store` -- would otherwise pass
+	 * every check above, because the decoded portion really is pure and
+	 * the deltas really are constant.  Eliding `n` copies of that store
+	 * (I2S LTXD/RTXD, a blitter command, a latch clear) is exactly the
+	 * silent divergence this whole design exists to prevent.
+	 *
+	 * dsp_exec_opcode_count is incremented in precisely three places --
+	 * DSPExec's main loop, and the inlined delay slots in
+	 * dsp_opcode_jump and dsp_opcode_jr -- so one traversal of a
+	 * branch-free admitted body charges, deterministically:
+	 *
+	 *     (idleBodyCount - 1)   body instructions before the jr
+	 *   + 1                     the loop-closing jr itself
+	 *   + 1                     its inlined delay slot
+	 *   = idleBodyCount + 1
+	 *
+	 * (idleBodyCount counts the decoded [head, jr) instructions -- movei
+	 * once, not three times -- plus the delay slot; the jr is not in the
+	 * array.)  Any other route from one arrival to the next must execute
+	 * the whole body AND at least one further instruction to get back,
+	 * so it costs strictly more.  Requiring exact equality therefore
+	 * admits the straight-line traversal and nothing else. */
+	if (opcost != (uint32_t)idleBodyCount + 1)
+	{
+		dsp_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+
 	/* Per-iteration register delta must be constant across both probes. */
 	for (i = 0; i < 32; i++)
 	{
@@ -1756,9 +1813,15 @@ void DSPExec(int32_t cycles)
 	 *     families note reads and writes for the memo (blit_memo.h:64-65,
 	 *     src/core/jaguar.c:1139), and skipping loads would change what
 	 *     the memo records;
-	 *   - riscClockScalePct != 100: the slice budget is rescaled per
-	 *     slice, so "cycles remaining" is no longer the same currency the
-	 *     measured per-iteration cost was charged in;
+	 *   - riscClockScalePct != 100: strictly speaking this one is
+	 *     conservative rather than necessary -- SCALE_RISC_CYCLES is
+	 *     applied where the budget is handed out (jaguar.c), not inside
+	 *     DSPExec, so `cycles` here is already in the same currency the
+	 *     measured per-iteration cost was charged in.  It stays because
+	 *     the overclock presets (#378) are themselves an accuracy
+	 *     trade-off already under investigation, and stacking a second
+	 *     non-stock execution path underneath them is not something this
+	 *     change should do unasked;
 	 *   - busArbiter.enabled (the dram_timing option): bus occupancy is
 	 *     accounted per access.  Belt-and-braces here -- dsp.c never
 	 *     touches busArbiter and JaguarReadLong charges it only for

--- a/src/jerry/dsp.h
+++ b/src/jerry/dsp.h
@@ -46,6 +46,13 @@ void DSPExecComp(int32_t cycles);
 
 extern uint32_t dsp_reg_bank_0[], dsp_reg_bank_1[];
 
+/* Idle-loop fast-forward diagnostics (issue #569).  Counted only on the
+ * cold probe path; read by test/tools, never by the emulator itself. */
+extern uint32_t dsp_idle_skip_fires;
+extern uint32_t dsp_idle_skip_rejects;
+extern uint32_t dsp_idle_skip_iters;
+extern uint32_t dsp_idle_skip_opcodes;
+
 // DSP interrupt numbers (in $F1A100, bits 4-8 & 16)
 
 enum { DSPIRQ_CPU = 0, DSPIRQ_SSI, DSPIRQ_TIMER0, DSPIRQ_TIMER1, DSPIRQ_EXT0, DSPIRQ_EXT1 };

--- a/test/tools/dsp_idle_ab.c
+++ b/test/tools/dsp_idle_ab.c
@@ -1,6 +1,9 @@
 /*
- * dsp_idle_ab.c -- scratch A/B determinism harness for the DSP idle-loop
- * fast-forward (issue #569).  NOT committed.
+ * dsp_idle_ab.c -- A/B determinism harness for the DSP idle-loop
+ * fast-forward (issue #569).  Built via `make test/tools/dsp_idle_ab`;
+ * not itself wired into `make test` (dsp_idle_probe_falsify is the
+ * committed, always-run regression guard -- this tool is for manual
+ * sweeps across titles/frame counts when re-validating the feature).
  *
  * Emits one CSV row per frame:
  *     frame,vhash,ahash,asamples,statehash

--- a/test/tools/dsp_idle_ab.c
+++ b/test/tools/dsp_idle_ab.c
@@ -1,0 +1,210 @@
+/*
+ * dsp_idle_ab.c -- scratch A/B determinism harness for the DSP idle-loop
+ * fast-forward (issue #569).  NOT committed.
+ *
+ * Emits one CSV row per frame:
+ *     frame,vhash,ahash,asamples,statehash
+ * where vhash is FNV-1a over the visible XRGB8888 framebuffer, ahash is
+ * FNV-1a over every int16 audio sample the core emitted for that frame,
+ * and statehash is FNV-1a over retro_serialize()'s blob (only on frames
+ * that are a multiple of --state-every, else 0).
+ *
+ * Two arms are byte-identical iff the two CSVs are byte-identical.
+ *
+ * A trailer (to stderr) reports the deterministic counters:
+ *   dsp_exec_opcode_count total + per frame, and the idle-skip
+ *   fire/reject/iteration counts.
+ *
+ * Build:  make test/tools/dsp_idle_ab TEST_EXPORTS=1
+ *
+ * Run (one arm of an option sweep):
+ *   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) ./test/tools/dsp_idle_ab \
+ *      ./virtualjaguar_libretro.dylib "<rom>" --frames 3300 --warmup 300 \
+ *      --state-every 100 --csv arm.csv --system-dir test/roms/private \
+ *      --option virtualjaguar_risc_idle_skip=enabled
+ *
+ * Then `cmp` the two arms' CSVs: byte-identical means the option changed
+ * nothing observable.  Always confirm the comparator can actually SEE a
+ * change (perturb one arm deliberately) before trusting a clean result --
+ * "we compared and found nothing" is also what a broken comparator says.
+ *
+ * Needs the wide test ABI (make TEST_EXPORTS=1) for the dlsym'd counters.
+ */
+
+#include "../harness/harness.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FNV_OFF 1469598103934665603ULL
+#define FNV_PRM 1099511628211ULL
+
+static FILE    *g_csv;
+static uint64_t g_vhash = FNV_OFF;
+static uint64_t g_ahash;
+static uint64_t g_asamples;
+static unsigned g_warmup;
+static unsigned g_state_every;
+
+static uint32_t *p_dsp_opcodes;
+static uint32_t *p_fires;
+static uint32_t *p_rejects;
+static uint32_t *p_iters;
+static uint32_t *p_skipops;
+
+static size_t   (*p_serialize_size)(void);
+static int      (*p_serialize)(void *, size_t);
+static void     *g_state_buf;
+static size_t    g_state_size;
+
+static uint64_t  g_op_base;
+static uint32_t  g_fires_base, g_rej_base, g_iters_base, g_skip_base;
+
+static uint64_t fnv(uint64_t h, const void *p, size_t n)
+{
+    const uint8_t *b = (const uint8_t *)p;
+    size_t i;
+    for (i = 0; i < n; i++) {
+        h ^= (uint64_t)b[i];
+        h *= FNV_PRM;
+    }
+    return h;
+}
+
+static void ab_video(void *ud, const void *data, unsigned w, unsigned h,
+                     size_t pitch)
+{
+    uint64_t hv = FNV_OFF;
+    unsigned y;
+    (void)ud;
+    if (!data)
+        return;                     /* duped frame: keep previous hash */
+    for (y = 0; y < h; y++)
+        hv = fnv(hv, (const uint8_t *)data + (size_t)y * pitch,
+                 (size_t)w * 4);
+    hv = fnv(hv, &w, sizeof(w));
+    hv = fnv(hv, &h, sizeof(h));
+    g_vhash = hv;
+}
+
+static size_t ab_audio(const int16_t *data, size_t frames)
+{
+    if (data && frames) {
+        g_ahash = fnv(g_ahash, data, frames * 2 * sizeof(int16_t));
+        g_asamples += (uint64_t)frames;
+    }
+    return frames;
+}
+
+static bool ab_frame(void *ud, unsigned frame)
+{
+    uint64_t sh = 0;
+    (void)ud;
+    if (frame >= g_warmup) {
+        if (g_state_every && ((frame - g_warmup) % g_state_every) == 0
+            && p_serialize && g_state_buf) {
+            memset(g_state_buf, 0, g_state_size);
+            if (p_serialize(g_state_buf, g_state_size))
+                sh = fnv(FNV_OFF, g_state_buf, g_state_size);
+        }
+        fprintf(g_csv, "%u,%016llx,%016llx,%llu,%016llx\n", frame,
+                (unsigned long long)g_vhash, (unsigned long long)g_ahash,
+                (unsigned long long)g_asamples, (unsigned long long)sh);
+    }
+    if (frame == g_warmup) {
+        /* Baseline EVERY counter at the same point -- mixing a windowed
+         * opcode delta with a since-boot skip total makes the derived
+         * "interpreted" figure nonsense (it can even go negative). */
+        if (p_dsp_opcodes) g_op_base    = *p_dsp_opcodes;
+        if (p_fires)       g_fires_base = *p_fires;
+        if (p_rejects)     g_rej_base   = *p_rejects;
+        if (p_iters)       g_iters_base = *p_iters;
+        if (p_skipops)     g_skip_base  = *p_skipops;
+    }
+    g_ahash    = FNV_OFF;
+    g_asamples = 0;
+    return true;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    const char *csv = "ab.csv";
+    void (*set_batch)(size_t (*)(const int16_t *, size_t));
+    int i;
+    unsigned counted;
+
+    g_warmup      = 0;
+    g_state_every = 0;
+    g_ahash       = FNV_OFF;
+
+    for (i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--csv") && i + 1 < argc)
+            csv = argv[++i];
+        else if (!strcmp(argv[i], "--warmup") && i + 1 < argc)
+            g_warmup = (unsigned)strtoul(argv[++i], NULL, 10);
+        else if (!strcmp(argv[i], "--state-every") && i + 1 < argc)
+            g_state_every = (unsigned)strtoul(argv[++i], NULL, 10);
+    }
+
+    cfg.frames             = 3300;
+    cfg.quiet              = 1;
+    cfg.video_callback     = ab_video;
+    cfg.frame_callback     = ab_frame;
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+    if (!harness_load_rom(&cfg))
+        return 1;
+
+    g_csv = fopen(csv, "w");
+    if (!g_csv) {
+        fprintf(stderr, "cannot open %s\n", csv);
+        return 1;
+    }
+
+    /* Take over the audio batch callback so we see raw samples. */
+    set_batch = (void (*)(size_t (*)(const int16_t *, size_t)))
+                harness_dlsym(&cfg, "retro_set_audio_sample_batch");
+    if (set_batch)
+        set_batch(ab_audio);
+    else
+        fprintf(stderr, "WARN: no retro_set_audio_sample_batch\n");
+
+    p_dsp_opcodes = (uint32_t *)harness_dlsym(&cfg, "dsp_exec_opcode_count");
+    p_fires       = (uint32_t *)harness_dlsym(&cfg, "dsp_idle_skip_fires");
+    p_rejects     = (uint32_t *)harness_dlsym(&cfg, "dsp_idle_skip_rejects");
+    p_iters       = (uint32_t *)harness_dlsym(&cfg, "dsp_idle_skip_iters");
+    p_skipops     = (uint32_t *)harness_dlsym(&cfg, "dsp_idle_skip_opcodes");
+
+    p_serialize_size = (size_t (*)(void))harness_dlsym(&cfg, "retro_serialize_size");
+    p_serialize      = (int (*)(void *, size_t))harness_dlsym(&cfg, "retro_serialize");
+    if (g_state_every && p_serialize_size) {
+        g_state_size = p_serialize_size();
+        g_state_buf  = calloc(1, g_state_size);
+    }
+
+    harness_run(&cfg);
+
+    counted = (cfg.frames > g_warmup) ? (cfg.frames - g_warmup) : 1;
+    fprintf(stderr,
+            "TRAILER frames=%u warmup=%u dsp_opcodes_total=%llu "
+            "dsp_opcodes_per_frame=%.1f fires=%u rejects=%u iters_skipped=%u "
+            "opcodes_skipped=%u interpreted_per_frame=%.1f\n",
+            cfg.frames, g_warmup,
+            p_dsp_opcodes ? (unsigned long long)(*p_dsp_opcodes - g_op_base) : 0ULL,
+            p_dsp_opcodes ? (double)(*p_dsp_opcodes - g_op_base) / (double)counted : 0.0,
+            p_fires ? (*p_fires - g_fires_base) : 0,
+            p_rejects ? (*p_rejects - g_rej_base) : 0,
+            p_iters ? (*p_iters - g_iters_base) : 0,
+            p_skipops ? (*p_skipops - g_skip_base) : 0,
+            p_dsp_opcodes
+              ? ((double)(*p_dsp_opcodes - g_op_base)
+                 - (double)(p_skipops ? (*p_skipops - g_skip_base) : 0))
+                / (double)counted
+              : 0.0);
+
+    fclose(g_csv);
+    harness_shutdown(&cfg);
+    return 0;
+}

--- a/test/tools/dsp_idle_probe_falsify.c
+++ b/test/tools/dsp_idle_probe_falsify.c
@@ -1,0 +1,222 @@
+/*
+ * test/tools/dsp_idle_probe_falsify.c — falsification test for the DSP
+ * idle-loop fast-forward's admission rule (issue #569).
+ *
+ * The probe (src/jerry/dsp.c) is only hooked on a TAKEN backward `jr`.
+ * That means an arrival at the loop head says nothing about how the
+ * PREVIOUS arrival got there: a not-taken `jr`, a `jump`, or plain
+ * fall-through all reach the head without the probe ever seeing them.
+ * So verifying that the *decoded* body is pure is not the same as
+ * verifying that the *executed* path was — and a compound period with
+ * the same net register/flag effect, containing an undecoded `store`,
+ * would otherwise satisfy every other admission condition.  Eliding
+ * copies of such a store (I2S LTXD/RTXD, a blitter command, a latch
+ * clear) is silent, hardware-visible divergence.
+ *
+ * This test hand-assembles two DSP programs into DSP local RAM and
+ * drives DSPExec() directly, white-box:
+ *
+ *   A. a genuinely idle loop  ->  the probe MUST fire.
+ *      addqt #1,r0 ; jr always,-2 ; (ds) nop
+ *      Guards against the test passing simply because the feature is
+ *      dead (which is exactly how a compile-time VJ_TRACE gate and a
+ *      probe-reset bug each silently disabled it during development).
+ *
+ *   B. the compound-period exploit  ->  the probe MUST NOT fire.
+ *      head:  subq #1,r1
+ *      jr:    jr NE,head
+ *             nop                  <- delay slot, decoded
+ *             store r3,(r4)        <- NEVER DECODED
+ *             movei #2,r1          <- NEVER DECODED
+ *             jump always,(r5)     <- NEVER DECODED, r5 = head
+ *             nop
+ *      r1 cycles 2 -> 1 (jr taken, arrival) -> 0 (jr NOT taken, the
+ *      undecoded tail runs and resets r1 to 2) -> 1 (taken, arrival).
+ *      Every arrival sees r1 == 1, so all 64 register deltas are zero,
+ *      the flags match, cost and opcode cost are uniform, the decoded
+ *      portion is whitelisted, and the nonzero-delta rule is vacuous.
+ *      Only the executed-path check (opcost == idleBodyCount + 1)
+ *      rejects it.
+ *
+ * Build: cc -O2 -Wall -std=c99 $(INCFLAGS) -o test/tools/dsp_idle_probe_falsify \
+ *          test/tools/dsp_idle_probe_falsify.c test/harness/harness.c -ldl -lm
+ * Needs the wide test ABI (make TEST_EXPORTS=1).  Uses test/roms/yarc.j64,
+ * which is in-tree, so this never skips.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../harness/harness.h"
+
+/* RISC opcode indices (src/jerry/dsp.c dsp_opcode[]) */
+#define OP_ADDQT   3
+#define OP_SUBQ    6
+#define OP_STORE  47
+#define OP_JUMP   52
+#define OP_JR     53
+#define OP_NOP    57
+#define OP_MOVEI  38
+
+/* Branch condition codes: 0 = always, 1 = NE (fails when Z is set). */
+#define CC_ALWAYS  0
+#define CC_NE      1
+
+#define DSP_RAM_BASE 0x00F1B000u
+
+#define PROG_A_OFF   0x0100          /* $F1B100 */
+#define PROG_B_OFF   0x0200          /* $F1B200 */
+#define SCRATCH_OFF  0x0400          /* $F1B400 -- the exploit's store target */
+
+static uint8_t  *dsp_ram;
+static uint32_t *p_dsp_pc;
+static uint32_t *p_dsp_control;
+static uint32_t *p_bank0;
+static uint32_t *p_bank1;
+static uint32_t *p_fires;
+static uint32_t *p_rejects;
+static uint32_t *p_opcount;
+static void    (*p_dspexec)(int32_t);
+
+static uint16_t enc(uint32_t idx, uint32_t p1, uint32_t p2)
+{
+    return (uint16_t)((idx << 10) | ((p1 & 0x1F) << 5) | (p2 & 0x1F));
+}
+
+static void put16(uint32_t off, uint16_t w)
+{
+    dsp_ram[off]     = (uint8_t)(w >> 8);
+    dsp_ram[off + 1] = (uint8_t)(w & 0xFF);
+}
+
+/* Write the same value into both banks: which one is current depends on
+ * D_FLAGS REGPAGE/IMASK, which is not exported.  Writing both makes the
+ * setup correct either way. */
+static void setreg(unsigned n, uint32_t v)
+{
+    p_bank0[n] = v;
+    p_bank1[n] = v;
+}
+
+static void build_prog_a(void)
+{
+    /* addqt #1,r0 ; jr always,-2 ; (ds) nop
+     * jr offset -2 -> target = (jr+2) + (-2*2) = jr - 2 = head. */
+    put16(PROG_A_OFF + 0, enc(OP_ADDQT, 1, 0));
+    put16(PROG_A_OFF + 2, enc(OP_JR, 0x1E /* -2 */, CC_ALWAYS));
+    put16(PROG_A_OFF + 4, enc(OP_NOP, 0, 0));
+}
+
+static void build_prog_b(void)
+{
+    put16(PROG_B_OFF +  0, enc(OP_SUBQ, 1, 1));               /* subq #1,r1     */
+    put16(PROG_B_OFF +  2, enc(OP_JR, 0x1E /* -2 */, CC_NE)); /* jr ne,head     */
+    put16(PROG_B_OFF +  4, enc(OP_NOP, 0, 0));                /* (delay slot)   */
+    put16(PROG_B_OFF +  6, enc(OP_STORE, 4, 3));              /* store r3,(r4)  */
+    put16(PROG_B_OFF +  8, enc(OP_MOVEI, 0, 1));              /* movei #2,r1    */
+    put16(PROG_B_OFF + 10, 0x0002);                           /*   LSW          */
+    put16(PROG_B_OFF + 12, 0x0000);                           /*   MSW          */
+    put16(PROG_B_OFF + 14, enc(OP_JUMP, 5, CC_ALWAYS));       /* jump (r5)      */
+    put16(PROG_B_OFF + 16, enc(OP_NOP, 0, 0));                /* (delay slot)   */
+
+    setreg(1, 2);                                  /* loop counter             */
+    setreg(3, 0xDEADBEEFu);                        /* value the store writes   */
+    setreg(4, DSP_RAM_BASE + SCRATCH_OFF);         /* store destination        */
+    setreg(5, DSP_RAM_BASE + PROG_B_OFF);          /* jump target = head       */
+}
+
+/* Run one hand-assembled program from `off` for `cycles`, returning how
+ * many times the fast-forward fired. */
+static uint32_t run_prog(uint32_t off, int32_t cycles,
+                         uint32_t *rejects_out, uint32_t *opcodes_out)
+{
+    uint32_t f0 = *p_fires, r0 = *p_rejects, o0 = *p_opcount;
+
+    *p_dsp_pc      = DSP_RAM_BASE + off;
+    *p_dsp_control |= 0x01;                        /* DSPGO */
+    p_dspexec(cycles);
+
+    if (rejects_out)
+        *rejects_out = *p_rejects - r0;
+    if (opcodes_out)
+        *opcodes_out = *p_opcount - o0;
+    return *p_fires - f0;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    harness_result res[3];
+    unsigned nres = 0;
+    uint32_t fires_a, fires_b, rej_a, rej_b, ops_a, ops_b;
+    static char detail_a[192], detail_b[192], detail_c[192];
+    int ok_a, ok_b;
+
+    cfg.frames = 2;
+    cfg.quiet  = 1;
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+    /* The feature is off by default; this test is about the admission
+     * rule, so turn it on explicitly. */
+    harness_set_option(&cfg, "virtualjaguar_risc_idle_skip", "enabled");
+    if (!harness_load_rom(&cfg))
+        return 1;
+    harness_run(&cfg);                             /* let options apply */
+
+    dsp_ram       = (uint8_t *)((uint8_t *(*)(void))harness_dlsym(&cfg, "DSPGetRAM"))();
+    p_dsp_pc      = (uint32_t *)harness_dlsym(&cfg, "dsp_pc");
+    p_dsp_control = (uint32_t *)harness_dlsym(&cfg, "dsp_control");
+    p_bank0       = (uint32_t *)harness_dlsym(&cfg, "dsp_reg_bank_0");
+    p_bank1       = (uint32_t *)harness_dlsym(&cfg, "dsp_reg_bank_1");
+    p_fires       = (uint32_t *)harness_dlsym(&cfg, "dsp_idle_skip_fires");
+    p_rejects     = (uint32_t *)harness_dlsym(&cfg, "dsp_idle_skip_rejects");
+    p_opcount     = (uint32_t *)harness_dlsym(&cfg, "dsp_exec_opcode_count");
+    p_dspexec     = (void (*)(int32_t))harness_dlsym(&cfg, "DSPExec");
+
+    if (!dsp_ram || !p_dsp_pc || !p_dsp_control || !p_bank0 || !p_bank1
+        || !p_fires || !p_rejects || !p_opcount || !p_dspexec) {
+        fprintf(stderr, "dsp_idle_probe_falsify: missing test ABI symbols "
+                        "(build with TEST_EXPORTS=1)\n");
+        return 1;
+    }
+
+    build_prog_a();
+    build_prog_b();
+
+    fires_a = run_prog(PROG_A_OFF, 20000, &rej_a, &ops_a);
+    fires_b = run_prog(PROG_B_OFF, 20000, &rej_b, &ops_b);
+
+    ok_a = (fires_a > 0);
+    ok_b = (fires_b == 0);
+
+    snprintf(detail_a, sizeof detail_a,
+             "genuinely idle loop (addqt/jr/nop) fired %u time(s), "
+             "%u reject(s), %u opcodes charged", fires_a, rej_a, ops_a);
+    res[nres].status = ok_a ? "PASS" : "FAIL";
+    res[nres].name   = "idle_loop_still_fires";
+    res[nres].detail = detail_a;
+    nres++;
+
+    snprintf(detail_b, sizeof detail_b,
+             "compound period hiding an undecoded store fired %u time(s) "
+             "(must be 0), %u reject(s), %u opcodes charged",
+             fires_b, rej_b, ops_b);
+    res[nres].status = ok_b ? "PASS" : "FAIL";
+    res[nres].name   = "undecoded_store_path_rejected";
+    res[nres].detail = detail_b;
+    nres++;
+
+    snprintf(detail_c, sizeof detail_c,
+             "exploit arrival-to-arrival costs 10 opcodes vs the "
+             "idleBodyCount+1 = 3 a straight-line body would charge");
+    res[nres].status = "INFO";
+    res[nres].name   = "executed_path_invariant";
+    res[nres].detail = detail_c;
+    nres++;
+
+    harness_report(&cfg, res, nres);
+    harness_shutdown(&cfg);
+    return (ok_a && ok_b) ? 0 : 1;
+}


### PR DESCRIPTION
Item **P1** of the 2026-08 performance audit — tracking epic #569, method and evidence in `docs/perf-audit-2026-08.md`. This is the headline finding: the DSP interpreter burns its entire per-frame cycle budget parked in 2-5 instruction idle/poll loops — 90-99.7% of frame-end DSP PCs on Iron Soldier / AvP / Doom.

⚠️ **Needs a Development-panel link to #569.**

## The mechanism

Within a single `DSPExec()` call, nothing else in the machine executes — the slice budget is "time until the next scheduled event," and no interrupt can be dispatched mid-call for a loop body that performs no store (verified against this tree's actual IRQ-delivery structure, which turned out to differ from the initial hypothesis — see below). So a *provably idle* loop body — one that performs no store and reads only plain RAM — is a pure function of the register file for the remainder of the call, and its remaining iterations can be extrapolated in closed form instead of interpreted one at a time. Same cycles charged, same end register/flag state, same opcode-count bookkeeping (the crash-detect watchdog still sees progress) — bit-exact, not an approximation.

A conservative whitelist admits only ALU/move/compare/RAM-load opcodes in the loop body; a two-iteration fixed-point probe proves the loop is truly idle (constant register deltas, constant flags, constant per-iteration cost, and — critically — a check that no register feeding the loop's own exit condition has a nonzero delta, since a monotonic counter in the delay slot would otherwise make the loop self-terminate). Seven independent hard gates (pipeline timing, dram_timing, non-1x clock scale, blit-memo recording, single-step, vjtrace/watch) disable the whole mechanism whenever another feature adds per-instruction state this model doesn't account for.

**Two real errors in the original design brief were found and corrected during implementation** (re-verified independently by the controller against source before proceeding): the brief assumed DSP interrupts dispatch at slice entry, matching the GPU's `GPUHandleIRQs()` pattern — but `DSPExec` in this tree has no such call at all. The actual, narrower mechanism: `IMASKCleared` (the only in-loop interrupt-dispatch trigger) is set only by a store to `D_FLAGS`, which the no-store admission rule already excludes from any candidate body, and the only other IRQ-delivery path (`DSPSetIRQLine`) fires only from event callbacks — i.e. only between slices, never from inside one. The brief also misquoted DSP local RAM's size (4KB vs. the actual 8KB, `dsp_ram_8[0x2000]`).

## A Critical bug found in review, fixed, and falsified in both directions

A first-round review found the fixed-point probe verified the *decoded* loop body was pure but never confirmed the *executed* control-flow path between its snapshots actually followed that decoded body — a not-taken branch, a `jump`, or fall-through could reach the loop head without the probe running, opening a narrow path where a compound loop shape (e.g. a store sandwiched between a not-taken exit and a jump back) with a net-zero register delta could satisfy every check and silently elide a non-idempotent hardware write (an audio sample, a blitter command, a control-latch clear).

**The fix is exact, not a heuristic**: `dsp_exec_opcode_count` increments at exactly three reachable sites in the interpreter, so a branch-free admitted body has a deterministic, computable opcode count (`idleBodyCount + 1`). Comparing the *measured* executed count against that *computed* decoded-body count closes the gap completely. A committed, `make test`-wired falsification tool (`test/tools/dsp_idle_probe_falsify.c`) hand-assembles both a genuinely idle loop and the exploit shape into DSP RAM and demonstrates the exploit *fires* (eliding the store) without the check and is *rejected* with it — both directions captured in the same harness, not argued from first principles alone.

A second, independent re-review then attempted to construct a case where a different compound path could still charge exactly the same opcode count as the straight-line body — and proved this is impossible: the admission rule's whitelist excludes every PC-modifying opcode except the loop-closing branch itself, so there is exactly one executable path from a loop's decoded head to its branch. Opcode-count equality is therefore a *complete* characterization of the straight-line traversal, not merely a heuristic filter.

## Evidence

- **1,621,218+ case exhaustive checks** and a dedicated falsification harness (0 mismatches, both fire/reject directions demonstrated).
- **Byte-identical A/B — framebuffer hash, every audio sample, and periodic full-savestate digest — across 9 titles (7 cart, 2 CD: Primal Rage, Battle Morph), regenerated against the fixed code**, with two genuine positive controls: every title's sweep asserts a real `risc_clock_scale=2x` arm *diverges* (proves the comparator isn't blind), and a deliberate corruption of the extrapolation logic itself was detected and localized to a specific frame via the periodic savestate-digest column.
- **All 7 hard gates individually exercised** end-to-end through the frontend option layer (fires: 148,463 baseline → 0 with each gate active); 2 are inspection-only (single-step is dead code in this tree, vjtrace/watch default off) — stated honestly, not folded into the same claim.
- **Measured effect: DSP opcodes actually interpreted per frame drop 66-87%** across seven titles (Iron Soldier 490k→166k, Tempest 2000 619k→82k, Primal Rage 439k→78k). No wall-clock FPS number is claimed from this host — load averaged 30-300+ throughout this work; real numbers need the Pi/A10X (see the audit doc's recipes). One exception: Doom's identical-configuration control arms agreed closely enough to report **+37% to +64%** across five interleaved pairings.
- RetroArch smoke test (Iron Soldier cart + Primal Rage CD, 1800 frames/arm, both arms): exit 0, zero crash-detect lines, byte-identical screenshots, confirmed to be the game rendering (not a black frame).
- Full suite green: 76 test groups, 0 failures.

## What's still owed before the default is ever flipped to `enabled`

- **A human listening pass.** This is the one thing headless tooling structurally cannot verify — the repo's own rule for DSP changes exists because "does this sound right" is a perceptual judgment, and this bug class (a silently elided hardware write) manifests as an audio anomaly. The digest-based A/B hashes every sample the core emits and is stronger evidence than a spot-check would be, but it is not the same thing.
- A quiet-host and Pi/A10X wall-clock measurement (this host's load made that impossible here).
- Broader corpus coverage beyond the 9 titles tested.

**Given that, this ships with the option defaulting to `disabled`, enforced at three independent layers** (the string-compare gate in `libretro.c`, the core-options metadata, and the zero-initialized settings struct as a fallback) — not because the evidence is weak, but because the cost of a wrong default (a silent, per-title, unattributable divergence) is asymmetric against the cost of a right one (an opt-in speed win, one config line away). This was an explicit reviewer recommendation the controller adopted rather than re-litigated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)