### PR TITLE
docs: settings and performance tuning guide, plus a site page

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ System clock 26.590906 MHz NTSC / 26.593900 MHz PAL. Full source map: [`docs/sou
 
 **Known limitations:** the blitter is not fully cycle-accurate (a few games need fast mode) and GPU/DSP pipeline hazards are not yet modelled ([#313](https://github.com/libretro/virtualjaguar-libretro/issues/313)), which shows up as some titles running fast.
 
+**Running slow?** The defaults are tuned for compatibility, not speed, and the biggest available speedup ships off by default. See the [settings & performance tuning guide](docs/settings-and-performance-guide.md) — it covers which options actually matter, and which combinations quietly cancel each other out.
+
 ---
 
 ## Documentation and support
@@ -320,7 +322,7 @@ System clock 26.590906 MHz NTSC / 26.593900 MHz PAL. Full source map: [`docs/sou
 - **[GitHub Discussions](https://github.com/libretro/virtualjaguar-libretro/discussions)** — questions and compatibility reports. Bring your frontend log.
 - **[Issues](https://github.com/libretro/virtualjaguar-libretro/issues)** — confirmed bugs.
 - **[Releases](https://github.com/libretro/virtualjaguar-libretro/releases)** — tagged builds for 16 platforms. The rolling **[`nightly` prerelease](https://github.com/libretro/virtualjaguar-libretro/releases/tag/nightly)** is rebuilt from every push to `develop`; it is gated on *compiling*, not on the test suite — treat it as bleeding edge.
-- **[`docs/`](docs)** — the full document index: [network play setup](docs/netlink-user-guide.md), [input devices / mouse](docs/input-devices-user-guide.md), [file formats](docs/README), [source layout](docs/source-layout.md), [savestate compatibility](docs/savestate-compat.md), [ROM patches / soft patching](docs/rom-patches.md), [CD read speed](docs/cd-read-speed.md), [CD known issues](docs/cd-known-issues.md), [cartridge triage](docs/cart-issue-triage.md), [profiling](docs/profiling.md), [release process](docs/release-process.md), [changelog](docs/WHATSNEW), [TODO](docs/TODO), and the distilled JTRM hardware references (`docs/jtrm-*.md`).
+- **[`docs/`](docs)** — the full document index: [settings & performance tuning](docs/settings-and-performance-guide.md), [network play setup](docs/netlink-user-guide.md), [input devices / mouse](docs/input-devices-user-guide.md), [file formats](docs/README), [source layout](docs/source-layout.md), [savestate compatibility](docs/savestate-compat.md), [ROM patches / soft patching](docs/rom-patches.md), [CD read speed](docs/cd-read-speed.md), [CD known issues](docs/cd-known-issues.md), [cartridge triage](docs/cart-issue-triage.md), [profiling](docs/profiling.md), [release process](docs/release-process.md), [changelog](docs/WHATSNEW), [TODO](docs/TODO), and the distilled JTRM hardware references (`docs/jtrm-*.md`).
 - **[SECURITY.md](SECURITY.md)** — security policy and binary verification.
 
 ## Contributors

--- a/docs/settings-and-performance-guide.md
+++ b/docs/settings-and-performance-guide.md
@@ -1,0 +1,523 @@
+# Virtual Jaguar — Settings and Performance Guide
+
+*Accurate as of core version 3.5.1.* Several statements below are pinned to this
+release — that the enhancement-hook table ships empty, that the known-bad list
+has no rows yet, and that DSP idle-skip is off by default pending a wider
+compatibility pass. Check the release notes if you are on a newer build.
+
+The core ships about forty options. Almost none of them need your attention.
+
+This guide is for the person who opened *Quick Menu → Options*, saw a wall of
+settings, and wants to know which three actually matter. It covers what the
+defaults do, what the visual enhancements cost, what to change when a game runs
+slow, and which combinations quietly cancel each other out.
+
+It is not a list of every option — the in-menu descriptions cover those. It is
+the map.
+
+---
+
+## 1. Start here: the defaults are already the right answer
+
+Load a game and play it. The out-of-box configuration is:
+
+- **Accurate blitter** — SIMD-accelerated (SSE2 on x86, NEON on ARM). The most
+  compatible renderer.
+- **Stock clocks** — 68000 at 1x, GPU/DSP at 1x. Real Jaguar speed.
+- **All experimental timing models off.**
+- **HLE BIOS** for cartridges and for Jaguar CD discs — the fastest and most
+  broadly compatible boot path.
+- **Per-title enhancement defaults on** — about twenty recognized games
+  automatically get a visual upgrade that was verified safe for them.
+- **Crash Detect on** — a cheap watchdog that writes a one-line diagnosis to the
+  RetroArch log if a game hangs. Leave it on; it is what makes your bug report
+  useful.
+
+If a game boots and plays, you are done. Stop here.
+
+### Options you can safely ignore forever
+
+| Category | Ignore unless… |
+|---|---|
+| **Network Link** (`netlink*`, `uart_device`, `voice_chat*`) | you are playing Doom, AirCars, BattleSphere Gold or Ultra Vortek against another person. See `docs/netlink-user-guide.md`. |
+| **Input Port 1 / Input Port 2** (the ~70 remap rows) | you need Numpad 7/8/9/`*`/`#` remapped, which RetroArch's own Controls menu cannot do. |
+| **Controller Type** | you are playing Tempest 2000 with a spinner, White Men Can't Jump / NBA Jam T.E. with a Team Tap, BattleSphere with the paddle ADC, or Balloons with a light gun. See `docs/input-devices-user-guide.md`. |
+| **Diagnostics** (`cd_trace`, `texture_dump`, `texdump_16bpp`) | you are filing a bug report or authoring a texture pack. |
+| **Timing models** (`dram_timing`, `gpu_pipeline_timing`, `blitter_timing`) | you are investigating accuracy, not playing. They only cost performance. |
+| **`enhancement_hooks`** | nothing — the patch table currently ships **empty**. The switch exists; there is nothing behind it yet. |
+| **`blit_memo`** | you are testing it. It is a prototype, applies to no title by default, and refuses CD content. |
+
+Four settings are worth knowing about: **Blitter**, **Internal Resolution**,
+**DSP Idle-Loop Fast-Forward**, and — for CD games only — **CD Boot Mode**.
+Everything below is about those.
+
+---
+
+## 2. Per-title enhancement defaults
+
+**Per-Title Enhancement Defaults** (`virtualjaguar_pertitle_defaults`, default
+**enabled**) lets the core recognize a cartridge by its CRC32 and pre-set
+options that were verified to look better on that specific game.
+
+Three rules make this safe:
+
+1. **Your choice always wins.** A preset is only applied to an option you have
+   left at its shipped default. Change the option yourself — to anything,
+   including back to the default value by hand — and the preset stops touching
+   it.
+2. **Everything in the table is presentation-only** (see §3). No preset changes
+   emulated state, clock speed, or timing.
+3. **A known-bad value is refused, and a warning is logged.** The database also
+   carries a negative list. If a preset would set something known to break that
+   title, the core declines and logs it. If *you* set that value explicitly, the
+   core honors you anyway — and logs `[titledb] … is known-bad for this title
+   (explicit user choice honored)`. (The negative list currently ships with zero
+   rows; the mechanism is in place ahead of the data.)
+
+To turn the whole thing off, set **Per-Title Enhancement Defaults** to
+*disabled*. Every title then runs stock.
+
+Everything the core does per title is logged with a `[titledb]` prefix, so the
+RetroArch log always tells you exactly what was applied.
+
+### Titles that configure themselves
+
+Twenty-one entries as of v3.5.0. All of them set internal resolution, true
+color, or both — nothing else.
+
+| Title | Internal Resolution | True Color |
+|---|---|---|
+| Alien vs Predator | 2x | — |
+| Cybermorph (both revisions) | — | on |
+| Air Cars | — | on |
+| Doom (retail) | 2x | — |
+| Doom EX / Doom II EX (9 homebrew variants) | 2x | — |
+| Hover Strike | 2x | — |
+| I-War | 2x | on |
+| Kasumi Ninja | — | on |
+| Missile Command 3D | 2x | — |
+| Skyhammer | 2x | on |
+| Tempest 2000 | — | on |
+| Towers II | 2x | — |
+
+Note what is **not** in the table: no preset overclocks anything, and no preset
+enables blit memoization. If you see a game running faster or slower than
+stock, it is not the title database.
+
+**A separate switch, easy to confuse:** *Per-Title Enhancement **Hooks***
+(`virtualjaguar_enhancement_hooks`, default **disabled**) is a different
+mechanism — it applies per-game **byte patches to the cartridge image** for
+game-side bugs that no option can express. Cartridges only, applied at load,
+restart to change. Each patch verifies the bytes it expects before writing
+anything, so it can never corrupt a dump it was not written for. **The patch
+table currently ships empty**, so this switch does nothing today.
+
+---
+
+## 3. Enhancements (visual, presentation-only)
+
+Four options change how the picture looks without changing the machine:
+
+- **Internal Resolution** (`internal_resolution`) — `1x` / `2x`. Renders
+  internally at a multiple of native resolution. **Restart required**: applied
+  when content is loaded.
+- **True Color** (`true_color`) — renders Gouraud-shaded pixels at full
+  precision to reduce banding in 3D games. CRY 16bpp video modes only.
+  Combines with Internal Resolution.
+- **Texture Replacement** (`texture_replace`) — presents community texture-pack
+  art in place of the game's own blitter tiles. Only appears in the menu when a
+  pack directory exists for the loaded game. See §3.1.
+- **Widescreen** (`widescreen`) — reports a 16:9 aspect ratio to the frontend
+  instead of 4:3. This is a cosmetic stretch and nothing more; the Jaguar has no
+  wider display mode and the emulated framebuffer is identical either way.
+  Global only — there is no per-title widescreen preset, because no corpus
+  evidence exists for which games look acceptable stretched.
+
+**The reassuring part, said once:** all four are *presentation-only*. The
+emulated Jaguar — its RAM, its registers, the framebuffer the game itself sees —
+is bit-identical whether these are on or off. Save states made with them on load
+correctly with them off. Netplay peers with different settings stay in sync.
+Run-ahead is unaffected. You can turn them on and off freely without risking a
+save.
+
+**What they cost.** Internal Resolution and True Color are the only two
+enhancements with a real performance price, and it is not small: Alien vs
+Predator's own preset (2x + true color) was measured at roughly **30% of its
+frame time** on a desktop host. On a slow device, these are the first things to
+turn off — see §4.
+
+### 3.1 Texture packs
+
+Texture packs are art assets from the community, not something the core
+generates.
+
+To **use** one: put it in `<system dir>/vj_texpacks/<cart CRC32>/` and enable
+*Texture Replacement*. No restart needed. The option only appears once a pack
+directory exists.
+
+To **author** one: enable *Texture Dump Mode* (Diagnostics), play through the
+game, and the core writes every unique blitter source tile to
+`<system dir>/vj_texdump/<cart CRC32>/` as a PNG plus a manifest row. Redraw
+each tile keeping the same pixel dimensions (or an exact N× multiple if the pack
+targets N× internal resolution), save under the same filename into the
+`vj_texpacks` directory, and enable replacement. A pack pixel with alpha below
+128 means "keep the original pixel."
+
+Known limits: indexed sources of 8bpp or less are not yet presented (those tiles
+fall through to stock pixels), and GPU-computed surfaces — Doom's texture mapper,
+for example — are out of scope entirely. Only 8-bit-depth PNGs are accepted.
+
+Full detail: `docs/texture-dump.md`.
+
+---
+
+## 4. Performance tuning
+
+### 4.1 Where the frame time actually goes
+
+Profiling (`docs/perf-audit-2026-08.md`, `docs/op-perf-profile.md`; host arm64,
+mid-game save states) found the cost concentrated in one place:
+
+| Subsystem | Share of frame time |
+|---|---|
+| **DSP** | **50–67%** (Iron Soldier 67%, Alien vs Predator 63%) |
+| **GPU** | large and title-dependent — e.g. ~24% on Skyhammer alongside ~33% DSP |
+| Blitter (fast) | 5–17% |
+| Blitter (accurate) | up to ~34% on Alien vs Predator |
+| Object Processor | ~1% |
+| 68000 | 0.7–2.6% |
+
+The striking finding: **the DSP is parked in a 3–5 instruction wait loop for
+90–99.7% of every frame** on the titles measured (Iron Soldier 99.7%, Doom 90%,
+Alien vs Predator 74%) — while still interpreting its full 26.6 MHz cycle
+budget, 416k–590k opcodes per frame, spinning. The GPU does the same thing on
+some titles (Alien vs Predator 80%, jagniccc 73%).
+
+Two consequences for you:
+
+- **The 68000 and the Object Processor are not your problem.** They are noise.
+- **The single biggest available saving is not making the emulator faster — it
+  is not emulating the waiting.** That is what idle-skip does.
+
+*(All figures above are host profiles on desktop arm64, not device measurements.
+See §4.5.)*
+
+### 4.2 What to try first when a game runs slow
+
+In order. Stop as soon as it is fast enough.
+
+1. **Turn off Per-Title Enhancement Defaults.** If your game is in the §2 table,
+   it is rendering at 2x and/or full-precision Gouraud right now. This alone is
+   worth ~30% of the frame on Alien vs Predator. On a low-end device this is
+   step one, not step three.
+2. **Set Internal Resolution to 1x and True Color off** — the manual version of
+   step 1, if you want to keep per-title defaults for other games.
+3. **Turn on DSP Idle-Loop Fast-Forward** (`risc_idle_skip`). See §4.3 — this is
+   the biggest lever and it is **off by default**, so nobody gets it by accident.
+4. **Switch Blitter to Fast.** Measured 1.21× faster typical (Iron Soldier), up
+   to 1.58× on the title that gains most (Skyhammer). It breaks some games —
+   wireframe artifacts and missing geometry are the usual symptom — so switch
+   back the moment anything looks wrong.
+5. **Only then consider overclocking**, and read §4.4 first, because it can make
+   things worse.
+
+Note what is *not* on this list: there is no "frame skip" option and no internal
+speed limiter. Pacing is entirely your frontend's job (§4.6).
+
+### 4.3 DSP Idle-Loop Fast-Forward — the big lever, and the trap
+
+**What it does.** When the DSP is spinning in a provably redundant wait loop, the
+core computes where that loop would have ended and jumps there instead of
+interpreting every iteration. It is exact, not an approximation: registers,
+flags, cycles charged and instruction count all end up precisely where
+interpretation would have left them. Save states, run-ahead and netplay are
+unaffected. The saving reported with the feature in the v3.5.0 release notes is
+**66–87% fewer DSP opcodes interpreted per frame** on the titles A/B'd. (That
+figure comes from the shipped A/B, not from the profiling documents cited in
+§4.1 — those establish the 50–67% and 90–99.7% numbers, not this one.)
+
+**It ships off by default.** It was verified byte-identical on framebuffer,
+audio and periodic save-state digest across a nine-title corpus including two CD
+games — but nine titles is not a ~200-title library, and a silent audio or video
+divergence nobody can attribute is a worse failure than an opt-in toggle. So it
+waits one release cycle. **If you are chasing performance, you have to turn this
+on yourself.** If a title looks or sounds wrong with it on, turn it off and
+please report it.
+
+**It is DSP-only, despite the option key.** The key is `risc_idle_skip`, but only
+the DSP has the fast-forward path. The GPU spins in idle loops too and this
+option does nothing about that.
+
+#### The compounding trap
+
+**Idle-skip silently disables itself** when any of the following is in effect:
+
+| Setting | Value that disables idle-skip |
+|---|---|
+| **RISC (GPU/DSP) Clock Scale** | anything other than `1x` |
+| **DRAM Timing** | enabled |
+| **GPU Pipeline Timing** | enabled |
+| **Blit Memoization** | enabled or verify |
+
+It stays active under **M68K Clock Scale** at any value, and under **Blitter Bus
+Timing**. (Verified against `src/jerry/dsp.c`, `DSPExec()`.)
+
+Since **v3.5.1** the core says so: enable idle-skip alongside any of the above
+and one `[perf]` line lands in your frontend log naming the exact setting that
+is suppressing it. It warns only — your settings are always honoured, never
+overridden. Before v3.5.1 this happened silently. So:
+
+> **Overclocking the RISC to make a slow game faster can make it slower.**
+> Setting *RISC Clock Scale* to `2x` gives the GPU and DSP twice the cycles —
+> and simultaneously forfeits a 66–87% reduction in DSP work. On a
+> DSP-bound title you have traded away the bigger win to buy the smaller one.
+
+**The rule that follows from the profile data:**
+
+- **DSP-bound title** (Iron Soldier is the extreme case: 67% of frame in the
+  DSP, 99.7% of it spinning) → turn idle-skip **on**, leave RISC clock at **1x**.
+  Overclocking here buys cycles the game does not need and costs you the skip.
+- **GPU-bound title** → RISC overclock may genuinely help, and the idle-skip
+  loss may be acceptable. Try each on its own, one at a time, and compare.
+- **Never both.** They are mutually exclusive by construction, not by
+  preference.
+
+### 4.4 Overclocking
+
+Two independent scales, both under **Timing**:
+
+| Option | Values | Scales |
+|---|---|---|
+| `m68k_clock_scale` | 0.5x, **1x**, 1.5x, 2x, 3x | the 68000 (~13.3 MHz stock) |
+| `risc_clock_scale` | 0.5x, **1x**, 1.5x, 2x | the GPU and DSP (~26.6 MHz stock) |
+
+Timers, audio pacing and bus costs stay at stock speed in both cases, so nothing
+pitch-shifts and music does not speed up.
+
+**These are enhancements, not accuracy fixes.** They can smooth framerate-limited
+games, and they can break titles that depend on stock timing. If you file a bug,
+reproduce it at 1x first — a bug report from an overclocked session cannot be
+acted on.
+
+**Known bad cases** (all reported against overclock, all still open):
+
+| Title | Setting | Symptom | Status |
+|---|---|---|---|
+| Defender 2000 | `m68k_clock_scale = 3x` | hangs at level start (GPU runs away into a data buffer) | Root-caused to a GPU task-dispatcher race, **not fixed** (#460). **2x and below are clean** — drop to 2x. |
+| Cybermorph | RISC overclock | Codex-level crash, erratic ship movement | **Reported but unconfirmed** — not reproducible headlessly, needs artifacts (#463). Treat as a caution, not an established fact. |
+| Club Drive | `risc_clock_scale = 2x` | crash | **Fixed** in v3.5.0 (#565). |
+
+If an overclocked game misbehaves, the experimental timing models (§5) sometimes
+help — but note that two of them disable idle-skip, so you may be stacking costs.
+
+### 4.5 Low-end platforms
+
+Honest position first: **no on-device profile has been captured for the Apple TV
+/ A10X class yet.** Issue #509 remains open specifically for that. Every number
+in §4.1 is a desktop host profile. Anyone quoting per-subsystem device
+percentages for tvOS is quoting a projection.
+
+What *is* known and actionable:
+
+- **Raspberry Pi and other ARM Linux / Android builds.** v3.5.0 fixed a real bug
+  where cross-compiled ARM64 Linux binaries shipped the *scalar* blitter instead
+  of NEON (#560), and added per-SoC compiler tuning for the nine Raspberry Pi
+  targets. Make sure you are on 3.5.0 or newer — this is a large, free win that
+  costs you no settings.
+- **Whatever the device, the first move is the same:** turn off per-title
+  enhancement defaults (§4.2 step 1). The 2x/true-color presets were chosen on
+  desktop-class hardware; on a Pi or an Apple TV they are the single most
+  expensive thing running.
+- **Then turn on idle-skip.** It removes work rather than doing it faster, which
+  is exactly the shape of win a weak CPU needs.
+- **Fast blitter last**, because it costs correctness.
+- **Do not overclock on a device that is already struggling.** It asks for more
+  work, not less — and it takes idle-skip away.
+
+### 4.6 Pacing, fast-forward and VRR
+
+**The core has no internal frame limiter.** It never sleeps, never blocks inside
+`retro_run()`, and does not register a frame-time or audio callback. Speed and
+pacing are entirely your frontend's responsibility.
+
+Practical consequences:
+
+- The core advertises **60.05445 fps / 48043.6 Hz** (NTSC) and **50.08013 fps /
+  48076.9 Hz** (PAL). These are the Jaguar's real field rates, not 60/50.
+- **Fast-forward doing nothing is usually a RetroArch setting**, not a core bug.
+  Check *Frame Throttle → Fast-Forward Ratio* (1.0× means no speed-up),
+  `vrr_runloop_enable`, and that audio sync goes non-blocking during
+  fast-forward.
+- **Fast-forward is capped by the core's own throughput.** If a heavy title
+  already takes close to 16.7 ms per frame on your hardware, holding
+  fast-forward will produce little or no visible speed-up — everything is
+  working as designed, there is simply no headroom.
+- **A backgrounded or occluded window gets throttled by the OS.** The same core
+  and config measured 120.8 fps foreground and 59.5 fps backgrounded on one
+  macOS machine. That looks exactly like a broken fast-forward and is not.
+
+Detail: `docs/frontend-pacing.md`.
+
+---
+
+## 5. Accuracy and timing models
+
+Three options under **Timing**, all **off by default**, all marked experimental
+and all still being calibrated. They exist because the emulated machine is, in
+specific ways, *too fast* — the GPU finishes renders 2–4× faster than silicon,
+and blits complete in zero time. Games that pace themselves on render or blit
+completion (Doom's menus and demo, Hover Strike) therefore run too fast.
+
+| Option | Models | Note |
+|---|---|---|
+| `dram_timing` | realistic DRAM access cost for the GPU and 68000 once they leave their local buses | Each processor pays only its own costs, so relative CPU/GPU timing is preserved. **Disables idle-skip.** |
+| `gpu_pipeline_timing` | the GPU's real instruction costs — single external-memory gateway, register scoreboard, ALU interlocks | **Disables idle-skip.** |
+| `blitter_timing` | charges the 68000 the bus time each blit really takes (on hardware the blitter freezes the cacheless 68000 while it runs) | Does **not** disable idle-skip. |
+
+**These are for accuracy investigation, not for everyday play.** They all cost
+performance, by design — they add work the emulator was previously skipping.
+Turn them on if you are comparing against real hardware, or if an overclocked
+game misbehaves and you want to see whether restoring realistic timing settles
+it. Otherwise leave them alone.
+
+---
+
+## 6. Jaguar CD
+
+CD discs ignore the cartridge BIOS setting entirely. **CD Boot Mode**
+(`cd_boot_mode`, **restart required**) decides everything:
+
+| Value | What it does |
+|---|---|
+| **HLE** (default) | The core emulates the CD BIOS services directly and runs with the console boot ROM off. Fastest and most broadly compatible. Start here. |
+| **Real BIOS** | Runs an actual CD BIOS with the boot ROM on. More faithful, still experimental. |
+| **Auto** | Currently identical to Real BIOS. |
+
+No files are required for either. Both CD BIOS images are built into the core; a
+CD BIOS ROM in your system directory is preferred over the embedded one when
+present, and **CD BIOS Type** (`cd_bios_type`, Retail / Developer) picks which
+wins. The Developer BIOS applies less strict disc checks and can boot images the
+Retail BIOS refuses. If a real-BIOS mode is chosen and no CD BIOS can be staged
+at all, the core falls back to HLE rather than failing.
+
+**When to switch to Real BIOS.** HLE is more compatible overall, but it is a
+reimplementation, and a title occasionally trips over something HLE gets wrong
+that the real BIOS handles. The documented case is **World Tour Racing**: it
+freezes in HLE mode around frame 660 during FMV playback, while real-BIOS mode
+dips at the same point and then recovers into sustained motion (#589, open;
+follows the separate first-freeze fix in #564). Note that real BIOS is a
+*workaround, not a fix* — that title still cannot progress fully in either
+mode, and on an incomplete disc rip neither mode boots at all.
+
+If a CD game hangs or an FMV stops mid-playback, trying Real BIOS is worth a
+minute before you file a report — and say which modes you tried, because "fails
+in both" and "works in one" are different bugs.
+
+**CD Read Speed** (`cd_read_speed`, HLE boot mode only):
+
+| Value | Effect |
+|---|---|
+| 1x | 150 KB/s |
+| **2x** (default) | 300 KB/s — matches the real drive, hardware-accurate |
+| 4x / 8x | shorter loads, increasing risk |
+| Instant | each read completes in one tick; most likely to hang |
+
+Higher speeds shorten load times but break timing-sensitive titles — some games
+pace code overlays, music cues and load handshakes off the drive rate. If a CD
+game hangs after you raised this, put it back to 2x before anything else.
+Real-BIOS mode always uses the accurate rate regardless of this setting. The
+speed is applied per read, so a transfer already in flight keeps the speed it
+started with.
+
+**Memory Track** (`memory_track`, default **enabled**, restart required)
+emulates the Memory Track save cartridge alongside the CD unit. CD games detect
+it and save settings, progress and high scores to its 128 KB NVRAM. Leave it on
+unless you specifically want games to warn that progress cannot be saved.
+
+---
+
+## 7. Options that need a restart
+
+Changing these mid-game does nothing visible. Reload the content.
+
+| Option | Menu name |
+|---|---|
+| `internal_resolution` | Internal Resolution |
+| `pal` | PAL |
+| `bios_type` | Cart BIOS Type |
+| `cd_bios_type` | CD BIOS Type |
+| `cd_boot_mode` | CD Boot Mode |
+| `memory_track` | Memory Track |
+| `jgd` | Jaguar GameDrive |
+| `enhancement_hooks` | Per-Title Enhancement Hooks |
+
+Everything else — blitter mode, true color, texture replacement, clock scales,
+timing models, idle-skip, CD read speed — takes effect immediately.
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Likely cause | Try this |
+|---|---|---|
+| **Game runs too fast** (menus fly past, input feels doubled) | The emulated GPU finishes renders 2–4× faster than silicon, so loops paced on render or blit completion outrun hardware. This is a known accuracy gap, not your configuration. | Turn on `gpu_pipeline_timing` and/or `blitter_timing`. Both cost performance and are still being calibrated. Also confirm you have not left a clock scale above 1x. |
+| **Game runs slow** | See §4.2. | Per-title defaults off → 1x / true color off → idle-skip on → fast blitter. |
+| **Fast-forward does nothing** | Frontend setting, or no headroom left. | Check RetroArch's Fast-Forward Ratio and audio sync. If the title already runs near 16.7 ms/frame, there is nothing to gain. Also check the window is focused — a backgrounded window gets OS-throttled. |
+| **Audio crackles or drops out** | Usually frontend audio buffering. | Raise your frontend's audio latency first. If it started after you enabled `risc_idle_skip`, turn it back off and please report it — that is exactly the feedback the opt-in period exists for. |
+| **Audio pitch changed after overclocking** | Should not happen — timers and audio pacing stay at stock speed under both clock scales. | Report it. |
+| **Black screen on a CD game** | Boot path, or a bad rip. | Switch `cd_boot_mode` to Real BIOS and restart. If that fails too, try `cd_bios_type` = Developer. Check the log for `[CD-BOOTSTUB]` — "zero-filled" or "magic mismatch" means the image itself is an incomplete rip, and no setting will fix it. |
+| **CD game hangs after loading got faster** | `cd_read_speed` above 2x. | Set it back to 2x (accurate). |
+| **FMV freezes mid-playback** | Known HLE gap on at least one title. | Try `cd_boot_mode` = Real BIOS. For World Tour Racing specifically this is a known open bug (#589). |
+| **CD game says it cannot save** | Memory Track disabled. | Set `memory_track` = enabled and restart. |
+| **Controller not detected by the game** | The game wants a peripheral you have not selected, or a bank-switching device that has not been "woken". | Set the port's Controller Type explicitly. Bank-switching devices (analog, driving, 6D) present as a plain RetroPad until an axis actually moves, so deflect the stick before the game probes. Tempest 2000's rotary needs an in-game unlock (Option on pad 1 at SELECT GAME TYPE, then Pause on both pads). See `docs/input-devices-user-guide.md`. |
+| **Extra Team Tap pads do nothing** | They live on other RetroArch ports. | A Team Tap on port 1 puts players on RetroArch ports 1, 3, 4, 5; on port 2, ports 2, 6, 7, 8. Remap the extra pads from RetroArch's own Controls menu — the core's per-port remap rows apply to socket 0 only. |
+| **Numpad 7/8/9/`*`/`#` cannot be remapped** | RetroArch's Controls menu limitation. | Enable `alt_inputs` (Enable Core Options Remapping) and use the core's own Input Port rows. Delete any existing remap file first — the two systems conflict. |
+| **Wireframe / missing geometry** | Fast blitter. | Set Blitter back to Accurate. |
+| **Homebrew hangs at boot** | GameDrive-locked image. | Set `jgd` = Enabled (force) and restart. |
+| **A game freezes and you want to report it** | — | Leave Crash Detect on (or set it to verbose), reproduce, and attach the RetroArch log. It names the failing subsystem: `gpu_pc_escape`, `dsp_pc_escape`, `gpu_wedge`, `dsp_wedge`, `video_stall`, `cd_seek_wedge`. For CD problems, also enable `cd_trace`. |
+
+### Before you file a bug
+
+- Set **both clock scales back to 1x**. Overclocked reports cannot be acted on.
+- Turn **off** `risc_idle_skip`, `blit_memo`, the fast blitter, and all three
+  timing models — then confirm the problem still happens.
+- Say whether per-title defaults were on, and whether the title is in the §2
+  table.
+- Attach the RetroArch log. The `[titledb]` and crash-watchdog lines are what
+  make a report actionable.
+
+---
+
+## Quick reference
+
+| Option key | Default | Change it when… |
+|---|---|---|
+| `usefastblitter` | Accurate | you need speed and can accept rendering bugs |
+| `true_color` | off | banding bothers you (and you have headroom) |
+| `internal_resolution` | 1x | you want sharper 3D (restart) |
+| `widescreen` | off | you prefer a stretched 16:9 picture |
+| `pertitle_defaults` | **on** | you are on slow hardware, or want stock behavior |
+| `enhancement_hooks` | off | never, today — the table is empty |
+| `blit_memo` | off | you are testing it |
+| `crash_detect` | **on** | leave it on |
+| `m68k_clock_scale` | 1x | a 68K-bound game stutters (avoid 3x — see #460) |
+| `risc_clock_scale` | 1x | a GPU-bound game stutters — **and never with idle-skip** |
+| `risc_idle_skip` | **off** | you want the single biggest speed-up available |
+| `dram_timing` / `gpu_pipeline_timing` / `blitter_timing` | off | accuracy investigation only |
+| `bios` (cartridges) | HLE | a cartridge needs the real boot ROM |
+| `cd_boot_mode` | HLE | a CD game hangs or an FMV freezes (restart) |
+| `cd_read_speed` | 2x | loads feel slow — and revert if anything hangs |
+| `memory_track` | **on** | leave it on |
+| `texture_replace` | off | you installed a texture pack |
+
+---
+
+### See also
+
+- `docs/input-devices-user-guide.md` — controllers, mice, spinners, light gun
+- `docs/netlink-user-guide.md` — link play and voice chat
+- `docs/texture-dump.md` — authoring texture packs
+- `docs/frontend-pacing.md` — pacing, fast-forward, VRR
+- `docs/enhancement-hooks.md` — the per-title policy in full
+- `docs/perf-audit-2026-08.md`, `docs/op-perf-profile.md` — the profiling data
+  behind §4

--- a/docs/settings-and-performance-guide.md
+++ b/docs/settings-and-performance-guide.md
@@ -180,8 +180,8 @@ mid-game save states) found the cost concentrated in one place:
 
 | Subsystem | Share of frame time |
 |---|---|
-| **DSP** | **50–67%** (Iron Soldier 67%, Alien vs Predator 63%) |
-| **GPU** | large and title-dependent — e.g. ~24% on Skyhammer alongside ~33% DSP |
+| **DSP** | **33–67%**, and it is the top cost on every title measured — **50–67%** on the DSP-heavy ones (Iron Soldier 67%, Alien vs Predator 63%), ~33% on Skyhammer |
+| **GPU** | large and title-dependent — e.g. ~24% on Skyhammer |
 | Blitter (fast) | 5–17% |
 | Blitter (accurate) | up to ~34% on Alien vs Predator |
 | Object Processor | ~1% |
@@ -343,7 +343,15 @@ pacing are entirely your frontend's responsibility.
 Practical consequences:
 
 - The core advertises **60.05445 fps / 48043.6 Hz** (NTSC) and **50.08013 fps /
-  48076.9 Hz** (PAL). These are the Jaguar's real field rates, not 60/50.
+  48076.9 Hz** (PAL). These are the Jaguar's real field rates, not 60/50, and
+  they are derived rather than hard-coded: a non-interlaced field is 524
+  halflines NTSC / 624 PAL (`VJ_HALFLINES_PER_FIELD_*` in `src/core/jaguar.h`),
+  so the rate falls out as `1e6 / (halflines × halfline_µs)`. The sample rate
+  follows from it in `retro_get_system_av_info()` — the core hands the frontend
+  a fixed batch of pairs exactly once per field, so the true output rate *is*
+  pairs × field rate. Advertising a flat 48000 against the corrected fps would
+  over-deliver by ~0.09% forever and slowly drain or overfill the frontend's
+  audio buffer.
 - **Fast-forward doing nothing is usually a RetroArch setting**, not a core bug.
   Check *Frame Throttle → Fast-Forward Ratio* (1.0× means no speed-up),
   `vrr_runloop_enable`, and that audio sync goes non-blocking during
@@ -444,7 +452,7 @@ Changing these mid-game does nothing visible. Reload the content.
 |---|---|
 | `internal_resolution` | Internal Resolution |
 | `pal` | PAL |
-| `bios_type` | Cart BIOS Type |
+| `bios_type` | Cart BIOS Type — *which* boot ROM (Series K / Model M / Custom) |
 | `cd_bios_type` | CD BIOS Type |
 | `cd_boot_mode` | CD Boot Mode |
 | `memory_track` | Memory Track |
@@ -504,7 +512,7 @@ timing models, idle-skip, CD read speed — takes effect immediately.
 | `risc_clock_scale` | 1x | a GPU-bound game stutters — **and never with idle-skip** |
 | `risc_idle_skip` | **off** | you want the single biggest speed-up available |
 | `dram_timing` / `gpu_pipeline_timing` / `blitter_timing` | off | accuracy investigation only |
-| `bios` (cartridges) | HLE | a cartridge needs the real boot ROM |
+| `bios` (cartridges) | HLE | a cartridge needs the real boot ROM. *Distinct from* `bios_type`, which picks **which** ROM once this is set to Real |
 | `cd_boot_mode` | HLE | a CD game hangs or an FMV freezes (restart) |
 | `cd_read_speed` | 2x | loads feel slow — and revert if anything hangs |
 | `memory_track` | **on** | leave it on |

--- a/docs/settings-and-performance-guide.md
+++ b/docs/settings-and-performance-guide.md
@@ -141,10 +141,13 @@ Run-ahead is unaffected. You can turn them on and off freely without risking a
 save.
 
 **What they cost.** Internal Resolution and True Color are the only two
-enhancements with a real performance price, and it is not small: Alien vs
-Predator's own preset (2x + true color) was measured at roughly **30% of its
-frame time** on a desktop host. On a slow device, these are the first things to
-turn off — see §4.
+enhancements with a real performance price, and it is not small: **2x + true
+color together** were measured at roughly **30% of frame time** on Alien vs
+Predator on a desktop host. Note AvP's shipped preset is **2x only** — #551
+dropped true color from it after a pixel-diff found it changed 0.0000% of
+pixels — so disabling AvP's preset recovers the 2x share of that figure, not
+all of it. On a slow device these are still the first things to turn off; see
+§4.
 
 ### 3.1 Texture packs
 
@@ -189,8 +192,15 @@ mid-game save states) found the cost concentrated in one place:
 
 The striking finding: **the DSP is parked in a 3–5 instruction wait loop for
 90–99.7% of every frame** on the titles measured (Iron Soldier 99.7%, Doom 90%,
-Alien vs Predator 74%) — while still interpreting its full 26.6 MHz cycle
-budget, 416k–590k opcodes per frame, spinning. The GPU does the same thing on
+Alien vs Predator 74%) — while the emulator still interprets **416k–590k
+opcodes per frame** doing it (Iron Soldier 590k, AvP 532k, Doom 461k, niccc
+417k). Note those counts *exceed* what real silicon could retire in a frame:
+26.59 MHz over a 60.05 Hz field is ~443k cycles, and no Jaguar RISC instruction
+takes less than one. The emulated DSP outruns the hardware because pipeline
+hazards are not modelled ([#313](https://github.com/libretro/virtualjaguar-libretro/issues/313))
+— which is the same root cause behind titles that run too fast. So this is
+interpreter work being done, not a hardware cycle budget being filled, and
+that is precisely why skipping it is free. The GPU does the same thing on
 some titles (Alien vs Predator 80%, jagniccc 73%).
 
 Two consequences for you:
@@ -299,7 +309,7 @@ games, and they can break titles that depend on stock timing. If you file a bug,
 reproduce it at 1x first — a bug report from an overclocked session cannot be
 acted on.
 
-**Known bad cases** (all reported against overclock, all still open):
+**Known bad cases** (all reported against overclock; status per row):
 
 | Title | Setting | Symptom | Status |
 |---|---|---|---|
@@ -313,7 +323,8 @@ help — but note that two of them disable idle-skip, so you may be stacking cos
 ### 4.5 Low-end platforms
 
 Honest position first: **no on-device profile has been captured for the Apple TV
-/ A10X class yet.** Issue #509 remains open specifically for that. Every number
+/ A10X class yet.** Issue #601 tracks that capture (its parent epic #509 closed
+once every other child shipped). Every number
 in §4.1 is a desktop host profile. Anyone quoting per-subsystem device
 percentages for tvOS is quoting a projection.
 

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -91,7 +91,7 @@ SHARE_IMAGE_ALT = (
 
 # Page order defines nav order.
 PAGES = ["index.html", "compatibility.html", "enhancements.html",
-         "why-this-core.html"]
+         "performance.html", "why-this-core.html"]
 
 EXPECTED_HEADER = ["Title", "Mode", "Score", "Stage", "Watchdog", "PC evidence"]
 CART_EXPECTED_HEADER = ["Title", "HLE", "HLE notes", "Real BIOS", "BIOS notes"]

--- a/site/pages/performance.html
+++ b/site/pages/performance.html
@@ -31,7 +31,7 @@
 <div class="table-wrap"><table>
   <thead><tr><th>Subsystem</th><th>Share of frame time</th></tr></thead>
   <tbody>
-    <tr><td><strong>DSP</strong></td><td><strong>50–67%</strong> (Iron Soldier 67%, Alien vs Predator 63%)</td></tr>
+    <tr><td><strong>DSP</strong></td><td><strong>33–67%</strong>, the top cost on every title measured — 50–67% on the DSP-heavy ones (Iron Soldier 67%, Alien vs Predator 63%), ~33% on Skyhammer</td></tr>
     <tr><td>GPU</td><td>large, title-dependent — ~24% on Skyhammer</td></tr>
     <tr><td>Blitter (fast)</td><td>5–17%</td></tr>
     <tr><td>Blitter (accurate)</td><td>up to ~34% on Alien vs Predator</td></tr>
@@ -119,5 +119,5 @@
   This page is the short version. The complete guide — every option, a
   restart-required table, a symptom&nbsp;→&nbsp;setting troubleshooting table, and
   the evidence behind each figure above — lives in the repository:
-  <a href="{{REPO}}/blob/master/docs/settings-and-performance-guide.md">settings-and-performance-guide.md</a>.
+  <a href="{{REPO}}/blob/develop/docs/settings-and-performance-guide.md">settings-and-performance-guide.md</a>.
 </p>

--- a/site/pages/performance.html
+++ b/site/pages/performance.html
@@ -1,0 +1,123 @@
+<!-- title: Settings & Performance — Virtual Jaguar libretro -->
+<!-- nav: Performance -->
+<!-- description: Which of the core's forty-odd options actually matter, what to change when an Atari Jaguar game runs slow, and which settings quietly cancel each other out. -->
+
+<h1>Settings &amp; performance</h1>
+<p class="lede">
+  The core ships about forty options. Almost none of them need your attention —
+  but two of them interact in a way that can make a slow game slower.
+</p>
+
+<h2>The defaults are already the right answer</h2>
+<p>
+  Accurate blitter, stock clocks, every experimental timing model off, HLE BIOS,
+  and per-title enhancement defaults on — roughly twenty recognised games get a
+  visual upgrade that was verified safe for that specific title. If a game boots
+  and plays, you are done.
+</p>
+<p>
+  Four settings are worth knowing about: <strong>Blitter</strong>,
+  <strong>Internal Resolution</strong>, <strong>DSP Idle-Loop Fast-Forward</strong>,
+  and — for CD games — <strong>CD Boot Mode</strong>. Everything else is either a
+  diagnostic, a controller, or networking.
+</p>
+
+<h2>Where the frame time actually goes</h2>
+<p>
+  Profiling found the cost concentrated in one place, and it is not where
+  intuition puts it:
+</p>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Subsystem</th><th>Share of frame time</th></tr></thead>
+  <tbody>
+    <tr><td><strong>DSP</strong></td><td><strong>50–67%</strong> (Iron Soldier 67%, Alien vs Predator 63%)</td></tr>
+    <tr><td>GPU</td><td>large, title-dependent — ~24% on Skyhammer</td></tr>
+    <tr><td>Blitter (fast)</td><td>5–17%</td></tr>
+    <tr><td>Blitter (accurate)</td><td>up to ~34% on Alien vs Predator</td></tr>
+    <tr><td>Object Processor</td><td>~1%</td></tr>
+    <tr><td>68000</td><td>0.7–2.6%</td></tr>
+  </tbody>
+</table></div>
+
+<p>
+  The striking part: <strong>the DSP sits in a 3–5 instruction wait loop for
+  90–99.7% of every frame</strong> on the titles measured — while still
+  interpreting its full 26.6&nbsp;MHz budget, hundreds of thousands of opcodes
+  per frame, spinning. The 68000 and the Object Processor are noise.
+</p>
+<p class="footnote">
+  Host profiles on desktop arm64, not device measurements. No on-device Apple TV
+  capture exists yet.
+</p>
+
+<h2>What to try when a game runs slow</h2>
+<p>In order. Stop as soon as it is fast enough.</p>
+<ol>
+  <li><strong>Turn off Per-Title Enhancement Defaults.</strong> If your game is
+      recognised, it is rendering at 2x and/or full-precision Gouraud right now —
+      worth ~30% of the frame on Alien vs Predator. On a low-end device this is
+      step one, not step three.</li>
+  <li><strong>Internal Resolution 1x, True Color off</strong> — the manual
+      version of step 1, if you want to keep per-title defaults elsewhere.</li>
+  <li><strong>Turn on DSP Idle-Loop Fast-Forward.</strong> The biggest lever, and
+      it is <strong>off by default</strong> — nobody gets it by accident.</li>
+  <li><strong>Blitter → Fast.</strong> Measured 1.21× typical, up to 1.58× on the
+      title that gains most. It breaks some games — wireframe artifacts, missing
+      geometry — so switch back the moment anything looks wrong.</li>
+  <li><strong>Only then consider overclocking</strong>, and read the next section
+      first, because it can make things worse.</li>
+</ol>
+<p>
+  There is no frame-skip option and no internal speed limiter. Pacing is entirely
+  your frontend's job.
+</p>
+
+<h2>The compounding trap <span class="badge warn">read this before overclocking</span></h2>
+<p>
+  <strong>DSP Idle-Loop Fast-Forward disables itself</strong> when any of these is
+  in effect:
+</p>
+<div class="table-wrap"><table>
+  <thead><tr><th>Setting</th><th>Value that disables idle-skip</th></tr></thead>
+  <tbody>
+    <tr><td>RISC (GPU/DSP) Clock Scale</td><td>anything other than <code>1x</code></td></tr>
+    <tr><td>DRAM Timing</td><td>enabled</td></tr>
+    <tr><td>GPU Pipeline Timing</td><td>enabled</td></tr>
+    <tr><td>Blit Memoization</td><td>enabled or verify</td></tr>
+  </tbody>
+</table></div>
+<p>
+  It stays active under <strong>M68K Clock Scale</strong> at any value, and under
+  <strong>Blitter Bus Timing</strong> — neither of those turns it off.
+</p>
+
+<p class="caveat">
+  <strong>Overclocking the RISC to make a slow game faster can make it slower.</strong>
+  Setting RISC Clock Scale to <code>2x</code> gives the GPU and DSP twice the
+  cycles — and simultaneously forfeits a 66–87% reduction in DSP work. On a
+  DSP-bound title you have traded the bigger win for the smaller one.
+</p>
+
+<p>
+  Since <strong>v3.5.1</strong> the core tells you: enable idle-skip alongside any
+  of the above and one <code>[perf]</code> line lands in your frontend log naming
+  the exact setting suppressing it. It warns only — your settings are always
+  honoured, never overridden.
+</p>
+
+<h2>Jaguar CD</h2>
+<p>
+  <strong>CD Boot Mode</strong> defaults to HLE, which is the fastest and most
+  broadly compatible path and needs no BIOS files. Switch to real BIOS if a disc
+  misbehaves — it is a different implementation of the same boot sequence, and a
+  handful of titles work under one and not the other.
+</p>
+
+<h2>Full guide</h2>
+<p>
+  This page is the short version. The complete guide — every option, a
+  restart-required table, a symptom&nbsp;→&nbsp;setting troubleshooting table, and
+  the evidence behind each figure above — lives in the repository:
+  <a href="{{REPO}}/blob/master/docs/settings-and-performance-guide.md">settings-and-performance-guide.md</a>.
+</p>

--- a/site/pages/performance.html
+++ b/site/pages/performance.html
@@ -42,9 +42,12 @@
 
 <p>
   The striking part: <strong>the DSP sits in a 3–5 instruction wait loop for
-  90–99.7% of every frame</strong> on the titles measured — while still
-  interpreting its full 26.6&nbsp;MHz budget, hundreds of thousands of opcodes
-  per frame, spinning. The 68000 and the Object Processor are noise.
+  90–99.7% of every frame</strong> on the titles measured, while the emulator
+  interprets 416k–590k opcodes per frame doing it. That is more than real
+  silicon could retire in a frame (~443k cycles at 26.59&nbsp;MHz over a
+  60.05&nbsp;Hz field) because pipeline hazards are not modelled — so it is
+  interpreter work, not a hardware budget, which is exactly why skipping it is
+  free. The 68000 and the Object Processor are noise.
 </p>
 <p class="footnote">
   Host profiles on desktop arm64, not device measurements. No on-device Apple TV
@@ -56,8 +59,9 @@
 <ol>
   <li><strong>Turn off Per-Title Enhancement Defaults.</strong> If your game is
       recognised, it is rendering at 2x and/or full-precision Gouraud right now —
-      worth ~30% of the frame on Alien vs Predator. On a low-end device this is
-      step one, not step three.</li>
+      2x and true color together measured ~30% of the frame on Alien vs Predator.
+      AvP's shipped preset is 2x only, so disabling it recovers that share rather
+      than the whole 30%. On a low-end device this is step one, not step three.</li>
   <li><strong>Internal Resolution 1x, True Color off</strong> — the manual
       version of step 1, if you want to keep per-title defaults elsewhere.</li>
   <li><strong>Turn on DSP Idle-Loop Fast-Forward.</strong> The biggest lever, and


### PR DESCRIPTION
Closes the "nothing explains which of the ~40 options matter" gap. Adds `docs/settings-and-performance-guide.md`, a condensed `site/pages/performance.html`, and two README pointers.

## Why it's worth reviewing rather than skimming

The performance section is sourced, not folklore, and it corrects two claims that were circulating in our own issue text:

- **DSP idle-skip does NOT disable itself under `m68k_clock_scale` or `blitter_timing`** — only under RISC clock scale, `dram_timing`, `gpu_pipeline_timing`, and `blit_memo`. Verified against the gate in `src/jerry/dsp.c`, not taken from #595's body (which had it wrong; corrected there now).
- **The "GPU RISC ~74% / blitter ~17%" split is not in any committed doc.** It traces to notes about an uncaptured device run. The guide uses only doc-backed figures from `docs/perf-audit-2026-08.md` / `docs/op-perf-profile.md`, and labels them explicitly as host arm64 profiles rather than device measurements — no on-device A10X capture exists yet (#601).

## Content

- Defaults are the right answer; a "safe to ignore forever" table
- Per-title enhancement defaults, and that a user-set value always wins
- Enhancements: presentation-only guarantee stated once, not per option
- **Performance**: where frame time goes, an ordered what-to-try list that *ends* at overclocking rather than starting there, the compounding trap, low-end platform notes
- Timing models, Jaguar CD boot mode, restart-required table, symptom→setting troubleshooting table

## Verification

`python3 scripts/build_site.py` builds clean — the new page lands in the nav and the sitemap (5 URLs).

## Note

The guide states "since v3.5.1" for the `[perf]` warning, so it wants #602 to land first. Merging this to `develop` before then is harmless (the doc is ahead of the branch it describes for a few hours), but sequencing after is tidier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)