### PR TITLE
feat(netlink): voice chat over RetroArch netplay (#585)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1211,7 +1211,7 @@ clean:
 		test/tools/test_frame_timing test/tools/test_runahead_determinism test/tools/test_pertitle_db \
 		test/test_biosdb test/test_cart_bios_loader \
 		test/test_titledb test/test_titlehook test/tools/test_hook_gate \
-		test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace test/test_voicechat test/tools/test_voicechat_inertness test/tools/voicechat_pair test/tools/i2s_lag_probe \
+		test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace test/test_voicechat test/test_voice_netpacket test/tools/test_voicechat_inertness test/tools/voicechat_pair test/tools/i2s_lag_probe \
 		test/tools/dsp_idle_probe_falsify test/tools/dsp_idle_ab \
 		test/tools/joymatrix_identity test/tools/teamtap_ports \
 		test/tools/teamtap_rom_probe test/tools/mouse_decode_test \
@@ -1267,7 +1267,7 @@ test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
 # invocations get different values.
 test: EEPROM_GEN_TOOL := /tmp/vj_gen_eeprom_test_rom_$(shell echo $$PPID)
 test: EEPROM_FIXTURE := /tmp/vj_eeprom_lifecycle_$(shell echo $$PPID).j64
-test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_discover test/test_voicechat test/test_jlink_netpacket test/test_voicemodem_netpacket test/test_uart_loopback test/test_jlink_negotiate test/test_blitter_simd test/test_dsp_mac40 test/test_titledb test/test_titlehook test/test_biosdb \
+test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_discover test/test_voicechat test/test_jlink_netpacket test/test_voicemodem_netpacket test/test_voice_netpacket test/test_uart_loopback test/test_jlink_negotiate test/test_blitter_simd test/test_dsp_mac40 test/test_titledb test/test_titlehook test/test_biosdb \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
@@ -1325,6 +1325,10 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# Two private copies of the core, two netpacket sessions, packets
 	@# relayed between them: no sockets, no ports, no ROM.
 	./test/test_voicemodem_netpacket ./$(TARGET)
+	@# #585: host-side voice over framed vjag-netlink-2 netpacket (hello
+	@# negotiate + unreliable VJVC). Same two-copy relay pattern as the
+	@# voicemodem netpacket test; synthetic mic via env 78 mic iface.
+	./test/test_voice_netpacket ./$(TARGET)
 	./test/test_uart_loopback
 	@# #552: end-to-end wire-speedup negotiation against a hand-crafted
 	@# fake peer over real sockets -- proves the interop safety property
@@ -1985,6 +1989,10 @@ test/test_jlink_netpacket: test/test_jlink_netpacket.c
 test/test_voicemodem_netpacket: test/test_voicemodem_netpacket.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/test_voicemodem_netpacket.c -ldl
+
+test/test_voice_netpacket: test/test_voice_netpacket.c
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/test_voice_netpacket.c -ldl
 
 test/test_uart_loopback: test/test_uart_loopback.c src/jerry/uart.c src/jerry/uart.h src/jerry/jlink.c src/jerry/jlink_tcp.c src/jerry/jlink_netpacket.c src/jerry/jlink_discover.c src/jerry/voicemodem.c src/jerry/voicechat.c src/core/event.c
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/docs/netlink-design.md
+++ b/docs/netlink-design.md
@@ -367,9 +367,13 @@ until the frontend starts a netplay session; `start()` takes over the link
 (saving the option-configured mode, restored on `stop()`), TX batches go
 out once per frame as `RELIABLE|FLUSH_HINT` broadcasts (multi-console
 CatNet sessions work over netplay for free), received payloads feed the
-shared RX ring. Protocol version pinned as `vjag-netlink-1` so frontends
-refuse cross-incompatible core pairings. **No core option required** —
-stock settings + RetroArch's normal netplay UI just work.
+shared RX ring. Protocol version pinned as `vjag-netlink-2` (#585): every
+payload carries a 1-byte type (`NP_UART` / `NP_VOICE` / `NP_VOICE_HELLO`).
+Older cores advertising `vjag-netlink-1` are refused by the frontend
+protocol check — intentional break. Host-side voice rides `NP_VOICE` after
+a hello/ack negotiate (falls back to data-only). **No core option required**
+for the link itself — stock settings + RetroArch's normal netplay UI just
+work; enable *Voice Chat* on both sides for talk.
 
 Validation:
 - `test_jlink_netpacket` — a self-contained fake frontend exercising the

--- a/docs/netlink-user-guide.md
+++ b/docs/netlink-user-guide.md
@@ -33,6 +33,10 @@ Notes:
   itself is symmetric.
 - Known issue: with some RetroArch builds the `--connect` **command line
   flag** silently does nothing — use the Netplay menu instead.
+- **Voice chat** (core option *Voice Chat*) works over netplay when both
+  sides enable it and run a core that speaks `vjag-netlink-2`. If the peer
+  never confirms voice, the game link stays data-only. Cores still on
+  `vjag-netlink-1` cannot join a `vjag-netlink-2` session (update both).
 
 ## Option B: Direct TCP (any frontend on a platform with sockets)
 

--- a/docs/voice-chat-design.md
+++ b/docs/voice-chat-design.md
@@ -66,16 +66,15 @@ Availability follows `JLinkDiscActive()` (TCP host / TCP client only):
 
 | Mode | Voice |
 |------|-------|
-| TCP host / TCP client | Works |
-| Netpacket (RetroArch netplay) | Unavailable in #584 — follow-up: `docs/voice-chat-netplay-design.md` |
+| TCP host / TCP client | Works — `VJVC` on discovery UDP :42170 |
+| Netpacket (RetroArch netplay) | Works — framed `vjag-netlink-2` (`NP_VOICE` + hello negotiate); see `docs/voice-chat-netplay-design.md` |
 | Loopback | No peer; local mic monitor still works for a mic check |
 
-Netpacket was deferred in #584: its payloads had no framing, so
-multiplexing would break wire compat with 3.4.x peers, and the core
-never sees a peer IP to dial a UDP side channel. **Follow-up (accepted
-break):** frame the netpacket pipe (`vjag-netlink-2`), negotiate voice
-capability, carry `VJVC` as unreliable packets — see
-`docs/voice-chat-netplay-design.md`.
+Netpacket voice (#585) frames every netpacket payload with a type byte
+(`NP_UART` / `NP_VOICE` / `NP_VOICE_HELLO`), bumps `protocol_version` to
+`vjag-netlink-2` (intentional break with 3.4.x peers), and auto-negotiates
+voice capability. If the peer never confirms, the session stays data-only.
+TCP discovery-UDP voice from #584 is unchanged.
 
 ## Wire format
 

--- a/docs/voice-chat-netplay-design.md
+++ b/docs/voice-chat-netplay-design.md
@@ -1,7 +1,7 @@
 # Design: Voice chat over RetroArch netplay (#585)
 
 **Date:** 2026-08-25
-**Status:** design for review — not implemented
+**Status:** IMPLEMENTED (#585)
 **Issue:** [#585](https://github.com/libretro/virtualjaguar-libretro/issues/585)
 **Parent:** [#485](https://github.com/libretro/virtualjaguar-libretro/issues/485) / PR #584 (UDP discovery path, TCP only)
 **Intent:** next PR after #584 — make host-side voice work inside a RetroArch
@@ -18,12 +18,12 @@ netplay session via the netpacket interface (env 78).
   `protocol_version` / framing the netpacket pipe is acceptable. Do not spend
   effort preserving `vjag-netlink-1` unframed payloads for voice multiplexing.
 
-## What exists today (after #584)
+## Availability (after #585)
 
 | Path | Voice |
 |------|-------|
 | TCP host / TCP client | Works — `VJVC` on discovery UDP :42170 |
-| RetroArch netplay (`JLINK_MODE_NETPACKET`) | **Unavailable** — core never sees a peer IP; mic gated off; log once |
+| RetroArch netplay (`JLINK_MODE_NETPACKET`) | Works — framed `vjag-netlink-2` + hello negotiate |
 | Loopback | Local mic monitor only |
 
 Voice is still **host-side only** (zero emulated state). That invariant must

--- a/libretro.c
+++ b/libretro.c
@@ -1009,7 +1009,7 @@ static const struct retro_netpacket_callback netpacket_cb = {
    JLinkNPPoll,
    NULL,                /* connected */
    NULL,                /* disconnected */
-   "vjag-netlink-1"     /* protocol_version */
+   "vjag-netlink-2"     /* protocol_version */
 };
 
 /* ---- Voice chat (#485): frontend mic + host-side mix ------------------- */
@@ -1019,7 +1019,6 @@ static int vj_mic_iface_ok = 0;
 static int vj_mic_unavailable_logged = 0;
 static int vj_voice_want = 0;          /* option asks for voice chat */
 static int vj_voice_monitor = 0;       /* local mic-check mix */
-static int vj_voice_netpacket_logged = 0;
 
 static int voicechat_mic_read(int16_t *samples, size_t num)
 {
@@ -1047,14 +1046,16 @@ static void voicechat_ensure_mic(void)
       return;
    }
 
-   /* Mic capture only when we can TX to a peer (TCP + discovery) or when
-    * local monitor is on for a mic check. Opening the mic under netplay /
-    * disabled netlink leaves the OS indicator on while we discard samples. */
+   /* Mic capture only when we can TX to a peer (TCP + discovery, or
+    * netplay after voice hello confirms) or when local monitor is on
+    * for a mic check. Opening the mic while voice cannot TX leaves the
+    * OS indicator on while we discard samples. */
    mode = JLinkMode();
-   can_tx = JLinkDiscActive()
-            && (mode == JLINK_MODE_TCP_SERVER
-                || mode == JLINK_MODE_TCP_CLIENT)
-            && !JLinkNPActive();
+   can_tx = (JLinkDiscActive()
+             && (mode == JLINK_MODE_TCP_SERVER
+                 || mode == JLINK_MODE_TCP_CLIENT)
+             && !JLinkNPActive())
+            || (JLinkNPActive() && JLinkNPVoiceReady());
    if (!can_tx && !vj_voice_monitor)
    {
       voicechat_close_mic();
@@ -2557,20 +2558,7 @@ static void check_variables(void)
       VoiceChatSetVadThreshold(vad);
       VoiceChatSetMonitor(mon);
       VoiceChatSetMicRead(voicechat_mic_read);
-
-      if (want
-          && (JLinkMode() == JLINK_MODE_NETPACKET
-              || JLinkNPActive()))
-      {
-         if (!vj_voice_netpacket_logged)
-         {
-            LOG_INF("[VOICE] unavailable under RetroArch netplay "
-                    "(no peer address) -- data-only\n");
-            vj_voice_netpacket_logged = 1;
-         }
-      }
-      else
-         vj_voice_netpacket_logged = 0;
+      JLinkNPSetVoiceWant(want);
 
       if (want)
          voicechat_ensure_mic();
@@ -5059,10 +5047,10 @@ void retro_unload_game(void)
    /* Voice chat (#485): close mic and clear host-side buffers. */
    voicechat_close_mic();
    VoiceChatReset();
+   JLinkNPSetVoiceWant(0);
    vj_voice_want = 0;
    vj_voice_monitor = 0;
    vj_mic_unavailable_logged = 0;
-   vj_voice_netpacket_logged = 0;
    video_buffer_alloc_pixels = VIDEO_BUFFER_PIXELS;
    hires_restart_notice_logged = 0;
 
@@ -5320,10 +5308,10 @@ void retro_deinit(void)
    show_texture_replace = true;
    voicechat_close_mic();
    VoiceChatReset();
+   JLinkNPSetVoiceWant(0);
    vj_voice_want = 0;
    vj_voice_monitor = 0;
    vj_mic_unavailable_logged = 0;
-   vj_voice_netpacket_logged = 0;
    show_voice_chat_opts = true;
    /* Non-pad input devices: encoders, phases, attach mask, armed flag and
     * the option-derived type/scale all go back to their load-time values
@@ -5629,6 +5617,7 @@ void retro_run(void)
          voicechat_close_mic();
       if (VoiceChatEnabled() && key && input_state_cb)
          ptt = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, key) ? 1 : 0;
+      JLinkNPVoiceTick();
       VoiceChatFrameTick(ptt);
    }
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -411,7 +411,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_voice_chat",
       "Voice Chat (Host-Side)",
       NULL,
-      "Opt-in voice channel over the Network Link discovery socket -- the Jaguar Voice Modem's real selling point of simultaneous voice + data. This is NOT emulation: voice never entered the Jaguar; the console only issued audio-path control words. Capture uses the frontend microphone API when available. Default off so mic capture never starts unasked. Requires Network Link in TCP Host or TCP Client mode (unavailable under RetroArch netplay -- no peer address is exposed to the core). See docs/voice-chat-design.md.",
+      "Opt-in voice channel over the Network Link -- the Jaguar Voice Modem's real selling point of simultaneous voice + data. This is NOT emulation: voice never entered the Jaguar; the console only issued audio-path control words. Capture uses the frontend microphone API when available. Default off so mic capture never starts unasked. Works over TCP Host/Client (discovery UDP) and over RetroArch netplay when both sides enable the option and speak vjag-netlink-2 (auto-negotiated; falls back to data-only if the peer never confirms). See docs/voice-chat-design.md and docs/voice-chat-netplay-design.md.",
       NULL,
       "network",
       {

--- a/src/jerry/jlink_netpacket.c
+++ b/src/jerry/jlink_netpacket.c
@@ -143,14 +143,12 @@ static void JLinkNPHandleHello(const uint8_t *body, size_t len,
 
    if (flags & JLINK_NP_HELLO_FLAG_WANT)
    {
+      /* Any WANT from a peer is enough to arm: we already replied with a
+         reliable ACK (above) or they already ACKed us. Waiting for an
+         extra ACK bit would only delay mic open. */
       JLinkNPAckedAdd(client_id);
-      /* Treat WANT as enough to arm once we have answered; an ACK bit
-         from them (or a reciprocal WANT) confirms bidirectional. */
-      if ((flags & JLINK_NP_HELLO_FLAG_ACK) || npAckedCount > 0)
-      {
-         npVoiceReady = 1;
-         npVoiceDataOnly = 0;
-      }
+      npVoiceReady = 1;
+      npVoiceDataOnly = 0;
    }
 }
 
@@ -277,24 +275,34 @@ void JLinkNPFlush(void)
       return;
    npTxBuf[0] = JLINK_NP_TYPE_UART;
    npSend(RETRO_NETPACKET_RELIABLE | RETRO_NETPACKET_FLUSH_HINT,
-          npTxBuf, (size_t)(npTxLen + 1), RETRO_NETPACKET_BROADCAST);
+          npTxBuf, (size_t)npTxLen + 1, RETRO_NETPACKET_BROADCAST);
    npTxLen = 0;
 }
 
 void JLinkNPSetVoiceWant(int want)
 {
+   uint32_t now;
+
    npVoiceWant = want ? 1 : 0;
    if (!npVoiceWant)
    {
       JLinkNPVoiceReset();
       return;
    }
+   /* check_variables may call this often — respect the same 500 ms
+      hello throttle as JLinkNPVoiceTick so option re-reads cannot spam
+      reliable broadcasts during the negotiate window. */
    if (npActive && !npVoiceReady && !npVoiceDataOnly)
    {
+      now = JLinkNowMs();
       if (npHelloStartMs == 0)
-         npHelloStartMs = JLinkNowMs();
-      JLinkNPSendHello(0);
-      npHelloLastMs = JLinkNowMs();
+         npHelloStartMs = now;
+      if (npHelloLastMs == 0
+          || (uint32_t)(now - npHelloLastMs) >= JLINK_NP_HELLO_RETRY_MS)
+      {
+         JLinkNPSendHello(0);
+         npHelloLastMs = now;
+      }
    }
 }
 

--- a/src/jerry/jlink_netpacket.c
+++ b/src/jerry/jlink_netpacket.c
@@ -4,24 +4,164 @@
  * RELIABLE broadcast packet (flushed from the frontend's per-frame poll
  * callback, from retro_run via JLinkPoll, or when the batch fills).
  * Received packet payloads feed the shared jlink RX ring byte-for-byte.
+ *
+ * vjag-netlink-2 (#585): every payload is prefixed with a type byte
+ * (NP_UART / NP_VOICE / NP_VOICE_HELLO).  Voice stays host-side; only
+ * NP_UART bytes enter the UART ring.
  */
+#include <stdio.h>
 #include <string.h>
 #include "jlink.h"
 #include "jlink_netpacket.h"
+#include "voicechat.h"
 
-#define JLINK_NP_TXBUF_SIZE 512
+/* UART batch capacity (unchanged from vjag-netlink-1) + 1 type byte. */
+#define JLINK_NP_UART_CAP   512
+#define JLINK_NP_TXBUF_SIZE (JLINK_NP_UART_CAP + 1)
+
+#define JLINK_NP_HELLO_RETRY_MS   500
+#define JLINK_NP_HELLO_TIMEOUT_MS 5000
+#define JLINK_NP_VOICE_PEERS_MAX  8
 
 static retro_netpacket_send_t npSend = NULL;
 static retro_netpacket_poll_receive_t npPollReceive = NULL;
 static int npActive = 0;
 static int npPrevMode = JLINK_MODE_DISABLED;
 static uint8_t npTxBuf[JLINK_NP_TXBUF_SIZE];
-static uint32_t npTxLen = 0;
+static uint32_t npTxLen = 0;   /* UART payload bytes (excludes type) */
+
+/* Voice negotiate state. */
+static int npVoiceWant = 0;
+static int npVoiceReady = 0;
+static int npVoiceDataOnly = 0;
+static int npVoiceLogged = 0;
+static uint32_t npHelloStartMs = 0;
+static uint32_t npHelloLastMs = 0;
+static uint32_t npLocalSenderId = 0;
+static int npLocalSenderReady = 0;
+
+static uint16_t npAckedClients[JLINK_NP_VOICE_PEERS_MAX];
+static unsigned npAckedCount = 0;
+
+static uint32_t JLinkNPEnsureSenderId(void)
+{
+   if (!npLocalSenderReady)
+   {
+      uint32_t x = JLinkNowMs() ^ (uint32_t)(size_t)&npLocalSenderId;
+      if (x == 0)
+         x = 0xA5A5A5A5u;
+      x ^= x << 13;
+      x ^= x >> 17;
+      x ^= x << 5;
+      npLocalSenderId = x ? x : 1u;
+      npLocalSenderReady = 1;
+   }
+   return npLocalSenderId;
+}
+
+static void JLinkNPVoiceReset(void)
+{
+   npVoiceReady = 0;
+   npVoiceDataOnly = 0;
+   npVoiceLogged = 0;
+   npHelloStartMs = 0;
+   npHelloLastMs = 0;
+   npAckedCount = 0;
+   memset(npAckedClients, 0, sizeof(npAckedClients));
+}
+
+static int JLinkNPAckedHas(uint16_t client_id)
+{
+   unsigned i;
+   for (i = 0; i < npAckedCount; i++)
+   {
+      if (npAckedClients[i] == client_id)
+         return 1;
+   }
+   return 0;
+}
+
+static void JLinkNPAckedAdd(uint16_t client_id)
+{
+   if (JLinkNPAckedHas(client_id))
+      return;
+   if (npAckedCount >= JLINK_NP_VOICE_PEERS_MAX)
+      return;
+   npAckedClients[npAckedCount++] = client_id;
+}
+
+static void JLinkNPSendHello(int ack)
+{
+   uint8_t pkt[JLINK_NP_HELLO_PKT_LEN];
+   uint32_t sid;
+   uint8_t flags;
+
+   if (!npActive || !npSend || !npVoiceWant)
+      return;
+
+   sid = JLinkNPEnsureSenderId();
+   flags = (uint8_t)(JLINK_NP_HELLO_FLAG_WANT | (ack ? JLINK_NP_HELLO_FLAG_ACK : 0));
+   pkt[0] = JLINK_NP_TYPE_VOICE_HELLO;
+   pkt[1] = 'V';
+   pkt[2] = 'C';
+   pkt[3] = JLINK_NP_HELLO_VERSION;
+   pkt[4] = flags;
+   pkt[5] = (uint8_t)((sid >> 24) & 0xFF);
+   pkt[6] = (uint8_t)((sid >> 16) & 0xFF);
+   pkt[7] = (uint8_t)((sid >> 8) & 0xFF);
+   pkt[8] = (uint8_t)(sid & 0xFF);
+   npSend(RETRO_NETPACKET_RELIABLE | RETRO_NETPACKET_FLUSH_HINT,
+          pkt, JLINK_NP_HELLO_PKT_LEN, RETRO_NETPACKET_BROADCAST);
+}
+
+static void JLinkNPHandleHello(const uint8_t *body, size_t len,
+                               uint16_t client_id)
+{
+   uint8_t flags;
+   uint32_t sid;
+
+   if (!body || len < JLINK_NP_HELLO_BODY_LEN)
+      return;
+   if (body[0] != 'V' || body[1] != 'C')
+      return;
+   if (body[2] != JLINK_NP_HELLO_VERSION)
+      return;
+
+   flags = body[3];
+   sid = ((uint32_t)body[4] << 24) | ((uint32_t)body[5] << 16)
+       | ((uint32_t)body[6] << 8) | (uint32_t)body[7];
+   if (sid == 0 || sid == JLinkNPEnsureSenderId())
+      return; /* ignore echo / invalid */
+
+   if (!npVoiceWant)
+      return;
+
+   /* Answer offers only — never ACK an ACK, or both sides keep
+    * reflecting hellos forever. */
+   if (!(flags & JLINK_NP_HELLO_FLAG_ACK))
+      JLinkNPSendHello(1);
+
+   if (flags & JLINK_NP_HELLO_FLAG_WANT)
+   {
+      JLinkNPAckedAdd(client_id);
+      /* Treat WANT as enough to arm once we have answered; an ACK bit
+         from them (or a reciprocal WANT) confirms bidirectional. */
+      if ((flags & JLINK_NP_HELLO_FLAG_ACK) || npAckedCount > 0)
+      {
+         npVoiceReady = 1;
+         npVoiceDataOnly = 0;
+      }
+   }
+}
+
+static int JLinkNPVoiceSendThunk(const uint8_t *pkt, size_t len)
+{
+   return JLinkNPSendVoice(pkt, len);
+}
 
 void JLinkNPStart(uint16_t client_id, retro_netpacket_send_t send_fn,
                   retro_netpacket_poll_receive_t poll_receive_fn)
 {
-   (void)client_id;
    /* The libretro contract guarantees a valid send_fn, but a NULL here
       would otherwise leave the link claiming to be connected while
       JLinkNPFlush can never drain the TX buffer. */
@@ -32,15 +172,45 @@ void JLinkNPStart(uint16_t client_id, retro_netpacket_send_t send_fn,
    npSend = send_fn;
    npPollReceive = poll_receive_fn;
    npTxLen = 0;
+   npTxBuf[0] = JLINK_NP_TYPE_UART;
    npActive = 1;
+   (void)client_id;
+   JLinkNPVoiceReset();
+   VoiceChatSetNetSend(JLinkNPVoiceSendThunk);
    JLinkOpen(JLINK_MODE_NETPACKET);
+   if (npVoiceWant)
+   {
+      npHelloStartMs = JLinkNowMs();
+      npHelloLastMs = 0;
+      JLinkNPSendHello(0);
+      npHelloLastMs = npHelloStartMs;
+   }
 }
 
 void JLinkNPReceive(const void *buf, size_t len, uint16_t client_id)
 {
-   (void)client_id;
-   if (npActive && buf)
-      JLinkNPDeliver((const uint8_t *)buf, len);
+   const uint8_t *p;
+
+   if (!npActive || !buf || len < 1)
+      return;
+   p = (const uint8_t *)buf;
+   switch (p[0])
+   {
+      case JLINK_NP_TYPE_UART:
+         if (len > 1)
+            JLinkNPDeliver(p + 1, len - 1);
+         break;
+      case JLINK_NP_TYPE_VOICE:
+         if (len > 1)
+            VoiceChatOnRaw(p + 1, len - 1, NULL, 0);
+         break;
+      case JLINK_NP_TYPE_VOICE_HELLO:
+         JLinkNPHandleHello(p + 1, len - 1, client_id);
+         break;
+      default:
+         /* Unknown type: drop. Do not push into the UART ring. */
+         break;
+   }
 }
 
 void JLinkNPStop(void)
@@ -49,6 +219,8 @@ void JLinkNPStop(void)
    npSend = NULL;
    npPollReceive = NULL;
    npTxLen = 0;
+   VoiceChatSetNetSend(NULL);
+   JLinkNPVoiceReset();
    JLinkClose();
    if (npPrevMode != JLINK_MODE_DISABLED
        && npPrevMode != JLINK_MODE_NETPACKET)
@@ -58,6 +230,7 @@ void JLinkNPStop(void)
 
 void JLinkNPPoll(void)
 {
+   JLinkNPVoiceTick();
    JLinkNPFlush();
 }
 
@@ -70,16 +243,17 @@ void JLinkNPQueueByte(uint8_t b)
 {
    if (!npActive)
       return;
-   if (npTxLen >= JLINK_NP_TXBUF_SIZE)
+   if (npTxLen >= JLINK_NP_UART_CAP)
    {
       /* Full: flush to make room — dropping link bytes risks a game
          desync.  Only drop if the flush couldn't drain (inconsistent
          state; cannot happen for an active session). */
       JLinkNPFlush();
-      if (npTxLen >= JLINK_NP_TXBUF_SIZE)
+      if (npTxLen >= JLINK_NP_UART_CAP)
          return;
    }
-   npTxBuf[npTxLen++] = b;
+   npTxBuf[1 + npTxLen] = b;
+   npTxLen++;
    /* No flush here: the UART flushes at burst end (transmit shift
       register drains with nothing queued), which keeps mid-frame tic
       exchanges sub-millisecond WITHOUT emitting one reliable packet
@@ -101,7 +275,85 @@ void JLinkNPFlush(void)
 {
    if (!npActive || !npSend || npTxLen == 0)
       return;
+   npTxBuf[0] = JLINK_NP_TYPE_UART;
    npSend(RETRO_NETPACKET_RELIABLE | RETRO_NETPACKET_FLUSH_HINT,
-          npTxBuf, npTxLen, RETRO_NETPACKET_BROADCAST);
+          npTxBuf, (size_t)(npTxLen + 1), RETRO_NETPACKET_BROADCAST);
    npTxLen = 0;
+}
+
+void JLinkNPSetVoiceWant(int want)
+{
+   npVoiceWant = want ? 1 : 0;
+   if (!npVoiceWant)
+   {
+      JLinkNPVoiceReset();
+      return;
+   }
+   if (npActive && !npVoiceReady && !npVoiceDataOnly)
+   {
+      if (npHelloStartMs == 0)
+         npHelloStartMs = JLinkNowMs();
+      JLinkNPSendHello(0);
+      npHelloLastMs = JLinkNowMs();
+   }
+}
+
+int JLinkNPVoiceReady(void)
+{
+   return npActive && npVoiceWant && npVoiceReady;
+}
+
+void JLinkNPVoiceTick(void)
+{
+   uint32_t now;
+
+   if (!npActive || !npVoiceWant)
+      return;
+   if (npVoiceReady)
+      return;
+
+   now = JLinkNowMs();
+   if (npHelloStartMs == 0)
+      npHelloStartMs = now;
+
+   if (!npVoiceDataOnly
+       && (uint32_t)(now - npHelloStartMs) >= JLINK_NP_HELLO_TIMEOUT_MS)
+   {
+      npVoiceDataOnly = 1;
+      if (!npVoiceLogged)
+      {
+         fprintf(stderr, "[VOICE] peer has no voice chat -- data-only\n");
+         npVoiceLogged = 1;
+      }
+      return;
+   }
+
+   if (npVoiceDataOnly)
+      return;
+
+   if (npHelloLastMs == 0
+       || (uint32_t)(now - npHelloLastMs) >= JLINK_NP_HELLO_RETRY_MS)
+   {
+      JLinkNPSendHello(0);
+      npHelloLastMs = now;
+   }
+}
+
+int JLinkNPSendVoice(const uint8_t *pkt, size_t len)
+{
+   uint8_t frame[1 + VC_PKT_LEN];
+
+   if (!npActive || !npSend || !pkt || len == 0)
+      return 0;
+   if (!npVoiceReady)
+      return 0;
+   if (len > VC_PKT_LEN)
+      return 0;
+   frame[0] = JLINK_NP_TYPE_VOICE;
+   memcpy(frame + 1, pkt, len);
+   /* Best-effort: must not block lockstep UART. Frontends without
+      unreliable support silently promote to reliable (libretro.h). */
+   npSend(RETRO_NETPACKET_UNRELIABLE | RETRO_NETPACKET_UNSEQUENCED,
+          frame, len + 1, RETRO_NETPACKET_BROADCAST);
+   return 1;
 }

--- a/src/jerry/jlink_netpacket.h
+++ b/src/jerry/jlink_netpacket.h
@@ -6,6 +6,10 @@
  * the core option had configured); when it stops, the previous mode is
  * restored.  Multi-peer is native: TX batches are broadcast, so CatNet
  * titles work over netplay too.
+ *
+ * Wire protocol vjag-netlink-2 (#585): every payload starts with a 1-byte
+ * type (NP_UART / NP_VOICE / NP_VOICE_HELLO).  Voice is host-side only and
+ * never enters the UART ring.
  */
 #ifndef __JLINK_NETPACKET_H__
 #define __JLINK_NETPACKET_H__
@@ -17,6 +21,20 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* vjag-netlink-2 packet type prefixes. */
+#define JLINK_NP_TYPE_UART        0x01
+#define JLINK_NP_TYPE_VOICE       0x02
+#define JLINK_NP_TYPE_VOICE_HELLO 0x03
+
+/* Voice-hello body after the type byte:
+ *   'V','C', version, flags, senderId[4]
+ * flags: bit0 = wants voice, bit1 = ack of a hello already received. */
+#define JLINK_NP_HELLO_VERSION    1
+#define JLINK_NP_HELLO_FLAG_WANT  0x01
+#define JLINK_NP_HELLO_FLAG_ACK   0x02
+#define JLINK_NP_HELLO_BODY_LEN   8   /* without the type byte */
+#define JLINK_NP_HELLO_PKT_LEN    (1 + JLINK_NP_HELLO_BODY_LEN)
 
 /* retro_netpacket_callback members (wired up in libretro.c). */
 void JLinkNPStart(uint16_t client_id, retro_netpacket_send_t send_fn,
@@ -30,6 +48,12 @@ int  JLinkNPActive(void);
 void JLinkNPQueueByte(uint8_t b);
 void JLinkNPFlush(void);
 void JLinkNPPumpReceive(void);
+
+/* Voice overlay (#585): capability negotiate + unreliable voice TX. */
+void JLinkNPSetVoiceWant(int want);
+int  JLinkNPVoiceReady(void);
+void JLinkNPVoiceTick(void);
+int  JLinkNPSendVoice(const uint8_t *pkt, size_t len);
 
 #ifdef __cplusplus
 }

--- a/src/jerry/voicechat.c
+++ b/src/jerry/voicechat.c
@@ -14,6 +14,18 @@
 #define VC_VAD_HANG_FRAMES 8
 #define VC_MIC_PULL_MAX    320   /* up to 40 ms of 8 kHz per video frame */
 
+typedef struct
+{
+   uint32_t senderId;
+   int      inUse;
+   uint32_t lastMs;
+   int16_t  samples[VC_JITTER_SAMPLES];
+   unsigned head;
+   unsigned count;
+   uint16_t expectSeq;
+   int      haveExpect;
+} VoiceChatStream;
+
 static int vcEnabled = 0;
 static int vcGate = VC_GATE_OPEN_MIC;
 static unsigned vcPttKey = 0;
@@ -21,6 +33,7 @@ static unsigned vcVolume = 50;
 static unsigned vcVadThresh = 400;
 static int vcMonitor = 0;
 static VoiceChatMicReadFn vcMicRead = NULL;
+static VoiceChatNetSendFn vcNetSend = NULL;
 
 static uint32_t vcSenderId = 0;
 static int vcSenderIdReady = 0;
@@ -29,11 +42,7 @@ static char vcPeerAddr[VC_PEER_ADDR_MAX];
 static uint32_t vcLastKeepaliveMs = 0;
 static uint32_t vcLastVoiceMs = 0;
 
-static int16_t vcJitter[VC_JITTER_SAMPLES];
-static unsigned vcJitHead = 0;
-static unsigned vcJitCount = 0;
-static uint16_t vcJitExpectSeq = 0;
-static int vcJitHaveExpect = 0;
+static VoiceChatStream vcStreams[VC_MAX_SPEAKERS];
 
 static int16_t vcMonRing[VC_FRAME_SAMPLES];
 static unsigned vcMonCount = 0;
@@ -173,6 +182,8 @@ static uint32_t VoiceChatEnsureSenderId(void)
 
 void VoiceChatReset(void)
 {
+   unsigned i;
+
    vcEnabled = 0;
    vcGate = VC_GATE_OPEN_MIC;
    vcPttKey = 0;
@@ -180,33 +191,38 @@ void VoiceChatReset(void)
    vcVadThresh = 400;
    vcMonitor = 0;
    vcMicRead = NULL;
+   vcNetSend = NULL;
    vcSenderId = 0;
    vcSenderIdReady = 0;
    vcTxSeq = 0;
    vcPeerAddr[0] = '\0';
    vcLastKeepaliveMs = 0;
    vcLastVoiceMs = 0;
-   vcJitHead = 0;
-   vcJitCount = 0;
-   vcJitExpectSeq = 0;
-   vcJitHaveExpect = 0;
    vcMonCount = 0;
    vcVadOpen = 0;
    vcVadHang = 0;
    vcMicAccumN = 0;
-   memset(vcJitter, 0, sizeof(vcJitter));
+   memset(vcStreams, 0, sizeof(vcStreams));
    memset(vcMonRing, 0, sizeof(vcMonRing));
    memset(vcMicAccum, 0, sizeof(vcMicAccum));
+   for (i = 0; i < VC_MAX_SPEAKERS; i++)
+      vcStreams[i].inUse = 0;
 }
 
 void VoiceChatSetEnabled(int enabled)
 {
+   unsigned i;
+
    vcEnabled = enabled ? 1 : 0;
    if (!vcEnabled)
    {
-      vcJitHead = 0;
-      vcJitCount = 0;
-      vcJitHaveExpect = 0;
+      for (i = 0; i < VC_MAX_SPEAKERS; i++)
+      {
+         vcStreams[i].inUse = 0;
+         vcStreams[i].head = 0;
+         vcStreams[i].count = 0;
+         vcStreams[i].haveExpect = 0;
+      }
       vcMicAccumN = 0;
       vcMonCount = 0;
       vcVadOpen = 0;
@@ -256,6 +272,11 @@ void VoiceChatSetMicRead(VoiceChatMicReadFn fn)
    vcMicRead = fn;
 }
 
+void VoiceChatSetNetSend(VoiceChatNetSendFn fn)
+{
+   vcNetSend = fn;
+}
+
 void VoiceChatSetSenderId(uint32_t id)
 {
    vcSenderId = id ? id : 1;
@@ -278,66 +299,149 @@ const char *VoiceChatPeerAddr(void)
    return vcPeerAddr;
 }
 
-/* ---- Jitter buffer --------------------------------------------------- */
+/* ---- Jitter buffer (per-sender, up to VC_MAX_SPEAKERS) ---------------- */
 
-void VoiceChatJitterPush(const int16_t pcm[VC_FRAME_SAMPLES], uint16_t seq)
+static VoiceChatStream *VoiceChatFindStream(uint32_t senderId, int claim)
+{
+   unsigned i;
+   unsigned freeIdx;
+   unsigned staleIdx;
+   uint32_t staleMs;
+   uint32_t now;
+
+   freeIdx = VC_MAX_SPEAKERS;
+   staleIdx = 0;
+   staleMs = 0xFFFFFFFFu;
+   now = JLinkNowMs();
+
+   for (i = 0; i < VC_MAX_SPEAKERS; i++)
+   {
+      if (vcStreams[i].inUse && vcStreams[i].senderId == senderId)
+      {
+         vcStreams[i].lastMs = now;
+         return &vcStreams[i];
+      }
+      if (!vcStreams[i].inUse && freeIdx == VC_MAX_SPEAKERS)
+         freeIdx = i;
+      if (vcStreams[i].inUse && vcStreams[i].lastMs < staleMs)
+      {
+         staleMs = vcStreams[i].lastMs;
+         staleIdx = i;
+      }
+   }
+
+   if (!claim)
+      return NULL;
+
+   if (freeIdx < VC_MAX_SPEAKERS)
+      i = freeIdx;
+   else
+      i = staleIdx; /* reclaim least-recently-active */
+
+   memset(&vcStreams[i], 0, sizeof(vcStreams[i]));
+   vcStreams[i].inUse = 1;
+   vcStreams[i].senderId = senderId;
+   vcStreams[i].lastMs = now;
+   return &vcStreams[i];
+}
+
+static void VoiceChatStreamPush(VoiceChatStream *st,
+                                const int16_t pcm[VC_FRAME_SAMPLES],
+                                uint16_t seq)
 {
    unsigned i;
 
-   if (!pcm)
+   if (!st || !pcm)
       return;
 
-   /* Drop late / duplicate: if we already have an expectation and this
-    * seq is older than expect (wrapping-aware half-window), skip. */
-   if (vcJitHaveExpect)
+   if (st->haveExpect)
    {
-      int16_t delta = (int16_t)(seq - vcJitExpectSeq);
+      int16_t delta = (int16_t)(seq - st->expectSeq);
       if (delta < 0)
          return;
-      /* Fill gaps with silence so MixInto stays continuous. */
-      while (delta > 0 && vcJitCount + VC_FRAME_SAMPLES <= VC_JITTER_SAMPLES)
+      while (delta > 0 && st->count + VC_FRAME_SAMPLES <= VC_JITTER_SAMPLES)
       {
          for (i = 0; i < VC_FRAME_SAMPLES; i++)
          {
-            unsigned idx = (vcJitHead + vcJitCount) % VC_JITTER_SAMPLES;
-            vcJitter[idx] = 0;
-            vcJitCount++;
+            unsigned idx = (st->head + st->count) % VC_JITTER_SAMPLES;
+            st->samples[idx] = 0;
+            st->count++;
          }
-         vcJitExpectSeq++;
+         st->expectSeq++;
          delta--;
       }
    }
 
-   if (vcJitCount + VC_FRAME_SAMPLES > VC_JITTER_SAMPLES)
+   if (st->count + VC_FRAME_SAMPLES > VC_JITTER_SAMPLES)
    {
-      /* Overflow: drop oldest frame. */
-      vcJitHead = (vcJitHead + VC_FRAME_SAMPLES) % VC_JITTER_SAMPLES;
-      vcJitCount -= VC_FRAME_SAMPLES;
+      st->head = (st->head + VC_FRAME_SAMPLES) % VC_JITTER_SAMPLES;
+      st->count -= VC_FRAME_SAMPLES;
    }
 
    for (i = 0; i < VC_FRAME_SAMPLES; i++)
    {
-      unsigned idx = (vcJitHead + vcJitCount) % VC_JITTER_SAMPLES;
-      vcJitter[idx] = pcm[i];
-      vcJitCount++;
+      unsigned idx = (st->head + st->count) % VC_JITTER_SAMPLES;
+      st->samples[idx] = pcm[i];
+      st->count++;
    }
-   vcJitExpectSeq = (uint16_t)(seq + 1);
-   vcJitHaveExpect = 1;
+   st->expectSeq = (uint16_t)(seq + 1);
+   st->haveExpect = 1;
+}
+
+static int VoiceChatStreamPop(VoiceChatStream *st, int16_t *out)
+{
+   if (!st || !st->inUse || st->count == 0 || !out)
+      return 0;
+   *out = st->samples[st->head];
+   st->head = (st->head + 1) % VC_JITTER_SAMPLES;
+   st->count--;
+   return 1;
+}
+
+void VoiceChatJitterPushFrom(uint32_t senderId,
+                             const int16_t pcm[VC_FRAME_SAMPLES],
+                             uint16_t seq)
+{
+   VoiceChatStream *st = VoiceChatFindStream(senderId, 1);
+   VoiceChatStreamPush(st, pcm, seq);
+}
+
+void VoiceChatJitterPush(const int16_t pcm[VC_FRAME_SAMPLES], uint16_t seq)
+{
+   /* Default stream (senderId 0) for unit tests / single-peer helpers. */
+   VoiceChatJitterPushFrom(0, pcm, seq);
 }
 
 int VoiceChatJitterPop(int16_t *out)
 {
-   if (vcJitCount == 0 || !out)
+   VoiceChatStream *st = VoiceChatFindStream(0, 0);
+   if (!st)
       return 0;
-   *out = vcJitter[vcJitHead];
-   vcJitHead = (vcJitHead + 1) % VC_JITTER_SAMPLES;
-   vcJitCount--;
-   return 1;
+   return VoiceChatStreamPop(st, out);
 }
 
 unsigned VoiceChatJitterCount(void)
 {
-   return vcJitCount;
+   unsigned i;
+   unsigned total = 0;
+   for (i = 0; i < VC_MAX_SPEAKERS; i++)
+   {
+      if (vcStreams[i].inUse)
+         total += vcStreams[i].count;
+   }
+   return total;
+}
+
+unsigned VoiceChatActiveSpeakers(void)
+{
+   unsigned i;
+   unsigned n = 0;
+   for (i = 0; i < VC_MAX_SPEAKERS; i++)
+   {
+      if (vcStreams[i].inUse)
+         n++;
+   }
+   return n;
 }
 
 /* ---- TX helpers ------------------------------------------------------ */
@@ -370,6 +474,15 @@ static void VoiceChatSendFrame(uint8_t flags, const int16_t pcm[VC_FRAME_SAMPLES
                           VoiceChatEnsureSenderId(), mulaw);
    if (!n)
       return;
+
+   /* Netpacket path (#585): registered sink + netplay mode. No peer
+    * address needed — the frontend delivers by client_id. */
+   if (vcNetSend && JLinkMode() == JLINK_MODE_NETPACKET)
+   {
+      if (vcNetSend(pkt, n) && !isKeepalive)
+         vcLastVoiceMs = JLinkNowMs();
+      return;
+   }
 
    peer = vcPeerAddr;
    if (!peer[0] && JLinkMode() == JLINK_MODE_TCP_CLIENT)
@@ -506,17 +619,18 @@ void VoiceChatOnRaw(const uint8_t *buf, size_t len,
 
    for (i = 0; i < VC_FRAME_SAMPLES; i++)
       pcm[i] = VoiceChatMuLawDecode(mulaw[i]);
-   VoiceChatJitterPush(pcm, seq);
+   VoiceChatJitterPushFrom(senderId, pcm, seq);
 }
 
 void VoiceChatMixInto(uint16_t *buf, unsigned pairs)
 {
    unsigned i;
+   unsigned s;
    int vol;
    int mixed;
    int16_t *stereo;
    int left, right;
-   int16_t holdFar;
+   int16_t holdFar[VC_MAX_SPEAKERS];
    int16_t holdMon;
    unsigned monIdx;
 
@@ -527,7 +641,8 @@ void VoiceChatMixInto(uint16_t *buf, unsigned pairs)
 
    vol = (int)vcVolume;
    stereo = (int16_t *)buf;
-   holdFar = 0;
+   for (s = 0; s < VC_MAX_SPEAKERS; s++)
+      holdFar[s] = 0;
    holdMon = 0;
    monIdx = 0;
 
@@ -536,8 +651,16 @@ void VoiceChatMixInto(uint16_t *buf, unsigned pairs)
       /* 6× upsample: one 8 kHz sample every VC_UPSAMPLE output pairs. */
       if ((i % VC_UPSAMPLE) == 0)
       {
-         if (!VoiceChatJitterPop(&holdFar))
-            holdFar = 0;
+         for (s = 0; s < VC_MAX_SPEAKERS; s++)
+         {
+            if (!vcStreams[s].inUse)
+            {
+               holdFar[s] = 0;
+               continue;
+            }
+            if (!VoiceChatStreamPop(&vcStreams[s], &holdFar[s]))
+               holdFar[s] = 0;
+         }
          if (vcMonitor && monIdx < vcMonCount)
          {
             holdMon = vcMonRing[monIdx];
@@ -547,7 +670,9 @@ void VoiceChatMixInto(uint16_t *buf, unsigned pairs)
             holdMon = 0;
       }
 
-      mixed = ((int)holdFar * vol) / 100;
+      mixed = 0;
+      for (s = 0; s < VC_MAX_SPEAKERS; s++)
+         mixed += ((int)holdFar[s] * vol) / 100;
       if (vcMonitor)
          mixed += ((int)holdMon * vol) / 100;
 

--- a/src/jerry/voicechat.c
+++ b/src/jerry/voicechat.c
@@ -444,6 +444,17 @@ unsigned VoiceChatActiveSpeakers(void)
    return n;
 }
 
+int VoiceChatHasSpeaker(uint32_t senderId)
+{
+   unsigned i;
+   for (i = 0; i < VC_MAX_SPEAKERS; i++)
+   {
+      if (vcStreams[i].inUse && vcStreams[i].senderId == senderId)
+         return 1;
+   }
+   return 0;
+}
+
 /* ---- TX helpers ------------------------------------------------------ */
 
 static void VoiceChatSendFrame(uint8_t flags, const int16_t pcm[VC_FRAME_SAMPLES])

--- a/src/jerry/voicechat.h
+++ b/src/jerry/voicechat.h
@@ -109,6 +109,8 @@ void VoiceChatJitterPushFrom(uint32_t senderId,
 int  VoiceChatJitterPop(int16_t *out);
 unsigned VoiceChatJitterCount(void);
 unsigned VoiceChatActiveSpeakers(void);
+/* Test hook: 1 if senderId currently owns a jitter slot. */
+int VoiceChatHasSpeaker(uint32_t senderId);
 
 #ifdef __cplusplus
 }

--- a/src/jerry/voicechat.h
+++ b/src/jerry/voicechat.h
@@ -28,6 +28,7 @@ extern "C" {
 #define VC_PKT_LEN           (VC_HDR_LEN + VC_FRAME_SAMPLES)
 #define VC_UPSAMPLE          6     /* 48000 / 8000 */
 #define VC_PEER_ADDR_MAX     46
+#define VC_MAX_SPEAKERS      3     /* concurrent far-end mix (#585) */
 
 enum
 {
@@ -38,6 +39,12 @@ enum
 /* Optional mic read: fill up to num mono int16 samples; return count or
  * -1 if unavailable. Registered by libretro.c from the frontend mic API. */
 typedef int (*VoiceChatMicReadFn)(int16_t *samples, size_t num);
+
+/* Optional netpacket TX sink (#585). When set and the link is in
+ * JLINK_MODE_NETPACKET, VoiceChatSendFrame routes through this instead
+ * of the discovery UDP socket. Keeps voicechat.c free of a hard
+ * dependency on jlink_netpacket.c (unit tests link voicechat alone). */
+typedef int (*VoiceChatNetSendFn)(const uint8_t *pkt, size_t len);
 
 /* ---- Pure logic (unit-testable) -------------------------------------- */
 
@@ -70,6 +77,7 @@ void VoiceChatSetVolume(unsigned pct);    /* 0..100 */
 void VoiceChatSetVadThreshold(unsigned thresh);
 void VoiceChatSetMonitor(int enabled);
 void VoiceChatSetMicRead(VoiceChatMicReadFn fn);
+void VoiceChatSetNetSend(VoiceChatNetSendFn fn);
 void VoiceChatSetSenderId(uint32_t id);   /* tests; 0 = lazy random */
 
 /* Peer address for outbound unicast (dotted-quad or hostname). Cleared
@@ -93,10 +101,14 @@ void VoiceChatOnRaw(const uint8_t *buf, size_t len,
 void VoiceChatMixInto(uint16_t *buf, unsigned pairs);
 
 /* Test hooks: push decoded PCM into the jitter buffer; pop one 8 kHz
- * sample (-1 if empty). */
+ * sample (-1 if empty). Default stream uses senderId 0. */
 void VoiceChatJitterPush(const int16_t pcm[VC_FRAME_SAMPLES], uint16_t seq);
+void VoiceChatJitterPushFrom(uint32_t senderId,
+                             const int16_t pcm[VC_FRAME_SAMPLES],
+                             uint16_t seq);
 int  VoiceChatJitterPop(int16_t *out);
 unsigned VoiceChatJitterCount(void);
+unsigned VoiceChatActiveSpeakers(void);
 
 #ifdef __cplusplus
 }

--- a/test/test_jlink_netpacket.c
+++ b/test/test_jlink_netpacket.c
@@ -122,7 +122,8 @@ int main(int argc, char **argv)
     jlink_int_t jlink_mode;
     struct retro_game_info game;
     int i;
-    uint8_t rx_payload[2];
+    uint8_t rx_payload[3];
+    uint8_t junk[2];
 
     h = dlopen(core_path, RTLD_NOW);
     if (!h) { fprintf(stderr, "dlopen: %s\n", dlerror()); return 1; }
@@ -150,7 +151,7 @@ int main(int argc, char **argv)
     CHECK(np_cb.start && np_cb.receive && np_cb.stop && np_cb.poll,
           "callback members populated");
     CHECK(np_cb.protocol_version
-              && !strcmp(np_cb.protocol_version, "vjag-netlink-1"),
+              && !strcmp(np_cb.protocol_version, "vjag-netlink-2"),
           "protocol version pinned");
 
     p_set_video_refresh(video_cb);
@@ -181,14 +182,15 @@ int main(int argc, char **argv)
     jerry_ww(0xF10034, 0x0000, 0);
     jerry_ww(0xF10030, 0x00A5, 0);
     jerry_ww(0xF10030, 0x005A, 0);
-    for (i = 0; i < 3 && sent_len < 2; i++)
+    for (i = 0; i < 3 && sent_len < 3; i++)
     {
         p_run();
         if (np_cb.poll)
             np_cb.poll();
     }
-    CHECK(sent_len == 2 && sent_data[0] == 0xA5 && sent_data[1] == 0x5A,
-          "TX bytes arrive at frontend send_fn in order");
+    CHECK(sent_len == 3 && sent_data[0] == 0x01
+              && sent_data[1] == 0xA5 && sent_data[2] == 0x5A,
+          "TX bytes arrive framed as NP_UART + payload");
     CHECK((sent_flags & RETRO_NETPACKET_RELIABLE) != 0,
           "TX uses RELIABLE flag");
     CHECK(sent_client == RETRO_NETPACKET_BROADCAST,
@@ -198,8 +200,10 @@ int main(int argc, char **argv)
        polls RBF at frame granularity, so back-to-back ring deliveries at
        fast baud would overrun exactly as hardware would. */
     jerry_ww(0xF10034, 0x0FFF, 0);
-    rx_payload[0] = 0xC3; rx_payload[1] = 0x3C;
-    np_cb.receive(rx_payload, 2, 1);
+    rx_payload[0] = 0x01; /* NP_UART */
+    rx_payload[1] = 0xC3;
+    rx_payload[2] = 0x3C;
+    np_cb.receive(rx_payload, 3, 1);
     for (i = 0; i < 6 && !(jerry_rw(0xF10032, 0) & 0x0080); i++)
         p_run();
     CHECK((jerry_rw(0xF10032, 0) & 0x0080) != 0, "receive(): RBF sets");
@@ -207,6 +211,15 @@ int main(int argc, char **argv)
     for (i = 0; i < 6 && !(jerry_rw(0xF10032, 0) & 0x0080); i++)
         p_run();
     CHECK((jerry_rw(0xF10030, 0) & 0xFF) == 0x3C, "receive(): 2nd byte");
+
+    /* Unknown type must not enter the UART ring. */
+    junk[0] = 0x7F;
+    junk[1] = 0xEE;
+    np_cb.receive(junk, 2, 1);
+    for (i = 0; i < 3; i++)
+        p_run();
+    CHECK((jerry_rw(0xF10032, 0) & 0x0080) == 0,
+          "unknown type dropped (RBF clear)");
 
     /* --- session ends --- */
     np_cb.stop();

--- a/test/test_voice_netpacket.c
+++ b/test/test_voice_netpacket.c
@@ -1,0 +1,605 @@
+/* test_voice_netpacket.c — host-side voice over framed netpacket (#585).
+ *
+ * Two independent core images + a packet-queue relay (same pattern as
+ * test_voicemodem_netpacket). Exercises:
+ *   1) voice on both sides → hello/ack → NP_VOICE (unreliable) → far-side
+ *      mix energy
+ *   2) voice off on one side → hello never confirms → data-only, zero
+ *      NP_VOICE from the voice-enabled side after the timeout
+ *
+ * Usage: test_voice_netpacket <core.so|.dylib>
+ */
+#if !defined(_WIN32) && !defined(_DEFAULT_SOURCE)
+#define _DEFAULT_SOURCE 1
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <dlfcn.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <time.h>
+#include <libretro.h>
+
+#define ROM_SIZE      131072
+#define INBOX_PKTS    128
+#define INBOX_PKTMAX  512
+#define MAX_FRAMES    600
+
+#define NP_UART        0x01
+#define NP_VOICE       0x02
+#define NP_VOICE_HELLO 0x03
+
+static int failures = 0;
+#define CHECK(cond, msg) \
+    do { if (cond) printf("PASS %s\n", msg); \
+         else { printf("FAIL %s\n", msg); failures++; } } while (0)
+
+typedef void (*vj_void_t)(void);
+typedef int  (*vj_int_t)(void);
+
+typedef struct
+{
+   int         idx;
+   const char *name;
+   void       *handle;
+   char        path[512];
+   int         voice_want; /* GET_VARIABLE answer */
+
+   void (*set_environment)(retro_environment_t);
+   void (*set_video_refresh)(retro_video_refresh_t);
+   void (*set_audio_sample)(retro_audio_sample_t);
+   void (*set_audio_sample_batch)(retro_audio_sample_batch_t);
+   void (*set_input_poll)(retro_input_poll_t);
+   void (*set_input_state)(retro_input_state_t);
+   vj_void_t init;
+   bool (*load_game)(const struct retro_game_info *);
+   vj_void_t run;
+   vj_void_t unload_game;
+   vj_void_t deinit;
+
+   vj_int_t jlink_mode;
+   vj_int_t jlink_np_voice_ready;
+
+   struct retro_netpacket_callback np;
+   int np_registered;
+
+   uint8_t  inbox[INBOX_PKTS][INBOX_PKTMAX];
+   size_t   inbox_len[INBOX_PKTS];
+   unsigned inbox_head;
+   unsigned inbox_count;
+   int      inbox_overflow;
+
+   unsigned pkts_uart;
+   unsigned pkts_voice;
+   unsigned pkts_hello;
+   unsigned voice_unreliable_ok;
+   unsigned voice_flags_bad;
+
+   /* Accumulated far-end mix energy from audio_batch. */
+   unsigned long audio_abs_sum;
+   unsigned long audio_samples;
+} instance;
+
+static instance inst[2];
+static int active_idx = 0;
+
+/* ---- synthetic mic --------------------------------------------------- */
+
+struct retro_microphone {
+   int active;
+   unsigned phase;
+};
+
+static struct retro_microphone g_mic_obj;
+static int g_mic_open = 0;
+
+static retro_microphone_t *mic_open(const retro_microphone_params_t *p)
+{
+   (void)p;
+   g_mic_obj.active = 1;
+   g_mic_obj.phase = 0;
+   g_mic_open = 1;
+   return &g_mic_obj;
+}
+static void mic_close(retro_microphone_t *m)
+{
+   if (m)
+      m->active = 0;
+   g_mic_open = 0;
+}
+static bool mic_get_params(const retro_microphone_t *m,
+                           retro_microphone_params_t *p)
+{
+   (void)m;
+   if (p) p->rate = 8000;
+   return true;
+}
+static bool mic_set_state(retro_microphone_t *m, bool s)
+{
+   if (!m)
+      return false;
+   m->active = s ? 1 : 0;
+   return true;
+}
+static bool mic_get_state(const retro_microphone_t *m)
+{
+   return m && m->active;
+}
+static int mic_read(retro_microphone_t *m, int16_t *samples, size_t num)
+{
+   size_t i;
+   if (!m || !samples || !num || !m->active)
+      return -1;
+   /* Loud tone so VAD opens and far-side energy is unmistakable. */
+   for (i = 0; i < num; i++)
+   {
+      samples[i] = (int16_t)((m->phase & 1) ? 12000 : -12000);
+      m->phase++;
+   }
+   return (int)num;
+}
+
+static struct retro_microphone_interface g_mic_iface = {
+   RETRO_MICROPHONE_INTERFACE_VERSION,
+   mic_open, mic_close, mic_get_params,
+   mic_set_state, mic_get_state, mic_read
+};
+
+/* ---- frontend callbacks ---------------------------------------------- */
+
+static bool env_common(int idx, unsigned cmd, void *data)
+{
+   switch (cmd)
+   {
+      case RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE:
+         memcpy(&inst[idx].np, data,
+                sizeof(struct retro_netpacket_callback));
+         inst[idx].np_registered = 1;
+         return true;
+      case RETRO_ENVIRONMENT_GET_MICROPHONE_INTERFACE:
+         if (!data)
+            return false;
+         {
+            struct retro_microphone_interface *iface =
+               (struct retro_microphone_interface *)data;
+            unsigned want = iface->interface_version;
+            *iface = g_mic_iface;
+            if (want && want < RETRO_MICROPHONE_INTERFACE_VERSION)
+               iface->interface_version = want;
+            return true;
+         }
+      case RETRO_ENVIRONMENT_GET_VARIABLE:
+      {
+         struct retro_variable *var = (struct retro_variable *)data;
+         if (!var || !var->key)
+            return false;
+         if (!strcmp(var->key, "virtualjaguar_netlink"))
+         {
+            var->value = "disabled";
+            return true;
+         }
+         if (!strcmp(var->key, "virtualjaguar_voice_chat"))
+         {
+            var->value = inst[idx].voice_want ? "enabled" : "disabled";
+            return true;
+         }
+         if (!strcmp(var->key, "virtualjaguar_voice_chat_volume"))
+         {
+            var->value = "100";
+            return true;
+         }
+         if (!strcmp(var->key, "virtualjaguar_voice_chat_vad"))
+         {
+            var->value = "100";
+            return true;
+         }
+         return false;
+      }
+      case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE:
+         *(bool *)data = false;
+         return true;
+      case RETRO_ENVIRONMENT_GET_CAN_DUPE:
+         *(bool *)data = true;
+         return true;
+      case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+      case RETRO_ENVIRONMENT_SET_VARIABLES:
+      case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
+      case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+      case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS:
+      case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS:
+      case RETRO_ENVIRONMENT_SET_GEOMETRY:
+      case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
+      case RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER:
+         return true;
+      case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+      case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+         *(const char **)data = "/tmp";
+         return true;
+      default:
+         return false;
+   }
+}
+
+static bool env_cb0(unsigned cmd, void *data) { return env_common(0, cmd, data); }
+static bool env_cb1(unsigned cmd, void *data) { return env_common(1, cmd, data); }
+
+static void classify_pkt(instance *src, int flags, const uint8_t *buf, size_t len)
+{
+   if (!buf || len < 1)
+      return;
+   switch (buf[0])
+   {
+      case NP_UART:
+         src->pkts_uart++;
+         break;
+      case NP_VOICE:
+         src->pkts_voice++;
+         if ((flags & (RETRO_NETPACKET_RELIABLE | RETRO_NETPACKET_UNSEQUENCED))
+             == RETRO_NETPACKET_UNSEQUENCED)
+            src->voice_unreliable_ok++;
+         else if ((flags & RETRO_NETPACKET_RELIABLE) == 0)
+            src->voice_unreliable_ok++; /* UNRELIABLE==0 + UNSEQUENCED */
+         else
+            src->voice_flags_bad++;
+         break;
+      case NP_VOICE_HELLO:
+         src->pkts_hello++;
+         break;
+      default:
+         break;
+   }
+}
+
+static void send_common(int from, int flags, const void *buf, size_t len,
+                        uint16_t client_id)
+{
+   instance *src = &inst[from];
+   instance *dst = &inst[from ^ 1];
+   unsigned slot;
+
+   (void)client_id;
+   classify_pkt(src, flags, (const uint8_t *)buf, len);
+   if (!buf || !len)
+      return;
+   if (dst->inbox_count >= INBOX_PKTS || len > INBOX_PKTMAX)
+   {
+      dst->inbox_overflow = 1;
+      return;
+   }
+   slot = (dst->inbox_head + dst->inbox_count) % INBOX_PKTS;
+   memcpy(dst->inbox[slot], buf, len);
+   dst->inbox_len[slot] = len;
+   dst->inbox_count++;
+}
+
+static void send0(int f, const void *b, size_t l, uint16_t c)
+{ send_common(0, f, b, l, c); }
+static void send1(int f, const void *b, size_t l, uint16_t c)
+{ send_common(1, f, b, l, c); }
+
+static void deliver_inbox(instance *in)
+{
+   uint8_t buf[INBOX_PKTMAX];
+   size_t len;
+   unsigned head;
+
+   if (!in->np.receive)
+      return;
+   while (in->inbox_count > 0)
+   {
+      head = in->inbox_head;
+      len = in->inbox_len[head];
+      memcpy(buf, in->inbox[head], len);
+      in->inbox_head = (in->inbox_head + 1) % INBOX_PKTS;
+      in->inbox_count--;
+      in->np.receive(buf, len, (uint16_t)(in->idx ^ 1));
+   }
+}
+
+static void poll_recv0(void) { deliver_inbox(&inst[0]); }
+static void poll_recv1(void) { deliver_inbox(&inst[1]); }
+
+static void video_cb(const void *d, unsigned w, unsigned h, size_t p)
+{ (void)d; (void)w; (void)h; (void)p; }
+static void audio_sample_cb(int16_t l, int16_t r)
+{
+   instance *in = &inst[active_idx];
+   int al = l < 0 ? -l : l;
+   int ar = r < 0 ? -r : r;
+   in->audio_abs_sum += (unsigned)al + (unsigned)ar;
+   in->audio_samples += 2;
+}
+static size_t audio_batch_cb(const int16_t *d, size_t f)
+{
+   instance *in = &inst[active_idx];
+   size_t i;
+   if (!d)
+      return f;
+   for (i = 0; i < f * 2; i++)
+   {
+      int v = d[i];
+      if (v < 0)
+         v = -v;
+      in->audio_abs_sum += (unsigned)v;
+   }
+   in->audio_samples += f * 2;
+   return f;
+}
+static void input_poll_cb(void) {}
+static int16_t input_state_cb(unsigned a, unsigned b, unsigned c, unsigned d)
+{ (void)a; (void)b; (void)c; (void)d; return 0; }
+
+/* ---- load helpers ---------------------------------------------------- */
+
+static int copy_file(const char *src, const char *dst)
+{
+   FILE *fi, *fo;
+   char buf[65536];
+   size_t n;
+   int ok = 1;
+   fi = fopen(src, "rb");
+   if (!fi)
+      return 0;
+   fo = fopen(dst, "wb");
+   if (!fo)
+   {
+      fclose(fi);
+      return 0;
+   }
+   while ((n = fread(buf, 1, sizeof(buf), fi)) > 0)
+   {
+      if (fwrite(buf, 1, n, fo) != n)
+      {
+         ok = 0;
+         break;
+      }
+   }
+   fclose(fi);
+   if (fclose(fo) != 0)
+      ok = 0;
+   return ok;
+}
+
+static int inst_open(instance *in, int idx, const char *name,
+                     const char *core_path, int voice_want)
+{
+   const char *tmp = getenv("TMPDIR");
+   memset(in, 0, sizeof(*in));
+   in->idx = idx;
+   in->name = name;
+   in->voice_want = voice_want;
+   snprintf(in->path, sizeof(in->path), "%s/vj_np_vc_%ld_%s.lib",
+            (tmp && tmp[0]) ? tmp : "/tmp", (long)getpid(), name);
+   if (!copy_file(core_path, in->path))
+   {
+      fprintf(stderr, "cannot copy core to %s\n", in->path);
+      return 0;
+   }
+   chmod(in->path, 0755);
+   in->handle = dlopen(in->path, RTLD_NOW | RTLD_LOCAL);
+   if (!in->handle)
+   {
+      fprintf(stderr, "dlopen(%s): %s\n", in->path, dlerror());
+      return 0;
+   }
+
+#define SYM(var, sym) do { \
+      *(void **)&in->var = dlsym(in->handle, sym); \
+      if (!in->var) { fprintf(stderr, "missing %s\n", sym); return 0; } \
+   } while (0)
+   SYM(set_environment, "retro_set_environment");
+   SYM(set_video_refresh, "retro_set_video_refresh");
+   SYM(set_audio_sample, "retro_set_audio_sample");
+   SYM(set_audio_sample_batch, "retro_set_audio_sample_batch");
+   SYM(set_input_poll, "retro_set_input_poll");
+   SYM(set_input_state, "retro_set_input_state");
+   SYM(init, "retro_init");
+   SYM(load_game, "retro_load_game");
+   SYM(run, "retro_run");
+   SYM(unload_game, "retro_unload_game");
+   SYM(deinit, "retro_deinit");
+   SYM(jlink_mode, "JLinkMode");
+#undef SYM
+   /* Optional wide-ABI export (TEST_EXPORTS=1 builds). */
+   *(void **)&in->jlink_np_voice_ready = dlsym(in->handle, "JLinkNPVoiceReady");
+   return 1;
+}
+
+static void inst_cleanup(instance *in)
+{
+   if (in->path[0])
+      remove(in->path);
+}
+
+static uint8_t rom_buf[ROM_SIZE];
+
+static void make_rom(void)
+{
+   memset(rom_buf, 0, ROM_SIZE);
+   rom_buf[0x404] = 0x00; rom_buf[0x405] = 0x80;
+   rom_buf[0x406] = 0x20; rom_buf[0x407] = 0x00;
+   rom_buf[0x2000] = 0x60; rom_buf[0x2001] = 0xFE;
+}
+
+static void run_pair_frames(int frames)
+{
+   int f, i;
+   for (f = 0; f < frames; f++)
+   {
+      for (i = 0; i < 2; i++)
+      {
+         active_idx = i;
+         deliver_inbox(&inst[i]);
+         inst[i].run();
+         if (inst[i].np.poll)
+            inst[i].np.poll();
+         deliver_inbox(&inst[i]);
+      }
+   }
+}
+
+static int boot_pair(const char *core_path, int voice0, int voice1)
+{
+   struct retro_game_info game;
+   int i;
+
+   if (!inst_open(&inst[0], 0, "a", core_path, voice0))
+      return 0;
+   if (!inst_open(&inst[1], 1, "b", core_path, voice1))
+      return 0;
+
+   CHECK(dlsym(inst[0].handle, "JLinkMode")
+             != dlsym(inst[1].handle, "JLinkMode"),
+         "two core copies load as independent images");
+
+   inst[0].set_environment(env_cb0);
+   inst[1].set_environment(env_cb1);
+   CHECK(inst[0].np_registered && inst[1].np_registered,
+         "both cores register netpacket");
+   CHECK(inst[0].np.protocol_version
+             && !strcmp(inst[0].np.protocol_version, "vjag-netlink-2"),
+         "protocol_version is vjag-netlink-2");
+
+   make_rom();
+   memset(&game, 0, sizeof(game));
+   game.path = "voice_netpacket_stub.j64";
+   game.data = rom_buf;
+   game.size = ROM_SIZE;
+
+   for (i = 0; i < 2; i++)
+   {
+      inst[i].set_video_refresh(video_cb);
+      inst[i].set_audio_sample(audio_sample_cb);
+      inst[i].set_audio_sample_batch(audio_batch_cb);
+      inst[i].set_input_poll(input_poll_cb);
+      inst[i].set_input_state(input_state_cb);
+      inst[i].init();
+      if (!inst[i].load_game(&game))
+      {
+         fprintf(stderr, "load_game failed on %s\n", inst[i].name);
+         return 0;
+      }
+   }
+
+   inst[0].np.start(0, send0, poll_recv0);
+   inst[1].np.start(1, send1, poll_recv1);
+   CHECK(inst[0].jlink_mode() == 4 && inst[1].jlink_mode() == 4,
+         "netpacket session active on both");
+   return 1;
+}
+
+static void teardown_pair(void)
+{
+   int i;
+   for (i = 0; i < 2; i++)
+   {
+      if (inst[i].np.stop)
+         inst[i].np.stop();
+      if (inst[i].unload_game)
+         inst[i].unload_game();
+      if (inst[i].deinit)
+         inst[i].deinit();
+      if (inst[i].handle)
+         dlclose(inst[i].handle);
+      inst_cleanup(&inst[i]);
+      memset(&inst[i], 0, sizeof(inst[i]));
+   }
+}
+
+static int scenario_both_voice(const char *core_path)
+{
+   int frame;
+   int ready = 0;
+
+   printf("--- scenario: voice on both ---\n");
+   if (!boot_pair(core_path, 1, 1))
+      return 1;
+
+   for (frame = 0; frame < MAX_FRAMES; frame++)
+   {
+      run_pair_frames(1);
+      if (inst[0].pkts_hello > 0 && inst[1].pkts_hello > 0
+          && inst[0].pkts_voice > 0 && inst[1].pkts_voice > 0)
+      {
+         ready = 1;
+         break;
+      }
+      if (inst[0].jlink_np_voice_ready && inst[1].jlink_np_voice_ready
+          && inst[0].jlink_np_voice_ready()
+          && inst[1].jlink_np_voice_ready()
+          && inst[0].pkts_voice > 0)
+      {
+         ready = 1;
+         /* keep running a bit for mix energy */
+         if (frame > 30)
+            break;
+      }
+   }
+   /* Extra frames so MixInto sees jitter samples. */
+   run_pair_frames(60);
+
+   CHECK(inst[0].pkts_hello > 0 && inst[1].pkts_hello > 0,
+         "both sides emitted NP_VOICE_HELLO");
+   CHECK(inst[0].pkts_voice > 0 && inst[1].pkts_voice > 0,
+         "both sides emitted NP_VOICE");
+   CHECK(inst[0].voice_unreliable_ok > 0 && inst[1].voice_unreliable_ok > 0,
+         "NP_VOICE used unreliable|unsequenced flags");
+   CHECK(inst[0].voice_flags_bad == 0 && inst[1].voice_flags_bad == 0,
+         "no NP_VOICE went out RELIABLE-only");
+   CHECK(inst[0].audio_abs_sum > 10000 || inst[1].audio_abs_sum > 10000,
+         "far-side audio mix shows voice energy");
+   CHECK(!inst[0].inbox_overflow && !inst[1].inbox_overflow,
+         "relay did not drop packets");
+   (void)ready;
+
+   printf("a: hello=%u voice=%u uart=%u audio_sum=%lu\n",
+          inst[0].pkts_hello, inst[0].pkts_voice, inst[0].pkts_uart,
+          inst[0].audio_abs_sum);
+   printf("b: hello=%u voice=%u uart=%u audio_sum=%lu\n",
+          inst[1].pkts_hello, inst[1].pkts_voice, inst[1].pkts_uart,
+          inst[1].audio_abs_sum);
+
+   teardown_pair();
+   return 0;
+}
+
+static int scenario_data_only(const char *core_path)
+{
+   time_t t0;
+   unsigned voice_after_timeout;
+
+   printf("--- scenario: voice off on peer (data-only) ---\n");
+   if (!boot_pair(core_path, 1, 0))
+      return 1;
+
+   /* Side A wants voice; B does not. A must time out (~5s) to data-only
+    * and emit no NP_VOICE. */
+   t0 = time(NULL);
+   while ((time(NULL) - t0) < 6)
+      run_pair_frames(5);
+
+   voice_after_timeout = inst[0].pkts_voice;
+   CHECK(inst[0].pkts_hello > 0, "voice side still offers hello");
+   CHECK(inst[1].pkts_hello == 0, "peer with voice off sends no hello");
+   CHECK(voice_after_timeout == 0,
+         "no NP_VOICE after hello timeout (data-only)");
+   if (inst[0].jlink_np_voice_ready)
+      CHECK(!inst[0].jlink_np_voice_ready(),
+            "JLinkNPVoiceReady stays false (data-only)");
+
+   teardown_pair();
+   return 0;
+}
+
+int main(int argc, char **argv)
+{
+   const char *core_path = argc > 1 ? argv[1]
+                                    : "./virtualjaguar_libretro.dylib";
+   scenario_both_voice(core_path);
+   scenario_data_only(core_path);
+   printf(failures ? "FAILED (%d)\n" : "OK\n", failures);
+   return failures ? 1 : 0;
+}

--- a/test/test_voicechat.c
+++ b/test/test_voicechat.c
@@ -208,6 +208,73 @@ static void test_energy_and_mix(void)
    check(clipped == 1, "saturates near full scale without wrap");
 }
 
+static void test_multi_speaker(void)
+{
+   int16_t frame_a[VC_FRAME_SAMPLES];
+   int16_t frame_b[VC_FRAME_SAMPLES];
+   int16_t frame_c[VC_FRAME_SAMPLES];
+   int16_t frame_d[VC_FRAME_SAMPLES];
+   uint16_t buf[1600];
+   unsigned i;
+   int16_t s;
+   long sum;
+
+   for (i = 0; i < VC_FRAME_SAMPLES; i++)
+   {
+      frame_a[i] = 1000;
+      frame_b[i] = 2000;
+      frame_c[i] = 3000;
+      frame_d[i] = 4000;
+   }
+
+   VoiceChatReset();
+   VoiceChatSetEnabled(1);
+   VoiceChatSetVolume(100);
+
+   /* Independent gap-fill: A seq 0 then 2; B seq 0 continuous. */
+   VoiceChatJitterPushFrom(0x11111111u, frame_a, 0);
+   VoiceChatJitterPushFrom(0x22222222u, frame_b, 0);
+   VoiceChatJitterPushFrom(0x11111111u, frame_a, 2); /* gap of 1 */
+   check(VoiceChatActiveSpeakers() == 2, "two speakers claimed");
+   check(VoiceChatJitterCount() == VC_FRAME_SAMPLES * 4,
+         "A gap-fill + B frame counted (3+1 frames)");
+
+   VoiceChatReset();
+   VoiceChatSetEnabled(1);
+   VoiceChatSetVolume(100);
+   VoiceChatJitterPushFrom(1, frame_a, 0);
+   VoiceChatJitterPushFrom(2, frame_b, 0);
+   VoiceChatJitterPushFrom(3, frame_c, 0);
+   check(VoiceChatActiveSpeakers() == 3, "three speakers at cap");
+
+   for (i = 0; i < 1600; i++)
+      buf[i] = 0;
+   VoiceChatMixInto(buf, 800);
+   sum = 0;
+   for (i = 0; i < 1600; i++)
+      sum += (int16_t)buf[i];
+   check(sum > 0, "three speakers mix into output");
+
+   /* Fourth speaker reclaims the stalest slot. */
+   VoiceChatReset();
+   VoiceChatSetEnabled(1);
+   VoiceChatJitterPushFrom(10, frame_a, 0);
+   VoiceChatJitterPushFrom(20, frame_b, 0);
+   VoiceChatJitterPushFrom(30, frame_c, 0);
+   /* Drain so lastMs stays older on early slots; push advances lastMs. */
+   while (VoiceChatJitterPop(&s))
+      ;
+   /* Pop only drains senderId 0; drain via mix instead. */
+   VoiceChatReset();
+   VoiceChatSetEnabled(1);
+   VoiceChatJitterPushFrom(10, frame_a, 0);
+   VoiceChatJitterPushFrom(20, frame_b, 0);
+   VoiceChatJitterPushFrom(30, frame_c, 0);
+   VoiceChatJitterPushFrom(40, frame_d, 0);
+   check(VoiceChatActiveSpeakers() == 3,
+         "fourth speaker reclaims; still at cap of 3");
+}
+
 int main(void)
 {
    printf("test_voicechat\n");
@@ -217,6 +284,7 @@ int main(void)
    test_jitter();
    test_keepalive_seq_continuity();
    test_energy_and_mix();
+   test_multi_speaker();
    if (failures)
    {
       printf("%d FAILURES\n", failures);

--- a/test/test_voicechat.c
+++ b/test/test_voicechat.c
@@ -16,7 +16,8 @@ int JLinkMode(void) { return 0; }
 int JLinkDiscActive(void) { return 0; }
 int JLinkDiscPort(void) { return 42170; }
 const char *JLinkGetTCPHost(void) { return "127.0.0.1"; }
-uint32_t JLinkNowMs(void) { return 1000; }
+static uint32_t g_now_ms = 1000;
+uint32_t JLinkNowMs(void) { return g_now_ms; }
 int JLinkDiscSendTo(const uint8_t *buf, size_t len,
                     const char *to_addr, int to_port)
 {
@@ -216,7 +217,6 @@ static void test_multi_speaker(void)
    int16_t frame_d[VC_FRAME_SAMPLES];
    uint16_t buf[1600];
    unsigned i;
-   int16_t s;
    long sum;
 
    for (i = 0; i < VC_FRAME_SAMPLES; i++)
@@ -255,24 +255,25 @@ static void test_multi_speaker(void)
       sum += (int16_t)buf[i];
    check(sum > 0, "three speakers mix into output");
 
-   /* Fourth speaker reclaims the stalest slot. */
+   /* Fourth speaker reclaims the least-recently-active slot. Advance
+    * the stub clock between claims so lastMs differs; sender 10 is
+    * oldest and must be the one evicted. */
    VoiceChatReset();
    VoiceChatSetEnabled(1);
+   g_now_ms = 1000;
    VoiceChatJitterPushFrom(10, frame_a, 0);
+   g_now_ms = 2000;
    VoiceChatJitterPushFrom(20, frame_b, 0);
+   g_now_ms = 3000;
    VoiceChatJitterPushFrom(30, frame_c, 0);
-   /* Drain so lastMs stays older on early slots; push advances lastMs. */
-   while (VoiceChatJitterPop(&s))
-      ;
-   /* Pop only drains senderId 0; drain via mix instead. */
-   VoiceChatReset();
-   VoiceChatSetEnabled(1);
-   VoiceChatJitterPushFrom(10, frame_a, 0);
-   VoiceChatJitterPushFrom(20, frame_b, 0);
-   VoiceChatJitterPushFrom(30, frame_c, 0);
+   g_now_ms = 4000;
    VoiceChatJitterPushFrom(40, frame_d, 0);
    check(VoiceChatActiveSpeakers() == 3,
          "fourth speaker reclaims; still at cap of 3");
+   check(!VoiceChatHasSpeaker(10), "oldest speaker (10) was reclaimed");
+   check(VoiceChatHasSpeaker(20) && VoiceChatHasSpeaker(30)
+             && VoiceChatHasSpeaker(40),
+         "newer speakers 20/30/40 kept");
 }
 
 int main(void)

--- a/test/test_voicemodem_netpacket.c
+++ b/test/test_voicemodem_netpacket.c
@@ -47,7 +47,8 @@
 #include <libretro.h>
 
 #define ROM_SIZE     131072
-#define INBOX_SIZE   4096
+#define INBOX_PKTS   64
+#define INBOX_PKTMAX 512
 #define RXQ_SIZE     256
 #define MAX_FRAMES   3000
 #define CONNECT_TRIES 200
@@ -98,9 +99,12 @@ typedef struct
    struct retro_netpacket_callback np;
    int      np_registered;
 
-   /* packets the peer sent us, awaiting delivery into this core */
-   uint8_t  inbox[INBOX_SIZE];
-   size_t   inbox_len;
+   /* Packet queue (not a byte concat): vjag-netlink-2 framing is
+    * self-delimiting only when receive() is called once per packet. */
+   uint8_t  inbox[INBOX_PKTS][INBOX_PKTMAX];
+   size_t   inbox_len[INBOX_PKTS];
+   unsigned inbox_head;
+   unsigned inbox_count;
    int      inbox_overflow;
 
    unsigned pkts_out;
@@ -177,6 +181,8 @@ static void send_common(int from, int flags, const void *buf, size_t len,
 {
    instance *src = &inst[from];
    instance *dst = &inst[from ^ 1];
+   unsigned slot;
+
    if ((flags & RETRO_NETPACKET_RELIABLE) == 0)
       src->flags_ok = 0;
    if (client_id != RETRO_NETPACKET_BROADCAST)
@@ -185,13 +191,15 @@ static void send_common(int from, int flags, const void *buf, size_t len,
    src->bytes_out += (unsigned)len;
    if (!buf || !len)
       return;
-   if (dst->inbox_len + len > INBOX_SIZE)
+   if (dst->inbox_count >= INBOX_PKTS || len > INBOX_PKTMAX)
    {
       dst->inbox_overflow = 1;
       return;
    }
-   memcpy(dst->inbox + dst->inbox_len, buf, len);
-   dst->inbox_len += len;
+   slot = (dst->inbox_head + dst->inbox_count) % INBOX_PKTS;
+   memcpy(dst->inbox[slot], buf, len);
+   dst->inbox_len[slot] = len;
+   dst->inbox_count++;
 }
 
 static void send0(int f, const void *b, size_t l, uint16_t c)
@@ -202,16 +210,25 @@ static void send1(int f, const void *b, size_t l, uint16_t c)
 /* Hand this instance everything the peer has sent so far.  Snapshot,
    clear, THEN call receive(): the callback runs inside the core and can
    re-enter this function through poll_receive, and a packet delivered
-   twice would corrupt the inter-modem frame stream. */
+   twice would corrupt the inter-modem frame stream.  Deliver one
+   framed packet per receive() call (vjag-netlink-2). */
 static void deliver_inbox(instance *in)
 {
-   uint8_t buf[INBOX_SIZE];
-   size_t len = in->inbox_len;
-   if (!len || !in->np.receive)
+   uint8_t buf[INBOX_PKTMAX];
+   size_t len;
+   unsigned head;
+
+   if (!in->np.receive)
       return;
-   memcpy(buf, in->inbox, len);
-   in->inbox_len = 0;
-   in->np.receive(buf, len, (uint16_t)(in->idx ^ 1));
+   while (in->inbox_count > 0)
+   {
+      head = in->inbox_head;
+      len = in->inbox_len[head];
+      memcpy(buf, in->inbox[head], len);
+      in->inbox_head = (in->inbox_head + 1) % INBOX_PKTS;
+      in->inbox_count--;
+      in->np.receive(buf, len, (uint16_t)(in->idx ^ 1));
+   }
 }
 
 static void poll_recv0(void) { deliver_inbox(&inst[0]); }


### PR DESCRIPTION
## Summary
- Frame the libretro netpacket pipe as **`vjag-netlink-2`** with a 1-byte type prefix: `NP_UART` (reliable), `NP_VOICE` (unreliable|unsequenced VJVC body), `NP_VOICE_HELLO` (reliable negotiate).
- Auto-negotiate voice capability on session start; if hello never confirms within ~5s, fall back to **data-only** (game link still works; mic stays closed).
- Host-side voice only — never on the UART ring. TCP/UDP discovery voice from #584 unchanged.
- Multi-speaker mix: up to **3** concurrent far-end jitter buffers (CatNet-size sessions).
- Intentional break with `vjag-netlink-1` peers (frontend protocol check refuses mixed sessions).

Implements `docs/voice-chat-netplay-design.md` for issue #585.

## Test plan
- [x] `bash scripts/c89-lint.sh` on touched `.c`
- [x] `./test/test_voicechat` (incl. multi-speaker)
- [x] `./test/test_jlink_netpacket` (framed UART + unknown-type drop)
- [x] `./test/test_voicemodem_netpacket` (packet-queue relay)
- [x] `./test/test_voice_netpacket` (hello + voice energy; data-only timeout)
- [x] `test_voicechat_inertness` + `voicechat_pair_test`
- [x] `test_audio_clipping --self-test`; Iron Soldier presence in full suite
- [ ] RetroArch: two instances, netplay, voice on both — talk + Ultra Vortek data still connects (manual; RA present at `/Applications/RetroArch.app`)
- [x] **Link this PR to issue #585 in the Development panel (UI, by hand)**

Note: full `make TEST_EXPORTS=1 test` also hits pre-existing `test_pertitle_db` case4/case7 failures on clean `develop` (AvP true-color substitution) — unrelated to this change.

Made with [Cursor](https://cursor.com)