### PR TITLE
build: ship a Package.swift so Apple frontends stop vendoring this repo

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -503,6 +503,47 @@ jobs:
     - name: swift build
       run: swift build -v 2>&1 | tail -40
 
+    # The blind spot that let an `unsafeFlags` slip in: SwiftPM REFUSES to
+    # resolve a VERSIONED dependency on a package whose targets carry unsafe
+    # flags, but a package built as the ROOT (which `swift build` above does)
+    # is exempt -- so the restriction is invisible from inside the repo. This
+    # consumes the package the way a frontend actually would, by version tag,
+    # which is the only way to see it.
+    - name: a versioned consumer can build against this package
+      run: |
+        set -euo pipefail
+        work=$(mktemp -d)
+        # A tag on a throwaway clone; the real repo is untouched.
+        # Clone under the repo name: SwiftPM derives package identity from the
+        # URL's last path component, not from `name:` in the manifest.
+        git clone --quiet --no-hardlinks . "$work/virtualjaguar-libretro"
+        git -C "$work/virtualjaguar-libretro" -c user.email=ci@example.com -c user.name=CI tag -f 0.0.1
+        mkdir -p "$work/app/Sources/app"
+        echo 'print("ok")' > "$work/app/Sources/app/main.swift"
+        cat > "$work/app/Package.swift" <<PKG
+        // swift-tools-version:5.9
+        import PackageDescription
+        let package = Package(
+            name: "app",
+            dependencies: [.package(url: "$work/virtualjaguar-libretro", from: "0.0.1")],
+            targets: [.executableTarget(name: "app", dependencies: [
+                .product(name: "VirtualJaguar", package: "virtualjaguar-libretro")])]
+        )
+        PKG
+        cd "$work/app"
+        # `swift build`, NOT `swift package resolve`: resolve succeeds even with
+        # unsafe flags present -- the restriction is enforced when the dependency
+        # graph is loaded for a build. Verified both ways before relying on it.
+        if ! out=$(swift build 2>&1); then
+          echo "$out"
+          echo "::error::a versioned dependency on this package does not resolve."
+          echo "::error::If this says 'contains unsafe build flags', remove the .unsafeFlags"
+          echo "::error::from Package.swift -- they make the package unconsumable by any"
+          echo "::error::frontend pinning a release tag, which is the point of shipping it."
+          exit 1
+        fi
+        echo "OK: builds as a versioned dependency"
+
     - name: exactly one SIMD vtable, and it is not the scalar one
       run: |
         set -euo pipefail

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -445,8 +445,8 @@ jobs:
       if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
       run: make -j4 CC="${{ matrix.config.cc }}" CXX="${{ matrix.config.cxx }}" ${{ matrix.config.make_extra || '' }}
 
-  version-fallback-sync:
-    name: version fallback in sync
+  duplicated-lists-in-sync:
+    name: duplicated lists in sync
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
@@ -475,6 +475,49 @@ jobs:
           exit 1
         fi
         echo "OK: both say $mk"
+
+    # Package.swift repeats Makefile.common's source list, because SPM needs
+    # the file list in the manifest and cannot read a Makefile. Same posture as
+    # the check above: fail loudly, never auto-fix. The downstream Provenance
+    # wrapper kept its own copy of this list and drifted by 27 files over seven
+    # releases -- this is that lesson turned into a build failure.
+    - name: Package.swift sources match Makefile.common
+      run: sh scripts/check-package-sources.sh
+
+  spm-build:
+    name: SwiftPM build (macOS arm64)
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v7
+
+    # No Makefile target reads Package.swift, so without this job a manifest
+    # that does not even parse would merge unnoticed and only break the Apple
+    # frontend that consumes it. Building the package here is the only thing
+    # in CI that exercises it.
+    #
+    # This also covers the two things the source-list diff cannot see: that the
+    # arch guards resolve to exactly one blitter_simd_ops when all three
+    # variants are compiled together, and that libretro.c still compiles with
+    # no generated src/core/version.h (a fresh checkout has none -- the
+    # committed src/core/version_fallback.h is what makes that work).
+    - name: swift build
+      run: swift build -v 2>&1 | tail -40
+
+    - name: exactly one SIMD vtable, and it is not the scalar one
+      run: |
+        set -euo pipefail
+        B=$(find .build -type d -name 'virtualjaguar.build' | head -1)
+        [ -n "$B" ] || { echo "could not locate the build directory"; exit 1; }
+        total=0
+        for a in neon sse2 scalar; do
+          o="$B/src/tom/blitter_simd_$a.c.o"
+          n=0
+          [ -f "$o" ] && n=$(nm "$o" | grep -c '_blitter_simd_ops' || true)
+          echo "  blitter_simd_$a: $n"
+          total=$((total + n))
+        done
+        [ "$total" -eq 1 ] || { echo "::error::expected exactly 1 blitter_simd_ops definition, found $total"; exit 1; }
+        echo "OK: exactly one vtable"
 
   msvc-check:
     name: MSVC ${{ matrix.arch }} compilation check

--- a/Package.swift
+++ b/Package.swift
@@ -194,7 +194,16 @@ let package = Package(
                 .headerSearchPath("deps/lzma-25.01/include"),
                 .headerSearchPath("deps/miniz-3.1.1"),
                 .headerSearchPath("deps/zstd-1.5.7"),
-                .unsafeFlags(["-Wno-unused-function", "-Wno-unused-variable"]),
+                // No .unsafeFlags here, deliberately. SwiftPM REFUSES to resolve a
+                // versioned dependency (`from: "x.y.z"`) on any package whose
+                // targets carry unsafe flags -- only path and branch/revision
+                // dependencies are exempt. That would break the exact workflow
+                // this manifest exists to enable, and an in-repo `swift build`
+                // cannot detect it because the root package is exempt too.
+                // The flags only silenced unused-function/variable warnings in
+                // the unity TU; warnings are not worth that. The spm-consumer CI
+                // job resolves this package by version so the restriction is
+                // tested rather than remembered.
             ]
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,202 @@
+// swift-tools-version:5.9
+//
+// Swift Package Manager manifest for the Virtual Jaguar libretro core.
+//
+// This exists so Apple frontends can consume the core as a normal package
+// dependency instead of vendoring it as a submodule and re-declaring every
+// source file in their own manifest.  It builds the C core ONLY -- no Swift,
+// no frontend glue.  Whatever wraps it supplies that.
+//
+// It is inert for every other build system.  `make`, `jni/Android.mk` and the
+// MSVC projects never read this file, and nothing here changes a flag they use.
+//
+// ---------------------------------------------------------------------------
+// The source lists below MIRROR Makefile.common, which stays the single source
+// of truth.  scripts/check-package-sources.sh diffs the two and CI fails on
+// divergence -- hand-maintaining a second copy is exactly how the downstream
+// wrapper drifted by 27 files over seven releases.  If you add a .c file to
+// Makefile.common, add it here too, or CI will tell you.
+// ---------------------------------------------------------------------------
+//
+// Target names are prefixed.  SPM requires them to be unique across the WHOLE
+// package graph of the consuming app, and generic names collide: a frontend
+// carrying two cores that each vendor CHD cannot build if both call the target
+// "libchdr".  That is not hypothetical -- it happened.
+
+import PackageDescription
+
+// Mirrors SOURCES_C under $(CORE_DIR) in Makefile.common.
+let coreSources: [String] = [
+    "src/bios/jagbios.c",
+    "src/bios/jagbios_m.c",
+    "src/bios/jagcdbios.c",
+    "src/bios/jagdevcdbios.c",
+    "src/cd/cdintf.c",
+    "src/cd/cdrom.c",
+    "src/cd/jagcd_bios.c",
+    "src/cd/jagcd_cart.c",
+    "src/cd/jagcd_hle.c",
+    "src/core/biosdb.c",
+    "src/core/bus_arbiter.c",
+    "src/core/cheat.c",
+    "src/core/crash_detect.c",
+    "src/core/crc32.c",
+    "src/core/event.c",
+    "src/core/file.c",
+    "src/core/filedb.c",
+    "src/core/jaggd.c",
+    "src/core/jaguar.c",
+    "src/core/memtrack.c",
+    "src/core/nvmbios.c",
+    "src/core/perf_counters.c",
+    "src/core/perf_iface.c",
+    "src/core/settings.c",
+    "src/core/titledb.c",
+    "src/core/titlehook.c",
+    "src/core/universalhdr.c",
+    "src/core/vjag_memory.c",
+    "src/core/vjtrace.c",
+    "src/jerry/axistune.c",
+    "src/jerry/dac.c",
+    "src/jerry/dsp.c",
+    "src/jerry/eeprom.c",
+    "src/jerry/inputdev.c",
+    "src/jerry/jerry.c",
+    "src/jerry/jlink.c",
+    "src/jerry/jlink_discover.c",
+    "src/jerry/jlink_netpacket.c",
+    "src/jerry/jlink_tcp.c",
+    "src/jerry/joystick.c",
+    "src/jerry/paddle.c",
+    "src/jerry/quadrature.c",
+    "src/jerry/uart.c",
+    "src/jerry/voicechat.c",
+    "src/jerry/voicemodem.c",
+    "src/jerry/wavetable.c",
+    "src/m68000/cpudefs.c",
+    "src/m68000/cpuemu.c",
+    "src/m68000/cpuextra.c",
+    "src/m68000/cpustbl.c",
+    "src/m68000/m68kinterface.c",
+    "src/m68000/readcpu.c",
+    "src/tom/blit_memo.c",
+    "src/tom/blitter.c",
+    "src/tom/blitter_compare.c",
+    "src/tom/blitter_mmio.c",
+    "src/tom/blitter_simd_neon.c",
+    "src/tom/blitter_simd_scalar.c",
+    "src/tom/blitter_simd_sse2.c",
+    "src/tom/gpu.c",
+    "src/tom/op.c",
+    "src/tom/shadowfb.c",
+    "src/tom/texdump.c",
+    "src/tom/texreplace.c",
+    "src/tom/tom.c",
+    "libretro.c",
+]
+
+// Mirrors SOURCES_C under $(LIBRETRO_COMM_DIR) in Makefile.common.
+let libretroCommonSources: [String] = [
+    "compat/compat_posix_string.c",
+    "compat/compat_snprintf.c",
+    "compat/compat_strcasestr.c",
+    "compat/compat_strl.c",
+    "compat/fopen_utf8.c",
+    "encodings/encoding_utf.c",
+    "file/file_path.c",
+    "file/file_path_io.c",
+    "streams/file_stream.c",
+    "streams/file_stream_transforms.c",
+    "string/stdstring.c",
+    "time/rtime.c",
+    "vfs/vfs_implementation.c",
+]
+
+// Defines Makefile.common passes to every core translation unit.
+//
+// BLITTER_SIMD_AUTODETECT is the one that is NOT in the Makefile, and it is
+// load-bearing.  Makefile.common compiles exactly ONE blitter_simd_<arch>.c and
+// passes a matching -DBLITTER_SIMD_<ARCH>; SPM has no per-target source
+// selection, so it compiles all three and each guards itself via
+// src/tom/blitter_simd_arch.h.  Without this define blitter_simd.h would fall
+// through to its scalar branch and inline the SCALAR ops into the blitter hot
+// path on hardware that has NEON -- silently, because the blitter_simd_ops
+// vtable would still be NEON and only the core's own tests read that vtable.
+let coreDefines: [CSetting] = [
+    .define("__LIBRETRO__", to: "1"),
+    .define("INLINE", to: "inline"),
+    .define("BLITTER_SIMD_AUTODETECT", to: "1"),
+]
+
+let package = Package(
+    name: "VirtualJaguar",
+    products: [
+        .library(name: "VirtualJaguar", targets: ["virtualjaguar"]),
+    ],
+    targets: [
+        // The core.  path "." because libretro.c sits at the repo root and SPM
+        // requires sources to live under the target path; everything else is
+        // under src/.  The explicit `sources` list means SPM compiles only what
+        // is named, so the rest of the repo (docs, tests, scripts) is ignored.
+        .target(
+            name: "virtualjaguar",
+            dependencies: ["virtualjaguar-libretro-common", "virtualjaguar-libchdr"],
+            path: ".",
+            // Directories owned by the other two targets. SPM rejects
+            // overlapping target paths without this.
+            exclude: ["libretro-common", "deps"],
+            sources: coreSources,
+            publicHeadersPath: "src/core",
+            cSettings: coreDefines + [
+                .headerSearchPath("."),
+                .headerSearchPath("src"),
+                .headerSearchPath("src/core"),
+                .headerSearchPath("src/tom"),
+                .headerSearchPath("src/jerry"),
+                .headerSearchPath("src/cd"),
+                .headerSearchPath("src/bios"),
+                .headerSearchPath("src/m68000"),
+                .headerSearchPath("libretro-common/include"),
+                // src/cd/cdintf.c includes <libchdr/chd.h> unconditionally.
+                .headerSearchPath("deps/libchdr/include"),
+            ]
+        ),
+
+        .target(
+            name: "virtualjaguar-libretro-common",
+            path: "libretro-common",
+            sources: libretroCommonSources,
+            publicHeadersPath: "include",
+            cSettings: coreDefines + [
+                .headerSearchPath("include"),
+            ]
+        ),
+
+        // Vendored CHD reader, built the way Makefile.common builds it: one
+        // unity translation unit, with miniz's compressor left on because
+        // src/tom/texdump.c needs tdefl_write_image_to_png_file_in_memory_ex
+        // for its preview PNGs.
+        //
+        // No -std=c99 as the Makefile passes: SPM compiles C as gnu11, a
+        // superset, so the flag is unnecessary rather than missing.
+        .target(
+            name: "virtualjaguar-libchdr",
+            path: "deps/libchdr",
+            sources: ["unity.c"],
+            publicHeadersPath: "include",
+            cSettings: [
+                .define("_7ZIP_ST", to: "1"),
+                .define("MINIZ_DEFLATE_APIS", to: "1"),
+                .define("WANT_RAW_DATA_SECTOR", to: "1"),
+                .define("WANT_SUBCODE", to: "1"),
+                .define("VERIFY_BLOCK_CRC", to: "1"),
+                .headerSearchPath("include"),
+                .headerSearchPath("deps/lzma-25.01/include"),
+                .headerSearchPath("deps/miniz-3.1.1"),
+                .headerSearchPath("deps/zstd-1.5.7"),
+                .unsafeFlags(["-Wno-unused-function", "-Wno-unused-variable"]),
+            ]
+        ),
+    ],
+    cLanguageStandard: .gnu11
+)

--- a/scripts/check-package-sources.sh
+++ b/scripts/check-package-sources.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env sh
+# Assert Package.swift's source lists still match Makefile.common.
+#
+# Makefile.common is the single source of truth for what makes up the core.
+# Package.swift has to repeat it, because SPM needs the file list in the
+# manifest and cannot read a Makefile.  A second hand-maintained copy of a list
+# that changes every release is exactly the thing that rots: the downstream
+# Provenance wrapper carried its own copy and drifted by 27 files over seven
+# releases before anyone noticed, which is why this check exists rather than a
+# comment asking people to remember.
+#
+# Fails loudly and names the offending files.  It never edits Package.swift --
+# same posture as the docs/cd-boot-matrix.md drift guard and the
+# version_fallback.h check: a human decides what the right list is.
+#
+# Usage: sh scripts/check-package-sources.sh
+# POSIX sh -- no bashisms.
+
+set -e
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT"
+
+[ -f Makefile.common ] || { echo "check-package-sources: Makefile.common not found" >&2; exit 1; }
+[ -f Package.swift ]   || { echo "check-package-sources: Package.swift not found" >&2; exit 1; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# --- what Makefile.common says -------------------------------------------
+# Every $(CORE_DIR)/....c and $(LIBRETRO_COMM_DIR)/....c mentioned anywhere in
+# the file.  Deliberately includes the arch-conditional blitter_simd_*.c: SPM
+# compiles all three variants and lets each guard itself (see
+# src/tom/blitter_simd_arch.h), so the union is the correct comparison.
+grep -oE '\$\(CORE_DIR\)/[a-zA-Z0-9_/.-]+\.c' Makefile.common \
+  | sed 's|\$(CORE_DIR)/||' | sort -u > "$TMP/mk_core"
+grep -oE '\$\(LIBRETRO_COMM_DIR\)/[a-zA-Z0-9_/.-]+\.c' Makefile.common \
+  | sed 's|\$(LIBRETRO_COMM_DIR)/||' | sort -u > "$TMP/mk_lrc"
+
+# --- what Package.swift says ---------------------------------------------
+# Read each array by name so the two lists can never be confused for each other
+# if the file is reordered.
+extract_array() {
+  # $1 = swift array variable name, $2 = output file
+  sed -n "/^let $1: \[String\] = \[/,/^\]/p" Package.swift \
+    | grep -oE '"[^"]+\.c"' | tr -d '"' | sort -u > "$2"
+}
+extract_array coreSources          "$TMP/pkg_core"
+extract_array libretroCommonSources "$TMP/pkg_lrc"
+
+for f in mk_core mk_lrc pkg_core pkg_lrc; do
+  [ -s "$TMP/$f" ] || { echo "check-package-sources: '$f' came out empty -- the parser is broken, not the lists" >&2; exit 1; }
+done
+
+# --- compare ---------------------------------------------------------------
+status=0
+report() {
+  # $1 = label, $2 = makefile list, $3 = package list
+  missing=$(comm -23 "$2" "$3")
+  extra=$(comm -13 "$2" "$3")
+  if [ -n "$missing" ]; then
+    status=1
+    echo "ERROR: in Makefile.common but NOT in Package.swift ($1):" >&2
+    echo "$missing" | sed 's/^/    /' >&2
+  fi
+  if [ -n "$extra" ]; then
+    status=1
+    echo "ERROR: in Package.swift but NOT in Makefile.common ($1):" >&2
+    echo "$extra" | sed 's/^/    /' >&2
+  fi
+}
+
+report "coreSources"           "$TMP/mk_core" "$TMP/pkg_core"
+report "libretroCommonSources" "$TMP/mk_lrc"  "$TMP/pkg_lrc"
+
+if [ "$status" -ne 0 ]; then
+  echo "" >&2
+  echo "Makefile.common is the source of truth.  Update the arrays in" >&2
+  echo "Package.swift to match, then re-run this check." >&2
+  exit 1
+fi
+
+echo "check-package-sources.sh: OK -- $(wc -l < "$TMP/mk_core" | tr -d ' ') core + $(wc -l < "$TMP/mk_lrc" | tr -d ' ') libretro-common sources agree"

--- a/scripts/check-package-sources.sh
+++ b/scripts/check-package-sources.sh
@@ -16,7 +16,11 @@
 # Usage: sh scripts/check-package-sources.sh
 # POSIX sh -- no bashisms.
 
-set -e
+# -u as well as -e: these guard scripts are copied from, and an unset variable
+# silently expanding to empty is exactly how a drift check starts passing on
+# nothing.  `command rm` because this repo's shells alias rm to `rm -i`, which
+# blocks forever with no tty.
+set -eu
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$ROOT"
@@ -25,7 +29,7 @@ cd "$ROOT"
 [ -f Package.swift ]   || { echo "check-package-sources: Package.swift not found" >&2; exit 1; }
 
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
+trap 'command rm -rf "$TMP"' EXIT INT TERM
 
 # --- what Makefile.common says -------------------------------------------
 # Every $(CORE_DIR)/....c and $(LIBRETRO_COMM_DIR)/....c mentioned anywhere in


### PR DESCRIPTION
Closes the last item on #614.

> **Stacked.** Based on `fix/duplicate-boolean-h` (#624), which is based on
> `fix/drop-dangling-vfs-cdrom-header` (#622). Merge **#622 → #624 → this**.
>
> **The `src/core/boolean.h` deletion visible in this diff is #624's, not this change's.**
> GitHub shows the diff against `develop`, so the parent's commit rides along in the view.
> This PR adds only `Package.swift`, `scripts/check-package-sources.sh`, and two CI jobs.

## Why

Apple consumption of this core needs a fork branch plus a downstream manifest that
re-declares every source file. **That second copy of the list is the problem.** The
Provenance wrapper kept one and drifted by 27 files over seven releases, and a missing
`-DBLITTER_SIMD_<ARCH>` in it meant every arm64 build inlined the **scalar** blitter while
the linked vtable was NEON (#612) — invisible because only the core's own tests read that
vtable.

This manifest builds the C core only. A frontend depends on it as a package instead of
vendoring it, and the list lives next to the sources it mirrors.

Inert everywhere else: `make`, `jni/Android.mk` and the MSVC projects never read it, and
nothing here changes a flag they use.

## Three guards, because a hand-copied list rots

**`scripts/check-package-sources.sh`** diffs the manifest's arrays against
`Makefile.common`, which stays the single source of truth. Fails loudly and names the
files; never auto-fixes. Verified it catches **both** directions:

```
$ sh scripts/check-package-sources.sh          # a file dropped from Package.swift
ERROR: in Makefile.common but NOT in Package.swift (coreSources):
    src/tom/blit_memo.c

$ sh scripts/check-package-sources.sh          # a stale entry Makefile.common dropped
ERROR: in Package.swift but NOT in Makefile.common (coreSources):
    src/tom/ghost_file.c
```

**`swift build` in CI.** Nothing else in CI reads this file, so a manifest that does not
parse would merge unnoticed. That job also asserts **exactly one** `blitter_simd_ops`
survives when all three SIMD variants compile together — the invariant #617's arch guards
exist to hold, which no Makefile target can check because it compiles only one variant.

**A versioned consumer builds against it.** Added after review: SwiftPM refuses to build a
versioned dependency on a package whose targets carry `unsafeFlags`, and building in-repo
cannot detect that because the **root** package is exempt. This job makes a throwaway
tagged clone and a tiny consumer that depends on it by version, which is the only way to
see the restriction. It must use `swift build`, not `swift package resolve` — resolve
succeeds even with unsafe flags present.

## Details worth a look

- **Target names are prefixed** (`virtualjaguar-libretro-common`, `virtualjaguar-libchdr`).
  SPM requires uniqueness across the consuming app's *whole* package graph, and generic
  names collide — a frontend carrying two cores that each vendor CHD cannot build if both
  call the target `libchdr`. Not hypothetical; it broke the Provenance build this week.
- **`path: "."`** because `libretro.c` sits at the repo root. The explicit `sources` list
  means only named files compile, so `docs/`, `test/`, `scripts/` are ignored; the two
  subdirectories owned by other targets are excluded so SPM does not reject overlapping
  paths.
- **`HAVE_COCOATOUCH` / `__GCCUNIX__` are deliberately absent** — the downstream manifest
  defines both, but neither appears anywhere in the core sources.

## Cost

A root `Package.swift` makes GitHub label the repo "Swift" and makes SwiftPM treat it as a
package. That is the trade-off flagged in #614 and worth an explicit maintainer OK.

## Verification

| check | result |
|---|---|
| `swift build` (root) | clean, 80 files |
| `swift build` from a **versioned** consumer | links; fails as expected when `unsafeFlags` is reintroduced |
| `scripts/check-package-sources.sh` | 66 core + 13 libretro-common agree |
| `make -j` | 0 errors (unaffected) |
| `make TEST_EXPORTS=1 test` | 0 test(s) failed |
| SIMD vtables in the SPM objects (`nm`) | neon 1, sse2 0, scalar 0 |
| blitter hot path | 47 NEON vector instructions |