### PR TITLE
feat(blitter): self-guarding arch files, so an all-variants build links exactly one

### DIFF
--- a/src/tom/blitter_simd.h
+++ b/src/tom/blitter_simd.h
@@ -28,6 +28,8 @@
 #include <stdint.h>
 #include <boolean.h>
 
+#include "blitter_simd_arch.h"
+
 /* Portable always-inline, spelled to include the inline keyword itself
  * (MSVC's __forceinline IS the inline keyword for that compiler). */
 #if defined(_MSC_VER)
@@ -107,29 +109,22 @@ extern const blitter_simd_ops_t blitter_simd_ops;
  * for the host and would get the x86_64 simulator slice wrong.
  *
  * Deliberately opt-in: leaving it undefined keeps ndk-build and every
- * MSVC target on the scalar path they select today, byte for byte. */
+ * MSVC target on the scalar path they select today, byte for byte.
+ *
+ * The capability test itself lives in blitter_simd_arch.h, because the
+ * arch .c files need the same answer for their own guards and the two
+ * must never disagree -- see that header. */
 #if !defined(BLITTER_SIMD_NEON) && !defined(BLITTER_SIMD_SSE2) \
  && !defined(BLITTER_SIMD_SCALAR) && defined(BLITTER_SIMD_AUTODETECT)
-   /* NEON: mandatory on AArch64, opt-in on ARMv7-A.  __ARM_NEON is the
-    * ACLE spelling every GCC/Clang emits when NEON codegen is on;
-    * _M_ARM64 is MSVC's, where NEON is likewise mandatory. */
-#  if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__) \
-   || defined(_M_ARM64) || defined(_M_ARM64EC)
+#  if defined(BLITTER_SIMD_HAVE_NEON)
 #    define BLITTER_SIMD_NEON 1
-   /* SSE2: architectural baseline on x86-64, so the 64-bit spellings need
-    * no further test.  On 32-bit x86 it is NOT baseline -- GCC and Clang
-    * only emit SSE2 under -msse2 (or an -march implying it), and MSVC only
-    * under /arch:SSE2.  Makefile.common can *add* -msse2 (see its "required
-    * on i686 / gcc -m32" rule); autodetect can only observe, so it must ask
-    * whether SSE2 is actually enabled rather than infer it from the arch.
-    * Testing __SSE2__ / _M_IX86_FP keeps a plain i386 build on the scalar
-    * fall-through instead of handing blitter_simd_sse2.c intrinsics its
-    * target cannot compile. */
-#  elif defined(__x86_64__) || defined(_M_X64) \
-     || (defined(__i386__) && defined(__SSE2__)) \
-     || (defined(_M_IX86) && defined(_M_IX86_FP) && _M_IX86_FP == 2)
+#  elif defined(BLITTER_SIMD_HAVE_SSE2)
 #    define BLITTER_SIMD_SSE2 1
 #  endif
+   /* No else: a target with neither falls through to the scalar branch
+    * below, which is also the one blitter_simd_scalar.c compiles itself
+    * into under BLITTER_SIMD_BUILD_SCALAR.  Same macros, so the inline
+    * set and the vtable cannot disagree. */
 #endif
 
 #if defined(BLITTER_SIMD_NEON)

--- a/src/tom/blitter_simd_arch.h
+++ b/src/tom/blitter_simd_arch.h
@@ -1,0 +1,76 @@
+/*
+ * Blitter SIMD capability detection.
+ *
+ * Answers one question: which SIMD instruction sets does *this*
+ * compilation actually have?  Split out of blitter_simd.h rather than
+ * spelled inline there because two different places need the answer and
+ * they must never disagree:
+ *
+ *   1. blitter_simd.h's BLITTER_SIMD_AUTODETECT block, which picks the
+ *      inline implementation blitter.c gets.
+ *   2. Each blitter_simd_<arch>.c's top-of-file guard, which decides
+ *      whether that file contributes the blitter_simd_ops vtable.
+ *
+ * If those two ever answered differently the build would either define
+ * blitter_simd_ops twice or not at all, so they read the same macros
+ * from here.  The .c files cannot get the answer from blitter_simd.h
+ * itself: they have to select their implementation *before* including
+ * it (blitter_simd.h dispatches on BLITTER_SIMD_<ARCH>, and including
+ * it first would pull in the scalar inline set and collide with the
+ * arch one).
+ *
+ * These test CAPABILITY, not architecture.  SSE2 is baseline on x86-64
+ * but optional on 32-bit x86 (GCC/Clang need -msse2 or an -march that
+ * implies it; MSVC needs /arch:SSE2), and NEON is optional on ARMv7-A.
+ * Makefile.common can *add* -msse2 when it selects the SSE2 source --
+ * see its "required on i686 / gcc -m32" rule -- but a build that selects
+ * by guard has no such lever and must take the target as it finds it.
+ * Asking "is the feature on?" rather than "what arch is this?" is what
+ * keeps a plain i386 build off the SSE2 path instead of handing
+ * blitter_simd_sse2.c intrinsics its target cannot compile.
+ */
+
+#ifndef BLITTER_SIMD_ARCH_H
+#define BLITTER_SIMD_ARCH_H
+
+/* NEON.  __ARM_NEON is the ACLE spelling every GCC/Clang emits when NEON
+ * codegen is enabled; _M_ARM64 is MSVC's, where NEON is mandatory. */
+#if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__) \
+ || defined(_M_ARM64) || defined(_M_ARM64EC)
+#  define BLITTER_SIMD_HAVE_NEON 1
+#endif
+
+/* SSE2.  The 64-bit spellings need no further test; the 32-bit ones do. */
+#if defined(__x86_64__) || defined(_M_X64) \
+ || (defined(__i386__) && defined(__SSE2__)) \
+ || (defined(_M_IX86) && defined(_M_IX86_FP) && _M_IX86_FP == 2)
+#  define BLITTER_SIMD_HAVE_SSE2 1
+#endif
+
+/* Whether a blitter_simd_<arch>.c should compile its body at all.
+ *
+ * Without BLITTER_SIMD_AUTODETECT these are all true, so Makefile.common
+ * and ndk-build -- which compile exactly ONE arch file and pass a
+ * matching -DBLITTER_SIMD_<ARCH> -- are completely unaffected: the guard
+ * can never blank out the one file they chose.
+ *
+ * With it, a build that hands every arch file to the compiler at once
+ * (the Provenance SwiftPM manifest) gets exactly one non-empty file, and
+ * it is the same one blitter_simd.h selects for inlining.  Scalar is the
+ * fall-through, so such a build always links rather than failing to find
+ * blitter_simd_ops on a target with neither NEON nor SSE2.
+ */
+#if !defined(BLITTER_SIMD_AUTODETECT) || defined(BLITTER_SIMD_HAVE_NEON)
+#  define BLITTER_SIMD_BUILD_NEON 1
+#endif
+
+#if !defined(BLITTER_SIMD_AUTODETECT) || defined(BLITTER_SIMD_HAVE_SSE2)
+#  define BLITTER_SIMD_BUILD_SSE2 1
+#endif
+
+#if !defined(BLITTER_SIMD_AUTODETECT) \
+ || (!defined(BLITTER_SIMD_HAVE_NEON) && !defined(BLITTER_SIMD_HAVE_SSE2))
+#  define BLITTER_SIMD_BUILD_SCALAR 1
+#endif
+
+#endif /* BLITTER_SIMD_ARCH_H */

--- a/src/tom/blitter_simd_neon.c
+++ b/src/tom/blitter_simd_neon.c
@@ -7,6 +7,18 @@
  * uses to exercise the very same code the core runs.
  */
 
+#include "blitter_simd_arch.h"
+
+/* Compile this file at all?  Always yes for Makefile.common and
+ * ndk-build, which select exactly one arch file and pass a matching
+ * -DBLITTER_SIMD_NEON -- BLITTER_SIMD_BUILD_* is unconditionally true
+ * without BLITTER_SIMD_AUTODETECT, so the guard can never blank out
+ * the file they chose.  Under autodetect (the SwiftPM build, which
+ * hands every arch file to the compiler at once) exactly one of the
+ * three survives, and it is the same one blitter_simd.h selects for
+ * inlining -- both read blitter_simd_arch.h. */
+#if defined(BLITTER_SIMD_BUILD_NEON)
+
 /* Select our own arch before blitter_simd.h picks one.  This file IS
  * the neon implementation, so it must get the neon inline set even when
  * compiled standalone without the Makefile's -DBLITTER_SIMD_NEON --
@@ -55,3 +67,5 @@ const blitter_simd_ops_t blitter_simd_ops = {
    ops_byte_merge,
    ops_add16sat_x4
 };
+
+#endif /* BLITTER_SIMD_BUILD_NEON */

--- a/src/tom/blitter_simd_scalar.c
+++ b/src/tom/blitter_simd_scalar.c
@@ -7,6 +7,18 @@
  * uses to exercise the very same code the core runs.
  */
 
+#include "blitter_simd_arch.h"
+
+/* Compile this file at all?  Always yes for Makefile.common and
+ * ndk-build, which select exactly one arch file and pass a matching
+ * -DBLITTER_SIMD_SCALAR -- BLITTER_SIMD_BUILD_* is unconditionally true
+ * without BLITTER_SIMD_AUTODETECT, so the guard can never blank out
+ * the file they chose.  Under autodetect (the SwiftPM build, which
+ * hands every arch file to the compiler at once) exactly one of the
+ * three survives, and it is the same one blitter_simd.h selects for
+ * inlining -- both read blitter_simd_arch.h. */
+#if defined(BLITTER_SIMD_BUILD_SCALAR)
+
 /* Select our own arch before blitter_simd.h picks one.  This file IS
  * the scalar implementation, so it must get the scalar inline set even when
  * compiled standalone without the Makefile's -DBLITTER_SIMD_SCALAR --
@@ -55,3 +67,5 @@ const blitter_simd_ops_t blitter_simd_ops = {
    ops_byte_merge,
    ops_add16sat_x4
 };
+
+#endif /* BLITTER_SIMD_BUILD_SCALAR */

--- a/src/tom/blitter_simd_sse2.c
+++ b/src/tom/blitter_simd_sse2.c
@@ -7,6 +7,18 @@
  * uses to exercise the very same code the core runs.
  */
 
+#include "blitter_simd_arch.h"
+
+/* Compile this file at all?  Always yes for Makefile.common and
+ * ndk-build, which select exactly one arch file and pass a matching
+ * -DBLITTER_SIMD_SSE2 -- BLITTER_SIMD_BUILD_* is unconditionally true
+ * without BLITTER_SIMD_AUTODETECT, so the guard can never blank out
+ * the file they chose.  Under autodetect (the SwiftPM build, which
+ * hands every arch file to the compiler at once) exactly one of the
+ * three survives, and it is the same one blitter_simd.h selects for
+ * inlining -- both read blitter_simd_arch.h. */
+#if defined(BLITTER_SIMD_BUILD_SSE2)
+
 /* Select our own arch before blitter_simd.h picks one.  This file IS
  * the sse2 implementation, so it must get the sse2 inline set even when
  * compiled standalone without the Makefile's -DBLITTER_SIMD_SSE2 --
@@ -55,3 +67,5 @@ const blitter_simd_ops_t blitter_simd_ops = {
    ops_byte_merge,
    ops_add16sat_x4
 };
+
+#endif /* BLITTER_SIMD_BUILD_SSE2 */


### PR DESCRIPTION
Fixes #617. Second of the four SPM-compat fixes tracked in #614.

> **Stacked on #613** — based on `fix/spm-blitter-simd-autodetect`, not `develop`, because
> both need the same capability macros. Retarget to `develop` once #613 merges; the diff
> shown here is only this change.

## What

#613 taught `blitter_simd.h` which implementation `blitter.c` **inlines**. This teaches
the arch `.c` files which of them contributes the `blitter_simd_ops` **vtable**.

Both answers now come from one new header, `src/tom/blitter_simd_arch.h`. Previously they
would have been two independent copies of the same condition — and if those drift you get
either a duplicate `blitter_simd_ops` or an implementation inlined that isn't the one
linked, which is the silent-mismatch class #612 was about.

The `.c` files can't read the answer from `blitter_simd.h` itself: they must select their
implementation *before* including it, because it dispatches on `BLITTER_SIMD_<ARCH>` and
including it first pulls in the scalar inline set, which then collides with the arch one.
Hence a separate header.

## Makefile and ndk-build are untouched

`BLITTER_SIMD_BUILD_*` is unconditionally true without `BLITTER_SIMD_AUTODETECT`, so the
guard can never blank out the single file those builds selected. Bottom row proves it —
all three files still compile complete:

| target | neon | sse2 | scalar | total |
|---|---|---|---|---|
| `AUTODETECT` arm64 | **1** | 0 | 0 | 1 |
| `AUTODETECT` x86_64 | 0 | **1** | 0 | 1 |
| `AUTODETECT` armv7 `-mfpu=neon` | **1** | 0 | 0 | 1 |
| `AUTODETECT` i386 `-msse2` | 0 | **1** | 0 | 1 |
| `AUTODETECT` i386 `-mno-sse2` | 0 | 0 | **1** | 1 |
| **no `AUTODETECT` (Makefile)** | 1 | 1 | 1 | **3** |

(counting `const blitter_simd_ops_t blitter_simd_ops =` after preprocessing each file)

And the inline selection matches that table row for row — arm64 `NEON`, x86_64 `SSE2`,
armv7+neon `NEON`, i386+sse2 `SSE2`, i386-nosse `SCALAR`, bare `SCALAR`, explicit
`-DBLITTER_SIMD_NEON` `NEON`.

## Scalar is guarded too

That's what makes the set **total**: under autodetect scalar compiles exactly when
neither NEON nor SSE2 is available. So such a build always links, instead of failing to
find `blitter_simd_ops` on an exotic target — and a consumer no longer has to
hand-maintain an `exclude:` for the scalar file to dodge a duplicate symbol. The
downstream manifest can drop that entry.

## Capability, not architecture

Same reasoning established in review on #613: `Makefile.common` can *add* `-msse2` when it
selects the SSE2 source, but a build selecting by guard has no such lever and must take
the target as it finds it. Hence `__SSE2__` / `_M_IX86_FP` rather than `__i386__`. Row 5
above is that case.

## Verification

```
make -j                                  0 errors
make TEST_EXPORTS=1 test                 0 test(s) failed
scripts/c89-lint.sh (all three .c)       passed
test/test_blitter_simd standalone build  builds and passes
```

That last one matters: `c-cpp.yml` compiles an arch `.c` by hand with no
`-DBLITTER_SIMD_<ARCH>`, which is the path most likely to be broken by a top-of-file
guard. It isn't — no `AUTODETECT` there, so the guard is inert.