### PR TITLE
fix: scaled 24bpp OOB line-buffer write (#604) + widescreen statics/geometry (#605)

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -130,6 +130,14 @@ static int hook_restart_notice_logged = 0;
 static bool widescreen_enabled          = false;
 static bool widescreen_geometry_pending = false;
 
+/* Title-scoped, so it has to be re-armed per load exactly like the
+ * titledb warning latches -- iOS cannot dlclose the core (#605). */
+static void widescreen_reset(void)
+{
+   widescreen_enabled          = false;
+   widescreen_geometry_pending = false;
+}
+
 #ifdef VJ_TRACE
 /* vjtrace per-session frame counter (see the use site in retro_run()).
  * File-scope, not a retro_run()-local static, so retro_unload_game()/
@@ -4976,6 +4984,10 @@ bool retro_load_game(const struct retro_game_info *info)
    titledb_reset_negative_warnings();
    /* Compounding-settings (#595) warning latch: same reasoning, same reset. */
    perf_conflict_reset();
+   /* Widescreen (#530/#605): clear BEFORE the check_variables() below, so
+    * this load latches its own aspect rather than inheriting the previous
+    * title's on a core that was never dlclosed. */
+   widescreen_reset();
 
    /* Internal resolution (hi-res Stage 1, see shadowfb.h): read ONCE at
     * content load -- SET_GEOMETRY cannot grow past the advertised maximum,
@@ -5087,6 +5099,16 @@ bool retro_load_game(const struct retro_game_info *info)
     * check_variables() skipped this on the load path for exactly this
     * reason; the latch keeps later option reads from repeating it. */
    perf_warn_idle_skip_suppressed();
+
+   /* Widescreen (#605): the check_variables() above latched this load's
+    * aspect, and the frontend queries retro_get_system_av_info() after
+    * retro_load_game() returns -- so it already has the right geometry.
+    * Leaving the flag armed made the first retro_run() fire a
+    * value-identical SET_GEOMETRY on the very frame that submits the
+    * first video_cb, which is the frontend-reallocates-and-drops-a-frame
+    * case the geometry-change comment in retro_run() warns about.  Only
+    * a genuine mid-session toggle should notify. */
+   widescreen_geometry_pending = false;
 
    /* Open the disc image BEFORE JaguarInit() so CDROMInit -> CDIntfInit ->
     * CDIntfIsImageLoaded sees the disc and haveCDGoodness is set correctly. */
@@ -5289,6 +5311,13 @@ void retro_unload_game(void)
     * warning latch: same reasoning, same reset. */
    TitleDBSetPairsForTest(NULL, 0);
    perf_conflict_reset();
+   /* Widescreen (#530) is title-scoped like everything above and was
+    * missed when it landed (#605).  iOS never dlcloses the core, so
+    * leaving these set lets a 16:9 title hand its aspect ratio to the
+    * next one: retro_get_system_av_info() can be called before the new
+    * session's first check_variables(), and that is the negotiation
+    * that sizes the frontend's first render target. */
+   widescreen_reset();
 
    eeprom_dirty_cb = NULL;
    mt_dirty_cb     = NULL;
@@ -5673,6 +5702,8 @@ void retro_deinit(void)
     * warning latch: same per-load re-arm as above. */
    TitleDBSetPairsForTest(NULL, 0);
    perf_conflict_reset();
+   /* Widescreen (#530/#605): same per-load re-arm as above. */
+   widescreen_reset();
 
    eeprom_dirty_cb = NULL;
    mt_dirty_cb     = NULL;

--- a/src/tom/op.c
+++ b/src/tom/op.c
@@ -1917,9 +1917,18 @@ void OPProcessScaledBitmap(uint64_t p0, uint64_t p1, uint64_t p2, bool render)
             uint8_t bits3 = pixels >> 56, bits2 = pixels >> 48,
                     bits1 = pixels >> 40, bits0 = pixels >> 32;
 
+            /* Bounds-clamped for the same reason the fixed-bitmap stores
+             * are (#565, and the OP_LBUF_IN_BOUNDS comment above): this
+             * loop runs on the raw phrase `iwidth`, not on the clamped
+             * visibleDestPixels the 1-16 BPP branches above bound
+             * themselves with, and lbufDelta sign-extends OPFLAG_REFLECT
+             * -- so a reflected object with a garbage iwidth walks
+             * backward out of tomRam8 with nothing to stop it.  Four
+             * bytes per store here rather than two, so it leaves the
+             * buffer faster than the case that actually crashed. */
             if (flagTRANS && (bits3 | bits2 | bits1 | bits0) == 0)
                ;	// Do nothing...
-            else
+            else if (OP_LBUF_IN_BOUNDS(currentLineBuffer, 4))
                *currentLineBuffer = bits3,
                   *(currentLineBuffer + 1) = bits2,
                   *(currentLineBuffer + 2) = bits1,


### PR DESCRIPTION
Two defects found by a post-#565 sibling sweep, both verified by direct code reading before filing.

### #604 — `OPProcessScaledBitmap` 24bpp has #565's hole

#565 added `OP_LBUF_IN_BOUNDS` to all six pixel-store sites in `OPProcessFixedBitmap`. The **scaled** path's `depth==5` branch was never covered and has the identical mechanism: loops on the raw phrase `iwidth` (not the clamped `visibleDestPixels` its own 1-16 BPP siblings use), `lbufDelta` sign-extends `OPFLAG_REFLECT`, 4-byte stores. A reflected object with a garbage `iwidth` walks backward out of `tomRam8` — faster than the 2-byte case that actually aborted Club Drive.

Depths 0-4 of the same function are **not** vulnerable and are deliberately untouched: their loop bound derives from the same clamped `[0,lbufWidth]` range as the start pointer.

### #605 — widescreen statics + a redundant `SET_GEOMETRY` (my own #591 code)

1. `widescreen_enabled` / `widescreen_geometry_pending` were never reset in unload/deinit, breaking the repo's iOS no-dlclose rule — a 16:9 title could hand its aspect to the next one via an `av_info` query that lands before the new session's first `check_variables()`. Now reset at all three sites the titledb latches use; the load-path call sits **before** `check_variables()` so this load still latches its own value.
2. Pre-set widescreen left the pending flag armed through load, so the first `retro_run()` fired a **value-identical** `SET_GEOMETRY` on the exact frame submitting the first `video_cb` — the reallocate-and-drop case `retro_run()`'s own comment warns about, triggered by a no-op. Cleared at end of load; only a genuine mid-session toggle notifies now.

### Verification

- `make TEST_EXPORTS=1 test` → **exit 0, zero FAIL lines**
- `scripts/c89-lint.sh` clean on both files
- Clean build

Neither is runtime-reproduced — no known title hits #604 at stock settings, which was equally true of #565 until an overclock exposed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)