### PR TITLE
feat(netlink): default virtualjaguar_netlink_speed to auto

### DIFF
--- a/docs/netlink-design.md
+++ b/docs/netlink-design.md
@@ -410,9 +410,10 @@ Frontend matrix: RetroArch ≥ 1.16 → netpacket netplay; any other frontend
 
 `UARTFrameUsec()` is the single choke point for the whole link's emulated
 latency — **both** the TX drain and the RX arrival schedule through it — so
-`virtualjaguar_netlink_speed` (default off; originally values 2 / 4,
-replaced by a negotiated `auto` in #552 below) divides exactly that one
-number. Three things about the shape are load-bearing:
+`virtualjaguar_netlink_speed` (originally values 2 / 4, replaced by a
+negotiated `auto` in #552 below, which is also its default -- see that
+section) divides exactly that one number. Three things about the shape
+are load-bearing:
 
 - **Gated on an active transport, evaluated per call.** With
   `JLinkMode() == JLINK_MODE_DISABLED` the function takes a branch that is
@@ -470,7 +471,22 @@ at link-up, out-of-band, and fall back to stock timing if the peer
 rejects, does not understand the request, or does not answer. There is
 exactly one non-stock divisor now (`UART_WIRE_SPEEDUP_MAX`, still 4), so
 "negotiate" only ever has to answer one question — is the peer also in
-auto — not agree on a magnitude. A derive-from-shared-state approach
+auto — not agree on a magnitude.
+
+**Default flipped to `auto` (2026-08-26 addendum).** #498's `disabled`
+default existed because a bare option had no safety net: picking a
+magnitude by hand and getting it wrong (an old peer, a mismatched
+setting) could desync the two sides. #552's negotiation removed that
+risk structurally — every non-confirming case (old core, peer set to
+`disabled`, peer that never answers, or frontend netplay, which can
+never reach the negotiation channel at all — see `JLinkNegEligible()` in
+`src/jerry/jlink.c`) degrades to the untouched stock timing branch in
+`UARTFrameUsec()`, never to a guess. With the failure mode gone, there is
+no remaining reason to ship the enhancement off, so `auto` is now the
+default; the option itself still opts a player back out to authentic
+timing with one click.
+
+A derive-from-shared-state approach
 (ASICLK, frame period) was considered first and rejected: `asiClk` is 0
 after reset and only becomes the game's value once the game writes it, so
 at link-up the two sides can legitimately disagree purely from boot skew
@@ -510,9 +526,18 @@ purely reactive — it never needs the client's address ahead of time, because
 `recvfrom()` hands it over for free — and replies with its own packet as an
 ack the first time it sees one. Neither side raises
 `UARTWireSpeedupEffective` above 1 until it has *received* a decodable
-packet from the other, so the accelerated timing is never applied
-unilaterally — the asymmetric-benefit measurement above cannot recur by
-construction, not just by policy.
+packet from the other, so a side can never accelerate on its own say-so —
+but "I heard from you" does not imply "you heard from me": measured on
+`127.0.0.1` (2026-08-26, exercising the default-flip PR), the client's
+hello crossed the `SO_REUSEPORT` hash to reach the server -- which
+confirmed and raised to 4x -- while the server's ack hairpinned back to
+itself on every one of the client's 8 retries, so the client gave up and
+stayed at 1x the whole session. That is the asymmetric-benefit state from
+the #498 measurement above recurring via a lost ack, not by a player's
+manual choice; it is bounded to that one-machine `SO_REUSEPORT` hazard
+(see the KNOWN LIMITATION note below) and the #498 measurement already
+covers it as safe -- degraded benefit, not desync -- so it does not
+undermine the negotiation's purpose, only its "unilaterally" framing.
 
 Each packet carries a random per-session `senderId`, and a receiver ignores
 any incoming packet carrying its *own* id back — not part of the negotiation

--- a/docs/netlink-user-guide.md
+++ b/docs/netlink-user-guide.md
@@ -86,7 +86,7 @@ Desktop/testing shortcuts: environment variables `VJ_NETLINK_HOST` and
 
 ## Making link play feel snappier (optional, not authentic)
 
-*Network Link Wire Speed* (default **Off**, values **Off** / **Auto**)
+*Network Link Wire Speed* (default **Auto**, values **Off** / **Auto**)
 clocks the emulated serial port faster than the real hardware ran it, when
 the console on the other end agrees to.
 
@@ -100,10 +100,10 @@ bytes each way every frame, roughly 5.8 ms of pure wire time per
 direction against a 16.7 ms frame.
 
 That slowness is *real* — a Voice Modem or a JagLink cable behaved exactly
-this way — which is why this is off by default and labelled an
-enhancement rather than a fix.
+this way — which is why this is labelled an enhancement rather than a fix,
+even though negotiation makes it safe enough to ship on by default.
 
-- **Set *Auto* on either or both consoles — there is nothing to match.**
+- **It is *Auto* on both consoles by default — there is nothing to match.**
   The two cores agree on the speedup between themselves the moment the
   link comes up. If the other side is running an older core, has this set
   to *Off*, or never answers, this side quietly stays at authentic timing

--- a/docs/voice-modem.md
+++ b/docs/voice-modem.md
@@ -176,10 +176,11 @@ and `TCP_NODELAY` plus the adaptive reply wait already cover the network
 side.
 
 This is authentic — a real Voice Modem at 19200 baud was exactly this
-slow — so it is addressed as an **opt-in enhancement**, not a bug fix:
-core option `virtualjaguar_netlink_speed` (default Off; `auto`, #552)
-divides the character frame time by a fixed 4x once the two console
-instances negotiate that out-of-band and agree (see
+slow — so it is addressed as an **enhancement**, not a bug fix: core
+option `virtualjaguar_netlink_speed` (default `auto` since #552's
+negotiation made a bad guess impossible; `disabled` opts back out to
+authentic timing) divides the character frame time by a fixed 4x once
+the two console instances negotiate that out-of-band and agree (see
 `docs/netlink-design.md`'s negotiation section) — never a magnitude the
 player picks, and never applied unilaterally by one side. The knob is a
 single one: `UARTFrameUsec()` in `src/jerry/uart.c` schedules both the TX

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -420,7 +420,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_netlink_speed",
       "Network Link Wire Speed (Enhancement)",
       NULL,
-      "Clocks the emulated serial port faster than real hardware, so a link game's lockstep exchange finishes inside one video frame instead of spilling into the next -- at authentic speed (Ultra Vortek's Voice Modem mode settles at 19200 baud, about 5.8 ms of wire time each way per frame) you do not see your own move until the round trip completes. Off by default because a real Voice Modem or JagLink cable is exactly that slow. 'Auto' has the two consoles agree the speed-up between themselves at link-up: nothing to match by hand, and if the peer runs an older core, is not in Auto, or never answers, this side quietly stays at authentic timing instead of running ahead alone. Only takes effect over a direct Network Link (TCP host/client): frontend netplay has no channel for the two cores to negotiate over and always runs authentic timing. If a game starts dropping link data, turn this off.",
+      "Clocks the emulated serial port faster than real hardware, so a link game's lockstep exchange finishes inside one video frame instead of spilling into the next -- at authentic speed (Ultra Vortek's Voice Modem mode settles at 19200 baud, about 5.8 ms of wire time each way per frame) you do not see your own move until the round trip completes. A real Voice Modem or JagLink cable is exactly that slow, which is why this stays an opt-out enhancement rather than a fix. 'Auto' (the default) has the two consoles agree the speed-up between themselves at link-up: nothing to match by hand, and if the peer runs an older core, is not in Auto, or never answers, this side quietly stays at authentic timing instead of running ahead alone. Only takes effect over a direct Network Link (TCP host/client): frontend netplay has no channel for the two cores to negotiate over and always runs authentic timing. If a game starts dropping link data, turn this off.",
       NULL,
       "network",
       {
@@ -428,7 +428,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "auto",     "Auto (negotiated with peer)" },
          { NULL, NULL },
       },
-      "disabled"
+      "auto"
    },
    {
       "virtualjaguar_voice_chat",

--- a/test/tools/netlink_latency.c
+++ b/test/tools/netlink_latency.c
@@ -227,8 +227,9 @@ int main(int argc, char **argv)
     putenv((char *)"VJ_NETLINK_HOST=127.0.0.1");
     /* See the file header comment: --speed drives the jlink.c test-only
        VJ_FORCE_WIRE_SPEEDUP escape hatch, never the real
-       virtualjaguar_netlink_speed option (which is left at its "disabled"
-       default below -- #552 negotiation is not exercised by this tool). */
+       virtualjaguar_netlink_speed option (which is pinned to "disabled"
+       below regardless of the option's own default -- #552 negotiation
+       is not exercised by this tool). */
     if (strcmp(speed_opt, "disabled") != 0 && atoi(speed_opt) > 1)
     {
         static char speed_env[64];


### PR DESCRIPTION
## Summary

Flips `virtualjaguar_netlink_speed`'s default from `disabled` to `auto`. #552 replaced the option's old 2x/4x magnitude picker with a negotiated `auto` that only accelerates once the peer has proven it also wants it, out-of-band over the LAN discovery socket. Since a bad default can no longer desync link play, there's no remaining reason to ship the enhancement off.

## Verification of the four fallback paths (code, not just option text)

Per the task brief, the burden is on proving every non-confirming case degrades to authentic timing:

1. **Peer runs an older core.** `JLinkNegDecode()` requires an exact magic (`"VJNG"`)/version/length match; an old peer's `jlink_discover.c` (from #467) doesn't recognize it and silently drops the datagram, identically to a hostile packet (`src/jerry/jlink.c:427-429`, `docs/netlink-design.md`'s channel-selection rationale). The client never gets a reply, exhausts `JLINK_NEG_MAX_ATTEMPTS` (8 tries / ~4s), and sets `jlinkNegGaveUp=1` (`jlink.c:654-664`), which never raises `UARTSetWireSpeedupEffective` above 1.
2. **Peer explicitly set to "off".** `JLinkNegOnRaw()` gates on `JLinkNegEligible()` (`jlink.c:531`), which requires `UARTWireSpeedupIntent()` (`jlink.c:495`). An off peer's own intent is 0, so it never replies to a hello and never initiates one -- indistinguishable, on the wire, from "never answers." Locally, `UARTSetWireSpeedupIntent(0)` also force-drops any already-negotiated `Effective` back to 1 at the setter (`src/jerry/uart.c:91-96`).
3. **Peer never answers at all.** Same give-up path as (1); directly covered by `test/test_jlink_negotiate.c`'s `test_stays_stock_with_silent_peer`.
4. **Frontend netplay (`SET_NETPACKET_INTERFACE`).** `JLinkNegEligible()` requires `jlinkMode == JLINK_MODE_TCP_SERVER || JLINK_MODE_TCP_CLIENT` (`jlink.c:492-493`); netpacket mode never satisfies that. Independently, LAN discovery (`JLinkDiscStart()`) is only started when the *mode* option resolves to `"tcp_server"`/`"tcp_client"` (`libretro.c:1764-1781`) -- never for netpacket -- so `JLinkDiscActive()` is false and negotiation can't even begin. `UARTWireSpeedupEffective` stays at its init value of 1 (`uart.c:58`).

All four traced end-to-end; `make TEST_EXPORTS=1 test` (which includes `test_jlink_negotiate`, `test_uart_loopback`, `netlink_pair_test.sh`, `netlink_latency_test.sh`) is green: 1644 passed, 0 failed (remaining skips are the usual private-ROM-corpus gates, unrelated).

### A same-host wrinkle found while exercising a live two-instance link

Ran a real two-process TCP link (server + client) with the option left at its new default (`auto`, not overridden), `VJ_NETLINK_AUTO_DEBUG=1`. Result:

```
[server] jlink-auto: confirmed with 127.0.0.1:42170 (peerId=3a3ccd86)
[server] FINAL UARTWireSpeedup()=4
[client] jlink-auto: gave up after 8 hellos, no reply -- staying at stock timing
[client] FINAL UARTWireSpeedup()=1
[server] PASS: exchanged bytes correctly
[client] PASS: exchanged bytes correctly
```

This is the **documented same-host `SO_REUSEPORT` hazard** (`jlink.c:470-489`, `docs/netlink-design.md`'s "Measured limitation" note): two cores sharing 127.0.0.1's discovery port can have the hash favor one direction, so the client's hello crossed over and confirmed the server, but the server's ack hairpinned back to itself on every retry -- an asymmetric result (one side accelerated, one side stock), not a desync. This exact state (one side fast, one side stock) was already measured safe under #498 before #552 existed: `UARTKickRx()` back-pressure keeps the byte stream correct regardless, the lockstep exchange is gated by the *sum* of both sides' clocking, and both processes above still exchanged their bytes correctly. Play across two different machines is unaffected (no shared `SO_REUSEPORT` group across hosts).

I softened one sentence in `docs/netlink-design.md`'s #552 section that overclaimed this couldn't happen ("the asymmetric-benefit measurement above cannot recur by construction") -- it can, via a lost ack in this narrow same-host test topology, and now says so with the measurement above as evidence.

## Also changed

- Option description no longer says "Off by default"; states `'Auto' (the default)`.
- `docs/netlink-design.md`, `docs/voice-modem.md`, `docs/netlink-user-guide.md`: default-value mentions updated.
- `test/tools/netlink_latency.c`: a comment asserted the option's old default; it hardcodes `"disabled"` regardless of default, so only the comment needed fixing.
- `libretro_core_options_intl.h` needs no change -- `docs/core-option-translations.md` confirms every `options_intl[]` entry is still `NULL` (no translations exist yet), and the intl header itself has no `netlink_speed` string. The description-text edit will trigger `crowdin_source_upload.yml` on merge to `develop`; expected, no action needed.

## Test plan

- [x] `make -j$(getconf _NPROCESSORS_ONLN)` clean
- [x] `make TEST_EXPORTS=1 test` -- 1644 passed, 0 failed
- [x] `bash scripts/c89-lint.sh` on both touched `.c`/`.h` files
- [x] Live two-instance TCP link exercised with the option at its new default; negotiation settled (asymmetrically, per the known same-host limitation above) without desyncing byte delivery

Closes #645

---

Per this repo's `docs/agent/github.md`: the `Closes #645` tag above is scanned by `pr-issue-link.yml` on open/edit and creates the Development-panel link automatically -- no manual UI step needed for this PR.