### PR TITLE
docs(blitter): record the declined blit-memo AvP tagging decision (#411)

### DIFF
--- a/docs/blit-memo.md
+++ b/docs/blit-memo.md
@@ -226,12 +226,18 @@ matching stream — Club Drive (394,581 misses) and Checkered Flag
 1. **Give thin titles real input fixtures**, especially Club Drive and
    Checkered Flag, which blit heavily but never repeated a stream under
    generic input. Also sweep the PD/homebrew remainder.
-2. **Tag titles.** AvP is the obvious first candidate — best-evidenced
-   of any title (710,433 checks, 0 divergences, bit-identical A/B over
-   8,000 frames) — and Doom, Kasumi Ninja, Towers II and Missile
-   Command 3D now have six-figure clean check counts too. One line each
-   in `src/core/titledb.c` once a device check is done. Tagging is what
-   makes the feature do anything, so it should not sit undone for long.
+2. **Tagging AvP declined on measured benefit, not soundness.** AvP is
+   the best-evidenced title (710,433 checks, 0 divergences, bit-identical
+   A/B over 8,000 frames) and the corpus sweep is clean, but the memo only
+   skips idle-window redundant blits -- themselves ~15% of idle wall time
+   at 2x (see #411) -- so the -15%-of-that-slice effect measured above is
+   roughly 2% of idle time, unmeasurable in RetroArch. Tagging turns the
+   memo on by default for every AvP user for that gain, plus the 14.6MB
+   entry pool + 9.6MB shadow arena (item 3) and an untested run-ahead/
+   rollback interaction (item 6). Not tagged; revisit only if the benefit
+   is remeasured larger or those costs shrink. Doom, Kasumi Ninja, Towers
+   II and Missile Command 3D have six-figure clean check counts too but
+   have not been through this same cost/benefit pass.
 3. **Shrink the pool.** 4096 entries × 3,744 B = **14.6 MB**, too much
    for iOS. Most of an entry is two 768-byte state blobs and a 2 KB
    write log.

--- a/src/core/titledb.c
+++ b/src/core/titledb.c
@@ -146,13 +146,21 @@ static const TitleDBEntry titledb_table[] = {
       0xDC187F82, "Alien vs Predator",
       {
          { "virtualjaguar_internal_resolution", "2x" },
-         /* NOT tagged with virtualjaguar_blit_memo yet -- see
+         /* Deliberately NOT tagged with virtualjaguar_blit_memo -- see
           * docs/blit-memo.md.  AvP is the memo's best-evidenced title
           * (710,433 verify checks, 0 divergences, bit-identical A/B
-          * over 8,000 frames) but that covers the scenes one fixture
-          * reaches, and the corpus sweep is unfinished.  Tagging here
-          * turns the memo ON by default for every AvP user, so it
-          * waits for the full sweep plus a device check. */
+          * over 8,000 frames) and the full 64-title corpus sweep is
+          * clean too, so this is not a soundness gap. It is declined
+          * on measured benefit: the memo only ever skips idle-window
+          * redundant blits, which are themselves ~15% of idle wall
+          * time at 2x, so the memo buys roughly -15% of that slice --
+          * about 2% of idle time, unmeasurable in RetroArch (issue
+          * #411). Tagging would turn it on by default for every AvP
+          * user for a gain that small, adding a 14.6MB entry pool +
+          * 9.6MB shadow arena (too much for iOS, open item 3) and an
+          * untested interaction with run-ahead/rollback (open item 6).
+          * Revisit only if the benefit is remeasured larger, or the
+          * memory/determinism costs come down. */
          { NULL, NULL }
       }
    },


### PR DESCRIPTION
## Summary

`docs/blit-memo.md` and the `titledb.c` comment on AvP's row both still read as "tagging just needs a device check" — that's stale. A prior pass already measured and declined it: the memo only skips idle-window redundant blits, which are themselves ~15% of AvP's idle wall time at 2x, so tagging buys roughly -15% of that slice — about 2% of idle time, unmeasurable in RetroArch — for a 14.6MB entry pool + 9.6MB shadow arena (flagged elsewhere as too much for iOS) and an untested run-ahead/rollback interaction. Not a soundness gap (corpus sweep is clean, 710,433 checks, 0 divergences), a cost/benefit call.

This PR only corrects the record so a future pass doesn't re-derive the same answer a third time. No functional change.

## Test plan

- [x] `bash scripts/c89-lint.sh src/core/titledb.c` passes
- [x] `make -j$(getconf _NPROCESSORS_ONLN)` builds clean
- [x] `test/test_titledb` passes, 0 failures