### PR TITLE
feat(options): split Timing into Speed and Hardware Timing; overclock gate-1 tooling

### DIFF
--- a/docs/overclock-gate1-checklist.md
+++ b/docs/overclock-gate1-checklist.md
@@ -82,19 +82,28 @@ ROMs for all eight candidates are present in `jaguar-roms-private/ROMS/`.
 | Iron Soldier | `iron_soldier_v104_f2400.state` | Null — clock-insensitive, confirmed by underclock control |
 | Val D'Isere | `... (1994).state.auto` | **UNMEASURED** — near-static scene, needs a real gameplay state |
 
-**Cybermorph is the first title to clear gate 1.** 2400-frame window (ceiling 2399):
+**Cybermorph is the first title to clear gate 1.** All seven cells, one 2400-frame window
+(saturation ceiling 2399):
 
-| RISC scale | transitions | ≈ fps | vs stock |
+| cell | transitions | ≈ fps | vs stock |
 |---|---:|---:|---:|
-| 0.5x | 258/900 | — | −49.7% |
-| **1x (stock)** | **1359/2399** | **~34** | — |
-| 1.5x | 1967/2399 | ~49 | **+44.7%** |
-| 2x | 2349/2399 | ~59 | **+72.8%** |
+| RISC 0.5x (control) | 697/2400 | ~17 | **−48.7%** |
+| **RISC 1x, 68K 1x (stock)** | **1359/2400** | **~34** | — |
+| RISC 1.5x | 1967/2400 | ~49 | **+44.7%** |
+| RISC 2x | 2349/2400 | ~59 | **+72.8%** |
+| RISC 1x, 68K 1.5x | 1362/2400 | ~34 | +0.2% |
+| RISC 1.5x, 68K 1.5x | 1994/2400 | ~50 | +46.7% |
+| RISC 2x, 68K 1.5x | 2311/2400 | ~58 | +70.1% |
 
-The 68K axis is inert here (+0.6% at 1.5x): this is a RISC-bound title, so only
-`risc_clock_scale` matters.
+The 68K axis is inert (+0.2% on its own): this is a RISC-bound title, so only
+`risc_clock_scale` matters, and stacking the 68K scale on top adds nothing.
 
-At 2x, 2349 of 2399 fields carry a new frame — Cybermorph is now presenting at essentially
+**The control is what makes the rest trustworthy.** RISC 0.5x costs 48.7% — near-linear
+against the +44.7% that 1.5x gains — so the metric tracks clock speed in both directions on
+this title. Every figure above comes from the same 2400-frame window; nothing is spliced
+across window lengths.
+
+At 2x, 2349 of 2400 fields carry a new frame — Cybermorph is now presenting at essentially
 the display rate. That is a real ceiling rather than the trap-2 counter artefact, but it does
 mean **+72.8% is a floor on the 2x gain, not the exact figure**; the engine may have headroom
 the display cannot show.
@@ -112,8 +121,9 @@ the profile data: Iron Soldier is the extreme DSP case, 67% of frame time in the
 99.7% of that spinning in an idle loop. It needs **idle-skip**, not overclock.
 
 > **Always run the underclock arm.** A flat 1x/1.5x/2x row is ambiguous — genuine cap, or dead
-> measurement? 0.5x separates them. Cybermorph's control (0.5x = 258 against 1x's 513) is what
-> proves the metric was live for the whole sweep.
+> measurement? 0.5x separates them. Cybermorph's control (−48.7% at 0.5x, against +44.7% at
+> 1.5x) is what proves the metric was live for the whole sweep. `scripts/ocgrid.sh` runs this
+> arm unconditionally so it cannot be forgotten.
 
 **Val D'Isere is not a null — it is unmeasured.** 15 transitions in 900 frames, identical even
 at 0.5x. That is one changed frame every ~60, i.e. a static or paused screen; the state is a
@@ -156,12 +166,29 @@ at 0.5x. That is one changed frame every ~60, i.e. a static or paused screen; th
 FRAMES=900 scripts/ocgrid.sh out.txt "<rom path>" "<state path>"
 ```
 
-Six cells per title: {1x, 1.5x, 2x} RISC × {1x, 1.5x} 68K, each reported as a percentage
-against the stock cell.
+Results are written to `out.txt` and echoed to stdout. `CORE=` overrides the library path if
+you are not on macOS (`CORE=./virtualjaguar_libretro.so ...`).
+
+**Seven cells:** the six-cell grid — {1x, 1.5x, 2x} RISC × {1x, 1.5x} 68K — plus a **0.5x
+underclock control**, which the script always runs. Each is quoted as a percentage against
+the stock cell.
+
+The control is not optional and the script does not let you skip it. A flat 1x/1.5x/2x row
+cannot distinguish a real frame cap from a measurement that was never responding, and that
+ambiguity is the direct cause of both retracted tables on #378. **If 0.5x does not drop, the
+whole sweep is void** regardless of what the other arms say.
+
+The run is two-phase — every cell is measured before anything is printed — because the stock
+cell has to be known before the control can be quoted against it. There is no incremental
+output; a 7-cell 2400-frame sweep takes a few minutes.
 
 **Do not run this while anything else is building.** A concurrent `make` relinks
 `virtualjaguar_libretro.dylib` mid-sweep and the arms end up measuring different binaries.
 Check with `pgrep -f make` first.
+
+Host load does *not* matter here: the metric counts emulated framebuffer transitions, not
+wall-clock, so it is deterministic and load-immune. That is why this gate uses it rather than
+an fps measurement.
 
 ### Reading the output
 

--- a/docs/overclock-gate1-checklist.md
+++ b/docs/overclock-gate1-checklist.md
@@ -1,0 +1,198 @@
+# Overclock gate-1 checklist (#378)
+
+Working checklist for the **mechanical gate** of #378: *does a clock scale actually lift the
+internal frame rate of this title?* A preset only gets a per-title DB row if it clears this
+gate **and** the human play-test gate that follows it.
+
+Gate 1 is cheap and fully automatable — but it has produced **two retracted result tables**
+already. Both failures were measurement bugs, not emulator bugs. Read §1 before running
+anything.
+
+---
+
+## 1. The three traps that invalidated earlier runs
+
+**Trap 1 — no input measures the title screen.** A run with no `--press` and no savestate
+profiles the game wherever it lands unattended. A menu is by construction the *not
+compute-bound* case, so a flat result across 1x/1.5x/2x says nothing about the game.
+
+```
+Cybermorph, RISC 1x, frames 300-900
+  no input       64 transitions
+  with input    599 transitions      <- 9.4x
+```
+
+**Trap 2 — the transitions counter saturates at the window length.** Over frames 300–900 the
+ceiling is 600. Driven, Cybermorph and I-War both read exactly 600/600/600. A saturated
+counter cannot show a gain.
+
+> **`transitions == window length` is UNMEASURED, not a result.** The grid script flags this
+> as `SATURATED` — if you see it, lengthen the window or pick a quieter scene, and do not
+> compare arms.
+
+**Trap 3 — a shared input mash perturbs the game.** Driving every title with one generic
+press sequence made Doom read **0** (a press paused it) and halved Missile Command 3D at 1.5x.
+Those are input artefacts, not clock-scale effects.
+
+**The fix for all three is the same: a savestate dropped into real gameplay.** It removes the
+perturbation entirely and puts every arm in an identical starting state.
+
+---
+
+## 2. What a good savestate looks like
+
+Load the game in RetroArch, play into a **representative, sustained-load** moment, and save.
+
+- **In gameplay, not a menu, not a cutscene, not a pause.** The whole point is to measure the
+  engine under load.
+- **Somewhere the scene keeps changing on its own** for the next ~15 seconds without input —
+  driving forward, a firefight, a slope. If the picture goes static the counter reads a false
+  null.
+- **Avoid a scene so busy that every single frame differs** — that is what saturates the
+  counter. A mid-load scene discriminates best.
+- **Stock settings when you save.** 1x clocks, idle-skip off. The grid sets its own options;
+  a state saved under a non-stock config biases every arm.
+
+Drop the files in `jaguar-roms-private/states/`. Any filename is fine — the runner takes an
+explicit path.
+
+**Compressed states work — convert them first.** If RetroArch has "Save State Compression"
+on it writes an rzip container, which `retro_unserialize` rejects on size (it sees ~270 KB
+where the core wants 2.5 MB). Convert instead of re-saving:
+
+```bash
+python3 scripts/rzip_extract.py "<state>" /tmp/out.state
+```
+
+Files that are already raw are passed through unchanged, so it is safe to run over anything.
+Old savestate *versions* are fine — the core accepts back to `STATE_MIN_VERSION`, and both
+states measured above were older versions that loaded with only a size warning.
+
+---
+
+## 3. Status
+
+ROMs for all eight candidates are present in `jaguar-roms-private/ROMS/`.
+
+### Measured 2026-08-25
+
+| Title | Savestate | Result |
+|---|---|---|
+| **Cybermorph** | `Cybermorph (1993).state1` | **CLEARS GATE 1** — +44.7% at RISC 1.5x, +72.8% at 2x |
+| Iron Soldier | `iron_soldier_v104_f2400.state` | Null — clock-insensitive, confirmed by underclock control |
+| Val D'Isere | `... (1994).state.auto` | **UNMEASURED** — near-static scene, needs a real gameplay state |
+
+**Cybermorph is the first title to clear gate 1.** 2400-frame window (ceiling 2399):
+
+| RISC scale | transitions | ≈ fps | vs stock |
+|---|---:|---:|---:|
+| 0.5x | 258/900 | — | −49.7% |
+| **1x (stock)** | **1359/2399** | **~34** | — |
+| 1.5x | 1967/2399 | ~49 | **+44.7%** |
+| 2x | 2349/2399 | ~59 | **+72.8%** |
+
+The 68K axis is inert here (+0.6% at 1.5x): this is a RISC-bound title, so only
+`risc_clock_scale` matters.
+
+At 2x, 2349 of 2399 fields carry a new frame — Cybermorph is now presenting at essentially
+the display rate. That is a real ceiling rather than the trap-2 counter artefact, but it does
+mean **+72.8% is a floor on the 2x gain, not the exact figure**; the engine may have headroom
+the display cannot show.
+
+> **Two blockers before this becomes a DB preset.** Cybermorph is *also* the title with the
+> open overclock crash report — #463, "Codex-level crash + erratic ship movement under
+> overclock", currently `blocked` for want of reporter artefacts. The one title measured to
+> benefit is the one with an unconfirmed overclock crash against it, so #463 has to be settled
+> first. And gate 2 still applies: a title can render more frames while its logic runs too
+> fast (#401). Play-test before writing a row.
+
+**Iron Soldier is a genuine null, and the control proves it.** 0.5x reads 115 against 1x's
+116 — halving the RISC clock costs it *nothing*, so it was never clock-bound at 1x. That fits
+the profile data: Iron Soldier is the extreme DSP case, 67% of frame time in the DSP with
+99.7% of that spinning in an idle loop. It needs **idle-skip**, not overclock.
+
+> **Always run the underclock arm.** A flat 1x/1.5x/2x row is ambiguous — genuine cap, or dead
+> measurement? 0.5x separates them. Cybermorph's control (0.5x = 258 against 1x's 513) is what
+> proves the metric was live for the whole sweep.
+
+**Val D'Isere is not a null — it is unmeasured.** 15 transitions in 900 frames, identical even
+at 0.5x. That is one changed frame every ~60, i.e. a static or paused screen; the state is a
+`.state.auto` autosave that landed wherever the session ended. Needs a real gameplay save
+(see below).
+
+### Need a savestate — checklist
+
+- [ ] **Doom** — `Doom - Evil Unleashed (1994).jag`
+      *Where:* in a level, walking down a corridor with at least one monster active.
+      **Not** the attract demo (its pace is the #401 subject and it desyncs across cycle
+      changes, so it is invalid evidence either way) and **not** the menu (its speed is the
+      game's own code — see #396 notes).
+- [ ] **Club Drive** — `Club Drive (1994).jag`
+      *Where:* mid-race, car moving, scenery scrolling.
+      **Note:** this title used to abort at `risc_clock_scale=2x` (`dsp_pc_escape`, #565).
+      That is **fixed** as of v3.5.0, so the 2x arm should now complete — if it dies, that is
+      a regression worth its own issue.
+- [ ] **I-War** — `I-War (1995).jag`
+      *Where:* in flight with geometry on screen. Earlier runs **saturated** here (600/600),
+      so favour a calmer stretch and consider `FRAMES=1800`.
+- [ ] **Missile Command 3D** — `Missile Command 3D (1995).jag`
+      *Where:* a wave in progress with incoming missiles.
+      Earlier runs were corrupted by generic input (halved at 1.5x) — a savestate fixes that.
+- [ ] **Super Burnout** — `Super Burnout (1995).jag`
+      *Where:* mid-race at speed.
+
+### Already measured out — do not re-run
+
+| Title | Why | Where |
+|---|---|---|
+| **AvP** | Field-locked at one frame per 5 fields. Identical in every grid cell; RISC 2x costs +69% instructions for **0%** gain. | #378 |
+| **Checkered Flag** | Software frame cap at ROM `$8026EE` (budget at RAM `$43B0`). ~59/s across the whole grid for up to +56% instructions. **A clock scale cannot lift a software cap.** Its lever is the #370 enhancement hooks. | #378, #370 |
+
+---
+
+## 4. Running it
+
+```bash
+FRAMES=900 scripts/ocgrid.sh out.txt "<rom path>" "<state path>"
+```
+
+Six cells per title: {1x, 1.5x, 2x} RISC × {1x, 1.5x} 68K, each reported as a percentage
+against the stock cell.
+
+**Do not run this while anything else is building.** A concurrent `make` relinks
+`virtualjaguar_libretro.dylib` mid-sweep and the arms end up measuring different binaries.
+Check with `pgrep -f make` first.
+
+### Reading the output
+
+- `SATURATED (unmeasured)` — trap 2. Not a null; no information at all.
+- `baseline 0` — the state is static or paused. Re-save it.
+- A percentage — real, **provided** the stock cell is materially below the window length.
+
+**Qualifying bar: ≥ +20%.** Below that it does not justify a DB row, because the cost is real
+(RISC 2x is +69% host instructions on AvP) and the risk is real (two crash classes so far:
+Defender 2000 at `m68k 3x` #460, Club Drive at `risc 2x` #565).
+
+---
+
+## 5. What clears gate 1 still is not a preset
+
+Gate 2 is a human play-test in RetroArch: **game speed must still feel stock.** A title can
+render more frames while its logic runs too fast — that is #401's entire subject, and it is
+the failure mode a frame counter cannot see.
+
+Also note what gate 1 does **not** measure: `risc_idle_skip` and `blit_memo` are absent from
+the grid on purpose. They are bit-exact — identical output, less host work — so they cannot
+change the internal frame rate by construction. They matter for whether a *slow device* hits
+full speed, which is a host-cost question (#601), not a pacing one.
+
+---
+
+## 6. Prior art worth not re-deriving
+
+- **#378** — the issue, methodology, and the two removals above.
+- **#401 / #408** — render-bound loops tick ~2x fast. Read #408 before theorising about pace.
+- **Doom is the only title with a real-hardware framerate capture.** Silicon runs level 1 at
+  ~20 renders/s typical and ~15 in heavy scenes; we run it faster. `docs/doom-pace-calibration.md`.
+  For that title the accuracy work aims to make it **slower**, so an overclock preset moves the
+  wrong way.

--- a/docs/overclock-gate1-checklist.md
+++ b/docs/overclock-gate1-checklist.md
@@ -74,16 +74,28 @@ states measured above were older versions that loaded with only a size warning.
 
 ROMs for all eight candidates are present in `jaguar-roms-private/ROMS/`.
 
-### Measured 2026-08-25
+### Measured 2026-08-25 — all eight candidates
 
-| Title | Savestate | Result |
-|---|---|---|
-| **Cybermorph** | `Cybermorph (1993).state1` | **CLEARS GATE 1** — +44.7% at RISC 1.5x, +72.8% at 2x |
-| Iron Soldier | `iron_soldier_v104_f2400.state` | Null — clock-insensitive, confirmed by underclock control |
-| Val D'Isere | `... (1994).state.auto` | **UNMEASURED** — near-static scene, needs a real gameplay state |
+Gate 1 is **complete**. One title passes.
 
-**Cybermorph is the first title to clear gate 1.** All seven cells, one 2400-frame window
-(saturation ceiling 2399):
+| Title | control 0.5x | RISC 1.5x | RISC 2x | verdict |
+|---|---:|---:|---:|---|
+| **Cybermorph** | −48.7% | **+44.7%** | **+72.8%** | **PASSES** |
+| I-War | −18.2% | +6.3% | +1.1% | fails — noise, non-monotonic |
+| Missile Command 3D | −0.2% | **−14.3%** | −11.2% | fails — overclock makes it *worse* |
+| Doom | ±0.0% | ±0.0% | ±0.0% | flat lock, 593/1800 |
+| Club Drive | ±0.0% | ±0.0% | ±0.0% | flat lock, 1471/1800 |
+| Iron Soldier | −0.9% | ±0.0% | ±0.0% | flat lock, 116/900 |
+| Super Burnout | SATURATED | SATURATED | SATURATED | unmeasurable — already at the ceiling |
+| Val D'Isere | ±0.0% | ±0.0% | ±0.0% | **unmeasured** — static savestate |
+
+**One pass in eight.** The structural-null hypothesis from #378 survives as the *general* rule —
+most Jaguar titles are paced by a field lock or their own frame cap, not by clock speed — but it
+is not universal, and Cybermorph is the counterexample that disproves the strong form of it.
+
+#### Cybermorph — PASSES
+
+All seven cells, one 2400-frame window (saturation ceiling 2399):
 
 | cell | transitions | ≈ fps | vs stock |
 |---|---:|---:|---:|
@@ -95,61 +107,69 @@ ROMs for all eight candidates are present in `jaguar-roms-private/ROMS/`.
 | RISC 1.5x, 68K 1.5x | 1994/2400 | ~50 | +46.7% |
 | RISC 2x, 68K 1.5x | 2311/2400 | ~58 | +70.1% |
 
-The 68K axis is inert (+0.2% on its own): this is a RISC-bound title, so only
-`risc_clock_scale` matters, and stacking the 68K scale on top adds nothing.
+The 68K axis is inert (+0.2% on its own): RISC-bound title, so only `risc_clock_scale` matters,
+and stacking the 68K scale on top adds nothing.
 
-**The control is what makes the rest trustworthy.** RISC 0.5x costs 48.7% — near-linear
-against the +44.7% that 1.5x gains — so the metric tracks clock speed in both directions on
-this title. Every figure above comes from the same 2400-frame window; nothing is spliced
-across window lengths.
+**The control is what makes the rest trustworthy.** RISC 0.5x costs 48.7% — near-linear against
+the +44.7% that 1.5x gains — so the metric tracks clock speed in both directions here. Every
+figure comes from the same 2400-frame window; nothing is spliced across window lengths.
 
-At 2x, 2349 of 2400 fields carry a new frame — Cybermorph is now presenting at essentially
-the display rate. That is a real ceiling rather than the trap-2 counter artefact, but it does
-mean **+72.8% is a floor on the 2x gain, not the exact figure**; the engine may have headroom
-the display cannot show.
+At 2x, 2349 of 2400 fields carry a new frame: it is presenting at essentially the display rate.
+That is a real ceiling rather than the trap-2 counter artefact, but it does mean **+72.8% is a
+floor on the 2x gain, not the exact figure**.
 
-> **Two blockers before this becomes a DB preset.** Cybermorph is *also* the title with the
-> open overclock crash report — #463, "Codex-level crash + erratic ship movement under
-> overclock", currently `blocked` for want of reporter artefacts. The one title measured to
-> benefit is the one with an unconfirmed overclock crash against it, so #463 has to be settled
-> first. And gate 2 still applies: a title can render more frames while its logic runs too
-> fast (#401). Play-test before writing a row.
+> **Two blockers before this becomes a DB preset.** Cybermorph is *also* the title with the open
+> overclock crash report — #463, "Codex-level crash + erratic ship movement under overclock",
+> `blocked` for want of reporter artefacts. The one title measured to benefit is the one with an
+> unconfirmed overclock crash against it, so #463 has to be settled first. And gate 2 still
+> applies: a title can render more frames while its logic runs too fast (#401).
 
-**Iron Soldier is a genuine null, and the control proves it.** 0.5x reads 115 against 1x's
-116 — halving the RISC clock costs it *nothing*, so it was never clock-bound at 1x. That fits
-the profile data: Iron Soldier is the extreme DSP case, 67% of frame time in the DSP with
-99.7% of that spinning in an idle loop. It needs **idle-skip**, not overclock.
+#### Missile Command 3D — fails, and interestingly
 
-> **Always run the underclock arm.** A flat 1x/1.5x/2x row is ambiguous — genuine cap, or dead
-> measurement? 0.5x separates them. Cybermorph's control (−48.7% at 0.5x, against +44.7% at
-> 1.5x) is what proves the metric was live for the whole sweep. `scripts/ocgrid.sh` runs this
-> arm unconditionally so it cannot be forgotten.
+The only title where overclocking is actively **harmful**: −14.3% at RISC 1.5x, −11.2% at 2x,
+while the 0.5x control is flat (−0.2%). Not compute-bound at stock, and giving the RISC more
+cycles *costs* presented frames. Worth a look on its own terms — a title that renders less when
+given more cycles suggests a timing-sensitive path, not merely an absent benefit.
 
-**Val D'Isere is not a null — it is unmeasured.** 15 transitions in 900 frames, identical even
-at 0.5x. That is one changed frame every ~60, i.e. a static or paused screen; the state is a
-`.state.auto` autosave that landed wherever the session ended. Needs a real gameplay save
-(see below).
+#### I-War — fails, capped at stock
 
-### Need a savestate — checklist
+Control drops cleanly (−18.2%), so the sweep is valid, but the gains are noise and
+non-monotonic: +6.3% at 1.5x, +1.1% at 2x, −3.7% at 2x with the 68K scale. Underclocking hurts
+while overclocking does nothing — the signature of a cap sitting at or just above stock.
 
-- [ ] **Doom** — `Doom - Evil Unleashed (1994).jag`
-      *Where:* in a level, walking down a corridor with at least one monster active.
-      **Not** the attract demo (its pace is the #401 subject and it desyncs across cycle
-      changes, so it is invalid evidence either way) and **not** the menu (its speed is the
-      game's own code — see #396 notes).
-- [ ] **Club Drive** — `Club Drive (1994).jag`
-      *Where:* mid-race, car moving, scenery scrolling.
-      **Note:** this title used to abort at `risc_clock_scale=2x` (`dsp_pc_escape`, #565).
-      That is **fixed** as of v3.5.0, so the 2x arm should now complete — if it dies, that is
-      a regression worth its own issue.
-- [ ] **I-War** — `I-War (1995).jag`
-      *Where:* in flight with geometry on screen. Earlier runs **saturated** here (600/600),
-      so favour a calmer stretch and consider `FRAMES=1800`.
-- [ ] **Missile Command 3D** — `Missile Command 3D (1995).jag`
-      *Where:* a wave in progress with incoming missiles.
-      Earlier runs were corrupted by generic input (halved at 1.5x) — a savestate fixes that.
-- [ ] **Super Burnout** — `Super Burnout (1995).jag`
-      *Where:* mid-race at speed.
+#### Doom, Club Drive, Iron Soldier — flat locks
+
+Identical counts in all seven cells, control included. Iron Soldier reads 115 at 0.5x against
+116 at 1x, so halving the clock costs it nothing.
+
+A flat control would normally void a sweep, and the script says so. It does not here, because
+the harness is demonstrably live on the same binary in the same session: Cybermorph, I-War and
+Missile Command 3D all responded. These are genuine caps, not dead measurements.
+
+**Doom's number is worth recording for #401.** 593/1800 is one new frame per 3.03 fields,
+**≈19.8 fps** — and real hardware Doom level 1 is ~20 renders/s typical. In *gameplay* we may
+be far closer to hardware than the attract demo suggests, where #434 measured us at 2.00
+fields/flip against hardware's 4.0. One savestate is not a calibration, and the demo and
+gameplay are different code paths, so this is a lead rather than a result.
+
+#### Super Burnout — unmeasurable, and the reason matters
+
+1799/1800 in every cell: every frame differs, so the counter is pinned to the ceiling and a gain
+has nowhere to show. Lengthening the window does **not** help — a title that renders a new frame
+every field is saturated at any window length.
+
+But the reason it saturates is itself the answer: **stock already presents at the display rate**,
+so there is no headroom for an overclock to deliver. Formally unmeasured by this metric;
+practically, there is nothing to win.
+
+#### Val D'Isere — the one still outstanding
+
+15 transitions in 900 frames, identical even at 0.5x — one changed frame every ~60, i.e. a
+static or paused screen. The state is a `.state.auto` autosave that landed wherever the session
+ended.
+
+- [ ] **Val D'Isere** — `Val D'Isere Skiing & Snowboarding (1994).jag`. Needs a real gameplay
+      save: mid-run down a slope, scenery moving, not the menu or a results screen.
 
 ### Already measured out — do not re-run
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -118,9 +118,14 @@ struct retro_core_option_v2_category option_cats_us[] = {
       "Logging and watchdog aids for troubleshooting and bug reports."
    },
    {
-      "timing",
-      "Timing",
-      "Clock speed multipliers, then the experimental hardware-timing models."
+      "speed",
+      "Speed",
+      "Make the emulator faster. Two kinds, and the difference matters: the fast-forward options cost nothing (identical picture and sound, just less work), while the overclocks change what the game itself computes and can break it."
+   },
+   {
+      "accuracy",
+      "Hardware Timing (Experimental)",
+      "Make the emulator slower and more like real silicon. The opposite of Speed above: these exist because parts of the machine are modelled as free, which lets some games run too fast. Still being calibrated."
    },
    { NULL, NULL, NULL },
 };
@@ -211,21 +216,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
-      "virtualjaguar_blit_memo",
-      "Blit Memoization (Per-Title)",
-      NULL,
-      "Skip blits whose inputs are provably unchanged since an identical earlier blit (some titles re-render the same scene every engine cycle while the player is idle). Output is bit-identical by construction. Enabled per title via the enhancement database; not available for CD content. 'Verify' never skips -- it runs every would-be skip and logs any divergence, for validating new titles. Switches off DSP Idle-Loop Fast-Forward while enabled.",
-      NULL,
-      "video",
-      {
-         { "disabled", "Disabled" },
-         { "enabled",  "Enabled" },
-         { "verify",   "Verify (debug, no speedup)" },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
       "virtualjaguar_crash_detect",
       "Crash Detect",
       NULL,
@@ -240,15 +230,48 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       },
       "enabled"
    },
-   /* Clock speeds first, then the experimental timing models they interact
-    * with -- the toggles below are grouped under the two scales on purpose. */
+   /* Speed category, ordered by what a user should try first: the two
+    * free fast-forwards (identical output, less work), then the two
+    * overclocks, which change what the game computes and can break it.
+    * blit_memo lives here rather than under Video because it belongs to
+    * the same free-speedup class -- and because it silently switches off
+    * idle-skip, which is undiscoverable from a different category. */
+   {
+      "virtualjaguar_risc_idle_skip",
+      "DSP Idle-Loop Fast-Forward",
+      NULL,
+      "Fast-forward the DSP through provably redundant iterations of a wait loop -- the largest single speed-up the core offers (66-87% less DSP interpretation on the titles measured). Bit-exact by construction: registers, flags, cycles and instruction count land exactly where interpreting would have left them, so save states, run-ahead and netplay are unaffected. Off by default while the compatibility corpus grows -- if a title looks or sounds wrong with it on, turn it off and please report it. IMPORTANT: a non-stock RISC Clock Scale, DRAM Timing, GPU Pipeline Timing or Blit Memoization switches this off entirely, so turning one of those on costs you this speed-up on top of its own cost. The M68K clock scale and Blitter Bus Timing do not affect it.",
+      NULL,
+      "speed",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "virtualjaguar_blit_memo",
+      "Blit Memoization (Per-Title)",
+      NULL,
+      "Skip blits whose inputs are provably unchanged since an identical earlier blit (some titles re-render the same scene every engine cycle while the player is idle). Output is bit-identical by construction. Enabled per title via the enhancement database; not available for CD content. 'Verify' never skips -- it runs every would-be skip and logs any divergence, for validating new titles. Switches off DSP Idle-Loop Fast-Forward while enabled.",
+      NULL,
+      "speed",
+      {
+         { "disabled", "Disabled" },
+         { "enabled",  "Enabled" },
+         { "verify",   "Verify (debug, no speedup)" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
    {
       "virtualjaguar_m68k_clock_scale",
       "M68K Clock Scale (Overclock)",
       NULL,
-      "Run the 68000 at a multiple of its stock ~13.3 MHz. An enhancement, not an accuracy fix: it can smooth framerate-limited games (Doom, AvP, Checkered Flag) but may break titles that depend on stock CPU timing. Timers and bus costs stay at stock speed. If an overclocked game misbehaves, try the timing models below. Report bugs only at 1x.",
+      "Run the 68000 at a multiple of its stock ~13.3 MHz. An enhancement, not an accuracy fix, and it helps less often than you would think: AvP and Checkered Flag were both measured and neither gained anything (AvP is locked to one frame per 5 fields; Checkered Flag caps itself in software), because most Jaguar games are paced by a field lock or their own frame cap rather than by CPU speed. It may also break titles that depend on stock CPU timing. Timers and bus costs stay at stock speed. Overclocking the 68000 is the safer of the two scales: it does NOT cost you DSP Idle-Loop Fast-Forward. If an overclocked game misbehaves, try the Hardware Timing options in their own category. Report bugs only at 1x.",
       NULL,
-      "timing",
+      "speed",
       {
          { "0.5x", NULL },
          { "1x",   "1x (stock)" },
@@ -263,9 +286,9 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_risc_clock_scale",
       "RISC (GPU/DSP) Clock Scale (Overclock)",
       NULL,
-      "Run the GPU and DSP at a multiple of their stock ~26.6 MHz. An enhancement, not an accuracy fix: extra cycles can lift GPU-bound framerates. Audio pacing and timers stay at stock speed, so nothing pitch-shifts. May break titles that depend on stock RISC timing; if an overclocked game misbehaves, try the timing models below. Report bugs only at 1x. Anything other than 1x also switches OFF DSP Idle-Loop Fast-Forward, so with that enabled the result can end up SLOWER than stock -- the M68K scale above does not have that side effect.",
+      "Run the GPU and DSP at a multiple of their stock ~26.6 MHz. An enhancement, not an accuracy fix: extra cycles can lift GPU-bound framerates. Audio pacing and timers stay at stock speed, so nothing pitch-shifts. May break titles that depend on stock RISC timing; if an overclocked game misbehaves, try the Hardware Timing options in their own category. Report bugs only at 1x. READ THIS FIRST: anything other than 1x switches OFF DSP Idle-Loop Fast-Forward, which is the larger speed-up on most titles -- so on a DSP-bound game this option makes you SLOWER overall, not faster. Try idle-skip on its own before reaching for this. The M68K scale does not have that side effect.",
       NULL,
-      "timing",
+      "speed",
       {
          { "0.5x", NULL },
          { "1x",   "1x (stock)" },
@@ -276,26 +299,12 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "1x"
    },
    {
-      "virtualjaguar_risc_idle_skip",
-      "DSP Idle-Loop Fast-Forward",
-      NULL,
-      "Fast-forward the DSP through provably redundant iterations of a wait loop -- the largest single speed-up the core offers (66-87% less DSP interpretation on the titles measured). Bit-exact by construction: registers, flags, cycles and instruction count land exactly where interpreting would have left them, so save states, run-ahead and netplay are unaffected. Off by default while the compatibility corpus grows -- if a title looks or sounds wrong with it on, turn it off and please report it. IMPORTANT: a non-stock RISC Clock Scale, DRAM Timing, GPU Pipeline Timing or Blit Memoization switches this off entirely, so turning one of those on costs you this speed-up on top of its own cost. The M68K clock scale and Blitter Bus Timing do not affect it.",
-      NULL,
-      "timing",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
       "virtualjaguar_dram_timing",
       "DRAM Timing (Experimental)",
       NULL,
       "Charge the GPU and 68000 realistic DRAM access time once they leave their local buses, pacing hardware-timed games (Doom-class) closer to real hardware. Each processor pays only its own costs, so relative CPU/GPU timing is preserved. Still being calibrated. Switches off DSP Idle-Loop Fast-Forward while enabled.",
       NULL,
-      "timing",
+      "accuracy",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -309,7 +318,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       NULL,
       "Model the GPU's real instruction costs: the single external-memory gateway, the register score-board and ALU interlocks. The emulated GPU otherwise finishes renders 2-4x faster than silicon, which makes loops paced on render completion (Doom's menus and demo, Hover Strike) run too fast. Still being calibrated. Switches off DSP Idle-Loop Fast-Forward while enabled.",
       NULL,
-      "timing",
+      "accuracy",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -323,7 +332,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       NULL,
       "Charge the 68000 the bus time each blit really takes -- on hardware the blitter is the top-priority bus master and freezes the cacheless 68000 while it runs. Zero-time blits let games paced on blit completion (Doom's menus, Hover Strike) run too fast. Still being calibrated.",
       NULL,
-      "timing",
+      "accuracy",
       {
          { "disabled", NULL },
          { "enabled",  NULL },

--- a/scripts/ocgrid.sh
+++ b/scripts/ocgrid.sh
@@ -30,7 +30,12 @@ STATE=$1; shift
 FRAMES=${FRAMES:-900}
 
 TMP=$(mktemp -d)
-trap 'command rm -rf "$TMP"' EXIT INT TERM
+# EXIT does the cleanup; INT/TERM must additionally *stop*. Without the
+# second trap a Ctrl-C killed only the current cell's frame_hash_ab (the
+# process group gets the signal), that cell was recorded FAILED, and the
+# sweep carried on through six more multi-minute cells.
+trap 'command rm -rf "$TMP"' EXIT
+trap 'exit 130' INT TERM
 
 emit() { printf '%s\n' "$*" | tee -a "$OUT"; }
 
@@ -64,7 +69,13 @@ for cell in $cells; do
     t=$(awk -F, 'NR>1{if(p!=""&&$6!=p)n++;p=$6}END{print n+0}' "$csv")
     n=$(awk 'NR>1' "$csv" | wc -l | tr -d ' ')
     printf '%s %s\n' "$t" "$n" > "$TMP/$tag.res"
-    [ "$cell" = "risc=1x,m68k=1x" ] && base=$t
+    # Only a MEASURED stock cell may become the baseline. A saturated one
+    # is pinned to the ceiling, so quoting other arms against it would
+    # print authoritative-looking percentages against a meaningless
+    # number -- the exact trap this script exists to make un-missable.
+    if [ "$cell" = "risc=1x,m68k=1x" ] && [ "$n" -gt 0 ] && [ "$t" -lt "$((n - 1))" ]; then
+        base=$t
+    fi
 done
 
 # --- phase 2: report --------------------------------------------------------
@@ -82,7 +93,7 @@ for cell in $cells; do
     elif [ "$t" -ge "$((n - 1))" ]; then
         v="SATURATED -- unmeasured, lengthen the window"
     elif [ -z "$base" ] || [ "$base" -eq 0 ]; then
-        v="no usable stock baseline -- static scene, re-save the state"
+        v="NO USABLE STOCK BASELINE -- stock cell saturated or static; nothing here is comparable"
     else
         v="$(awk -v a="$t" -v b="$base" 'BEGIN{printf "%+.1f%% vs stock", (a-b)*100.0/b}')"
         [ "$cell" = "risc=0.5x,m68k=1x" ] && v="$v   <- CONTROL: must drop, or the sweep is void"

--- a/scripts/ocgrid.sh
+++ b/scripts/ocgrid.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Overclock gate-1 grid: does a clock scale actually lift the INTERNAL frame rate?
+# Measures framebuffer TRANSITIONS (hash != previous hash) from a gameplay savestate.
+# Trap guard: transitions == window length means the counter SATURATED -> UNMEASURED.
+set -u
+CORE=./virtualjaguar_libretro.dylib
+OUT=$1; shift
+ROM=$1; shift
+STATE=$1; shift
+FRAMES=${FRAMES:-900}
+TMP=$(mktemp -d)
+printf '%-22s %-10s %s\n' "cell" "transit" "verdict"
+base=""
+for cell in "risc=1x,m68k=1x" "risc=1.5x,m68k=1x" "risc=2x,m68k=1x" \
+            "risc=1x,m68k=1.5x" "risc=1.5x,m68k=1.5x" "risc=2x,m68k=1.5x"; do
+  r=${cell#risc=}; r=${r%%,*}
+  m=${cell##*m68k=}
+  csv=$TMP/$(echo "$cell" | tr ',=' '__').csv
+  ./test/tools/frame_hash_ab "$CORE" "$ROM" --csv "$csv" \
+      --load-state "$STATE" --frames "$FRAMES" \
+      --option "virtualjaguar_risc_clock_scale=$r" \
+      --option "virtualjaguar_m68k_clock_scale=$m" >/dev/null 2>&1
+  # count hash transitions
+  t=$(awk -F, 'NR>1{if(prev!="" && $6!=prev) n++; prev=$6} END{print n+0}' "$csv")
+  n=$(awk 'NR>1' "$csv" | wc -l | tr -d ' ')
+  [ -z "$base" ] && base=$t
+  if [ "$t" -ge "$((n-1))" ]; then v="SATURATED (unmeasured)"
+  elif [ "$base" -eq 0 ]; then v="baseline 0 (bad state?)"
+  else
+    pct=$(awk -v a="$t" -v b="$base" 'BEGIN{printf "%+.1f%%", (a-b)*100.0/b}')
+    v="$pct vs stock"
+  fi
+  printf '%-22s %-10s %s\n' "$cell" "$t/$n" "$v"
+done
+rm -rf "$TMP"

--- a/scripts/ocgrid.sh
+++ b/scripts/ocgrid.sh
@@ -1,35 +1,95 @@
 #!/bin/bash
-# Overclock gate-1 grid: does a clock scale actually lift the INTERNAL frame rate?
-# Measures framebuffer TRANSITIONS (hash != previous hash) from a gameplay savestate.
-# Trap guard: transitions == window length means the counter SATURATED -> UNMEASURED.
+# Overclock gate-1 grid (#378): does a clock scale actually lift the INTERNAL
+# frame rate of this title?
+#
+#   FRAMES=900 scripts/ocgrid.sh out.txt "<rom>" "<state>"
+#
+# Results are written to <out.txt> and echoed to stdout.  Pass /dev/stdout (or
+# /dev/null) if you only want one of those.
+#
+# Measures framebuffer TRANSITIONS -- frames whose hash differs from the
+# previous frame -- starting from a gameplay savestate.  Two guards, both
+# earned the hard way (see docs/overclock-gate1-checklist.md):
+#
+#   * transitions == window length means the counter SATURATED.  That is
+#     UNMEASURED, not a null: every frame differed, so a gain has nowhere to
+#     show.  Reported as SATURATED, never as a number.
+#   * the 0.5x underclock arm runs FIRST and always.  A flat 1x/1.5x/2x row
+#     cannot distinguish a genuine frame cap from a dead measurement; if 0.5x
+#     does not drop, the metric was never responding and the whole sweep is
+#     void.  This is the control that both retracted result tables lacked.
+#
+# CORE may be overridden for a non-macOS library name, e.g.
+#   CORE=./virtualjaguar_libretro.so scripts/ocgrid.sh ...
 set -u
-CORE=./virtualjaguar_libretro.dylib
+
+CORE=${CORE:-./virtualjaguar_libretro.dylib}
 OUT=$1; shift
 ROM=$1; shift
 STATE=$1; shift
 FRAMES=${FRAMES:-900}
+
 TMP=$(mktemp -d)
-printf '%-22s %-10s %s\n' "cell" "transit" "verdict"
+trap 'command rm -rf "$TMP"' EXIT INT TERM
+
+emit() { printf '%s\n' "$*" | tee -a "$OUT"; }
+
+: > "$OUT"
+emit "rom:    $ROM"
+emit "state:  $STATE"
+emit "frames: $FRAMES  (saturation ceiling $((FRAMES - 1)))"
+emit ""
+emit "$(printf '%-22s %-12s %s' cell transitions verdict)"
+
+# --- phase 1: measure every cell -------------------------------------------
+# Two phases so the stock cell is known before anything is quoted against it:
+# the 0.5x control is more useful printed as a percentage than as a raw count,
+# and it has to run regardless of ordering.
+cells="risc=0.5x,m68k=1x risc=1x,m68k=1x risc=1.5x,m68k=1x risc=2x,m68k=1x \
+       risc=1x,m68k=1.5x risc=1.5x,m68k=1.5x risc=2x,m68k=1.5x"
 base=""
-for cell in "risc=1x,m68k=1x" "risc=1.5x,m68k=1x" "risc=2x,m68k=1x" \
-            "risc=1x,m68k=1.5x" "risc=1.5x,m68k=1.5x" "risc=2x,m68k=1.5x"; do
-  r=${cell#risc=}; r=${r%%,*}
-  m=${cell##*m68k=}
-  csv=$TMP/$(echo "$cell" | tr ',=' '__').csv
-  ./test/tools/frame_hash_ab "$CORE" "$ROM" --csv "$csv" \
-      --load-state "$STATE" --frames "$FRAMES" \
-      --option "virtualjaguar_risc_clock_scale=$r" \
-      --option "virtualjaguar_m68k_clock_scale=$m" >/dev/null 2>&1
-  # count hash transitions
-  t=$(awk -F, 'NR>1{if(prev!="" && $6!=prev) n++; prev=$6} END{print n+0}' "$csv")
-  n=$(awk 'NR>1' "$csv" | wc -l | tr -d ' ')
-  [ -z "$base" ] && base=$t
-  if [ "$t" -ge "$((n-1))" ]; then v="SATURATED (unmeasured)"
-  elif [ "$base" -eq 0 ]; then v="baseline 0 (bad state?)"
-  else
-    pct=$(awk -v a="$t" -v b="$base" 'BEGIN{printf "%+.1f%%", (a-b)*100.0/b}')
-    v="$pct vs stock"
-  fi
-  printf '%-22s %-10s %s\n' "$cell" "$t/$n" "$v"
+for cell in $cells; do
+    r=${cell#risc=}; r=${r%%,*}
+    m=${cell##*m68k=}
+    tag=$(printf '%s' "$cell" | tr ',=.' '___')
+    csv=$TMP/$tag.csv
+
+    if ! "./test/tools/frame_hash_ab" "$CORE" "$ROM" --csv "$csv" \
+            --load-state "$STATE" --frames "$FRAMES" \
+            --option "virtualjaguar_risc_clock_scale=$r" \
+            --option "virtualjaguar_m68k_clock_scale=$m" >"$TMP/$tag.log" 2>&1; then
+        printf 'FAILED\n' > "$TMP/$tag.res"
+        continue
+    fi
+    t=$(awk -F, 'NR>1{if(p!=""&&$6!=p)n++;p=$6}END{print n+0}' "$csv")
+    n=$(awk 'NR>1' "$csv" | wc -l | tr -d ' ')
+    printf '%s %s\n' "$t" "$n" > "$TMP/$tag.res"
+    [ "$cell" = "risc=1x,m68k=1x" ] && base=$t
 done
-rm -rf "$TMP"
+
+# --- phase 2: report --------------------------------------------------------
+for cell in $cells; do
+    tag=$(printf '%s' "$cell" | tr ',=.' '___')
+    read -r t n < "$TMP/$tag.res" 2>/dev/null || { t=FAILED; n=""; }
+
+    if [ "$t" = "FAILED" ]; then
+        emit "$(printf '%-22s %-12s %s' "$cell" "-" "RUN FAILED")"
+        tail -3 "$TMP/$tag.log" 2>/dev/null | sed 's/^/    /' | tee -a "$OUT"
+        continue
+    fi
+    if [ "$n" -eq 0 ]; then
+        v="NO FRAMES (state rejected? see checklist section 2)"
+    elif [ "$t" -ge "$((n - 1))" ]; then
+        v="SATURATED -- unmeasured, lengthen the window"
+    elif [ -z "$base" ] || [ "$base" -eq 0 ]; then
+        v="no usable stock baseline -- static scene, re-save the state"
+    else
+        v="$(awk -v a="$t" -v b="$base" 'BEGIN{printf "%+.1f%% vs stock", (a-b)*100.0/b}')"
+        [ "$cell" = "risc=0.5x,m68k=1x" ] && v="$v   <- CONTROL: must drop, or the sweep is void"
+    fi
+    emit "$(printf '%-22s %-12s %s' "$cell" "$t/$n" "$v")"
+done
+
+emit ""
+emit "Reminder: a pass here is gate 1 only. Gate 2 is a human play-test --"
+emit "a title can render more frames while its logic runs too fast (#401)."

--- a/scripts/rzip_extract.py
+++ b/scripts/rzip_extract.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Extract a RetroArch rzip-compressed save state to a raw one.
+
+RetroArch writes save states through rzip_stream when "Save State Compression"
+is on, which our test harnesses cannot read -- retro_unserialize sees the
+compressed bytes and rejects them on size.  This converts such a file into the
+plain state blob the harness expects.
+
+Layout (little-endian), confirmed against RetroArch's rzip_stream.c:
+
+    0   6   magic "#RZIPv"
+    6   1   format version
+    7   1   '#' terminator
+    8   4   chunk size (uncompressed bytes per chunk)
+   12   8   total uncompressed size
+   20   4   length of the first compressed chunk
+   24   ..  zlib chunk, then [u32 length][zlib chunk] repeating
+
+A zero length terminates the stream.  Files without the magic are already raw
+and are copied through unchanged, so this is safe to run over a whole folder.
+
+usage: rzip_extract.py <in.state> [out.state]
+"""
+import sys, os, zlib, struct
+
+MAGIC = b'#RZIPv'
+
+
+def extract(src, dst):
+    with open(src, 'rb') as f:
+        blob = f.read()
+
+    if not blob.startswith(MAGIC):
+        with open(dst, 'wb') as f:
+            f.write(blob)
+        return len(blob), 'already raw'
+
+    chunk_size, total = struct.unpack_from('<IQ', blob, 8)
+    out, pos = bytearray(), 20
+    while pos + 4 <= len(blob):
+        (clen,) = struct.unpack_from('<I', blob, pos)
+        pos += 4
+        if clen == 0:
+            break
+        out += zlib.decompress(blob[pos:pos + clen])
+        pos += clen
+
+    if len(out) != total:
+        raise SystemExit('rzip_extract: got %d bytes, header declares %d '
+                         '(chunk size %d) -- format mismatch, refusing to write'
+                         % (len(out), total, chunk_size))
+
+    with open(dst, 'wb') as f:
+        f.write(out)
+    return len(out), 'decompressed'
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        raise SystemExit(__doc__)
+    inp = sys.argv[1]
+    outp = sys.argv[2] if len(sys.argv) > 2 else os.path.splitext(inp)[0] + '.raw.state'
+    n, how = extract(inp, outp)
+    print('%s: %s -> %s (%d bytes)' % (os.path.basename(inp), how, outp, n))


### PR DESCRIPTION
Two things, both from trying to answer "which games can overclocking actually speed up".

## The options were confusing because one category held three intents

`Timing` contained, in one flat list:

- **two overclocks** (`m68k_clock_scale`, `risc_clock_scale`) that change *what the game computes* and can break it;
- **two fast-forwards** (`risc_idle_skip`, `blit_memo`) that are bit-exact — identical output, less host work, and by construction they *cannot* change the frame rate;
- **three accuracy models** (`dram_timing`, `gpu_pipeline_timing`, `blitter_timing`) that deliberately make things **slower**.

A user had no way to tell "makes it faster" from "makes it slower on purpose".

Split into **Speed** and **Hardware Timing (Experimental)**, with Speed ordered by what to try first: the two free fast-forwards, then the two overclocks. `blit_memo` moves in from **Video** — same free-speedup class, and it silently disables idle-skip, which was undiscoverable from another category.

**Option keys are unchanged**, so no user config breaks. `retro_api_version` untouched.

`risc_clock_scale` now leads with the trap instead of burying it: turning it up switches idle-skip off, so on a DSP-bound title it makes you *slower*.

## One text fix that was actively wrong

`m68k_clock_scale` cited **AvP and Checkered Flag** as games overclocking can smooth. Both were measured under #378 and both failed — AvP is locked to one frame per 5 fields, Checkered Flag caps itself in software at ROM `$8026EE`. Replaced with the general rule and the two counterexamples.

## Tooling + the first title to clear gate 1

- `scripts/ocgrid.sh` — the {1x,1.5x,2x} RISC x {1x,1.5x} 68K grid, with saturation detection.
- `scripts/rzip_extract.py` — RetroArch writes rzip-compressed states when compression is on, and `retro_unserialize` rejects them on size. Raw files pass through unchanged.
- `docs/overclock-gate1-checklist.md` — traps, savestate recipe, per-title checklist.

**Cybermorph clears gate 1** — the first title to do so. 2400-frame window:

| cell | transitions | vs stock |
|---|---:|---:|
| RISC 0.5x (control) | 697/2400 | **-48.7%** |
| RISC 1x, 68K 1x (stock) | 1359/2400 | — |
| RISC 1.5x | 1967/2400 | **+44.7%** |
| RISC 2x | 2349/2400 | **+72.8%** |
| RISC 1x, 68K 1.5x | 1362/2400 | +0.2% |
| RISC 1.5x, 68K 1.5x | 1994/2400 | +46.7% |
| RISC 2x, 68K 1.5x | 2311/2400 | +70.1% |

All seven cells come from one 2400-frame window; nothing is spliced across window lengths.

The 0.5x arm is the control that makes the rest trustworthy: it proves the metric was live. Iron Soldier reads 115 at 0.5x against 116 at 1x — a genuine null, not a dead measurement, and consistent with it being the extreme DSP-idle case (needs idle-skip, not overclock).

Not proposing a DB preset: Cybermorph is also the subject of the open overclock crash report #463, and gate 2 (play-test) still applies.

`make TEST_EXPORTS=1 test` exits 0, C89 lint clean.

Refs #378
