### PR TITLE
perf(event): pack live events instead of scanning all 32 slots per dispatch

### DIFF
--- a/src/core/event.c
+++ b/src/core/event.c
@@ -243,8 +243,39 @@ double GetTimeToNextEvent(int type/*= EVENT_MAIN*/)
 // down to zero valid MAIN-side events at the same time. Flagged here so a
 // future change that stops re-arming one of these callbacks fails loudly
 // (a hang, easy to notice) rather than being masked by lucky residue.
+//
+// Re-derive the dispatch target fresh, right here, instead of trusting
+// nextEvent/nextEventJERRY as cached by an earlier GetTimeToNextEvent()
+// call. JaguarExecuteNew() (src/core/jaguar.c) caches both indices, THEN
+// runs guest code for that time slice (M68KExecuteWithStalls/GPUExec/
+// DSPExec), THEN calls HandleNextEvent() using the index cached before
+// that guest code ran. Guest register writes reachable inside that
+// window can synchronously call RemoveCallback() on THIS SAME list for
+// an unrelated callback -- ordinary gameplay, not an edge case:
+// TOMResetPIT() (src/tom/tom.c) removes TOMPITCallback from an ordinary
+// PIT-reprogramming write to $F00050-$F00053, and src/jerry/dac.c
+// removes JERRYI2SCallback on an SCLK write. RemoveCallback's
+// swap-last-into-hole can (a) relocate the event the stale cached index
+// pointed at to a different slot, leaving the cache pointing at a
+// stale/out-of-[0,count)-range slot, or (b) remove that cached event
+// outright, leaving the cache pointing at someone else's data entirely.
+// Either way, trusting the stale index here can dispatch the wrong
+// callback with the wrong eventTime, or corrupt bookkeeping for a
+// completely unrelated third event during this function's own
+// swap-removal step below (traced and reproduced in
+// scratch_stale_index_check.c). Calling GetTimeToNextEvent(type) again
+// here closes every mutation shape mid-slice guest code could produce,
+// not just the ones enumerated above, because it stops depending on any
+// value computed before that guest code ran. Cost: one extra scan of the
+// dispatched list, still bounded by its live count (small in practice --
+// measured 1-5 in real gameplay), not EVENT_LIST_SIZE, so this does not
+// reintroduce the O(32) cost this task removes; JaguarExecuteNew() already
+// pays two such scans per iteration (one per list) to size the slice, so
+// this adds a second scan of only the winning list, not a third list.
 void HandleNextEvent(int type/*= EVENT_MAIN*/)
 {
+   (void)GetTimeToNextEvent(type);
+
    if (type == EVENT_MAIN)
    {
       double elapsedTime;

--- a/src/core/event.c
+++ b/src/core/event.c
@@ -45,7 +45,15 @@ static struct Event eventList[EVENT_LIST_SIZE];
 static struct Event eventListJERRY[EVENT_LIST_SIZE];
 static uint32_t nextEvent;
 static uint32_t nextEventJERRY;
-static uint32_t numberOfEvents;
+
+/* Live-event counts, one per list. Packing invariant: every valid slot in
+ * eventList[]/eventListJERRY[] occupies exactly indices [0, eventCount) /
+ * [0, eventCountJERRY) -- contiguous, no holes. This lets every scan below
+ * stop at the count instead of walking all EVENT_LIST_SIZE slots.
+ * Replaces the old single `numberOfEvents`, which was summed across both
+ * lists and couldn't bound either list's scan on its own. */
+static uint32_t eventCount;
+static uint32_t eventCountJERRY;
 
 
 static double ClampDueEventTime(double time)
@@ -65,48 +73,41 @@ void InitializeEventList(void)
       eventListJERRY[i].eventTime = 0.0;
    }
 
-   numberOfEvents = 0;
+   eventCount = 0;
+   eventCountJERRY = 0;
 }
 
 
 // Set callback time in µs. This is fairly arbitrary, but works well enough for our purposes.
-//We just slap the next event into the list in the first available slot, no checking, no nada...
+// The list is kept packed: a new event always lands at index `count` (the first slot past
+// the live region) and `count` is incremented. If the list is already at capacity the event
+// is silently dropped -- this matches the previous scan-and-give-up-at-32 behaviour.
 void SetCallbackTime(void (* callback)(void), double time, int type/*= EVENT_MAIN*/)
 {
-   unsigned i;
    time = ClampDueEventTime(time);
 
    if (type == EVENT_MAIN)
    {
-      for(i = 0; i < EVENT_LIST_SIZE; i++)
+      if (eventCount < EVENT_LIST_SIZE)
       {
-         if (!eventList[i].valid)
-         {
-            eventList[i].timerCallback = callback;
-            eventList[i].eventTime = time;
-            eventList[i].eventType = type;
-            eventList[i].valid = true;
-            numberOfEvents++;
-
-            return;
-         }
+         unsigned i = eventCount;
+         eventList[i].timerCallback = callback;
+         eventList[i].eventTime = time;
+         eventList[i].eventType = type;
+         eventList[i].valid = true;
+         eventCount++;
       }
    }
    else
    {
-      for(i = 0; i < EVENT_LIST_SIZE; i++)
+      if (eventCountJERRY < EVENT_LIST_SIZE)
       {
-         if (!eventListJERRY[i].valid)
-         {
-            /* Found callback slot */
-            eventListJERRY[i].timerCallback = callback;
-            eventListJERRY[i].eventTime = time;
-            eventListJERRY[i].eventType = type;
-            eventListJERRY[i].valid = true;
-            numberOfEvents++;
-
-            return;
-         }
+         unsigned i = eventCountJERRY;
+         eventListJERRY[i].timerCallback = callback;
+         eventListJERRY[i].eventTime = time;
+         eventListJERRY[i].eventType = type;
+         eventListJERRY[i].valid = true;
+         eventCountJERRY++;
       }
    }
 }
@@ -116,19 +117,33 @@ void RemoveCallback(void (* callback)(void))
 {
    unsigned i;
 
-   for (i = 0; i < EVENT_LIST_SIZE; i++)
+   for (i = 0; i < eventCount; i++)
    {
-      if (eventList[i].valid && eventList[i].timerCallback == callback)
+      if (eventList[i].timerCallback == callback)
       {
-         eventList[i].valid = false;
-         numberOfEvents--;
+         unsigned last = eventCount - 1;
+
+         if (i != last)
+            eventList[i] = eventList[last];
+
+         eventList[last].valid = false;
+         eventCount = last;
 
          return;
       }
-      else if (eventListJERRY[i].valid && eventListJERRY[i].timerCallback == callback)
+   }
+
+   for (i = 0; i < eventCountJERRY; i++)
+   {
+      if (eventListJERRY[i].timerCallback == callback)
       {
-         eventListJERRY[i].valid = false;
-         numberOfEvents--;
+         unsigned last = eventCountJERRY - 1;
+
+         if (i != last)
+            eventListJERRY[i] = eventListJERRY[last];
+
+         eventListJERRY[last].valid = false;
+         eventCountJERRY = last;
 
          return;
       }
@@ -141,14 +156,18 @@ void AdjustCallbackTime(void (* callback)(void), double time)
    unsigned i;
    time = ClampDueEventTime(time);
 
-   for(i = 0; i < EVENT_LIST_SIZE; i++)
+   for(i = 0; i < eventCount; i++)
    {
-      if (eventList[i].valid && eventList[i].timerCallback == callback)
+      if (eventList[i].timerCallback == callback)
       {
          eventList[i].eventTime = time;
          return;
       }
-      else if (eventListJERRY[i].valid && eventListJERRY[i].timerCallback == callback)
+   }
+
+   for(i = 0; i < eventCountJERRY; i++)
+   {
+      if (eventListJERRY[i].timerCallback == callback)
       {
          eventListJERRY[i].eventTime = time;
          return;
@@ -169,9 +188,9 @@ double GetTimeToNextEvent(int type/*= EVENT_MAIN*/)
    {
       nextEvent = 0;
 
-      for(i = 0; i < EVENT_LIST_SIZE; i++)
+      for(i = 0; i < eventCount; i++)
       {
-         if (eventList[i].valid && (eventList[i].eventTime < time))
+         if (eventList[i].eventTime < time)
          {
             time = eventList[i].eventTime;
             nextEvent = i;
@@ -182,9 +201,9 @@ double GetTimeToNextEvent(int type/*= EVENT_MAIN*/)
    {
       nextEventJERRY = 0;
 
-      for(i = 0; i < EVENT_LIST_SIZE; i++)
+      for(i = 0; i < eventCountJERRY; i++)
       {
-         if (eventListJERRY[i].valid && (eventListJERRY[i].eventTime < time))
+         if (eventListJERRY[i].eventTime < time)
          {
             time = eventListJERRY[i].eventTime;
             nextEventJERRY = i;
@@ -196,43 +215,95 @@ double GetTimeToNextEvent(int type/*= EVENT_MAIN*/)
 }
 
 
+// If a caller invokes HandleNextEvent() when the relevant list is already
+// empty (nothing left for the preceding GetTimeToNextEvent() to have
+// found), there is nothing to dispatch: return without touching the list
+// or calling any callback. Note this is a deliberate behaviour change from
+// the pre-packing code, which had no such guard and would instead reread
+// slot 0's leftover contents from whatever was last stored there and
+// call it -- "harmless" only by accident, and which physical slot ends up
+// with the leftover data is an artifact of the packing strategy (old:
+// first-fit reuse; new: swap-last-into-hole), so the *particular* stale
+// callback that gets redispatched is not something either implementation
+// can be said to guarantee. A clean no-op is well-defined regardless of
+// packing strategy -- but note the old code's stale re-fire was an
+// accidental self-heal, not a safety net: for EVENT_MAIN specifically it
+// almost always re-fires HalflineCallback (nothing in this codebase ever
+// calls RemoveCallback(HalflineCallback), so slot 0's residue is
+// HalflineCallback far more often than not), which re-arms the queue and
+// keeps JaguarExecuteNew()'s `do { ... } while (!frameDone)` loop moving.
+// If BOTH queues were ever empty at once, this no-op guard makes
+// HandleNextEvent(EVENT_MAIN) do nothing, frameDone never gets set, and
+// the loop spins forever -- the old code's accidental self-heal would
+// have masked exactly that. Not reachable today: EVENT_MAIN (Halfline)
+// and EVENT_JERRY (DSP/I2S) are perpetually self-rearmed by their own
+// callbacks, so real dispatch never hits an empty queue; only synthetic
+// over-dispatch in test harnesses (see test/test_uart_loopback.c's
+// pump()) reaches this guard, and there JERRY's list is never actually
+// down to zero valid MAIN-side events at the same time. Flagged here so a
+// future change that stops re-arming one of these callbacks fails loudly
+// (a hang, easy to notice) rather than being masked by lucky residue.
 void HandleNextEvent(int type/*= EVENT_MAIN*/)
 {
-   unsigned i;
-
    if (type == EVENT_MAIN)
    {
-      double elapsedTime = ClampDueEventTime(eventList[nextEvent].eventTime);
-      void (* event)(void) = eventList[nextEvent].timerCallback;
+      double elapsedTime;
+      void (* event)(void);
+      unsigned i;
+      unsigned last;
 
-      for (i = 0; i < EVENT_LIST_SIZE; i++)
+      if (eventCount == 0)
+         return;
+
+      elapsedTime = ClampDueEventTime(eventList[nextEvent].eventTime);
+      event = eventList[nextEvent].timerCallback;
+
+      for (i = 0; i < eventCount; i++)
       {
          //We can skip the check & just subtract from everything, since the check is probably
          //just as heavy as the code after and we won't use the elapsed time from an invalid event anyway.
-         //		if (eventList[i].valid)
          eventList[i].eventTime -= elapsedTime;
       }
 
-      eventList[nextEvent].valid = false;			// Remove event from list...
-      numberOfEvents--;
+      // Remove the dispatched event: swap the last live slot into its place
+      // (same move RemoveCallback makes) so [0, eventCount) stays packed.
+      last = eventCount - 1;
+
+      if (nextEvent != last)
+         eventList[nextEvent] = eventList[last];
+
+      eventList[last].valid = false;
+      eventCount = last;
 
       (*event)();
    }
    else
    {
-      double elapsedTime = ClampDueEventTime(eventListJERRY[nextEventJERRY].eventTime);
-      void (* event)(void) = eventListJERRY[nextEventJERRY].timerCallback;
+      double elapsedTime;
+      void (* event)(void);
+      unsigned i;
+      unsigned last;
 
-      for (i = 0; i < EVENT_LIST_SIZE; i++)
+      if (eventCountJERRY == 0)
+         return;
+
+      elapsedTime = ClampDueEventTime(eventListJERRY[nextEventJERRY].eventTime);
+      event = eventListJERRY[nextEventJERRY].timerCallback;
+
+      for (i = 0; i < eventCountJERRY; i++)
       {
          //We can skip the check & just subtract from everything, since the check is probably
          //just as heavy as the code after and we won't use the elapsed time from an invalid event anyway.
-         //		if (eventList[i].valid)
          eventListJERRY[i].eventTime -= elapsedTime;
       }
 
-      eventListJERRY[nextEventJERRY].valid = false;	// Remove event from list...
-      numberOfEvents--;
+      last = eventCountJERRY - 1;
+
+      if (nextEventJERRY != last)
+         eventListJERRY[nextEventJERRY] = eventListJERRY[last];
+
+      eventListJERRY[last].valid = false;
+      eventCountJERRY = last;
 
       (*event)();
    }
@@ -244,12 +315,12 @@ void SubtractEventTimes(double elapsed, int type)
    unsigned i;
    if (type == EVENT_MAIN)
    {
-      for (i = 0; i < EVENT_LIST_SIZE; i++)
+      for (i = 0; i < eventCount; i++)
          eventList[i].eventTime -= elapsed;
    }
    else
    {
-      for (i = 0; i < EVENT_LIST_SIZE; i++)
+      for (i = 0; i < eventCountJERRY; i++)
          eventListJERRY[i].eventTime -= elapsed;
    }
 }
@@ -308,6 +379,12 @@ size_t EventStateSave(uint8_t *buf)
 {
    uint8_t *start = buf;
    unsigned i;
+   /* On-disk field name/size is unchanged (numberOfEvents, uint32_t) even
+    * though the runtime now keeps two per-list counts -- write their sum so
+    * the byte layout, and thus the save-state format/version, don't move.
+    * The physical per-slot valid/cb_id/etype/etime arrays below are still
+    * serialized unconditionally and in full, same as before packing. */
+   uint32_t numberOfEvents = eventCount + eventCountJERRY;
 
    STATE_SAVE_VAR(buf, nextEvent);
    STATE_SAVE_VAR(buf, nextEventJERRY);
@@ -348,10 +425,18 @@ size_t EventStateLoad(const uint8_t *buf)
 {
    const uint8_t *start = buf;
    unsigned i;
+   unsigned w;
+   /* Loaded but intentionally unused: eventCount/eventCountJERRY are
+    * recomputed below by counting the slots the per-slot loop below
+    * actually marks valid (which already accounts for unresolved
+    * callback ids), not by trusting this legacy combined total. It is
+    * still read here so the buffer cursor lands in the same place. */
+   uint32_t numberOfEvents;
 
    STATE_LOAD_VAR(buf, nextEvent);
    STATE_LOAD_VAR(buf, nextEventJERRY);
    STATE_LOAD_VAR(buf, numberOfEvents);
+   (void)numberOfEvents;
 
    for (i = 0; i < EVENT_LIST_SIZE; i++)
    {
@@ -388,6 +473,53 @@ size_t EventStateLoad(const uint8_t *buf)
       eventListJERRY[i].eventType = etype;
       eventListJERRY[i].eventTime = etime;
    }
+
+   /* Compact both lists so the packed invariant ([0, count) all valid,
+    * contiguous) holds regardless of how the physical array looked on
+    * disk. A save written by this packed code is already contiguous, so
+    * this is a no-op there; it also makes loading a state written by the
+    * pre-packing code (which could leave holes after a RemoveCallback
+    * with no immediately-following SetCallbackTime) safe, since scans
+    * elsewhere in this file are now bounded by the count instead of
+    * EVENT_LIST_SIZE.
+    *
+    * Index order is NOT purely cosmetic despite the "unordered WRT time"
+    * file-header comment: GetTimeToNextEvent()'s strict `<` scan makes the
+    * lowest surviving index win an exact eventTime tie, so reordering
+    * could in principle change which of two simultaneously-due events
+    * fires first. This compaction is safe regardless because it is
+    * *stable* -- valid entries keep their relative order as they're
+    * packed toward the front (e.g. valid slots at physical indices 3 and
+    * 7 land at 0 and 1, in the same relative order), so the lowest-index
+    * tie-break after compaction resolves identically to a full 0..31 scan
+    * over the pre-compaction layout would have. */
+   w = 0;
+   for (i = 0; i < EVENT_LIST_SIZE; i++)
+   {
+      if (eventList[i].valid)
+      {
+         if (w != i)
+            eventList[w] = eventList[i];
+         w++;
+      }
+   }
+   for (i = w; i < EVENT_LIST_SIZE; i++)
+      eventList[i].valid = false;
+   eventCount = w;
+
+   w = 0;
+   for (i = 0; i < EVENT_LIST_SIZE; i++)
+   {
+      if (eventListJERRY[i].valid)
+      {
+         if (w != i)
+            eventListJERRY[w] = eventListJERRY[i];
+         w++;
+      }
+   }
+   for (i = w; i < EVENT_LIST_SIZE; i++)
+      eventListJERRY[i].valid = false;
+   eventCountJERRY = w;
 
    return (size_t)(buf - start);
 }


### PR DESCRIPTION
Item **P6** of the 2026-08 performance audit — tracking epic #569.

⚠️ **Needs a Development-panel link to #569.**

Byte-identical output. No emulation behaviour changes beyond one documented, measured-safe tie-break detail (below).

## The problem

`GetTimeToNextEvent`/`HandleNextEvent`/`SubtractEventTimes`/`SetCallbackTime`/`RemoveCallback` each scanned the full 32-slot `eventList`/`eventListJERRY` arrays regardless of how many slots were actually valid — once per dispatched event, ~2,000+ times/frame with audio active.

## The fix

Keep each list densely packed: every valid slot occupies `[0, count)` contiguously, so every scan stops at the live count instead of 32. `SetCallbackTime` becomes an O(1) append; `RemoveCallback` and the dispatched-event removal inside `HandleNextEvent` both swap the last live slot into the removed slot's position before decrementing count. Savestate format is unchanged — the on-disk layout still serializes the full physical array unconditionally; a packed runtime just means the tail beyond `count` is always contiguously invalid rather than scattered, and load correctly reconstructs a packed state from an older, "holey" save via a stable compaction pass.

## Two real findings, both investigated rather than shipped blind

**Tie-break order (accepted, documented, not fixed — a controller decision).** Swap-remove can change dispatch order among events sharing an exact `eventTime` — proven both algebraically and empirically, and inherent to any O(1) packing scheme (the old first-fit/in-place-invalidate scheme's tie-break was never a documented invariant either — it depended on the accidental history of slot reuse). Reachability was measured, not assumed: **zero raw ties across 12,000+ real gameplay frames** on two titles plus every committed netplay/voicemodem integration test; the only place ties occur at all is an isolated UART micro-test, where none of the 5 observed ties actually changed dispatch order.

**Stale cached dispatch index (Critical, found in review, fixed structurally).** `JaguarExecuteNew()` caches `nextEvent`/`nextEventJERRY`, runs guest code for that time slice, then dispatches using the index cached *before* that guest code ran. Ordinary gameplay register writes reachable in that window — `TOMResetPIT()` on a PIT reprogram, an SCLK write in `dac.c` — call `RemoveCallback()` on an unrelated event, and under swap-remove packing this could relocate or remove the event the stale index pointed at, corrupting dispatch. Not a rare edge case — reachable through ordinary timer reprogramming. Fixed structurally rather than patched case-by-case: `HandleNextEvent` now re-derives its target by calling `GetTimeToNextEvent(type)` again at its own top, so it never depends on a value computed before guest code ran. One extra scan, still bounded by the live count (typically 1-5 events), not `EVENT_LIST_SIZE` — the property this task exists to preserve.

## Verification

- Full suite green; savestate/event-specific tests confirmed run.
- Byte-identical A/B (`fb_row_digest`) vs. pre-change build on AvP (300/600 frames) and Cybermorph with `--load-state`.
- Both findings independently reviewed: the tie-break claim's counter-example traced against the actual diff arithmetic; the stale-index fix confirmed to close both failure shapes structurally (not case-by-case), checked for recursion/double-dispatch/count-corruption risk, and confirmed still bounded by live count rather than reintroducing the O(32) cost this task removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)