### PR TITLE
perf(blitter): opt-in arch autodetect so SPM builds stop inlining scalar

### DIFF
--- a/src/tom/blitter_simd.h
+++ b/src/tom/blitter_simd.h
@@ -89,7 +89,35 @@ extern const blitter_simd_ops_t blitter_simd_ops;
  * added to SOURCES_C.  Builds that don't go through it (ndk-build, and
  * every MSVC target) get scalar, which is what those already selected.
  * A mismatch between the -D and the compiled .c is a hard compile error
- * rather than a silent slow path -- see blitter_simd_<arch>.c. */
+ * rather than a silent slow path -- see blitter_simd_<arch>.c.
+ *
+ * BLITTER_SIMD_AUTODETECT is the opt-in for build systems that compile
+ * the arch .c files by guard rather than by selection, and so cannot
+ * pass a matching -D.  The Swift Package Manager manifest used by the
+ * Provenance frontend is the case this exists for: it hands every
+ * blitter_simd_<arch>.c to the compiler at once and lets each file's
+ * own top-of-file arch guard blank out the ones that don't apply.
+ * Without a -D those builds fell through to the scalar branch below and
+ * inlined the scalar ops into BlitterMidsummer2 on hardware that has
+ * NEON -- the vtable was NEON, but the vtable is only used by
+ * test/test_blitter_simd.c, so nothing caught it.  That is a silent
+ * slow path of exactly the kind the paragraph above says cannot happen,
+ * and it is why the detection is spelled here, where the real target
+ * compiler evaluates it, rather than in the manifest, which is compiled
+ * for the host and would get the x86_64 simulator slice wrong.
+ *
+ * Deliberately opt-in: leaving it undefined keeps ndk-build and every
+ * MSVC target on the scalar path they select today, byte for byte. */
+#if !defined(BLITTER_SIMD_NEON) && !defined(BLITTER_SIMD_SSE2) \
+ && !defined(BLITTER_SIMD_SCALAR) && defined(BLITTER_SIMD_AUTODETECT)
+#  if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__)
+#    define BLITTER_SIMD_NEON 1
+#  elif defined(__x86_64__) || defined(__i386__) \
+     || defined(_M_X64) || defined(_M_IX86)
+#    define BLITTER_SIMD_SSE2 1
+#  endif
+#endif
+
 #if defined(BLITTER_SIMD_NEON)
 #  include "blitter_simd_neon.h"
 #elif defined(BLITTER_SIMD_SSE2)

--- a/src/tom/blitter_simd.h
+++ b/src/tom/blitter_simd.h
@@ -110,10 +110,24 @@ extern const blitter_simd_ops_t blitter_simd_ops;
  * MSVC target on the scalar path they select today, byte for byte. */
 #if !defined(BLITTER_SIMD_NEON) && !defined(BLITTER_SIMD_SSE2) \
  && !defined(BLITTER_SIMD_SCALAR) && defined(BLITTER_SIMD_AUTODETECT)
-#  if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__)
+   /* NEON: mandatory on AArch64, opt-in on ARMv7-A.  __ARM_NEON is the
+    * ACLE spelling every GCC/Clang emits when NEON codegen is on;
+    * _M_ARM64 is MSVC's, where NEON is likewise mandatory. */
+#  if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__) \
+   || defined(_M_ARM64) || defined(_M_ARM64EC)
 #    define BLITTER_SIMD_NEON 1
-#  elif defined(__x86_64__) || defined(__i386__) \
-     || defined(_M_X64) || defined(_M_IX86)
+   /* SSE2: architectural baseline on x86-64, so the 64-bit spellings need
+    * no further test.  On 32-bit x86 it is NOT baseline -- GCC and Clang
+    * only emit SSE2 under -msse2 (or an -march implying it), and MSVC only
+    * under /arch:SSE2.  Makefile.common can *add* -msse2 (see its "required
+    * on i686 / gcc -m32" rule); autodetect can only observe, so it must ask
+    * whether SSE2 is actually enabled rather than infer it from the arch.
+    * Testing __SSE2__ / _M_IX86_FP keeps a plain i386 build on the scalar
+    * fall-through instead of handing blitter_simd_sse2.c intrinsics its
+    * target cannot compile. */
+#  elif defined(__x86_64__) || defined(_M_X64) \
+     || (defined(__i386__) && defined(__SSE2__)) \
+     || (defined(_M_IX86) && defined(_M_IX86_FP) && _M_IX86_FP == 2)
 #    define BLITTER_SIMD_SSE2 1
 #  endif
 #endif


### PR DESCRIPTION
Fixes the silent-scalar blitter in SPM/Xcode builds reported in #612.

## What

`blitter_simd.h` gains an **opt-in** `BLITTER_SIMD_AUTODETECT` gate. When the
consumer defines it and no explicit `BLITTER_SIMD_*` is set, the arch is derived
from the compiler's own predefined macros.

## Why the header and not `Package.swift`

The SPM manifest is compiled for the **host**. A manifest-side check would pick
arm64 for the x86_64 simulator slice. The header is evaluated by the real target
compiler, so it gets every slice right.

## Why opt-in

`ndk-build` and every MSVC target pass no `-D` and select scalar deliberately —
the existing header comment says so. Gating on `BLITTER_SIMD_AUTODETECT` leaves
them byte-identical. Every Makefile target is unaffected because Makefile.common
already passes an explicit `-D`.

## Verification

Preprocessor probe (see #612 for the probe source), this tree:

| flags | selected |
|---|---|
| *(bare, no `-D`)* — MSVC / ndk-build path | `SCALAR` (unchanged) |
| `-DBLITTER_SIMD_AUTODETECT`, arm64 | `NEON` |
| `-DBLITTER_SIMD_AUTODETECT -target x86_64-apple-macos14` | `SSE2` |
| `-DBLITTER_SIMD_SCALAR -DBLITTER_SIMD_AUTODETECT` | `SCALAR` (explicit wins) |
| `-DBLITTER_SIMD_NEON` — Makefile path | `NEON` (unchanged) |

Row 3 is the one that proves the fix is at the right layer.

```
make -j10                    # clean
make TEST_EXPORTS=1 test     # OK: 0 test(s) failed.
```

Header-only change; `scripts/c89-lint.sh` has no `.c` to check here, and the
sibling `blitter_simd_*.c` files are untouched.

## Follow-up (separate repo, not this PR)

`Provenance-Emu/Core-VirtualJaguar`'s `Package.swift` needs
`.define("BLITTER_SIMD_AUTODETECT", to: "1")` on the `libjaguar` target to
actually consume this.