### PR TITLE
fix(cd,titledb): Android CUE/BIN case-sensitivity + true_color null rows

### DIFF
--- a/src/cd/cdintf.c
+++ b/src/cd/cdintf.c
@@ -19,6 +19,8 @@
 #endif
 #include <streams/file_stream.h>
 #include <streams/file_stream_transforms.h>
+#include <file/file_path.h>
+#include <vfs/vfs_implementation.h>
 #include "cdintf.h"
 #include "jaguar.h"
 #include "log.h"
@@ -180,6 +182,61 @@ static bool GetDirectoryFromPath(const char *path, char *dir, size_t dirSize)
 
    dir[0] = '\0';
    return false;
+}
+
+/* Redump-style CUE sheets and the actual extracted filename can differ
+ * only in letter case. NTFS (Windows) is case-insensitive, so the exact
+ * string from the sheet always resolves there; ext4 / SAF (Android) is
+ * case-sensitive and rfopen() on the literal path silently fails, which
+ * is why CDI (a single self-contained file, no external name reference)
+ * boots the same titles that CUE/BIN does not (#566). Only consulted
+ * when the exact-case path does not already exist. */
+static void FixBinFileCase(char *fullPath, size_t fullPathSize)
+{
+   char dir[4096];
+   char dirNoSep[4096];
+   const char *base;
+   size_t dirLen;
+   libretro_vfs_implementation_dir *d;
+
+   if (path_is_valid(fullPath))
+      return;
+
+   GetDirectoryFromPath(fullPath, dir, sizeof(dir));
+   base = fullPath + strlen(dir);
+
+   dirLen = strlen(dir);
+   if (dirLen >= sizeof(dirNoSep))
+      dirLen = sizeof(dirNoSep) - 1;
+   memcpy(dirNoSep, dir, dirLen);
+   dirNoSep[dirLen] = '\0';
+   if (dirLen > 0 && (dirNoSep[dirLen - 1] == '/' || dirNoSep[dirLen - 1] == '\\'))
+      dirNoSep[dirLen - 1] = '\0';
+   if (dirNoSep[0] == '\0')
+   {
+      dirNoSep[0] = '.';
+      dirNoSep[1] = '\0';
+   }
+
+   d = retro_vfs_opendir_impl(dirNoSep, false);
+   if (!d)
+      return;
+
+   while (retro_vfs_readdir_impl(d))
+   {
+      const char *name = retro_vfs_dirent_get_name_impl(d);
+      if (name && strcasecmp(name, base) == 0 && strcmp(name, base) != 0)
+      {
+         char candidate[4096];
+         snprintf(candidate, sizeof(candidate), "%s%s", dir, name);
+         if (path_is_valid(candidate))
+         {
+            snprintf(fullPath, fullPathSize, "%s", candidate);
+            break;
+         }
+      }
+   }
+   retro_vfs_closedir_impl(d);
 }
 
 static void CDIntfFinalizeSessions(void)
@@ -740,6 +797,8 @@ static bool ParseCueSheet(const char *cuePath)
                snprintf(currentBinFile, sizeof(currentBinFile), "%s%s", dir, binName);
             else
                snprintf(currentBinFile, sizeof(currentBinFile), "%s", binName);
+
+            FixBinFileCase(currentBinFile, sizeof(currentBinFile));
 
             // If we don't have a bin path set yet, set it as the primary
             if (!disc.binPath[0])

--- a/src/core/titledb.c
+++ b/src/core/titledb.c
@@ -44,6 +44,21 @@
  * shaded 1.70M/2400f=708/f (cleared), QUALIFY16 13/2400f=0.005/f (below
  * threshold) -> true_color only.
  *
+ * Issue #551: the shaded-blit-count proxy for virtualjaguar_true_color
+ * does not predict a visible difference. Pixel-diffed A/B pairs (same
+ * ROM, same scripted input, same frame, only the option toggled) found
+ * three rows that clear the >=10 shaded-blits/frame threshold by wide
+ * margins and still produce 0.0000% changed pixels: Alien vs Predator
+ * (61-frame sweep, menu through moving gameplay), the Doom engine family
+ * (retail + every JagDoomEX romhack alias, which by policy share the
+ * retail row's pairs because they share the same renderer), and Missile
+ * Command 3D. true_color was dropped from those rows below; Cybermorph
+ * keeps it — it is the one row with a committed A/B screenshot actually
+ * showing the banding fix (39.04% pixels changed). The remaining
+ * true_color rows are unaudited against pixel evidence and are not
+ * claimed correct or incorrect by this pass — see #551 for the
+ * re-qualification this doesn't attempt.
+ *
  * ------------------------------------------------------------------
  * hooks[] authoring checklist (issue #370, docs/enhancement-hooks.md)
  *
@@ -119,15 +134,18 @@
  * ------------------------------------------------------------------
  */
 static const TitleDBEntry titledb_table[] = {
-   /* Alien vs Predator (retail) — 2x internal resolution + true color.
+   /* Alien vs Predator (retail) — 2x internal resolution.
     * Evidence: docs/avp-renderer-analysis.md (Stage 2 A/B, frame 6000),
     * docs/hires-stage0-census.md (census GO), shipped in v3.2.0.
+    * true_color dropped per #551: pixel-diffed across a 61-frame sweep
+    * (menu through moving gameplay), 0.0000% pixels changed with the
+    * option toggled -- the shaded-blit-count heuristic that qualified it
+    * (113/f) does not predict a visible difference here.
     * CRCs: Alien vs Predator (World) from src/core/filedb.c line 106. */
    {
       0xDC187F82, "Alien vs Predator",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          /* NOT tagged with virtualjaguar_blit_memo yet -- see
           * docs/blit-memo.md.  AvP is the memo's best-evidenced title
           * (710,433 verify checks, 0 divergences, bit-identical A/B
@@ -178,15 +196,17 @@ static const TitleDBEntry titledb_table[] = {
       }
    },
 
-   /* Doom (retail) — true color + 2x: census row "Doom" 2400f,
-    * shaded 445.8/f (>=10), QUALIFY16 433.3/f (>=5), scene: gameplay
-    * (E1M1).
+   /* Doom (retail) — 2x: census row "Doom" 2400f, shaded 445.8/f (>=10),
+    * QUALIFY16 433.3/f (>=5), scene: gameplay (E1M1).
+    * true_color dropped per #551: pixel-diffed as "Doom (World) EX",
+    * 0.0000% pixels changed with the option toggled -- the shaded-blit
+    * heuristic clears by a wide margin and still predicts nothing
+    * visible here.
     * CRC: Doom (World) from src/core/filedb.c line 62. */
    {
       0x5E2CDBC0, "Doom",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },
@@ -222,7 +242,6 @@ static const TitleDBEntry titledb_table[] = {
       0x754096DB, "Doom EX (JagDoomEX)",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },
@@ -230,7 +249,6 @@ static const TitleDBEntry titledb_table[] = {
       0x4643E9DB, "Doom EX (JagDoomEX 2)",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },
@@ -238,7 +256,6 @@ static const TitleDBEntry titledb_table[] = {
       0x35743B9C, "Doom EX (JagDoomEX 3)",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },
@@ -246,7 +263,6 @@ static const TitleDBEntry titledb_table[] = {
       0xAD6B68BA, "Doom EX (JagDoomEX 4)",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },
@@ -254,7 +270,6 @@ static const TitleDBEntry titledb_table[] = {
       0xC4F4CACF, "Doom EX (JagDoomEX 5)",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },
@@ -262,7 +277,6 @@ static const TitleDBEntry titledb_table[] = {
       0x1F4EE4A5, "Doom EX (JagDoomEX 6)",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },
@@ -270,7 +284,6 @@ static const TitleDBEntry titledb_table[] = {
       0x013A5359, "Doom EX (spectral)",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },
@@ -278,7 +291,6 @@ static const TitleDBEntry titledb_table[] = {
       0xB92D1CA3, "Doom EX (transparent)",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },
@@ -286,7 +298,6 @@ static const TitleDBEntry titledb_table[] = {
       0xEA12E234, "Doom EX (JagDoom2EX)",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },
@@ -329,15 +340,17 @@ static const TitleDBEntry titledb_table[] = {
       }
    },
 
-   /* Missile Command 3D (retail) — true color + 2x: census row
-    * "Missile Command 3D" 2400f, shaded 1650/f (>=10), QUALIFY16
-    * 1866.7/f (>=5), scene: gameplay (Original 3D mode).
+   /* Missile Command 3D (retail) — 2x: census row "Missile Command 3D"
+    * 2400f, shaded 1650/f (>=10), QUALIFY16 1866.7/f (>=5), scene:
+    * gameplay (Original 3D mode).
+    * true_color dropped per #551: pixel-diffed, 0.0000% pixels changed
+    * with the option toggled -- the shaded-blit heuristic clears by a
+    * wide margin and still predicts nothing visible here.
     * CRC: Missile Command 3D (World) from src/core/filedb.c line 105. */
    {
       0xDA9C4162, "Missile Command 3D",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         { "virtualjaguar_true_color",          "enabled" },
          { NULL, NULL }
       }
    },


### PR DESCRIPTION
## Summary

Two independent, verified fixes from a v3.5.0 tracker triage pass:

- **`src/cd/cdintf.c`**: Some Jaguar CD CUE/BIN images fail to load on Android while the same images work on Windows and their CDI equivalents work everywhere (#566). Root cause: a CUE sheet's `FILE` line and the actual extracted `.bin` filename can differ only in letter case (redump-style sheets vs. rehosted zips). NTFS (Windows) is case-insensitive so the literal path always resolves there; ext4/SAF (Android) is case-sensitive, so `rfopen()` on the exact string silently fails — exactly why CDI (a single self-contained file with no external name reference) is unaffected. Added a case-insensitive directory-scan fallback, consulted only when the exact-case path doesn't already exist, applied once when the `FILE` line's path is built during CUE parsing.
- **`src/core/titledb.c`**: `virtualjaguar_true_color` was defaulted on for three titles (Alien vs Predator, the whole Doom engine family incl. every JagDoomEX romhack alias, Missile Command 3D) based on a shaded-blit-count heuristic that turned out not to predict a visible difference — #551's pixel-diffed A/B pairs measured 0.0000% changed pixels for all three despite clearing the heuristic threshold by wide margins. Dropped the option from those rows; `virtualjaguar_internal_resolution` is untouched, and Cybermorph keeps `true_color` (it has a committed A/B screenshot actually showing the fix).

Also closed #552 and #560 (both already shipped on `develop` via #558 and #562/#567 respectively, but never hand-linked/closed per #371's Development-panel workflow note), and triaged the remaining new/unscoped issues (#564, #565, #568, #569) with milestone + size + a status comment explaining why no code change was attempted this pass (mainly: no `test/roms/private` corpus mounted in this session's environment). Flagged a milestone/body contradiction on #529 rather than guessing at a resolution.

## Test plan

- [x] `make -j$(getconf _NPROCESSORS_ONLN)` builds clean on host
- [x] `make TEST_EXPORTS=1 test` passes — 0 failures (skips are all pre-existing private-ROM/disc gaps, unrelated to this change)
- [x] `bash scripts/c89-lint.sh src/cd/cdintf.c src/core/titledb.c` passes
- [x] `test/test_titledb` passes, including the Doom-EX-alias-row assertion
- [x] Manual repro/fix verification for the CUE/BIN fix: built a synthetic case-mismatched CUE (`game.cue` referencing `game.bin`) + BIN (`Game.BIN` on disk) pair and drove `CDIntfOpenImage()` directly via `dlopen`/`dlsym` against the built core — confirmed it fails (track length resolves to 0) before the fix and succeeds (track length matches the real file) after it, in both directions

## Branch base

- [x] **Base is `develop`** (the integration branch)


---
_Generated by [Claude Code](https://claude.ai/code/session_01D8dhYmXz3YaRkYeJQHWnNx)_