### PR TITLE
feat(netlink): host-side voice chat over the discovery socket (#485)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ __pycache__/
 /test/tools/present_rate_probe
 test/tools/blitter_static_leak
 test/tools/voicemodem_pair
+test/tools/voicechat_pair
 /test/tools/netlink_discover_probe
 /test/tools/netlink_rebuild_witness
 test/roms/tier1/

--- a/Makefile
+++ b/Makefile
@@ -1211,7 +1211,7 @@ clean:
 		test/tools/test_frame_timing test/tools/test_runahead_determinism test/tools/test_pertitle_db \
 		test/test_biosdb test/test_cart_bios_loader \
 		test/test_titledb test/test_titlehook test/tools/test_hook_gate \
-		test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace test/tools/i2s_lag_probe \
+		test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace test/test_voicechat test/tools/test_voicechat_inertness test/tools/voicechat_pair test/tools/i2s_lag_probe \
 		test/tools/dsp_idle_probe_falsify test/tools/dsp_idle_ab \
 		test/tools/joymatrix_identity test/tools/teamtap_ports \
 		test/tools/teamtap_rom_probe test/tools/mouse_decode_test \
@@ -1267,7 +1267,7 @@ test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
 # invocations get different values.
 test: EEPROM_GEN_TOOL := /tmp/vj_gen_eeprom_test_rom_$(shell echo $$PPID)
 test: EEPROM_FIXTURE := /tmp/vj_eeprom_lifecycle_$(shell echo $$PPID).j64
-test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_discover test/test_jlink_netpacket test/test_voicemodem_netpacket test/test_uart_loopback test/test_jlink_negotiate test/test_blitter_simd test/test_dsp_mac40 test/test_titledb test/test_titlehook test/test_biosdb \
+test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_discover test/test_voicechat test/test_jlink_netpacket test/test_voicemodem_netpacket test/test_uart_loopback test/test_jlink_negotiate test/test_blitter_simd test/test_dsp_mac40 test/test_titledb test/test_titlehook test/test_biosdb \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
@@ -1283,7 +1283,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_chd test/test_chd_unit test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda test/test_cd_synth_subq \
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
-		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/netlink_discover_probe test/tools/netlink_rebuild_witness test/tools/netlink_mismatch_witness test/tools/perf_iface_witness test/tools/voicemodem_pair test/tools/netlink_game test/tools/test_pertitle_db \
+		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/netlink_discover_probe test/tools/netlink_rebuild_witness test/tools/netlink_mismatch_witness test/tools/perf_iface_witness test/tools/voicemodem_pair test/tools/voicechat_pair test/tools/test_voicechat_inertness test/tools/netlink_game test/tools/test_pertitle_db \
 		test/tools/test_hook_gate \
 		test/tools/i2s_lag_probe test/tools/joymatrix_identity \
 		test/tools/teamtap_ports \
@@ -1316,6 +1316,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	./test/test_jlink
 	./test/test_jlink_tcp
 	./test/test_jlink_discover
+	./test/test_voicechat
 	./test/test_jlink_netpacket ./$(TARGET)
 	@# The voice modem over the OTHER transport (#494).  voicemodem_pair
 	@# and uv_modem_game_test both drive TCP; this is the only check on
@@ -1345,6 +1346,8 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	   else exit $$rc; fi; \
 	 fi
 	bash test/tools/voicemodem_pair_test.sh ./$(TARGET)
+	bash test/tools/voicechat_pair_test.sh
+	./test/tools/test_voicechat_inertness ./$(TARGET) test/roms/yarc.j64 --quiet
 	bash test/tools/netlink_latency_test.sh ./$(TARGET)
 	@# Wire-speed enhancement (#498).  Three real core pairs whose only
 	@# difference is each side's virtualjaguar_netlink_speed, so the
@@ -1940,17 +1943,32 @@ test/test_event_queue: test/test_event_queue.c src/core/event.c src/core/event.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_event_queue.c src/core/event.c
 
-test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c
+test/test_jlink: test/test_jlink.c src/jerry/jlink.c src/jerry/jlink.h src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/voicechat.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_jlink.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c
+		-o $@ test/test_jlink.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/voicechat.c
 
-test/test_jlink_tcp: test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/jlink.h src/jerry/jlink_tcp.h
+test/test_jlink_tcp: test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/voicechat.c src/jerry/jlink.h src/jerry/jlink_tcp.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c
+		-o $@ test/test_jlink_tcp.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/voicechat.c
 
 test/test_jlink_discover: test/test_jlink_discover.c src/jerry/jlink_discover.c src/jerry/jlink_discover.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \
 		-o $@ test/test_jlink_discover.c src/jerry/jlink_discover.c
+
+test/test_voicechat: test/test_voicechat.c src/jerry/voicechat.c src/jerry/voicechat.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_voicechat.c src/jerry/voicechat.c
+
+test/tools/voicechat_pair: test/tools/voicechat_pair.c src/jerry/voicechat.c src/jerry/jlink_discover.c
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/voicechat_pair.c src/jerry/voicechat.c src/jerry/jlink_discover.c
+
+test/tools/test_voicechat_inertness: test/tools/test_voicechat_inertness.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/test_voicechat_inertness.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 
 test/test_jlink_netpacket: test/test_jlink_netpacket.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
@@ -1960,13 +1978,13 @@ test/test_voicemodem_netpacket: test/test_voicemodem_netpacket.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_voicemodem_netpacket.c -ldl
 
-test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/core/event.c
+test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/voicechat.c src/core/event.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_uart_loopback.c src/jerry/uart.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/core/event.c -lm
+		-o $@ test/test_uart_loopback.c src/jerry/uart.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/voicechat.c src/core/event.c -lm
 
-test/test_jlink_negotiate: test/test_jlink_negotiate.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/core/event.c
+test/test_jlink_negotiate: test/test_jlink_negotiate.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/voicechat.c src/core/event.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/test_jlink_negotiate.c src/jerry/uart.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/core/event.c -lm
+		-o $@ test/test_jlink_negotiate.c src/jerry/uart.c src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/voicechat.c src/core/event.c -lm
 
 test/test_uart_core: test/test_uart_core.c test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) -Itest \

--- a/Makefile
+++ b/Makefile
@@ -1347,7 +1347,15 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	 fi
 	bash test/tools/voicemodem_pair_test.sh ./$(TARGET)
 	bash test/tools/voicechat_pair_test.sh
-	./test/tools/test_voicechat_inertness ./$(TARGET) test/roms/yarc.j64 --quiet
+	@# Voice-chat inertness (#485): yarc.j64 is the committed public fixture
+	@# (same as test_texdump).  Guard exit 77 anyway so a stripped checkout
+	@# ledgers a skip instead of failing make test.
+	@if ./test/tools/test_voicechat_inertness ./$(TARGET) test/roms/yarc.j64 --quiet; then :; \
+	 else rc=$$?; \
+	   if [ $$rc -eq 77 ]; then \
+	     bash scripts/test-skip.sh record "Voice chat inertness (#485)" "yarc.j64 missing from test/roms/"; \
+	   else exit $$rc; fi; \
+	 fi
 	bash test/tools/netlink_latency_test.sh ./$(TARGET)
 	@# Wire-speed enhancement (#498).  Three real core pairs whose only
 	@# difference is each side's virtualjaguar_netlink_speed, so the

--- a/Makefile.common
+++ b/Makefile.common
@@ -59,6 +59,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/jerry/jlink_discover.c \
 	$(CORE_DIR)/src/jerry/jlink_netpacket.c \
 	$(CORE_DIR)/src/jerry/voicemodem.c \
+	$(CORE_DIR)/src/jerry/voicechat.c \
 	$(CORE_DIR)/src/jerry/uart.c \
 	$(CORE_DIR)/src/tom/op.c \
 	$(CORE_DIR)/src/tom/shadowfb.c \

--- a/docs/voice-chat-design.md
+++ b/docs/voice-chat-design.md
@@ -98,9 +98,12 @@ issue #485's stated budget. Encode/decode is a table, not a compressor;
 compression is deferred until bandwidth proves a problem.
 
 Receive path: jitter buffer → 6× upsample to 48 kHz (exact ratio) with
-linear interpolation → saturating add into both channels of
-`sampleBuffer` immediately before `SoundCallback`. `dac.c` is untouched;
-`sampleBuffer` is not in any serialize path.
+zero-order hold (each 8 kHz sample repeated across six stereo pairs) →
+saturating add into both channels of `sampleBuffer` immediately before
+`SoundCallback`. `dac.c` is untouched; `sampleBuffer` is not in any
+serialize path. Linear interpolation is deliberately not used here —
+period-correct phone-line fidelity does not require it, and the hold
+matches what a simple µ-law path historically did.
 
 ## Gate modes
 

--- a/docs/voice-chat-design.md
+++ b/docs/voice-chat-design.md
@@ -1,0 +1,150 @@
+# Design: Voice chat over the netlink transport (#485)
+
+**Date:** 2026-08-25
+**Status:** IMPLEMENTED
+**Issue:** [#485](https://github.com/libretro/virtualjaguar-libretro/issues/485)
+**Follow-up to:** [#481](https://github.com/libretro/virtualjaguar-libretro/issues/481) / PR #483 (Voice Modem *data* path)
+
+## Framing: this is not emulation
+
+The Jaguar Voice Modem's headline feature was simultaneous voice + data.
+Voice was compressed by the modem and carried modem-to-modem over the
+phone line; the Jaguar only issued audio-path control words (`$A040` /
+`$A0A0`, see `docs/voice-modem.md`). Voice samples never entered the
+console.
+
+So this feature is a **host-side voice channel** added to our netlink
+transport. It must contribute **zero** emulated state: no savestate
+fields, no effect on the framebuffer or any register. That is the same
+"the machine cannot observe it" property that makes texture dump and
+blit-memo host-side work safe, and it is asserted by
+`test/tools/test_voicechat_inertness.c` the same way (savestate digests
++ framebuffer hashes identical with voice on and off).
+
+**Explicitly not in scope:** synthesising DTMF tone audio. DTMF is already
+handled functionally (`$8A2n` / `$6800`); the tones themselves never
+reached the TV on real hardware. Inventing them would invent observable
+behaviour. See issue #485.
+
+## Why a side channel (not the UART byte pipe)
+
+Two hard reasons, both in the code today:
+
+1. `JLinkStateSave` serialises the 256-byte RX ring into savestates
+   (`src/jerry/jlink.c`). Voice bytes there would become emulated state.
+2. The wire is paced at emulated 19200 baud. An ~8 KB/s audio stream
+   would starve game packets.
+
+Voice therefore never touches `jlinkRing`, the UART, or any JERRY
+register.
+
+## Transport: ride the discovery socket
+
+`jlink_discover.c` already exposes an extension seam for "#552 or any
+future second protocol":
+
+- `JLinkDiscSetRawHandler` — every non-beacon datagram
+- `JLinkDiscSendTo` — unicast on the same bound socket
+
+Reusing UDP port **42170** means:
+
+- no second Local Network permission prompt on iOS/macOS
+- no new firewall port
+- automatic backward compatibility — a peer without this build fails
+  the beacon magic check and silently drops the datagram (same path as
+  a corrupt packet)
+
+Peer addressing copies the #552 choreography:
+
+- TCP **client** already knows the server address (it dialed it) and
+  sends first (voice frames + a periodic keepalive so the server learns
+  the client even when the mic gate is closed)
+- TCP **server** learns the client address from the inbound datagram
+  source and can reply
+
+Availability follows `JLinkDiscActive()` (TCP host / TCP client only):
+
+| Mode | Voice |
+|------|-------|
+| TCP host / TCP client | Works |
+| Netpacket (RetroArch netplay) | Unavailable — no peer address exposed to the core; log once, data-only |
+| Loopback | No peer; local mic monitor still works for a mic check |
+
+Netpacket was rejected for voice: its payloads have no framing today, so
+multiplexing would break wire compat with 3.4.x peers, and the core
+never sees a peer IP to dial a side channel.
+
+## Wire format
+
+Magic **`VJVC`** (distinct from `VJAG` beacons and `VJNG` negotiation).
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 4 | Magic `VJVC` |
+| 4 | 1 | Version (`1`) |
+| 5 | 1 | Flags (`0x01` = keepalive / silence presence) |
+| 6 | 2 | Sequence (big-endian) |
+| 8 | 4 | `senderId` (random per-process; SO_REUSEPORT self-filter) |
+| 12 | 160 | G.711 µ-law payload (20 ms at 8 kHz) |
+
+Total **172 bytes**, far under any practical MTU. `JLinkDiscPoll`'s
+`recvfrom` buffer is enlarged past the 40-byte beacon size so these
+datagrams are not truncated before the raw handler sees them.
+
+## Codec and bandwidth
+
+G.711 µ-law at 8 kHz mono ≈ **8 KB/s** — period-appropriate and matching
+issue #485's stated budget. Encode/decode is a table, not a compressor;
+compression is deferred until bandwidth proves a problem.
+
+Receive path: jitter buffer → 6× upsample to 48 kHz (exact ratio) with
+linear interpolation → saturating add into both channels of
+`sampleBuffer` immediately before `SoundCallback`. `dac.c` is untouched;
+`sampleBuffer` is not in any serialize path.
+
+## Gate modes
+
+Core option `virtualjaguar_voice_chat_gate`:
+
+- **`open_mic`** — full-duplex with a noise-gate / VAD threshold
+  (`virtualjaguar_voice_chat_vad`); works on every frontend including
+  mobile.
+- **`push_to_talk`** — keyboard key via `RETRO_DEVICE_KEYBOARD`
+  (`virtualjaguar_voice_chat_ptt_key`). No RetroPad button is free (all
+  16 map to Jaguar buttons), so PTT is desktop-oriented.
+
+Default for the master switch `virtualjaguar_voice_chat` is **disabled** —
+mic capture must never start unasked.
+
+## Graceful degradation
+
+- Frontend without `RETRO_ENVIRONMENT_GET_MICROPHONE_INTERFACE`, or
+  `open_mic` returning NULL: log once, leave the **receive** path armed
+  so a player with no mic can still hear others; data netplay unchanged.
+- Permission denied / `read_mic` returning -1: treat as silence that
+  frame.
+- Peer without voice chat: datagrams dropped at magic check; data path
+  unaffected.
+
+## Inertness argument
+
+Voice state lives only in host-side buffers (jitter queue, peer address,
+seq counters, mic handle). None of it is written by `JLinkStateSave`,
+UART state, or any JERRY/TOM register path. Mixing into `sampleBuffer`
+happens after `JaguarExecuteNew()` and before `audio_batch_cb`, so the
+emulated machine cannot observe it. The inertness test runs `yarc.j64`
+with voice off then on (synthetic mic + monitor) and requires identical
+per-frame framebuffer hashes and savestate digests at N/2 and N.
+
+## Files
+
+| Path | Role |
+|------|------|
+| `src/jerry/voicechat.c` / `.h` | Codec, framing, jitter, VAD/PTT, mix, peer keepalive |
+| `src/jerry/jlink_discover.c` | Larger `recvfrom` buffer |
+| `src/jerry/jlink.c` | Magic-keyed raw dispatcher (`VJNG` / `VJVC`) |
+| `libretro.c` / `libretro_core_options.h` | Mic iface, options, tick + mix |
+| `test/test_voicechat.c` | Pure-logic unit tests |
+| `test/tools/test_voicechat_inertness.c` | Savestate + fb inertness gate |
+| `test/tools/voicechat_pair_test.sh` | Two-core TCP energy check |
+| `test/harness/harness.c` | Synthetic mic behind `--mic-tone` |

--- a/docs/voice-modem.md
+++ b/docs/voice-modem.md
@@ -206,6 +206,13 @@ modem is rate-agnostic. Modem session state is host-side (like jlink's
 sockets) and deliberately not serialized in savestates: loading a state
 mid-call behaves as a pulled phone line.
 
+**Host-side voice chat** (the JVM's actual selling point — simultaneous
+voice + data) is a separate, opt-in feature that never touches this UART
+protocol or the emulated machine: see `docs/voice-chat-design.md`
+(issue #485). DTMF *tone audio* remains out of scope here and there —
+tones never reached the TV on real hardware; functional DTMF signalling
+(`$8A2n` / `$6800`) is already enough for Ultra Vortek.
+
 ## Troubleshooting a call that never connects
 
 Ultra Vortek prints INITIALIZING VOICE MODEM *before* any reply arrives, so

--- a/libretro.c
+++ b/libretro.c
@@ -1018,6 +1018,7 @@ static retro_microphone_t *vj_mic = NULL;
 static int vj_mic_iface_ok = 0;
 static int vj_mic_unavailable_logged = 0;
 static int vj_voice_want = 0;          /* option asks for voice chat */
+static int vj_voice_monitor = 0;       /* local mic-check mix */
 static int vj_voice_netpacket_logged = 0;
 
 static int voicechat_mic_read(int16_t *samples, size_t num)
@@ -1037,12 +1038,29 @@ static void voicechat_close_mic(void)
 static void voicechat_ensure_mic(void)
 {
    struct retro_microphone_params params;
+   int mode;
+   int can_tx;
 
    if (!vj_voice_want)
    {
       voicechat_close_mic();
       return;
    }
+
+   /* Mic capture only when we can TX to a peer (TCP + discovery) or when
+    * local monitor is on for a mic check. Opening the mic under netplay /
+    * disabled netlink leaves the OS indicator on while we discard samples. */
+   mode = JLinkMode();
+   can_tx = JLinkDiscActive()
+            && (mode == JLINK_MODE_TCP_SERVER
+                || mode == JLINK_MODE_TCP_CLIENT)
+            && !JLinkNPActive();
+   if (!can_tx && !vj_voice_monitor)
+   {
+      voicechat_close_mic();
+      return;
+   }
+
    if (!vj_mic_iface_ok || !vj_mic_iface.open_mic)
    {
       if (!vj_mic_unavailable_logged)
@@ -2531,6 +2549,7 @@ static void check_variables(void)
          mon = 1;
 
       vj_voice_want = want;
+      vj_voice_monitor = mon;
       VoiceChatSetEnabled(want);
       VoiceChatSetGate(gate);
       VoiceChatSetPTTKey(ptt);
@@ -5041,6 +5060,7 @@ void retro_unload_game(void)
    voicechat_close_mic();
    VoiceChatReset();
    vj_voice_want = 0;
+   vj_voice_monitor = 0;
    vj_mic_unavailable_logged = 0;
    vj_voice_netpacket_logged = 0;
    video_buffer_alloc_pixels = VIDEO_BUFFER_PIXELS;
@@ -5301,6 +5321,7 @@ void retro_deinit(void)
    voicechat_close_mic();
    VoiceChatReset();
    vj_voice_want = 0;
+   vj_voice_monitor = 0;
    vj_mic_unavailable_logged = 0;
    vj_voice_netpacket_logged = 0;
    show_voice_chat_opts = true;
@@ -5595,10 +5616,17 @@ void retro_run(void)
    UARTPoll();
 
    /* Host-side voice chat (#485): capture/gate/send. Never touches the
-    * emulated UART. PTT is read from the keyboard device. */
+    * emulated UART. PTT is read from the keyboard device.  Re-evaluate
+    * mic open/close each frame so TCP+discovery becoming ready (or a
+    * netplay session taking over) does not leave the OS mic indicator
+    * stuck on or off. */
    {
       int ptt = 0;
       unsigned key = VoiceChatPTTKey();
+      if (vj_voice_want)
+         voicechat_ensure_mic();
+      else
+         voicechat_close_mic();
       if (VoiceChatEnabled() && key && input_state_cb)
          ptt = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, key) ? 1 : 0;
       VoiceChatFrameTick(ptt);

--- a/libretro.c
+++ b/libretro.c
@@ -38,6 +38,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "jlink.h"
 #include "jlink_discover.h"
 #include "jlink_netpacket.h"
+#include "voicechat.h"
 #include "uart.h"
 #include "joystick.h"
 #include "inputdev.h"
@@ -223,6 +224,9 @@ static bool show_texture_replace   = true;
  * reads them. */
 static bool show_netlink_host      = true;
 static bool show_netlink_port      = true;
+/* Voice-chat dependent options (#485): hidden while the master switch
+ * is off so the network category stays quiet by default. */
+static bool show_voice_chat_opts   = true;
 /* One-shot "push every managed key regardless of its cached show_* prev"
  * flag (task 4, #467).  update_option_visibility() normally only
  * re-pushes SET_CORE_OPTIONS_DISPLAY for a group when that group's
@@ -959,6 +963,37 @@ static bool update_option_visibility(void)
       }
    }
 
+   /* Voice chat dependent options (#485): hide the sub-keys while the
+    * master switch is off. */
+   {
+      static const char * const voice_keys[] = {
+         "virtualjaguar_voice_chat_gate",
+         "virtualjaguar_voice_chat_ptt_key",
+         "virtualjaguar_voice_chat_volume",
+         "virtualjaguar_voice_chat_vad",
+         "virtualjaguar_voice_chat_monitor",
+      };
+      bool show_voice_prev = show_voice_chat_opts;
+
+      var.key = "virtualjaguar_voice_chat";
+      var.value = NULL;
+      environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var);
+      show_voice_chat_opts = (var.value
+                              && strcmp(var.value, "enabled") == 0);
+
+      if (force || show_voice_chat_opts != show_voice_prev)
+      {
+         option_display.visible = show_voice_chat_opts;
+         for (i = 0; i < ARRAY_SIZE(voice_keys); i++)
+         {
+            option_display.key = voice_keys[i];
+            environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY,
+                       &option_display);
+         }
+         updated = true;
+      }
+   }
+
    return updated;
 }
 
@@ -976,6 +1011,83 @@ static const struct retro_netpacket_callback netpacket_cb = {
    NULL,                /* disconnected */
    "vjag-netlink-1"     /* protocol_version */
 };
+
+/* ---- Voice chat (#485): frontend mic + host-side mix ------------------- */
+static struct retro_microphone_interface vj_mic_iface;
+static retro_microphone_t *vj_mic = NULL;
+static int vj_mic_iface_ok = 0;
+static int vj_mic_unavailable_logged = 0;
+static int vj_voice_want = 0;          /* option asks for voice chat */
+static int vj_voice_netpacket_logged = 0;
+
+static int voicechat_mic_read(int16_t *samples, size_t num)
+{
+   if (!vj_mic || !vj_mic_iface.read_mic)
+      return -1;
+   return vj_mic_iface.read_mic(vj_mic, samples, num);
+}
+
+static void voicechat_close_mic(void)
+{
+   if (vj_mic && vj_mic_iface.close_mic)
+      vj_mic_iface.close_mic(vj_mic);
+   vj_mic = NULL;
+}
+
+static void voicechat_ensure_mic(void)
+{
+   struct retro_microphone_params params;
+
+   if (!vj_voice_want)
+   {
+      voicechat_close_mic();
+      return;
+   }
+   if (!vj_mic_iface_ok || !vj_mic_iface.open_mic)
+   {
+      if (!vj_mic_unavailable_logged)
+      {
+         LOG_INF("[VOICE] microphone interface unavailable -- "
+                 "receive-only voice chat (data netplay unchanged)\n");
+         vj_mic_unavailable_logged = 1;
+      }
+      return;
+   }
+   if (vj_mic)
+      return;
+
+   params.rate = VC_RATE_HZ;
+   vj_mic = vj_mic_iface.open_mic(&params);
+   if (!vj_mic)
+   {
+      if (!vj_mic_unavailable_logged)
+      {
+         LOG_INF("[VOICE] open_mic failed -- receive-only voice chat\n");
+         vj_mic_unavailable_logged = 1;
+      }
+      return;
+   }
+   if (vj_mic_iface.set_mic_state)
+      vj_mic_iface.set_mic_state(vj_mic, true);
+   VoiceChatSetMicRead(voicechat_mic_read);
+}
+
+static unsigned voicechat_ptt_key_from_str(const char *s)
+{
+   if (!s)
+      return RETROK_v;
+   if (!strcmp(s, "c"))
+      return RETROK_c;
+   if (!strcmp(s, "space"))
+      return RETROK_SPACE;
+   if (!strcmp(s, "tab"))
+      return RETROK_TAB;
+   if (!strcmp(s, "lctrl"))
+      return RETROK_LCTRL;
+   if (!strcmp(s, "grave"))
+      return RETROK_BACKQUOTE;
+   return RETROK_v;
+}
 
 void retro_set_environment(retro_environment_t cb)
 {
@@ -1004,6 +1116,16 @@ void retro_set_environment(retro_environment_t cb)
    vfs_iface_info.iface                      = NULL;
    if (cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
       filestream_vfs_init(&vfs_iface_info);
+
+   /* Microphone interface (#485): experimental env 75. Failure is
+    * non-fatal -- voice stays receive-capable / data-only. */
+   memset(&vj_mic_iface, 0, sizeof(vj_mic_iface));
+   vj_mic_iface.interface_version = RETRO_MICROPHONE_INTERFACE_VERSION;
+   vj_mic_iface_ok = 0;
+   if (cb(RETRO_ENVIRONMENT_GET_MICROPHONE_INTERFACE, &vj_mic_iface)
+       && vj_mic_iface.interface_version > 0
+       && vj_mic_iface.open_mic)
+      vj_mic_iface_ok = 1;
 
    environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS, &achievements);
 
@@ -2365,6 +2487,77 @@ static void check_variables(void)
       netlink_apply(netlink_resolve_mode(var.value), var.value);
    else
       netlink_apply(JLINK_MODE_DISABLED, NULL);
+
+   /* Voice chat (#485): host-side, out-of-band. Default off. */
+   {
+      int want = 0;
+      int gate = VC_GATE_OPEN_MIC;
+      unsigned vol = 50;
+      unsigned vad = 400;
+      int mon = 0;
+      unsigned ptt = RETROK_v;
+
+      var.key = "virtualjaguar_voice_chat";
+      var.value = NULL;
+      if (get_variable_pertitle(&var) && var.value
+          && strcmp(var.value, "enabled") == 0)
+         want = 1;
+
+      var.key = "virtualjaguar_voice_chat_gate";
+      var.value = NULL;
+      if (get_variable_pertitle(&var) && var.value
+          && strcmp(var.value, "push_to_talk") == 0)
+         gate = VC_GATE_PTT;
+
+      var.key = "virtualjaguar_voice_chat_ptt_key";
+      var.value = NULL;
+      if (get_variable_pertitle(&var) && var.value)
+         ptt = voicechat_ptt_key_from_str(var.value);
+
+      var.key = "virtualjaguar_voice_chat_volume";
+      var.value = NULL;
+      if (get_variable_pertitle(&var) && var.value)
+         vol = (unsigned)atoi(var.value);
+
+      var.key = "virtualjaguar_voice_chat_vad";
+      var.value = NULL;
+      if (get_variable_pertitle(&var) && var.value)
+         vad = (unsigned)atoi(var.value);
+
+      var.key = "virtualjaguar_voice_chat_monitor";
+      var.value = NULL;
+      if (get_variable_pertitle(&var) && var.value
+          && strcmp(var.value, "enabled") == 0)
+         mon = 1;
+
+      vj_voice_want = want;
+      VoiceChatSetEnabled(want);
+      VoiceChatSetGate(gate);
+      VoiceChatSetPTTKey(ptt);
+      VoiceChatSetVolume(vol);
+      VoiceChatSetVadThreshold(vad);
+      VoiceChatSetMonitor(mon);
+      VoiceChatSetMicRead(voicechat_mic_read);
+
+      if (want
+          && (JLinkMode() == JLINK_MODE_NETPACKET
+              || JLinkNPActive()))
+      {
+         if (!vj_voice_netpacket_logged)
+         {
+            LOG_INF("[VOICE] unavailable under RetroArch netplay "
+                    "(no peer address) -- data-only\n");
+            vj_voice_netpacket_logged = 1;
+         }
+      }
+      else
+         vj_voice_netpacket_logged = 0;
+
+      if (want)
+         voicechat_ensure_mic();
+      else
+         voicechat_close_mic();
+   }
 
    var.key = "virtualjaguar_bios";
    var.value = NULL;
@@ -4844,6 +5037,12 @@ void retro_unload_game(void)
     * and log the session summary; the next load's check_variables() +
     * TexReplaceContentLoaded() reload if the option is still on. */
    TexReplaceShutdown();
+   /* Voice chat (#485): close mic and clear host-side buffers. */
+   voicechat_close_mic();
+   VoiceChatReset();
+   vj_voice_want = 0;
+   vj_mic_unavailable_logged = 0;
+   vj_voice_netpacket_logged = 0;
    video_buffer_alloc_pixels = VIDEO_BUFFER_PIXELS;
    hires_restart_notice_logged = 0;
 
@@ -5099,6 +5298,12 @@ void retro_deinit(void)
    /* Texture replacement (#369): free the pack map, reset every static. */
    TexReplaceShutdown();
    show_texture_replace = true;
+   voicechat_close_mic();
+   VoiceChatReset();
+   vj_voice_want = 0;
+   vj_mic_unavailable_logged = 0;
+   vj_voice_netpacket_logged = 0;
+   show_voice_chat_opts = true;
    /* Non-pad input devices: encoders, phases, attach mask, armed flag and
     * the option-derived type/scale all go back to their load-time values
     * (iOS cannot dlclose a core). */
@@ -5389,6 +5594,16 @@ void retro_run(void)
    JLinkPoll();
    UARTPoll();
 
+   /* Host-side voice chat (#485): capture/gate/send. Never touches the
+    * emulated UART. PTT is read from the keyboard device. */
+   {
+      int ptt = 0;
+      unsigned key = VoiceChatPTTKey();
+      if (VoiceChatEnabled() && key && input_state_cb)
+         ptt = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, key) ? 1 : 0;
+      VoiceChatFrameTick(ptt);
+   }
+
    /* Log link up/down edges.  JLinkConnected() already abstracts TCP and
     * netpacket, so this reports the one fact a user debugging "it says it
     * has a modem but won't dial" needs and previously could not get from
@@ -5487,6 +5702,13 @@ void retro_run(void)
    DACPrepareFrame(vjs.hardwareTypeNTSC == 1 ? BUFNTSC : BUFPAL);
    JaguarExecuteNew();
    cheat_apply_all();
+   /* Mix far-end voice into sampleBuffer after emulation, before the
+    * frontend batch submit -- dac.c untouched; not in any savestate. */
+   {
+      unsigned pairs = (unsigned)((vjs.hardwareTypeNTSC == 1 ? BUFNTSC
+                                                            : BUFPAL) / 2);
+      VoiceChatMixInto(sampleBuffer, pairs);
+   }
    SoundCallback(NULL, sampleBuffer, vjs.hardwareTypeNTSC == 1 ? BUFNTSC : BUFPAL);
 
    /* Give every presented row defined content.

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -408,6 +408,98 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "virtualjaguar_voice_chat",
+      "Voice Chat (Host-Side)",
+      NULL,
+      "Opt-in voice channel over the Network Link discovery socket -- the Jaguar Voice Modem's real selling point of simultaneous voice + data. This is NOT emulation: voice never entered the Jaguar; the console only issued audio-path control words. Capture uses the frontend microphone API when available. Default off so mic capture never starts unasked. Requires Network Link in TCP Host or TCP Client mode (unavailable under RetroArch netplay -- no peer address is exposed to the core). See docs/voice-chat-design.md.",
+      NULL,
+      "network",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "virtualjaguar_voice_chat_gate",
+      "Voice Chat Transmit Gate",
+      NULL,
+      "'Open mic' transmits whenever the mic energy exceeds the VAD threshold (works on every frontend including mobile). 'Push to talk' transmits only while the configured keyboard key is held (desktop-oriented -- no RetroPad button is free).",
+      NULL,
+      "network",
+      {
+         { "open_mic",     "Open mic (VAD)" },
+         { "push_to_talk", "Push to talk (keyboard)" },
+         { NULL, NULL },
+      },
+      "open_mic"
+   },
+   {
+      "virtualjaguar_voice_chat_ptt_key",
+      "Voice Chat Push-to-Talk Key",
+      NULL,
+      "Keyboard key that opens the mic in Push-to-talk mode. Keys already claimed by the Jaguar keypad mapping are omitted.",
+      NULL,
+      "network",
+      {
+         { "v",     "V" },
+         { "c",     "C" },
+         { "space", "Space" },
+         { "tab",   "Tab" },
+         { "lctrl", "Left Ctrl" },
+         { "grave", "Backquote (`)" },
+         { NULL, NULL },
+      },
+      "v"
+   },
+   {
+      "virtualjaguar_voice_chat_volume",
+      "Voice Chat Volume",
+      NULL,
+      "Far-end (and optional local monitor) mix level into the game audio. Kept conservative by default so voice does not clip the DAC mix.",
+      NULL,
+      "network",
+      {
+         { "25",  "25%" },
+         { "50",  "50%" },
+         { "75",  "75%" },
+         { "100", "100%" },
+         { NULL, NULL },
+      },
+      "50"
+   },
+   {
+      "virtualjaguar_voice_chat_vad",
+      "Voice Chat VAD Threshold",
+      NULL,
+      "Absolute-average energy gate for Open-mic mode. Raise if background noise keys the mic; lower if soft speech is cut off.",
+      NULL,
+      "network",
+      {
+         { "200",  "Low (200)" },
+         { "400",  "Medium (400)" },
+         { "800",  "High (800)" },
+         { "1600", "Very high (1600)" },
+         { NULL, NULL },
+      },
+      "400"
+   },
+   {
+      "virtualjaguar_voice_chat_monitor",
+      "Voice Chat Local Monitor",
+      NULL,
+      "Mix your own mic into the local audio output for a mic check. Does not change what is sent to the peer.",
+      NULL,
+      "network",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "virtualjaguar_cd_trace",
       "CD Trace (Diagnostic)",
       NULL,

--- a/src/jerry/jlink.c
+++ b/src/jerry/jlink.c
@@ -12,6 +12,7 @@
 #include "jlink_netpacket.h"
 #include "jlink_discover.h"
 #include "voicemodem.h"
+#include "voicechat.h"
 #include "state.h"
 #include "uart.h"   /* UARTWireSpeedupIntent/UARTSetWireSpeedupEffective (#552) */
 
@@ -548,6 +549,28 @@ static void JLinkNegOnRaw(const uint8_t *buf, size_t len,
       JLinkDiscSendTo(out, n, from_addr, from_port);
 }
 
+/* Magic-keyed dispatcher for every non-beacon datagram on the discovery
+   socket: VJNG -> wire-speed negotiation (#552), VJVC -> voice chat
+   (#485).  Unknown magics are ignored (same as a hostile packet). */
+static void JLinkDiscRawDispatch(const uint8_t *buf, size_t len,
+                                 const char *from_addr, int from_port)
+{
+   if (!buf || len < 4)
+      return;
+   if (buf[0] == JLINK_NEG_MAGIC_0 && buf[1] == JLINK_NEG_MAGIC_1
+       && buf[2] == JLINK_NEG_MAGIC_2 && buf[3] == JLINK_NEG_MAGIC_3)
+   {
+      JLinkNegOnRaw(buf, len, from_addr, from_port);
+      return;
+   }
+   if (buf[0] == VC_MAGIC_0 && buf[1] == VC_MAGIC_1
+       && buf[2] == VC_MAGIC_2 && buf[3] == VC_MAGIC_3)
+   {
+      VoiceChatOnRaw(buf, len, from_addr, from_port);
+      return;
+   }
+}
+
 /* Called every JLinkFrameTick -- reconciles negotiation state against
    the CURRENT connection every frame (not once at connect) so a state
    load, an option toggle, or a peer disconnect all take effect on the
@@ -585,7 +608,7 @@ static void JLinkNegTick(uint32_t nowMs)
       }
    }
 
-   JLinkDiscSetRawHandler(JLinkNegOnRaw);
+   JLinkDiscSetRawHandler(JLinkDiscRawDispatch);
 
    if (!JLinkNegEligible() || !connected)
    {

--- a/src/jerry/jlink_discover.c
+++ b/src/jerry/jlink_discover.c
@@ -347,7 +347,11 @@ int JLinkDiscActive(void)
 
 int JLinkDiscPoll(uint32_t now_ms)
 {
-   uint8_t  pkt[JLINK_DISC_PKT_LEN];
+   /* Buffer must fit voice-chat datagrams (VC_PKT_LEN=172) as well as
+    * 40-byte beacons and 12-byte negotiation packets.  Beacons still
+    * decode only at exact JLINK_DISC_PKT_LEN; oversized datagrams reach
+    * the raw handler whole instead of being silently truncated. */
+   uint8_t  pkt[256];
    struct sockaddr_in from;
    char     addr[JLINK_DISC_ADDR_MAX];
    char     name[JLINK_DISC_NAME_MAX];
@@ -385,7 +389,7 @@ int JLinkDiscPoll(uint32_t now_ms)
       if (!JLinkDiscDecode(pkt, (size_t)n, &dev, &port, name, sizeof(name)))
       {
          /* Not a beacon -- offer it to a registered second protocol
-            (#552) before dropping it, exactly like an out-of-spec or
+            (#552 / #485) before dropping it, exactly like an out-of-spec or
             hostile packet always has been dropped here. */
          if (discRawHandler)
          {

--- a/src/jerry/voicechat.c
+++ b/src/jerry/voicechat.c
@@ -1,0 +1,546 @@
+/* voicechat.c — host-side voice over the discovery UDP socket (#485).
+ *
+ * Never touches jlinkRing / UART / savestate. See docs/voice-chat-design.md.
+ */
+#include "voicechat.h"
+#include "jlink.h"
+#include "jlink_discover.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+#define VC_JITTER_FRAMES   8
+#define VC_JITTER_SAMPLES  (VC_JITTER_FRAMES * VC_FRAME_SAMPLES)
+#define VC_KEEPALIVE_MS    500
+#define VC_VAD_HANG_FRAMES 8
+#define VC_MIC_PULL_MAX    320   /* up to 40 ms of 8 kHz per video frame */
+
+static int vcEnabled = 0;
+static int vcGate = VC_GATE_OPEN_MIC;
+static unsigned vcPttKey = 0;
+static unsigned vcVolume = 50;
+static unsigned vcVadThresh = 400;
+static int vcMonitor = 0;
+static VoiceChatMicReadFn vcMicRead = NULL;
+
+static uint32_t vcSenderId = 0;
+static int vcSenderIdReady = 0;
+static uint16_t vcTxSeq = 0;
+static char vcPeerAddr[VC_PEER_ADDR_MAX];
+static uint32_t vcLastKeepaliveMs = 0;
+
+static int16_t vcJitter[VC_JITTER_SAMPLES];
+static unsigned vcJitHead = 0;
+static unsigned vcJitCount = 0;
+static uint16_t vcJitExpectSeq = 0;
+static int vcJitHaveExpect = 0;
+
+static int16_t vcMonRing[VC_FRAME_SAMPLES];
+static unsigned vcMonCount = 0;
+
+static int vcVadOpen = 0;
+static unsigned vcVadHang = 0;
+
+static int16_t vcMicAccum[VC_FRAME_SAMPLES];
+static unsigned vcMicAccumN = 0;
+
+/* ---- µ-law (ITU-T G.711) --------------------------------------------- */
+
+uint8_t VoiceChatMuLawEncode(int16_t pcm)
+{
+   int sign, exp, mantissa;
+   unsigned mag;
+   unsigned mask;
+   int sample = pcm;
+
+   sign = (sample >> 8) & 0x80;
+   if (sign)
+      sample = -sample;
+   if (sample > 32635)
+      sample = 32635;
+   sample += 0x84;
+   mag = (unsigned)sample;
+   mask = 0x4000;
+   exp = 7;
+   while (exp > 0)
+   {
+      if (mag & mask)
+         break;
+      mask >>= 1;
+      exp--;
+   }
+   mantissa = (int)((mag >> (exp + 3)) & 0x0F);
+   return (uint8_t)(~(sign | (exp << 4) | mantissa));
+}
+
+int16_t VoiceChatMuLawDecode(uint8_t mulaw)
+{
+   int sign, exp, data;
+   int sample;
+
+   mulaw = (uint8_t)~mulaw;
+   sign = mulaw & 0x80;
+   exp = (mulaw >> 4) & 0x07;
+   data = mulaw & 0x0F;
+   sample = ((data << 3) + 0x84) << exp;
+   sample -= 0x84;
+   return (int16_t)(sign ? -sample : sample);
+}
+
+/* ---- Packet codec ---------------------------------------------------- */
+
+size_t VoiceChatEncodePkt(uint8_t *buf, size_t cap,
+                          uint8_t flags, uint16_t seq, uint32_t senderId,
+                          const uint8_t mulaw[VC_FRAME_SAMPLES])
+{
+   if (!buf || cap < VC_PKT_LEN || !mulaw)
+      return 0;
+   buf[0] = VC_MAGIC_0;
+   buf[1] = VC_MAGIC_1;
+   buf[2] = VC_MAGIC_2;
+   buf[3] = VC_MAGIC_3;
+   buf[4] = VC_VERSION;
+   buf[5] = flags;
+   buf[6] = (uint8_t)((seq >> 8) & 0xFF);
+   buf[7] = (uint8_t)(seq & 0xFF);
+   buf[8] = (uint8_t)((senderId >> 24) & 0xFF);
+   buf[9] = (uint8_t)((senderId >> 16) & 0xFF);
+   buf[10] = (uint8_t)((senderId >> 8) & 0xFF);
+   buf[11] = (uint8_t)(senderId & 0xFF);
+   memcpy(buf + VC_HDR_LEN, mulaw, VC_FRAME_SAMPLES);
+   return VC_PKT_LEN;
+}
+
+int VoiceChatDecodePkt(const uint8_t *buf, size_t len,
+                       uint8_t *flags, uint16_t *seq, uint32_t *senderId,
+                       uint8_t mulaw[VC_FRAME_SAMPLES])
+{
+   if (!buf || len != VC_PKT_LEN)
+      return 0;
+   if (buf[0] != VC_MAGIC_0 || buf[1] != VC_MAGIC_1
+       || buf[2] != VC_MAGIC_2 || buf[3] != VC_MAGIC_3)
+      return 0;
+   if (buf[4] != VC_VERSION)
+      return 0;
+   if (flags)
+      *flags = buf[5];
+   if (seq)
+      *seq = (uint16_t)(((uint16_t)buf[6] << 8) | buf[7]);
+   if (senderId)
+      *senderId = ((uint32_t)buf[8] << 24) | ((uint32_t)buf[9] << 16)
+                | ((uint32_t)buf[10] << 8) | (uint32_t)buf[11];
+   if (mulaw)
+      memcpy(mulaw, buf + VC_HDR_LEN, VC_FRAME_SAMPLES);
+   return 1;
+}
+
+unsigned VoiceChatFrameEnergy(const int16_t *pcm, unsigned n)
+{
+   unsigned i;
+   unsigned long sum = 0;
+
+   if (!pcm || n == 0)
+      return 0;
+   for (i = 0; i < n; i++)
+   {
+      int v = pcm[i];
+      if (v < 0)
+         v = -v;
+      sum += (unsigned)v;
+   }
+   return (unsigned)(sum / n);
+}
+
+/* ---- Config ---------------------------------------------------------- */
+
+static uint32_t VoiceChatEnsureSenderId(void)
+{
+   if (!vcSenderIdReady)
+   {
+      srand((unsigned)(JLinkNowMs() ^ (uint32_t)(size_t)&vcSenderId));
+      vcSenderId = ((uint32_t)rand() << 16) ^ (uint32_t)rand();
+      if (vcSenderId == 0)
+         vcSenderId = 1;
+      vcSenderIdReady = 1;
+   }
+   return vcSenderId;
+}
+
+void VoiceChatReset(void)
+{
+   vcEnabled = 0;
+   vcGate = VC_GATE_OPEN_MIC;
+   vcPttKey = 0;
+   vcVolume = 50;
+   vcVadThresh = 400;
+   vcMonitor = 0;
+   vcMicRead = NULL;
+   vcSenderId = 0;
+   vcSenderIdReady = 0;
+   vcTxSeq = 0;
+   vcPeerAddr[0] = '\0';
+   vcLastKeepaliveMs = 0;
+   vcJitHead = 0;
+   vcJitCount = 0;
+   vcJitExpectSeq = 0;
+   vcJitHaveExpect = 0;
+   vcMonCount = 0;
+   vcVadOpen = 0;
+   vcVadHang = 0;
+   vcMicAccumN = 0;
+   memset(vcJitter, 0, sizeof(vcJitter));
+   memset(vcMonRing, 0, sizeof(vcMonRing));
+   memset(vcMicAccum, 0, sizeof(vcMicAccum));
+}
+
+void VoiceChatSetEnabled(int enabled)
+{
+   vcEnabled = enabled ? 1 : 0;
+   if (!vcEnabled)
+   {
+      vcJitHead = 0;
+      vcJitCount = 0;
+      vcJitHaveExpect = 0;
+      vcMicAccumN = 0;
+      vcMonCount = 0;
+      vcVadOpen = 0;
+      vcVadHang = 0;
+   }
+}
+
+int VoiceChatEnabled(void)
+{
+   return vcEnabled;
+}
+
+void VoiceChatSetGate(int gate)
+{
+   vcGate = (gate == VC_GATE_PTT) ? VC_GATE_PTT : VC_GATE_OPEN_MIC;
+}
+
+void VoiceChatSetPTTKey(unsigned retrok)
+{
+   vcPttKey = retrok;
+}
+
+unsigned VoiceChatPTTKey(void)
+{
+   return vcPttKey;
+}
+
+void VoiceChatSetVolume(unsigned pct)
+{
+   if (pct > 100)
+      pct = 100;
+   vcVolume = pct;
+}
+
+void VoiceChatSetVadThreshold(unsigned thresh)
+{
+   vcVadThresh = thresh;
+}
+
+void VoiceChatSetMonitor(int enabled)
+{
+   vcMonitor = enabled ? 1 : 0;
+}
+
+void VoiceChatSetMicRead(VoiceChatMicReadFn fn)
+{
+   vcMicRead = fn;
+}
+
+void VoiceChatSetSenderId(uint32_t id)
+{
+   vcSenderId = id ? id : 1;
+   vcSenderIdReady = 1;
+}
+
+void VoiceChatSetPeerAddr(const char *addr)
+{
+   if (!addr || !addr[0])
+   {
+      vcPeerAddr[0] = '\0';
+      return;
+   }
+   strncpy(vcPeerAddr, addr, VC_PEER_ADDR_MAX - 1);
+   vcPeerAddr[VC_PEER_ADDR_MAX - 1] = '\0';
+}
+
+const char *VoiceChatPeerAddr(void)
+{
+   return vcPeerAddr;
+}
+
+/* ---- Jitter buffer --------------------------------------------------- */
+
+void VoiceChatJitterPush(const int16_t pcm[VC_FRAME_SAMPLES], uint16_t seq)
+{
+   unsigned i;
+
+   if (!pcm)
+      return;
+
+   /* Drop late / duplicate: if we already have an expectation and this
+    * seq is older than expect (wrapping-aware half-window), skip. */
+   if (vcJitHaveExpect)
+   {
+      int16_t delta = (int16_t)(seq - vcJitExpectSeq);
+      if (delta < 0)
+         return;
+      /* Fill gaps with silence so MixInto stays continuous. */
+      while (delta > 0 && vcJitCount + VC_FRAME_SAMPLES <= VC_JITTER_SAMPLES)
+      {
+         for (i = 0; i < VC_FRAME_SAMPLES; i++)
+         {
+            unsigned idx = (vcJitHead + vcJitCount) % VC_JITTER_SAMPLES;
+            vcJitter[idx] = 0;
+            vcJitCount++;
+         }
+         vcJitExpectSeq++;
+         delta--;
+      }
+   }
+
+   if (vcJitCount + VC_FRAME_SAMPLES > VC_JITTER_SAMPLES)
+   {
+      /* Overflow: drop oldest frame. */
+      vcJitHead = (vcJitHead + VC_FRAME_SAMPLES) % VC_JITTER_SAMPLES;
+      vcJitCount -= VC_FRAME_SAMPLES;
+   }
+
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+   {
+      unsigned idx = (vcJitHead + vcJitCount) % VC_JITTER_SAMPLES;
+      vcJitter[idx] = pcm[i];
+      vcJitCount++;
+   }
+   vcJitExpectSeq = (uint16_t)(seq + 1);
+   vcJitHaveExpect = 1;
+}
+
+int VoiceChatJitterPop(int16_t *out)
+{
+   if (vcJitCount == 0 || !out)
+      return 0;
+   *out = vcJitter[vcJitHead];
+   vcJitHead = (vcJitHead + 1) % VC_JITTER_SAMPLES;
+   vcJitCount--;
+   return 1;
+}
+
+unsigned VoiceChatJitterCount(void)
+{
+   return vcJitCount;
+}
+
+/* ---- TX helpers ------------------------------------------------------ */
+
+static void VoiceChatSendFrame(uint8_t flags, const int16_t pcm[VC_FRAME_SAMPLES])
+{
+   uint8_t mulaw[VC_FRAME_SAMPLES];
+   uint8_t pkt[VC_PKT_LEN];
+   size_t n;
+   unsigned i;
+   const char *peer;
+
+   if (!pcm)
+      return;
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+      mulaw[i] = VoiceChatMuLawEncode(pcm[i]);
+
+   n = VoiceChatEncodePkt(pkt, sizeof(pkt), flags, vcTxSeq,
+                          VoiceChatEnsureSenderId(), mulaw);
+   vcTxSeq++;
+   if (!n)
+      return;
+
+   peer = vcPeerAddr;
+   if (!peer[0] && JLinkMode() == JLINK_MODE_TCP_CLIENT)
+      peer = JLinkGetTCPHost();
+   if (!peer || !peer[0])
+      return;
+   if (!JLinkDiscActive())
+      return;
+   JLinkDiscSendTo(pkt, n, peer, JLinkDiscPort());
+}
+
+static int VoiceChatGateOpen(int ptt_down, unsigned energy)
+{
+   if (vcGate == VC_GATE_PTT)
+      return ptt_down ? 1 : 0;
+
+   if (energy >= vcVadThresh)
+   {
+      vcVadOpen = 1;
+      vcVadHang = VC_VAD_HANG_FRAMES;
+      return 1;
+   }
+   if (vcVadHang > 0)
+   {
+      vcVadHang--;
+      return 1;
+   }
+   vcVadOpen = 0;
+   return 0;
+}
+
+static void VoiceChatProcessMicFrame(const int16_t pcm[VC_FRAME_SAMPLES],
+                                     int ptt_down)
+{
+   unsigned energy;
+   int open;
+   unsigned i;
+
+   energy = VoiceChatFrameEnergy(pcm, VC_FRAME_SAMPLES);
+   open = VoiceChatGateOpen(ptt_down, energy);
+
+   if (vcMonitor)
+   {
+      for (i = 0; i < VC_FRAME_SAMPLES; i++)
+         vcMonRing[i] = pcm[i];
+      vcMonCount = VC_FRAME_SAMPLES;
+   }
+
+   if (open)
+      VoiceChatSendFrame(0, pcm);
+}
+
+/* ---- Per-frame / wire ------------------------------------------------ */
+
+void VoiceChatFrameTick(int ptt_down)
+{
+   int16_t pull[VC_MIC_PULL_MAX];
+   int got;
+   unsigned i;
+   uint32_t now;
+   int16_t silence[VC_FRAME_SAMPLES];
+
+   if (!vcEnabled)
+      return;
+
+   /* Seed peer from TCP client host when discovery is up. */
+   if (!vcPeerAddr[0] && JLinkMode() == JLINK_MODE_TCP_CLIENT
+       && JLinkGetTCPHost() && JLinkGetTCPHost()[0])
+      VoiceChatSetPeerAddr(JLinkGetTCPHost());
+
+   if (vcMicRead)
+   {
+      got = vcMicRead(pull, VC_MIC_PULL_MAX);
+      if (got > 0)
+      {
+         for (i = 0; i < (unsigned)got; i++)
+         {
+            vcMicAccum[vcMicAccumN++] = pull[i];
+            if (vcMicAccumN >= VC_FRAME_SAMPLES)
+            {
+               VoiceChatProcessMicFrame(vcMicAccum, ptt_down);
+               vcMicAccumN = 0;
+            }
+         }
+      }
+   }
+
+   /* Presence keepalive so a TCP server learns the client address even
+    * when the gate is closed. */
+   now = JLinkNowMs();
+   if (JLinkDiscActive()
+       && (JLinkMode() == JLINK_MODE_TCP_CLIENT
+           || JLinkMode() == JLINK_MODE_TCP_SERVER)
+       && (vcLastKeepaliveMs == 0
+           || (uint32_t)(now - vcLastKeepaliveMs) >= VC_KEEPALIVE_MS))
+   {
+      memset(silence, 0, sizeof(silence));
+      VoiceChatSendFrame(VC_FLAG_KEEPALIVE, silence);
+      vcLastKeepaliveMs = now;
+   }
+}
+
+void VoiceChatOnRaw(const uint8_t *buf, size_t len,
+                    const char *from_addr, int from_port)
+{
+   uint8_t flags;
+   uint16_t seq;
+   uint32_t senderId;
+   uint8_t mulaw[VC_FRAME_SAMPLES];
+   int16_t pcm[VC_FRAME_SAMPLES];
+   unsigned i;
+
+   (void)from_port;
+
+   if (!vcEnabled)
+      return;
+   if (!VoiceChatDecodePkt(buf, len, &flags, &seq, &senderId, mulaw))
+      return;
+   if (senderId == VoiceChatEnsureSenderId())
+      return; /* own packet looped via SO_REUSEPORT */
+
+   if (from_addr && from_addr[0])
+      VoiceChatSetPeerAddr(from_addr);
+
+   if (flags & VC_FLAG_KEEPALIVE)
+      return; /* presence only */
+
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+      pcm[i] = VoiceChatMuLawDecode(mulaw[i]);
+   VoiceChatJitterPush(pcm, seq);
+}
+
+void VoiceChatMixInto(uint16_t *buf, unsigned pairs)
+{
+   unsigned i;
+   int vol;
+   int mixed;
+   int16_t *stereo;
+   int left, right;
+   int16_t holdFar;
+   int16_t holdMon;
+   unsigned monIdx;
+
+   if (!vcEnabled || !buf || pairs == 0)
+      return;
+   if (vcVolume == 0 && !vcMonitor)
+      return;
+
+   vol = (int)vcVolume;
+   stereo = (int16_t *)buf;
+   holdFar = 0;
+   holdMon = 0;
+   monIdx = 0;
+
+   for (i = 0; i < pairs; i++)
+   {
+      /* 6× upsample: one 8 kHz sample every VC_UPSAMPLE output pairs. */
+      if ((i % VC_UPSAMPLE) == 0)
+      {
+         if (!VoiceChatJitterPop(&holdFar))
+            holdFar = 0;
+         if (vcMonitor && monIdx < vcMonCount)
+         {
+            holdMon = vcMonRing[monIdx];
+            monIdx++;
+         }
+         else
+            holdMon = 0;
+      }
+
+      mixed = ((int)holdFar * vol) / 100;
+      if (vcMonitor)
+         mixed += ((int)holdMon * vol) / 100;
+
+      left = (int)stereo[i * 2 + 0] + mixed;
+      right = (int)stereo[i * 2 + 1] + mixed;
+      if (left > 32767)
+         left = 32767;
+      if (left < -32768)
+         left = -32768;
+      if (right > 32767)
+         right = 32767;
+      if (right < -32768)
+         right = -32768;
+      stereo[i * 2 + 0] = (int16_t)left;
+      stereo[i * 2 + 1] = (int16_t)right;
+   }
+   if (vcMonitor)
+      vcMonCount = 0;
+}

--- a/src/jerry/voicechat.c
+++ b/src/jerry/voicechat.c
@@ -7,7 +7,6 @@
 #include "jlink_discover.h"
 
 #include <string.h>
-#include <stdlib.h>
 
 #define VC_JITTER_FRAMES   8
 #define VC_JITTER_SAMPLES  (VC_JITTER_FRAMES * VC_FRAME_SAMPLES)
@@ -28,6 +27,7 @@ static int vcSenderIdReady = 0;
 static uint16_t vcTxSeq = 0;
 static char vcPeerAddr[VC_PEER_ADDR_MAX];
 static uint32_t vcLastKeepaliveMs = 0;
+static uint32_t vcLastVoiceMs = 0;
 
 static int16_t vcJitter[VC_JITTER_SAMPLES];
 static unsigned vcJitHead = 0;
@@ -153,14 +153,19 @@ unsigned VoiceChatFrameEnergy(const int16_t *pcm, unsigned n)
 
 /* ---- Config ---------------------------------------------------------- */
 
+/* Local xorshift32 — never touch the process-global C PRNG (srand/rand),
+ * which the rest of the core / frontend may use for anything observable. */
 static uint32_t VoiceChatEnsureSenderId(void)
 {
    if (!vcSenderIdReady)
    {
-      srand((unsigned)(JLinkNowMs() ^ (uint32_t)(size_t)&vcSenderId));
-      vcSenderId = ((uint32_t)rand() << 16) ^ (uint32_t)rand();
-      if (vcSenderId == 0)
-         vcSenderId = 1;
+      uint32_t x = JLinkNowMs() ^ (uint32_t)(size_t)&vcSenderId;
+      if (x == 0)
+         x = 0xA5A5A5A5u;
+      x ^= x << 13;
+      x ^= x >> 17;
+      x ^= x << 5;
+      vcSenderId = x ? x : 1u;
       vcSenderIdReady = 1;
    }
    return vcSenderId;
@@ -180,6 +185,7 @@ void VoiceChatReset(void)
    vcTxSeq = 0;
    vcPeerAddr[0] = '\0';
    vcLastKeepaliveMs = 0;
+   vcLastVoiceMs = 0;
    vcJitHead = 0;
    vcJitCount = 0;
    vcJitExpectSeq = 0;
@@ -343,15 +349,25 @@ static void VoiceChatSendFrame(uint8_t flags, const int16_t pcm[VC_FRAME_SAMPLES
    size_t n;
    unsigned i;
    const char *peer;
+   uint16_t seq;
+   int isKeepalive;
 
    if (!pcm)
       return;
    for (i = 0; i < VC_FRAME_SAMPLES; i++)
       mulaw[i] = VoiceChatMuLawEncode(pcm[i]);
 
-   n = VoiceChatEncodePkt(pkt, sizeof(pkt), flags, vcTxSeq,
+   /* Keepalives must NOT consume the voice sequence: the receiver drops
+    * them before VoiceChatJitterPush, so advancing vcTxSeq here would
+    * open a one-frame gap the jitter filler turns into a 20 ms silence
+    * hole every keepalive interval during active speech. */
+   isKeepalive = (flags & VC_FLAG_KEEPALIVE) ? 1 : 0;
+   seq = vcTxSeq;
+   if (!isKeepalive)
+      vcTxSeq++;
+
+   n = VoiceChatEncodePkt(pkt, sizeof(pkt), flags, seq,
                           VoiceChatEnsureSenderId(), mulaw);
-   vcTxSeq++;
    if (!n)
       return;
 
@@ -363,6 +379,9 @@ static void VoiceChatSendFrame(uint8_t flags, const int16_t pcm[VC_FRAME_SAMPLES
    if (!JLinkDiscActive())
       return;
    JLinkDiscSendTo(pkt, n, peer, JLinkDiscPort());
+
+   if (!isKeepalive)
+      vcLastVoiceMs = JLinkNowMs();
 }
 
 static int VoiceChatGateOpen(int ptt_down, unsigned energy)
@@ -442,11 +461,15 @@ void VoiceChatFrameTick(int ptt_down)
    }
 
    /* Presence keepalive so a TCP server learns the client address even
-    * when the gate is closed. */
+    * when the gate is closed.  Suppressed when a real voice frame went
+    * out recently — voice packets already teach the peer address, and
+    * firing keepalives during speech is pointless. */
    now = JLinkNowMs();
    if (JLinkDiscActive()
        && (JLinkMode() == JLINK_MODE_TCP_CLIENT
            || JLinkMode() == JLINK_MODE_TCP_SERVER)
+       && (vcLastVoiceMs == 0
+           || (uint32_t)(now - vcLastVoiceMs) >= VC_KEEPALIVE_MS)
        && (vcLastKeepaliveMs == 0
            || (uint32_t)(now - vcLastKeepaliveMs) >= VC_KEEPALIVE_MS))
    {

--- a/src/jerry/voicechat.h
+++ b/src/jerry/voicechat.h
@@ -1,0 +1,105 @@
+/* voicechat.h — host-side voice channel over the netlink discovery socket.
+ *
+ * Not emulation: voice never entered the Jaguar. This sits entirely
+ * outside the emulated machine (issue #485). See docs/voice-chat-design.md.
+ *
+ * Pure codec/framing/jitter/VAD are unit-testable without sockets; the
+ * send/receive path rides jlink_discover's raw datagram seam.
+ */
+#ifndef __VOICECHAT_H__
+#define __VOICECHAT_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VC_MAGIC_0           'V'
+#define VC_MAGIC_1           'J'
+#define VC_MAGIC_2           'V'
+#define VC_MAGIC_3           'C'
+#define VC_VERSION           1
+#define VC_FLAG_KEEPALIVE    0x01
+#define VC_RATE_HZ           8000
+#define VC_FRAME_SAMPLES     160   /* 20 ms at 8 kHz */
+#define VC_HDR_LEN           12
+#define VC_PKT_LEN           (VC_HDR_LEN + VC_FRAME_SAMPLES)
+#define VC_UPSAMPLE          6     /* 48000 / 8000 */
+#define VC_PEER_ADDR_MAX     46
+
+enum
+{
+   VC_GATE_OPEN_MIC = 0,
+   VC_GATE_PTT      = 1
+};
+
+/* Optional mic read: fill up to num mono int16 samples; return count or
+ * -1 if unavailable. Registered by libretro.c from the frontend mic API. */
+typedef int (*VoiceChatMicReadFn)(int16_t *samples, size_t num);
+
+/* ---- Pure logic (unit-testable) -------------------------------------- */
+
+uint8_t VoiceChatMuLawEncode(int16_t pcm);
+int16_t VoiceChatMuLawDecode(uint8_t mulaw);
+
+/* Encode a full packet into buf (capacity >= VC_PKT_LEN). Returns length
+ * written, or 0 if capacity is too small. */
+size_t VoiceChatEncodePkt(uint8_t *buf, size_t cap,
+                          uint8_t flags, uint16_t seq, uint32_t senderId,
+                          const uint8_t mulaw[VC_FRAME_SAMPLES]);
+
+/* Decode. Returns 1 on success and fills outs; 0 on reject. */
+int VoiceChatDecodePkt(const uint8_t *buf, size_t len,
+                       uint8_t *flags, uint16_t *seq, uint32_t *senderId,
+                       uint8_t mulaw[VC_FRAME_SAMPLES]);
+
+/* Absolute-average energy of pcm[0..n); used by VAD. */
+unsigned VoiceChatFrameEnergy(const int16_t *pcm, unsigned n);
+
+/* ---- Configuration / lifecycle --------------------------------------- */
+
+void VoiceChatReset(void);
+void VoiceChatSetEnabled(int enabled);
+int  VoiceChatEnabled(void);
+void VoiceChatSetGate(int gate);          /* VC_GATE_* */
+void VoiceChatSetPTTKey(unsigned retrok); /* RETROK_* value; 0 = none */
+unsigned VoiceChatPTTKey(void);
+void VoiceChatSetVolume(unsigned pct);    /* 0..100 */
+void VoiceChatSetVadThreshold(unsigned thresh);
+void VoiceChatSetMonitor(int enabled);
+void VoiceChatSetMicRead(VoiceChatMicReadFn fn);
+void VoiceChatSetSenderId(uint32_t id);   /* tests; 0 = lazy random */
+
+/* Peer address for outbound unicast (dotted-quad or hostname). Cleared
+ * on reset; also learned from inbound datagrams. */
+void VoiceChatSetPeerAddr(const char *addr);
+const char *VoiceChatPeerAddr(void);
+
+/* ---- Per-frame / wire ------------------------------------------------ */
+
+/* ptt_down: 1 while the configured PTT key is held (ignored in open_mic).
+ * Pulls mic, gates, packetizes, sends; drains discovery via caller. */
+void VoiceChatFrameTick(int ptt_down);
+
+/* Raw datagram handler (magic VJVC). Learns peer from from_addr. */
+void VoiceChatOnRaw(const uint8_t *buf, size_t len,
+                    const char *from_addr, int from_port);
+
+/* Mix far-end (and optional local monitor) into interleaved stereo
+ * sampleBuffer (uint16_t L,R pairs). Saturating add; never touches
+ * emulated state. */
+void VoiceChatMixInto(uint16_t *buf, unsigned pairs);
+
+/* Test hooks: push decoded PCM into the jitter buffer; pop one 8 kHz
+ * sample (-1 if empty). */
+void VoiceChatJitterPush(const int16_t pcm[VC_FRAME_SAMPLES], uint16_t seq);
+int  VoiceChatJitterPop(int16_t *out);
+unsigned VoiceChatJitterCount(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/harness/harness.c
+++ b/test/harness/harness.c
@@ -335,12 +335,99 @@ static void cb_log(enum retro_log_level level, const char *fmt, ...)
 
 static struct retro_log_callback log_cb_struct = { cb_log };
 
+/* ---- Synthetic microphone (#485) ------------------------------------ */
+
+struct retro_microphone {
+    int active;
+    unsigned phase;   /* free-running phase for a ~440 Hz tone at 8 kHz */
+};
+
+static struct retro_microphone g_synth_mic;
+
+static retro_microphone_t *synth_open_mic(const retro_microphone_params_t *params)
+{
+    (void)params;
+    memset(&g_synth_mic, 0, sizeof(g_synth_mic));
+    g_synth_mic.active = 0;
+    return &g_synth_mic;
+}
+
+static void synth_close_mic(retro_microphone_t *microphone)
+{
+    if (microphone)
+        microphone->active = 0;
+}
+
+static bool synth_get_params(const retro_microphone_t *microphone,
+                             retro_microphone_params_t *params)
+{
+    if (!microphone || !params)
+        return false;
+    params->rate = 8000;
+    return true;
+}
+
+static bool synth_set_mic_state(retro_microphone_t *microphone, bool state)
+{
+    if (!microphone)
+        return false;
+    microphone->active = state ? 1 : 0;
+    return true;
+}
+
+static bool synth_get_mic_state(const retro_microphone_t *microphone)
+{
+    return microphone && microphone->active;
+}
+
+static int synth_read_mic(retro_microphone_t *microphone,
+                          int16_t *samples, size_t num_samples)
+{
+    size_t i;
+    if (!microphone || !samples)
+        return -1;
+    if (!microphone->active) {
+        /* Contract: disabled mic returns -1. */
+        return -1;
+    }
+    /* Soft 440 Hz-ish square-ish tone via a saw phase — enough energy for
+     * VAD and presence checks without needing a real sine table. */
+    for (i = 0; i < num_samples; i++) {
+        int16_t s = (int16_t)(((microphone->phase & 0x1F) < 16) ? 4000 : -4000);
+        samples[i] = s;
+        microphone->phase++;
+    }
+    return (int)num_samples;
+}
+
+static struct retro_microphone_interface g_synth_mic_iface = {
+    RETRO_MICROPHONE_INTERFACE_VERSION,
+    synth_open_mic,
+    synth_close_mic,
+    synth_get_params,
+    synth_set_mic_state,
+    synth_get_mic_state,
+    synth_read_mic
+};
+
 static bool cb_environment(unsigned cmd, void *data)
 {
     switch (cmd) {
     case RETRO_ENVIRONMENT_GET_LOG_INTERFACE:
         *(struct retro_log_callback *)data = log_cb_struct;
         return true;
+    case RETRO_ENVIRONMENT_GET_MICROPHONE_INTERFACE:
+        if (!data || !active_cfg || !active_cfg->mic_tone)
+            return false;
+        {
+            struct retro_microphone_interface *iface =
+                (struct retro_microphone_interface *)data;
+            unsigned want = iface->interface_version;
+            *iface = g_synth_mic_iface;
+            if (want && want < RETRO_MICROPHONE_INTERFACE_VERSION)
+                iface->interface_version = want;
+            return true;
+        }
     case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
     case RETRO_ENVIRONMENT_SET_VARIABLES:
     case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
@@ -410,6 +497,8 @@ bool harness_init_from_args(harness_config *cfg, int argc, char **argv)
             cfg->use_bios = 1;
         } else if (strcmp(argv[i], "--quiet") == 0) {
             cfg->quiet = 1;
+        } else if (strcmp(argv[i], "--mic-tone") == 0) {
+            cfg->mic_tone = 1;
         } else if (strcmp(argv[i], "--frames") == 0 && i + 1 < argc) {
             cfg->frames = (unsigned)atoi(argv[++i]);
         } else if (strcmp(argv[i], "--snapshot-interval") == 0 && i + 1 < argc) {

--- a/test/harness/harness.h
+++ b/test/harness/harness.h
@@ -60,6 +60,7 @@
  *     --snap FRAME            VJSN state snapshot at FRAME (repeatable)
  *     --snap-prefix BASE      Snapshot filename base (default vjt_snap)
  *     --mark FRAME:TAG        Inject a MARK event at FRAME (repeatable)
+ *     --mic-tone              Provide a synthetic 8 kHz mic tone (#485)
  *
  * ======================================================================
  * CORE OPTION OVERRIDE TABLE
@@ -252,6 +253,11 @@ typedef struct {
     int           want_fb_hash;
     uint32_t      last_fb_hash;
 
+    /* Synthetic microphone (#485): when non-zero, the environment callback
+     * answers GET_MICROPHONE_INTERFACE with a tone generator at 8 kHz so
+     * voice-chat paths can be exercised without a real frontend mic. */
+    int           mic_tone;
+
     /* Runtime state (set by harness) */
     void  *core_handle;
     unsigned current_frame;
@@ -299,6 +305,7 @@ typedef struct {
     .num_mark_specs = 0, \
     .want_fb_hash = 0, \
     .last_fb_hash = 0, \
+    .mic_tone = 0, \
     .core_handle = NULL, \
     .current_frame = 0, \
     .audio = {0}, \

--- a/test/test_voicechat.c
+++ b/test/test_voicechat.c
@@ -137,6 +137,37 @@ static void test_jitter(void)
          "gap fill inserts silence frame");
 }
 
+static void test_keepalive_seq_continuity(void)
+{
+   /* Models the RX side of the keepalive fix: keepalives are dropped
+    * before VoiceChatJitterPush, so consecutive voice frames must arrive
+    * with unbroken seq (TX must not consume seq for keepalives).  Pushing
+    * 0 then 1 must not insert a silence gap. */
+   int16_t frame[VC_FRAME_SAMPLES];
+   int16_t s;
+   unsigned i;
+   unsigned silence = 0;
+
+   VoiceChatReset();
+   VoiceChatSetEnabled(1);
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+      frame[i] = 1000;
+   VoiceChatJitterPush(frame, 0);
+   /* A keepalive would be dropped here — no JitterPush. */
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+      frame[i] = 2000;
+   VoiceChatJitterPush(frame, 1);
+
+   check(VoiceChatJitterCount() == VC_FRAME_SAMPLES * 2,
+         "keepalive does not open a voice seq gap");
+   while (VoiceChatJitterPop(&s))
+   {
+      if (s == 0)
+         silence++;
+   }
+   check(silence == 0, "no silence inserted between contiguous voice seqs");
+}
+
 static void test_energy_and_mix(void)
 {
    int16_t loud[VC_FRAME_SAMPLES];
@@ -184,6 +215,7 @@ int main(void)
    test_pkt_roundtrip();
    test_pkt_rejects();
    test_jitter();
+   test_keepalive_seq_continuity();
    test_energy_and_mix();
    if (failures)
    {

--- a/test/test_voicechat.c
+++ b/test/test_voicechat.c
@@ -1,0 +1,195 @@
+/* test/test_voicechat.c — pure-logic unit tests for voicechat (#485).
+ *
+ * Compiles voicechat.c against stubs for the jlink/discovery seams so
+ * codec, framing, jitter, VAD energy, and mix saturation need no sockets.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "voicechat.h"
+
+/* ---- Stubs for symbols voicechat.c pulls from jlink / discover ------ */
+
+int JLinkMode(void) { return 0; }
+int JLinkDiscActive(void) { return 0; }
+int JLinkDiscPort(void) { return 42170; }
+const char *JLinkGetTCPHost(void) { return "127.0.0.1"; }
+uint32_t JLinkNowMs(void) { return 1000; }
+int JLinkDiscSendTo(const uint8_t *buf, size_t len,
+                    const char *to_addr, int to_port)
+{
+   (void)buf; (void)len; (void)to_addr; (void)to_port;
+   return 0;
+}
+
+static int failures = 0;
+
+static void check(int cond, const char *what)
+{
+   if (!cond) { printf("FAIL: %s\n", what); failures++; }
+   else        printf("  ok: %s\n", what);
+}
+
+static void test_mulaw_roundtrip(void)
+{
+   static const int16_t samples[] = {
+      0, 100, -100, 1000, -1000, 8000, -8000, 16000, -16000, 30000, -30000
+   };
+   unsigned i;
+
+   for (i = 0; i < sizeof(samples) / sizeof(samples[0]); i++)
+   {
+      uint8_t e = VoiceChatMuLawEncode(samples[i]);
+      int16_t d = VoiceChatMuLawDecode(e);
+      int err = (int)d - (int)samples[i];
+      if (err < 0)
+         err = -err;
+      /* G.711 is lossy; allow ~2% of full scale for large samples, and
+       * a floor for near-zero values. */
+      check(err < 600 || err < (int)(abs(samples[i]) / 8 + 1),
+            "mulaw round-trip within bound");
+   }
+}
+
+static void test_pkt_roundtrip(void)
+{
+   uint8_t mulaw[VC_FRAME_SAMPLES];
+   uint8_t out[VC_FRAME_SAMPLES];
+   uint8_t pkt[VC_PKT_LEN];
+   uint8_t flags = 0;
+   uint16_t seq = 0;
+   uint32_t sid = 0;
+   size_t n;
+   unsigned i;
+
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+      mulaw[i] = (uint8_t)(i & 0xFF);
+
+   n = VoiceChatEncodePkt(pkt, sizeof(pkt), VC_FLAG_KEEPALIVE, 0x1234,
+                          0xA1B2C3D4u, mulaw);
+   check(n == VC_PKT_LEN, "encode writes VC_PKT_LEN");
+   check(VoiceChatDecodePkt(pkt, n, &flags, &seq, &sid, out) == 1,
+         "decode accepts own packet");
+   check(flags == VC_FLAG_KEEPALIVE, "flags survive");
+   check(seq == 0x1234, "seq survives");
+   check(sid == 0xA1B2C3D4u, "senderId survives");
+   check(memcmp(mulaw, out, VC_FRAME_SAMPLES) == 0, "payload survives");
+}
+
+static void test_pkt_rejects(void)
+{
+   uint8_t mulaw[VC_FRAME_SAMPLES];
+   uint8_t pkt[VC_PKT_LEN];
+   uint8_t flags;
+   uint16_t seq;
+   uint32_t sid;
+
+   memset(mulaw, 0, sizeof(mulaw));
+   VoiceChatEncodePkt(pkt, sizeof(pkt), 0, 1, 2, mulaw);
+
+   check(VoiceChatDecodePkt(pkt, VC_PKT_LEN - 1, &flags, &seq, &sid, mulaw) == 0,
+         "truncated rejected");
+   check(VoiceChatDecodePkt(pkt, VC_PKT_LEN + 1, &flags, &seq, &sid, mulaw) == 0,
+         "oversized rejected");
+   pkt[0] = 'X';
+   check(VoiceChatDecodePkt(pkt, VC_PKT_LEN, &flags, &seq, &sid, mulaw) == 0,
+         "wrong magic rejected");
+   pkt[0] = VC_MAGIC_0;
+   pkt[4] = 99;
+   check(VoiceChatDecodePkt(pkt, VC_PKT_LEN, &flags, &seq, &sid, mulaw) == 0,
+         "wrong version rejected");
+}
+
+static void test_jitter(void)
+{
+   int16_t frame[VC_FRAME_SAMPLES];
+   int16_t s;
+   unsigned i;
+
+   VoiceChatReset();
+   VoiceChatSetEnabled(1);
+
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+      frame[i] = (int16_t)(i + 1);
+
+   VoiceChatJitterPush(frame, 0);
+   check(VoiceChatJitterCount() == VC_FRAME_SAMPLES, "jitter holds one frame");
+   check(VoiceChatJitterPop(&s) == 1 && s == 1, "pop first sample");
+   check(VoiceChatJitterCount() == VC_FRAME_SAMPLES - 1, "count decrements");
+
+   /* Push next seq; should append without gap fill. */
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+      frame[i] = (int16_t)(1000 + i);
+   VoiceChatJitterPush(frame, 1);
+   check(VoiceChatJitterCount() == VC_FRAME_SAMPLES * 2 - 1,
+         "second frame appended");
+
+   /* Skip ahead to force gap fill (seq 3 after expect 2). */
+   VoiceChatReset();
+   VoiceChatSetEnabled(1);
+   VoiceChatJitterPush(frame, 0);
+   while (VoiceChatJitterPop(&s))
+      ;
+   VoiceChatJitterPush(frame, 2); /* gap of one frame of silence */
+   check(VoiceChatJitterCount() == VC_FRAME_SAMPLES * 2,
+         "gap fill inserts silence frame");
+}
+
+static void test_energy_and_mix(void)
+{
+   int16_t loud[VC_FRAME_SAMPLES];
+   int16_t quiet[VC_FRAME_SAMPLES];
+   uint16_t buf[1600]; /* 800 stereo pairs */
+   unsigned i;
+   int clipped;
+
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+   {
+      loud[i] = 8000;
+      quiet[i] = 10;
+   }
+   check(VoiceChatFrameEnergy(loud, VC_FRAME_SAMPLES) > 7000,
+         "loud energy high");
+   check(VoiceChatFrameEnergy(quiet, VC_FRAME_SAMPLES) < 50,
+         "quiet energy low");
+
+   VoiceChatReset();
+   VoiceChatSetEnabled(1);
+   VoiceChatSetVolume(100);
+   VoiceChatJitterPush(loud, 0);
+
+   /* Fill buffer near positive full scale so mix must clamp. */
+   for (i = 0; i < 1600; i++)
+      buf[i] = (uint16_t)30000; /* as int16_t = 30000 */
+
+   VoiceChatMixInto(buf, 800);
+   clipped = 0;
+   for (i = 0; i < 1600; i++)
+   {
+      int16_t v = (int16_t)buf[i];
+      if (v > 32767 || v < -32768) /* unreachable for int16_t store */
+         clipped = -1;
+      if (v == 32767)
+         clipped = 1;
+   }
+   check(clipped == 1, "saturates near full scale without wrap");
+}
+
+int main(void)
+{
+   printf("test_voicechat\n");
+   test_mulaw_roundtrip();
+   test_pkt_roundtrip();
+   test_pkt_rejects();
+   test_jitter();
+   test_energy_and_mix();
+   if (failures)
+   {
+      printf("%d FAILURES\n", failures);
+      return 1;
+   }
+   printf("ALL PASS\n");
+   return 0;
+}

--- a/test/tools/test_voicechat_inertness.c
+++ b/test/tools/test_voicechat_inertness.c
@@ -1,0 +1,235 @@
+/* test_voicechat_inertness.c -- Voice chat must leave the emulated
+ * machine unobservable (issue #485).  Spec: docs/voice-chat-design.md.
+ *
+ * Runs yarc.j64 twice (voice off, then voice on with synthetic mic +
+ * local monitor) and asserts per-frame framebuffer hashes and savestate
+ * digests at N/2 and N are identical.
+ *
+ * Exit: 0 PASS, 1 FAIL, 2 harness error, 77 SKIP (ROM missing).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "../harness/harness.h"
+
+#define MAX_FRAMES 600
+#define DEFAULT_FRAMES 120
+#define DEFAULT_ROM "test/roms/yarc.j64"
+
+#define FNV_OFFSET 1469598103934665603ULL
+#define FNV_PRIME  1099511628211ULL
+
+typedef struct {
+    uint64_t fb[MAX_FRAMES];
+    unsigned fb_count;
+    uint64_t digest_mid;
+    uint64_t digest_end;
+} run_result;
+
+static run_result *g_cur;
+
+static uint64_t fnv1a(uint64_t hh, const void *data, size_t len)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    size_t i;
+    for (i = 0; i < len; i++) {
+        hh ^= p[i];
+        hh *= FNV_PRIME;
+    }
+    return hh;
+}
+
+static uint64_t hash_file(const char *path)
+{
+    FILE *fp;
+    uint8_t buf[4096];
+    size_t n;
+    uint64_t hh = FNV_OFFSET;
+
+    fp = fopen(path, "rb");
+    if (!fp)
+        return 0;
+    while ((n = fread(buf, 1, sizeof(buf), fp)) > 0)
+        hh = fnv1a(hh, buf, n);
+    fclose(fp);
+    return hh;
+}
+
+static void video_cb(void *ud, const void *data,
+                     unsigned width, unsigned height, size_t pitch)
+{
+    const uint8_t *row = (const uint8_t *)data;
+    uint64_t hh;
+    unsigned y;
+
+    (void)ud;
+    if (!g_cur || g_cur->fb_count >= MAX_FRAMES)
+        return;
+    hh = FNV_OFFSET;
+    hh = fnv1a(hh, &width, sizeof(width));
+    hh = fnv1a(hh, &height, sizeof(height));
+    if (data) {
+        for (y = 0; y < height; y++)
+            hh = fnv1a(hh, row + (size_t)y * pitch, (size_t)width * 4);
+    }
+    g_cur->fb[g_cur->fb_count] = hh;
+}
+
+static int do_run(const char *core, const char *rom, unsigned frames,
+                  int voice_on, run_result *out)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    unsigned i;
+    char state_path[] = "/tmp/vj_voicechat_inert.state";
+
+    memset(out, 0, sizeof(*out));
+    cfg.core_path = core;
+    cfg.rom_path = rom;
+    cfg.frames = frames;
+    cfg.quiet = 1;
+    cfg.mic_tone = voice_on ? 1 : 0;
+    cfg.video_callback = video_cb;
+
+    cfg.options[cfg.num_options].key = "virtualjaguar_voice_chat";
+    cfg.options[cfg.num_options].value = voice_on ? "enabled" : "disabled";
+    cfg.num_options++;
+    if (voice_on) {
+        cfg.options[cfg.num_options].key = "virtualjaguar_voice_chat_monitor";
+        cfg.options[cfg.num_options].value = "enabled";
+        cfg.num_options++;
+        cfg.options[cfg.num_options].key = "virtualjaguar_voice_chat_gate";
+        cfg.options[cfg.num_options].value = "open_mic";
+        cfg.num_options++;
+        /* Loopback so discovery/keepalive do not need a peer; voice still
+         * mixes locally via monitor. */
+        cfg.options[cfg.num_options].key = "virtualjaguar_netlink";
+        cfg.options[cfg.num_options].value = "loopback";
+        cfg.num_options++;
+    }
+
+    if (!harness_load_core(&cfg))
+        return 0;
+    if (!harness_load_rom(&cfg)) {
+        harness_shutdown(&cfg);
+        return 0;
+    }
+
+    g_cur = out;
+    for (i = 0; i < frames; i++) {
+        harness_step(&cfg);
+        out->fb_count++;
+        if (i + 1 == frames / 2) {
+            if (harness_save_state(&cfg, state_path))
+                out->digest_mid = hash_file(state_path);
+        }
+        if (i + 1 == frames) {
+            if (harness_save_state(&cfg, state_path))
+                out->digest_end = hash_file(state_path);
+        }
+    }
+    g_cur = NULL;
+    harness_shutdown(&cfg);
+    unlink(state_path);
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    const char *core = NULL;
+    const char *rom = DEFAULT_ROM;
+    unsigned frames = DEFAULT_FRAMES;
+    run_result off, on;
+    harness_result results[4];
+    unsigned nres = 0;
+    int failed = 0;
+    int i;
+    struct stat st;
+    harness_config report_cfg = HARNESS_CONFIG_DEFAULT;
+    char d_fb[256], d_ss[256];
+    int first_diff;
+
+    for (i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--frames") && i + 1 < argc)
+            frames = (unsigned)atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--json"))
+            report_cfg.json_output = 1;
+        else if (!strcmp(argv[i], "--quiet"))
+            report_cfg.quiet = 1;
+        else if (argv[i][0] != '-') {
+            if (!core)
+                core = argv[i];
+            else
+                rom = argv[i];
+        }
+    }
+    if (!core)
+        core = "./virtualjaguar_libretro.dylib";
+    if (frames > MAX_FRAMES)
+        frames = MAX_FRAMES;
+
+    if (stat(rom, &st) != 0) {
+        fprintf(stderr, "SKIP: ROM missing: %s\n", rom);
+        return 77;
+    }
+
+    if (!do_run(core, rom, frames, 0, &off)) {
+        fprintf(stderr, "harness failed (voice off)\n");
+        return 2;
+    }
+    if (!do_run(core, rom, frames, 1, &on)) {
+        fprintf(stderr, "harness failed (voice on)\n");
+        return 2;
+    }
+
+    first_diff = -1;
+    for (i = 0; i < (int)frames; i++) {
+        if (off.fb[i] != on.fb[i]) {
+            first_diff = i;
+            break;
+        }
+    }
+    if (first_diff < 0)
+        snprintf(d_fb, sizeof(d_fb),
+                 "%u frames identical on/off", frames);
+    else
+        snprintf(d_fb, sizeof(d_fb),
+                 "framebuffer diverges at frame %d", first_diff + 1);
+    results[nres].status = (first_diff < 0) ? "PASS" : "FAIL";
+    results[nres].name = "fb_inertness";
+    results[nres].detail = d_fb;
+    if (first_diff >= 0)
+        failed = 1;
+    nres++;
+
+    if (off.digest_mid && off.digest_end
+        && off.digest_mid == on.digest_mid
+        && off.digest_end == on.digest_end) {
+        snprintf(d_ss, sizeof(d_ss),
+                 "savestate digests @%u/%u identical",
+                 frames / 2, frames);
+        results[nres].status = "PASS";
+    } else if (!off.digest_mid || !off.digest_end
+               || !on.digest_mid || !on.digest_end) {
+        snprintf(d_ss, sizeof(d_ss), "savestate capture failed");
+        results[nres].status = "FAIL";
+        failed = 1;
+    } else {
+        snprintf(d_ss, sizeof(d_ss),
+                 "savestate digests differ (mid %d end %d)",
+                 off.digest_mid != on.digest_mid,
+                 off.digest_end != on.digest_end);
+        results[nres].status = "FAIL";
+        failed = 1;
+    }
+    results[nres].name = "savestate_inertness";
+    results[nres].detail = d_ss;
+    nres++;
+
+    harness_report(&report_cfg, results, nres);
+    return failed ? 1 : 0;
+}

--- a/test/tools/voicechat_pair.c
+++ b/test/tools/voicechat_pair.c
@@ -1,0 +1,181 @@
+/* voicechat_pair.c — two-process UDP voice-chat transport check (#485).
+ *
+ * Roles:
+ *   --role recv  listen on discovery port, enable voice, wait for energy
+ *   --role send  send keepalive + loud frames to peer
+ *
+ * Does not load a ROM; links voicechat + jlink_discover directly so the
+ * side-channel wire path is exercised without RetroArch.
+ *
+ * Usage: voicechat_pair --role recv|send --port N [--host ADDR]
+ * Exit: 0 PASS, 1 FAIL, 2 bind busy (shell retries).
+ */
+#if !defined(_WIN32) && !defined(_DEFAULT_SOURCE)
+#define _DEFAULT_SOURCE 1
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+
+#include "voicechat.h"
+#include "jlink_discover.h"
+#include "jlink.h"
+
+/* Stubs: voicechat only needs these for FrameTick peer seeding; we drive
+ * OnRaw / Encode / MixInto directly. */
+int JLinkMode(void) { return 2; } /* TCP_SERVER-ish */
+const char *JLinkGetTCPHost(void) { return "127.0.0.1"; }
+uint32_t JLinkNowMs(void)
+{
+   static uint32_t t = 1000;
+   return t += 16;
+}
+
+static int role_recv(int port, unsigned timeout_ms)
+{
+   uint16_t mix[960]; /* 480 pairs */
+   unsigned i;
+   unsigned waited = 0;
+   int energy_ok = 0;
+   char envport[32];
+
+   memset(mix, 0, sizeof(mix));
+
+   snprintf(envport, sizeof(envport), "%d", port);
+   setenv("VJ_DISC_PORT", envport, 1);
+
+   VoiceChatReset();
+   VoiceChatSetEnabled(1);
+   VoiceChatSetVolume(100);
+   VoiceChatSetSenderId(0x11111111u);
+
+   if (!JLinkDiscStart(1 /* listen_only */, JLINK_DISC_DEV_JAGLINK, 42171)) {
+      fprintf(stderr, "voicechat_pair recv: DiscStart failed\n");
+      return 2;
+   }
+   JLinkDiscSetRawHandler(VoiceChatOnRaw);
+
+   while (waited < timeout_ms) {
+      JLinkDiscPoll(JLinkNowMs());
+      if (VoiceChatJitterCount() > 0) {
+         VoiceChatMixInto(mix, 480);
+         {
+            /* Treat non-zero mixed samples as energy present. */
+            int16_t *s = (int16_t *)mix;
+            long sum = 0;
+            for (i = 0; i < 960; i++) {
+               int v = s[i];
+               if (v < 0)
+                  v = -v;
+               sum += v;
+            }
+            if (sum / 960 > 100)
+               energy_ok = 1;
+         }
+         if (energy_ok)
+            break;
+      }
+      usleep(10000);
+      waited += 10;
+   }
+
+   JLinkDiscStop();
+   if (!energy_ok) {
+      fprintf(stderr, "voicechat_pair recv: no far-end energy after %ums\n",
+              timeout_ms);
+      return 1;
+   }
+   printf("voicechat_pair recv: PASS (energy ok)\n");
+   return 0;
+}
+
+static int role_send(const char *host, int port, unsigned nframes)
+{
+   /* Dedicated socket (ephemeral bind) -- do NOT share the receiver's
+    * SO_REUSEPORT discovery bind. Same-host unicast to a REUSEPORT group
+    * can land on the sender's own socket (see #552 / jlink.c notes). */
+   int16_t loud[VC_FRAME_SAMPLES];
+   uint8_t mulaw[VC_FRAME_SAMPLES];
+   uint8_t pkt[VC_PKT_LEN];
+   unsigned i, f;
+   size_t n;
+   int sock;
+   struct sockaddr_in to;
+   struct addrinfo hints, *res = NULL;
+   char portstr[16];
+
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+      loud[i] = 8000;
+
+   sock = (int)socket(AF_INET, SOCK_DGRAM, 0);
+   if (sock < 0) {
+      fprintf(stderr, "voicechat_pair send: socket failed\n");
+      return 1;
+   }
+
+   memset(&hints, 0, sizeof(hints));
+   hints.ai_family = AF_INET;
+   hints.ai_socktype = SOCK_DGRAM;
+   snprintf(portstr, sizeof(portstr), "%d", port);
+   if (getaddrinfo(host, portstr, &hints, &res) != 0 || !res) {
+      fprintf(stderr, "voicechat_pair send: resolve %s failed\n", host);
+      close(sock);
+      return 1;
+   }
+   memcpy(&to, res->ai_addr, sizeof(to));
+   freeaddrinfo(res);
+
+   for (f = 0; f < nframes; f++) {
+      for (i = 0; i < VC_FRAME_SAMPLES; i++)
+         mulaw[i] = VoiceChatMuLawEncode(loud[i]);
+      n = VoiceChatEncodePkt(pkt, sizeof(pkt), 0, (uint16_t)f,
+                             0x22222222u, mulaw);
+      if (!n || sendto(sock, (const char *)pkt, (int)n, 0,
+                       (struct sockaddr *)&to, sizeof(to)) < 0) {
+         fprintf(stderr, "voicechat_pair send: send failed frame %u\n", f);
+         close(sock);
+         return 1;
+      }
+      usleep(20000);
+   }
+
+   close(sock);
+   printf("voicechat_pair send: PASS (%u frames)\n", nframes);
+   return 0;
+}
+
+int main(int argc, char **argv)
+{
+   const char *role = NULL;
+   const char *host = "127.0.0.1";
+   int port = 42170;
+   int i;
+
+   for (i = 1; i < argc; i++) {
+      if (!strcmp(argv[i], "--role") && i + 1 < argc)
+         role = argv[++i];
+      else if (!strcmp(argv[i], "--host") && i + 1 < argc)
+         host = argv[++i];
+      else if (!strcmp(argv[i], "--port") && i + 1 < argc)
+         port = atoi(argv[++i]);
+   }
+   if (!role) {
+      fprintf(stderr, "usage: voicechat_pair --role recv|send --port N "
+              "[--host ADDR]\n");
+      return 1;
+   }
+   if (!strcmp(role, "recv"))
+      return role_recv(port, 3000);
+   if (!strcmp(role, "send"))
+      return role_send(host, port, 30);
+   fprintf(stderr, "unknown role %s\n", role);
+   return 1;
+}

--- a/test/tools/voicechat_pair_test.sh
+++ b/test/tools/voicechat_pair_test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# voicechat_pair_test.sh — two-process UDP voice-chat transport check (#485).
+# Usage: voicechat_pair_test.sh [port]
+set -u
+
+PORT="${1:-${VJ_DISC_PORT:-$(( 25000 + ($$ % 4000) ))}}"
+BIN="$(dirname "$0")/voicechat_pair"
+
+if [ ! -x "$BIN" ]; then
+    echo "voicechat_pair_test: $BIN not built" >&2
+    exit 1
+fi
+
+run_pair() {
+    local port="$1"
+    local recv_rc send_rc recv_pid
+
+    "$BIN" --role recv --port "$port" &
+    recv_pid=$!
+    sleep 0.3
+    "$BIN" --role send --port "$port" --host 127.0.0.1
+    send_rc=$?
+    wait "$recv_pid"
+    recv_rc=$?
+
+    if [ "$recv_rc" -eq 0 ] && [ "$send_rc" -eq 0 ]; then
+        echo "voicechat_pair_test: PASS (port $port)"
+        return 0
+    fi
+    if [ "$recv_rc" -eq 2 ] || [ "$send_rc" -eq 2 ]; then
+        return 2
+    fi
+    echo "voicechat_pair_test: FAIL (recv=$recv_rc send=$send_rc)" >&2
+    return 1
+}
+
+port="$PORT"
+for attempt in 1 2 3; do
+    run_pair "$port"
+    rc=$?
+    [ "$rc" -ne 2 ] && exit "$rc"
+    port=$((port + 211))
+    echo "voicechat_pair_test: port busy, retrying on $port" >&2
+done
+echo "voicechat_pair_test: FAIL (no bindable port after 3 tries)" >&2
+exit 1


### PR DESCRIPTION
## Summary
- Adds an **opt-in, out-of-band voice channel** for issue #485 — the Jaguar Voice Modem’s real selling point (simultaneous voice + data) — without pretending voice ever entered the emulated machine.
- Mic capture via `RETRO_ENVIRONMENT_GET_MICROPHONE_INTERFACE`, G.711 µ-law @ 8 kHz over `VJVC` datagrams on the existing discovery UDP port (42170), VAD or keyboard PTT, saturating mix into `sampleBuffer` before `SoundCallback`.
- Works in TCP Host/Client modes; unavailable under RetroArch netplay (no peer address); graceful degrade if mic API is missing. DTMF tone audio remains out of scope.

## Design
See [`docs/voice-chat-design.md`](docs/voice-chat-design.md). Cross-linked from `docs/voice-modem.md`.

## Test plan
- [x] `bash scripts/c89-lint.sh` on touched sources
- [x] `make TEST_EXPORTS=1 test` — 0 failed (private-ROM skips only)
- [x] `./test/test_voicechat` — codec/framing/jitter/mix unit tests
- [x] `bash test/tools/voicechat_pair_test.sh` — UDP energy pair
- [x] `./test/tools/test_voicechat_inertness` — fb hashes + savestate digests identical voice on/off
- [x] `./test/test_audio_clipping --self-test`
- [ ] RetroArch: default off; enable with mic; two TCP instances carry voice; Ultra Vortek data path still connects

## Linking
**Please link this PR to issue #485 in the GitHub Development panel** — `Closes #485` does not create the link on this repo (PRs target `develop`, default branch is `master`). CI `pr-issue-link.yml` will fail until that is done by hand.


Made with [Cursor](https://cursor.com)