### PR TITLE
docs(netlink): record why ComLynx cross-linking stays a non-goal

### DIFF
--- a/docs/netlink-design.md
+++ b/docs/netlink-design.md
@@ -69,7 +69,16 @@ automated testing.
   exists for Jaguar today; the TCP backend plus user-supplied tunneling
   (Tailscale etc.) is the interim story. A relay is a separate future project.
 - Modeling CatBox RS-232 DSP-port registers beyond the UART itself, MIDI, or
-  ComLynx cross-compatibility.
+  ComLynx cross-compatibility. On ComLynx specifically, so this stays
+  asked-and-answered (issue #638): the Jaguar's async serial *is* the
+  ComLynx-compatible port and `src/jerry/uart.c` already emulates it, so
+  nothing here is unimplemented. What is absent is Jaguar-to-Lynx
+  cross-console linking, and it stays absent because no adapter ever shipped
+  and no software on either machine is known to use it. It would also not be
+  a free reuse of this transport: the ComLynx cable ties RX and TX together
+  into a single-wire shared bus, so senders see their own transmission echoed
+  and peers daisy-chain onto one wire -- whereas the design below is
+  point-to-point.
 - Cycle-exact UART timing beyond baud-rate pacing (start/8-data/stop bit
   times); games rate-limit on TBE/RBF status, not on bit edges.
 


### PR DESCRIPTION
Closes the ComLynx question raised alongside #638.

`docs/netlink-design.md` listed "ComLynx cross-compatibility" as a non-goal in a single clause, which reads as *the connector is unemulated*. It is not: the Jaguar's asynchronous serial at `$F10030`-`$F10034` **is** the ComLynx-compatible port, and `src/jerry/uart.c` already emulates it per JTRM Rev 8 pp.93-95, with netlink shipping on top.

This spells out three things so the question stops being re-asked:

1. **What is actually absent** — Jaguar-to-Lynx *cross-console* linking, not the UART.
2. **Why it stays absent** — no adapter ever shipped, and no software on either machine is known to use it.
3. **Why it would not be a free reuse of this transport** — the ComLynx cable ties RX and TX together into a single-wire shared bus, so senders see their own transmission echoed and peers daisy-chain onto one wire. The design in this doc is point-to-point.

Docs only, no code. Tracked long-form in #638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)