### PR TITLE
fix(op): stop object processing at VBB when VDE is past the end of the field

### DIFF
--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -1532,7 +1532,40 @@ void TOMExecHalfline(uint16_t halfline, bool render)
    // Really, this value is somewhere around 507 for an NTSC Jaguar. But this
    // should work in a majority of cases, at least until we can figure it out properly.
    if (endingHalfline > GET16(tomRam8, VP))
+   {
       startingHalfline = 0;
+
+      /* A VDE past the end of the field is the documented "OP runs every
+       * line" idiom (JTRM: set VDE=$FFFF to work around the VDE-compare
+       * bug), not a request to run the object list through vertical
+       * blanking as well.  Left unclamped it does exactly that, and the
+       * extra passes are destructive rather than merely wasted: the OP
+       * decrements an object's HEIGHT and advances its DATA pointer on
+       * every pass that reaches it, so a pass landing after the game has
+       * rebuilt its list for the next field silently eats the first line
+       * of every object in it.
+       *
+       * Super Burnout (#632) is the case that exposed this.  It sets
+       * VDB=25, VDE=$7FF, VP=523, VBB=500, VI=521, and rebuilds the
+       * display list in its vertical-interrupt handler.  The OP then ran
+       * once more at halfline 522 -- 22 halflines into blanking, one
+       * halfline after VI -- consuming line 0 of the freshly written HUD
+       * object.  The visible result was the top scanline missing from the
+       * whole first HUD text row, so LAP rendered as LHP and POSITION as
+       * POSTTTON, identically on both blitters because the blitter was
+       * never involved.
+       *
+       * Clamping to VBB is the narrow reading: blanking begins there, so
+       * that is where the object list stops being displayed.  It applies
+       * only on this branch -- a title with a real in-range VDE keeps
+       * exactly the window it asked for, including one that deliberately
+       * extends past VBB. */
+      {
+         uint16_t vbb = GET16(tomRam8, VBB);
+         if (vbb > 0 && vbb < endingHalfline)
+            endingHalfline = vbb;
+      }
+   }
 
    if ((halfline >= startingHalfline) && (halfline < endingHalfline))
    {


### PR DESCRIPTION
Fixes the Super Burnout HUD text clipping reported in #632.

## Symptom

The in-race HUD's first text row lost its topmost scanline: `LAP` rendered as `LHP` (the `A`
has no apex, so it reads as an `H`), `POSITION` as `POSTTTON`. Identical on both blitters.

The decisive glyph is the `O` in `POSITION`: it keeps its **bottom** closing row but has no top
row, so the glyph is clipped at the top by one line — not shifted, and not a 6-row font.

## Cause

Super Burnout is the only title in the corpus that sets `VDE` past the end of the field:

```
VDB=25  VDE=$7FF (2047)  VP=523  VBB=500  VI=521
```

That trips the existing "OP start bug" branch in `TOMExecHalfline()`, which opens
`startingHalfline` to 0 — but leaves `endingHalfline` at the out-of-range `VDE`. The object list
is then processed on **every halfline of the field, including all of vertical blanking**.

Those extra passes are not merely wasted work. The OP decrements an object's `HEIGHT` and advances
its `DATA` pointer on every pass that reaches it, so a pass landing after the game has rebuilt its
list eats the first line of every object in it.

Super Burnout rebuilds its display list in the vertical-interrupt handler at halfline 521. Traced
on the HUD text object (`ypos=92`, `height=64`, `dwidth=192`, 4bpp):

```
hl 92..218    h 63->0   lines 1..63 drawn      (display rows 33..96)
hl 220..520   h 0       exhausted
hl 522        h 64      <- list rebuilt at VI=521; this pass consumes line 0
next field    h 63      line 1 lands on row 33, where line 0 belongs
```

Exactly one pass, 22 halflines into blanking, one halfline after VI.

## Fix

Clamp `endingHalfline` to `VBB` on that branch only. A title with a real in-range `VDE` keeps
exactly the window it asked for, including one that deliberately extends past `VBB`.

## Result

```
before                            after
33 ...##......##...##.##...##     33 ...##.......#####..######.
34 ...##......##...##.##...##     34 ...##......##...##.##...##
35 ...##......#######.######.     35 ...##......##...##.##...##
36 ...##......##...##.##.....     36 ...##......#######.######.
37 ...##......##...##.##.....     37 ...##......##...##.##.....
38 ...#######.##...##.##.....     38 ...##......##...##.##.....
                                  39 ...#######.##...##.##.....
```

Seven rows; `A` has its apex, `P` has its top bar.

## Verification

- **Corpus regression sweep**: every `.jag`/`.j64`/`.rom` in the private library, 600 frames from
  cold boot, full framebuffer-hash stream compared between the baseline and fixed cores. Results
  posted below. Only titles that set `VDE > VP` can be reached by this branch at all.
- `test_audio_presence` (Iron Soldier): RMS 1174.2 on both builds, unchanged.
- `scripts/c89-lint.sh src/tom/tom.c`: passes.

## Caveat — this clamp is empirically derived, not JTRM-verified

**JTRM v8 p.15** (text layer, primary source) says only:

> **VDB** — "specifies the half line on which object processing begins. Object processing restarts
> on every line until the half line specified by the VDE register. The border colour (or black) is
> displayed outside these active lines."
> **VDE** — "specifies the half line at which object processing ends."

It does **not** say `VBB` stops the OP. The "set `VDE=$FFFF` so the OP runs every line" claim lives
in `docs/jtrm-register-map.md` and I could not confirm it against a PDF —
`05 - Hardware Bugs & Warnings.pdf` is a scanned image with no text layer.

A live alternative root cause remains: our 68K runs the whole VBI handler between halfline events,
so the list rebuild completes within one halfline where hardware would take longer than that. If
so, the true fix is interrupt-phase accuracy — the same class as #635 (White Men Can't Jump) and
#401. This PR fixes the visible defect with a narrow, corpus-verified clamp; it does not settle
that question.
