### PR TITLE
perf(68k): skip the CD-HLE/Memory-Track/boot-strategy hook chain when none are active

### DIFF
--- a/src/cd/jagcd_cart.c
+++ b/src/cd/jagcd_cart.c
@@ -81,19 +81,17 @@ static bool cart_boot(const struct retro_game_info *info)
     return true;
 }
 
-static bool cart_instruction_hook(uint32_t pc)
-{
-    (void)pc;
-    return false;
-}
-
 static void cart_reset(void)
 {
 }
 
+/* instruction_hook is NULL -- cart boot never traps any PC, and jaguar.c's
+ * M68KInstructionHook already NULL-checks bootConfig.strategy->instruction_hook
+ * before calling it, so this is identical to the always-false stub it
+ * replaces (see perf(68k) hook-chain guard, issue #569). */
 const CDBootStrategy cd_boot_strategy_cart = {
     "cart",
     cart_boot,
-    cart_instruction_hook,
+    NULL,
     cart_reset
 };

--- a/src/cd/jagcd_hle.c
+++ b/src/cd/jagcd_hle.c
@@ -98,7 +98,11 @@
 /* State                                                               */
 /* ------------------------------------------------------------------ */
 
-static bool hle_active = false;
+/* Non-static: jaguar.c's M68KInstructionHook reads this directly as the
+ * outer guard for the CD-HLE hook, mirroring JaguarCDHLEHook's own internal
+ * gate exactly (see perf(68k) hook-chain guard, issue #569). All writers
+ * remain in this file. */
+bool hle_active = false;
 
 /* Saved from the last CD_read call so CD_poll can report completion. */
 static uint32_t hle_read_dest      = 0;

--- a/src/cd/jagcd_hle.h
+++ b/src/cd/jagcd_hle.h
@@ -26,6 +26,14 @@ bool JaguarCDHLEGPUDataPhase(void);
 /* True if HLE mode is active (set by JaguarCDHLEBoot on success). */
 bool JaguarCDHLEActive(void);
 
+/* JaguarCDHLEHook's own internal gate, exposed as a plain bool for
+ * jaguar.c's M68KInstructionHook outer guard -- a direct mirror of the
+ * "if (!hle_active) return false;" check at the top of JaguarCDHLEHook,
+ * not the more conservative JaguarCDHLEActive() compound (which also
+ * requires bootConfig.strategy == &cd_boot_strategy_hle). All writers
+ * live in jagcd_hle.c. */
+extern bool hle_active;
+
 /* Streamed CD_read transfer: CD_read arms a transfer that this tick
  * advances at the real double-speed drive rate (352,800 B/s).  Called
  * once per halfline from HalflineCallback when CD content is loaded.

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -387,25 +387,39 @@ void M68KInstructionHook(void)
    if (m68kPC & 0x01)		// Oops! We're fetching an odd address!
       return;
 
-   /* CD HLE jump-table dispatch.  When CD HLE BIOS is active, a small set
-    * of magic PCs in cart ROM space resolve to BIOS routines emulated in
-    * jagcd_hle.c instead of executing the cart bytes.  Returns true if the
-    * hook handled the call (PC/registers updated). */
-   if (JaguarCDHLEHook(m68kPC))
-      return;
+   /* The three hooks below each do a cheap internal check and return
+    * false for the overwhelming majority of titles (plain cart games:
+    * no CD HLE, no Memory Track cart inserted, and -- since cart's
+    * strategy->instruction_hook is NULL -- no boot-strategy hook either).
+    * Gate on the same three conditions directly so that common case pays
+    * three plain reads and one branch instead of three cross-TU calls
+    * every single 68K instruction. Order inside the guard matches the
+    * original unconditional call order exactly (CD HLE, then Memory
+    * Track, then boot strategy) -- only the outer gate is new. */
+   if (hle_active || jaguarMemTrackInserted
+         || (bootConfig.strategy && bootConfig.strategy->instruction_hook))
+   {
+      /* CD HLE jump-table dispatch.  When CD HLE BIOS is active, a small
+       * set of magic PCs in cart ROM space resolve to BIOS routines
+       * emulated in jagcd_hle.c instead of executing the cart bytes.
+       * Returns true if the hook handled the call (PC/registers
+       * updated). */
+      if (JaguarCDHLEHook(m68kPC))
+         return;
 
-   /* Memory Track NVM BIOS dispatcher ($2404) — active for CD content in
-    * BOTH boot modes; the module is RAM-resident on hardware, independent
-    * of which CD BIOS variant booted the disc. */
-   if (NVMBiosHook(m68kPC))
-      return;
+      /* Memory Track NVM BIOS dispatcher ($2404) — active for CD content
+       * in BOTH boot modes; the module is RAM-resident on hardware,
+       * independent of which CD BIOS variant booted the disc. */
+      if (NVMBiosHook(m68kPC))
+         return;
 
-   /* CD boot strategy hook (cart strategy is a no-op for cart games;
-    * HLE/BIOS strategies trap specific PCs to inject boot stubs, patch
-    * auth checks, etc.). */
-   if (bootConfig.strategy && bootConfig.strategy->instruction_hook
-         && bootConfig.strategy->instruction_hook(m68kPC))
-      return;
+      /* CD boot strategy hook (cart strategy has no instruction_hook;
+       * HLE/BIOS strategies trap specific PCs to inject boot stubs,
+       * patch auth checks, etc.). */
+      if (bootConfig.strategy && bootConfig.strategy->instruction_hook
+            && bootConfig.strategy->instruction_hook(m68kPC))
+         return;
+   }
 }
 
 /* Custom UAE 68000 read/write/IRQ functions */


### PR DESCRIPTION
Item **P7** of the 2026-08 performance audit — tracking epic #569.

⚠️ **Needs a Development-panel link to #569.**

Byte-identical output for every boot path (cart/CD-HLE/CD-BIOS). No emulation behaviour changes.

## The problem

`M68KInstructionHook` runs once per emulated 68K instruction and unconditionally calls three functions — CD-HLE dispatch, Memory Track NVM BIOS, CD boot strategy hook — each of which does a cheap internal check and returns false for the overwhelming majority of titles. Profiled at ~3× the cost of the 68K interpreter itself on Iron Soldier and jagniccc.

**The obvious fix has a trap the first attempt caught before shipping it.** A guard built from `bootConfig.strategy && bootConfig.strategy->instruction_hook` looks right, but `cd_boot_strategy_cart` installs a *non-NULL* stub (`cart_instruction_hook`, an unconditional `return false`) for every cart title — the exact workload this task targets — making that guard unconditionally true and delivering zero benefit. Caught in review before an A/B was even run (which would have shown a misleading green, since only two harnesses exercise a real `bootConfig.strategy`).

## The fix (3 files)

- `src/cd/jagcd_cart.c` — null `cd_boot_strategy_cart`'s `instruction_hook` member, delete the dead stub. Behaviour-preserving on its own: the call site already treats a NULL member identically to a function that always returns false. `cd_boot_strategy_bios`'s hook does real, PC-gated work (a GPU-auth-magic fix load-bearing for Myst's boot sequence) and is untouched.
- `src/cd/jagcd_hle.h`/`.c` — expose `hle_active` as a plain `extern bool`, mirroring the existing `jaguarMemTrackInserted` pattern. Bypasses `JaguarCDHLEActive()`, which has zero callers anywhere in the repo and would otherwise cost a cross-TU call on every instruction regardless of guard outcome (OR only short-circuits *later* terms, so the "all false" common path still evaluates every operand).
- `src/core/jaguar.c` — `if (hle_active || jaguarMemTrackInserted || (bootConfig.strategy && bootConfig.strategy->instruction_hook)) { existing three calls, same order }`. After the cart-vtable fix, this is genuinely reachable-false for cart titles.

## Verification

- Full suite green; HLE/NVM/memtrack/boot-config-specific tests individually confirmed passing.
- Byte-identical A/B via the real `retro_load_game` path (not a harness that skips `ResolveBootConfig`) for all three guard states: cart (false), CD-HLE Myst Demo (true via `hle_active`), CD-BIOS-mode Myst Demo (true, with the GPU-auth-magic path specifically confirmed to still fire).
- Two pre-existing `test_cd_hle_boot` failures (Ocean Depths, Simone discs) confirmed unrelated: reproduced identically against an isolated baseline dylib built at the pre-change commit, and the failure mode (`retro_load_game` returning false before boot starts) is structurally incapable of being caused by an instruction-hook change.
- Reviewed independently: cart guard traced to genuinely NULL, BIOS strategy confirmed untouched, `hle_active`'s exposure checked for naming collisions (none), the jaguar.c guard confirmed to be a pure wrap preserving call order and short-circuit semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)