### PR TITLE
fix(memory): rename the DEBUG enumerator so -DDEBUG=1 stops breaking the parse

### DIFF
--- a/src/core/vjag_memory.h
+++ b/src/core/vjag_memory.h
@@ -55,8 +55,14 @@ extern uint8_t * sclk, sstat;
 extern uint32_t * smode;
 
 // Read/write tracing enumeration
+//
+// Index 9 is spelled DEBUGGER, not DEBUG, and must stay that way: Xcode's
+// stock Debug configuration sets GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1, so
+// on any Xcode or SwiftPM consumer `DEBUG` arrives here already expanded to
+// `1` and the enumerator list fails to parse.  The wire value is unchanged
+// (9), and whoName[9] already read "Debugger".
 
-enum { UNKNOWN, JAGUAR, DSP, GPU, TOM, JERRY, M68K, BLITTER, OP, DEBUG };
+enum { UNKNOWN, JAGUAR, DSP, GPU, TOM, JERRY, M68K, BLITTER, OP, DEBUGGER };
 extern const char * whoName[10];
 
 // BIOS identification enum

--- a/test/harness/trace_probe.c
+++ b/test/harness/trace_probe.c
@@ -12,8 +12,8 @@
 #include <string.h>
 
 /* who codes from src/core/vjag_memory.h:
- *   UNKNOWN JAGUAR DSP GPU TOM JERRY M68K BLITTER OP DEBUG
- * DEBUG (9) marks a host-injected event (input edges, marks). */
+ *   UNKNOWN JAGUAR DSP GPU TOM JERRY M68K BLITTER OP DEBUGGER
+ * DEBUGGER (9) marks a host-injected event (input edges, marks). */
 #define TP_WHO_DEBUG 9
 
 #define TP_MAX_SNAPS  HARNESS_MAX_SNAP_FRAMES

--- a/test/tools/trace_dump.c
+++ b/test/tools/trace_dump.c
@@ -59,7 +59,9 @@ static const char *type_names[VJT_EV__COUNT] = {
 };
 
 /* Index = enum value in src/core/vjag_memory.h:
- *   enum { UNKNOWN, JAGUAR, DSP, GPU, TOM, JERRY, M68K, BLITTER, OP, DEBUG }; */
+ *   enum { UNKNOWN, JAGUAR, DSP, GPU, TOM, JERRY, M68K, BLITTER, OP, DEBUGGER };
+ * The printed name below stays "DEBUG": it is the trace file's own text
+ * format, which people grep, and is not tied to the C identifier. */
 #define WHO_COUNT 10
 static const char *who_names[WHO_COUNT] = {
     "UNKNOWN", "JAGUAR", "DSP", "GPU", "TOM", "JERRY",


### PR DESCRIPTION
Fixes #615. Third of the four SPM-compat fixes tracked in #614.

## The bug

`src/core/vjag_memory.h` declares `DEBUG` as an enumerator. Xcode's stock Debug
configuration sets `GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1`, so the identifier arrives
already expanded to `1`:

```
./src/core/vjag_memory.h:59:66: error: expected identifier
   59 | enum { UNKNOWN, JAGUAR, DSP, GPU, TOM, JERRY, M68K, BLITTER, OP, DEBUG };
      |                                                                  ^
<command line>:1:15: note: expanded from macro 'DEBUG'
```

**Makefile builds never hit this by naming luck, not by design** — the Makefile emits
`-D_DEBUG` (MSVC spelling) and `-DNDEBUG`, never a plain `-DDEBUG`. So it is invisible
to every CI target here and only bites downstream Apple consumers.

## The fix

Rename the enumerator to `DEBUGGER`. Wire value (9) unchanged; `whoName[9]` already read
`"Debugger"`, so the identifier now agrees with the repo's own name for index 9.

**Why not `#pragma push_macro`/`pop_macro`** (what the downstream fork branch does):
`pop_macro` restores `DEBUG` as a macro after the enum, so the enumerator exists but can
never be referenced by name — and testing `#ifdef DEBUG` after `#undef`-ing it needs a
helper macro too. Three preprocessor constructs plus a vendor pragma to preserve a name
**nothing in the tree references**. The enumerator has zero uses.

## On the trace tooling

`test/tools/trace_{dump,diff}.c` and `test/harness/trace_probe.c` mention `DEBUG`, but
only as string literals in their own hand-duplicated name tables and in comments — none
of them `#include` this header, so the compiler never tied them together.

Their comments that quote the enum are updated to match. Their `who_names[]` string
tables **deliberately keep printing `"DEBUG"`**: that is the trace file's own text
format, which people grep, and is independent of the C identifier.

(`whoName[9] = "Debugger"` vs the tools' `"DEBUG"` already disagreed before this PR.
Left alone — separate cleanup, and bundling it would make this harder to review.)

## Scope

One symbol. `UNKNOWN`/`GPU`/`OP` are collision-prone in the abstract, but none is
defined by a standard build configuration the way `DEBUG` is.

## Verification

| check | result |
|---|---|
| `cc -fsyntax-only -DDEBUG=1` on the header | **error before, clean now** |
| `cc -fsyntax-only` (no `-DDEBUG`) | clean (control) |
| `make -j` | 0 errors |
| `make TEST_EXPORTS=1 test` | 0 test(s) failed |
| `trace_dump.c` / `trace_diff.c` / `trace_probe.c` | 0 errors |
| `scripts/c89-lint.sh src/core/vjag_memory.c` | passed |