### PR TITLE
fix(op): OP fixed-bitmap REFLECT-mode line-buffer OOB write (#565)

### DIFF
--- a/src/tom/op.c
+++ b/src/tom/op.c
@@ -29,6 +29,26 @@
 #define BLEND_Y(dst, src)	op_blend_y[(((uint16_t)dst<<8)) | ((uint16_t)(src))]
 #define BLEND_CR(dst, src)	op_blend_cr[(((uint16_t)dst)<<8) | ((uint16_t)(src))]
 
+/* Real Jaguar TOM RAM (tomRam8[] in tom.c) is a fixed 0x4000-byte array. */
+#define TOM_RAM_BYTES 0x4000
+
+/* Issue #565: in OPProcessFixedBitmap, a REFLECT-mode object walks
+ * currentLineBuffer backward (lbufDelta < 0) with no lower bound once
+ * inside the per-pixel store loops below.  The phrase-granular clipping
+ * earlier in that function only promises "at most 8 bytes" of overstep for
+ * the ordinary partially-offscreen case (see the comment above
+ * lbufAddress); it does not protect against a garbage/transient
+ * object-list phrase.  Observed via `virtualjaguar_risc_clock_scale=2x`
+ * against Club Drive: the write pointer walked ~3 KB behind tomRam8[0] and
+ * stomped an unrelated global, aborting the process on the next free() of
+ * that corrupted pointer (dsp_pc_escape in the same log was a red herring
+ * -- an unrelated, self-contained DSP PC excursion the DSP's own execute
+ * loop already drains safely).  Real TOM's LBUF is a small, fixed-size
+ * RAM; clamp writes to tomRam8's own bounds so a bad object can only
+ * glitch a line, never corrupt host memory. */
+#define OP_LBUF_IN_BOUNDS(ptr, nbytes) \
+   ((ptr) >= tomRam8 && (ptr) + (nbytes) <= tomRam8 + TOM_RAM_BYTES)
+
 #define OBJECT_TYPE_BITMAP	0					// 000
 #define OBJECT_TYPE_SCALE	1					// 001
 #define OBJECT_TYPE_GPU		2					// 010
@@ -944,7 +964,7 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
                if (flagTRANS && (paletteRAM16[index | bit] == 0))
 #endif
                   ;	// Do nothing...
-               else
+               else if (OP_LBUF_IN_BOUNDS(currentLineBuffer, 2))
                {
                   if (!flagRMW)
                      //Optimize: Set palleteRAM16 to beginning of palette RAM + index*2 and use only [bit] as index...
@@ -1001,7 +1021,7 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
                if (flagTRANS && (paletteRAM16[index | bits] == 0))
 #endif
                   ;	// Do nothing...
-               else
+               else if (OP_LBUF_IN_BOUNDS(currentLineBuffer, 2))
                {
                   if (!flagRMW)
                      *(uint16_t *)currentLineBuffer = paletteRAM16[index | bits];
@@ -1052,7 +1072,7 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
                if (flagTRANS && (paletteRAM16[index | bits] == 0))
 #endif
                   ;	// Do nothing...
-               else
+               else if (OP_LBUF_IN_BOUNDS(currentLineBuffer, 2))
                {
                   if (!flagRMW)
                      *(uint16_t *)currentLineBuffer = paletteRAM16[index | bits];
@@ -1104,7 +1124,7 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
                if (flagTRANS && (paletteRAM16[bits] == 0))
 #endif
                   ;	// Do nothing...
-               else
+               else if (OP_LBUF_IN_BOUNDS(currentLineBuffer, 2))
                {
                   if (!flagRMW)
                      *(uint16_t *)currentLineBuffer = paletteRAM16[bits];
@@ -1156,7 +1176,7 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
             if (flagTRANS && ((bitsLo | bitsHi) == 0))
                //				if (flagTRANS && (bitsHi == 0x88) && (bitsLo == 0x00))
                ;	// Do nothing...
-            else
+            else if (OP_LBUF_IN_BOUNDS(currentLineBuffer, 2))
             {
                if (!flagRMW)
                {
@@ -1221,7 +1241,7 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
 
             if (flagTRANS && (bits3 | bits2 | bits1 | bits0) == 0)
                ;	// Do nothing...
-            else
+            else if (OP_LBUF_IN_BOUNDS(currentLineBuffer, 4))
                *currentLineBuffer = bits3,
                   *(currentLineBuffer + 1) = bits2,
                   *(currentLineBuffer + 2) = bits1,


### PR DESCRIPTION
## What

Fixes #565 — Club Drive aborts (SIGABRT) under `virtualjaguar_risc_clock_scale=2x`.

The crash-detect log's `dsp_pc_escape` was a red herring, exactly as the issue author suspected (same class as #461's misattribution). The real abort happens later, in `retro_unload_game` → `ShadowHiresShutdown()` → `free()` on a corrupted heap pointer.

Traced with an LLDB hardware watchpoint on the clobbered global (`shadowHiresActive`) straight to the writing instruction: `OPProcessFixedBitmap` (`src/tom/op.c`) — a fixed-bitmap Object Processor object in REFLECT mode (`lbufDelta = -2`) walks its line-buffer write pointer **backward** through `tomRam8[]` with no lower bound. The existing clipping only promises "at most 8 bytes" of overstep for the ordinary partially-offscreen case; a garbage/transient object-list phrase let the pointer walk ~3 KB behind `tomRam8[0]`, stomping an unrelated global and corrupting the heap. `risc_clock_scale=2x` is the trigger that exposes a bad object-list phrase for this title, not the cause — the OOB write is a pre-existing bug reachable at any clock scale given the right (garbage) object data.

`dsp_pc=$00FFFFFF` is a separate, harmless symptom: a `jump (Rn)` delay-slot write in `dsp_opcode_jump` sets `dsp_pc` to a raw unmasked register value, which `DSPExec`'s own guard safely drains next iteration. Recurs every 600 frames (rate-limited logging) — this explains the issue's noted frame=142-vs-742 discrepancy as the same recurring event, not environment noise.

## Fix

`src/tom/op.c`: `OP_LBUF_IN_BOUNDS` bounds macro, gating all six per-depth pixel-store sites (1/2/4/8/16/24 BPP) in `OPProcessFixedBitmap`. A bad object can now only glitch a rendered line, never corrupt host memory.

## Verification

- Club Drive `risc_clock_scale=2x`: exit 0 at 900 and 4000 frames (was SIGABRT/134)
- Club Drive 1x / 1.5x: still exit 0
- Cybermorph / I-War / Missile Command 3D at 2x (the issue's own control group): still exit 0
- `test/tools/dram_scale_sweep.sh`: PASS at all 16 scales
- `bash scripts/c89-lint.sh src/tom/op.c`: clean
- `make TEST_EXPORTS=1 test`: zero new failures — the only 2 present (`test_pertitle_db` case4/case7, #590) confirmed identical on unmodified develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)