### PR TITLE
docs(site): timing campaign is non-versioned, not v4.0.0

### DIFF
--- a/site/pages/compatibility.html
+++ b/site/pages/compatibility.html
@@ -123,7 +123,7 @@
     <p class="footnote">
       Render-bound game loops run about 2x fast in Doom and Hover Strike
       (<a href="{{REPO}}/issues/401">#401</a>; a real-hardware Doom capture now
-      anchors the v4.0.0 timing campaign). Battle Morph on CD is too fast
+      anchors the timing-accuracy campaign). Battle Morph on CD is too fast
       (<a href="{{REPO}}/issues/331">#331</a>). The non-default Fast blitter
       drops Iron Soldier's briefing wireframe; keep Accurate
       (<a href="{{REPO}}/blob/develop/docs/cart-issue-triage.md">triage doc</a>).


### PR DESCRIPTION
One phrase on the public compatibility page.

`site/pages/compatibility.html` described the real-hardware Doom capture as anchoring **"the v4.0.0 timing campaign"**. Both halves of that are now stale:

- Timing moved to a deliberately **non-versioned** milestone — it is partly gated on reporter hardware captures we do not control, and a version number on undatable work stalls the release train.
- The `v4.0.0` milestone was renumbered **v3.6.0** (standalone SDL frontend, #254). Everything in it is additive — no core-option removed or renamed, libretro API version unchanged, savestates still load — so it does not earn a major.

Net: the sentence named a version that no longer exists, for a campaign that no longer carries one. Drops the number rather than substituting another.

`scripts/build_site.py` and `scripts/check_site.py` both green (5 pages, sitemap and robots.txt verified). No code, no generated files.

Roadmap #371 reconciled in the same pass.