### PR TITLE
perf(libretro): honor GET_AUDIO_VIDEO_ENABLE for presentation only

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -5854,6 +5854,22 @@ void retro_run(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
       check_variables();
 
+   /* RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (presentation-skip half only:
+    * the audio bit is intentionally ignored -- DSP/DAC output is untouched).
+    * Queried every frame because the frontend may flip it frame-to-frame
+    * (e.g. hidden run-ahead re-executes, fast-forward). Default keeps the
+    * video bit set, so a frontend that doesn't implement the call --
+    * environ_cb() returns false and leaves av_enable_flags untouched --
+    * renders exactly as before. tomSkipVideoPresent gates ONLY the final
+    * host XRGB8888 store in TOMExecHalfline (tom.c); OP/GPU/DSP/blitter
+    * execution above it in JaguarExecuteNew() always runs unabridged, so
+    * this cannot desync emulation or run-ahead determinism (#400). */
+   {
+      enum retro_av_enable_flags av_enable_flags = RETRO_AV_ENABLE_VIDEO;
+      environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &av_enable_flags);
+      tomSkipVideoPresent = (av_enable_flags & RETRO_AV_ENABLE_VIDEO) ? 0 : 1;
+   }
+
    /* Apply pending geometry change BEFORE rendering this frame.  TOM's
     * scanline renderer reads tomWidth (pixels per row) and screenPitch
     * (line stride) live; if tomWidth grew but screenPitch is stale, later
@@ -6077,7 +6093,14 @@ void retro_run(void)
     * The reverse mismatch also exists -- a narrow window (e.g. VDB=38,
     * VDE=100 -> 34 rendered rows, presented height 31) writes past the
     * presented height.  That is harmless here (the allocation is 1024x512
-    * and the extra rows are simply not shown) and is left alone. */
+    * and the extra rows are simply not shown) and is left alone.
+    *
+    * Presentation-skip: this whole fixup only touches videoBuffer (the
+    * host output), so it is skipped along with the rest of presentation
+    * when the frontend has flagged this frame's video as discarded --
+    * TOMGetWrittenRowExtent()'s own bookkeeping (tomRowsWrittenCur/Prev/
+    * Last in tom.c) is unconditional and unaffected either way. */
+   if (!tomSkipVideoPresent)
    {
       uint32_t written = TOMGetWrittenRowExtent();
       /* Hi-res: TOM reports rows in STOCK units.  The decision below is
@@ -6133,8 +6156,18 @@ void retro_run(void)
     * and video stall. Fires LOG_WRN/LOG_ERR via vj_log_cb so the
     * signature shows up in the RetroArch log without extra wiring.
     * Off-mode short-circuits in CrashDetectFrameTick, so the cost
-    * when disabled is one indirect function call per frame. */
-   CrashDetectFrameTick(videoBuffer, (unsigned)game_width, (unsigned)game_height);
+    * when disabled is one indirect function call per frame.
+    *
+    * Pass fb=NULL while presentation is skipped: videoBuffer is frozen at
+    * whatever the last rendered frame left there, and a long presentation-
+    * skip run (run-ahead's hidden frames, fast-forward) would otherwise
+    * read as a false video_stall.  CrashDetectFrameTick treats a NULL fb
+    * as "no framebuffer to hash this frame" and skips only that one check;
+    * GPU/DSP PC-escape and wedge detection -- the checks that actually
+    * matter here, since nothing about emulation itself changed -- still
+    * run unconditionally. */
+   CrashDetectFrameTick(tomSkipVideoPresent ? NULL : videoBuffer,
+                         (unsigned)game_width, (unsigned)game_height);
 
    video_cb(videoBuffer, game_width, game_height, game_width << 2);
 

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -437,6 +437,10 @@ uint16_t tom_jerry_int_pending, tom_timer_int_pending, tom_object_int_pending,
 uint32_t * screenBuffer;
 uint32_t screenPitch;
 
+/* RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE presentation-skip -- see the
+ * declaration in tom.h for the safety argument.  Default 0 (render). */
+int tomSkipVideoPresent;
+
 typedef void (render_xxx_scanline_fn)(uint32_t *);
 
 // Private function prototypes
@@ -1635,27 +1639,39 @@ void TOMExecHalfline(uint16_t halfline, bool render)
       if (writtenRow + 1 > tomRowsWrittenCur)
          tomRowsWrittenCur = writtenRow + 1;
 
-      if (inActiveDisplayArea)
+      /* Presentation-skip (RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE): both
+       * branches below do nothing but store host XRGB8888 pixels into
+       * screenBuffer -- the CRY/RGB16 -> RGB32 conversion (stock, true-color
+       * or hi-res box-replication/supersampled) and the border-colour fill.
+       * screenBuffer is not addressable Jaguar memory, so skipping these
+       * stores is invisible to emulation; tomSkipVideoPresent stays 0
+       * (render as normal) unless the frontend just said this frame's
+       * video will be discarded. See the tom.h declaration for the full
+       * argument. */
+      if (!tomSkipVideoPresent)
       {
-         if (shadowHiresActive)
-            tom_render_scanline_hires(TOMCurrentLine);
-         else
-            scanline_render[TOMGetVideoMode()](TOMCurrentLine);
-      }
-      else
-      {
-         // If outside of VDB & VDE, then display the border color
-         // (replicated across the N sub-rows / N-wide pixels at hi-res).
-         uint8_t      g = tomRam8[BORD1], r = tomRam8[BORD1 + 1], b = tomRam8[BORD2 + 1];
-         uint32_t pixel = 0xFF000000 | (r << 16) | (g << 8) | (b << 0);
-         uint32_t hr;
-
-         for (hr = 0; hr < hiresRowScale; hr++)
+         if (inActiveDisplayArea)
          {
-            uint32_t * currentLineBuffer = TOMCurrentLine + hr * screenPitch;
+            if (shadowHiresActive)
+               tom_render_scanline_hires(TOMCurrentLine);
+            else
+               scanline_render[TOMGetVideoMode()](TOMCurrentLine);
+         }
+         else
+         {
+            // If outside of VDB & VDE, then display the border color
+            // (replicated across the N sub-rows / N-wide pixels at hi-res).
+            uint8_t      g = tomRam8[BORD1], r = tomRam8[BORD1 + 1], b = tomRam8[BORD2 + 1];
+            uint32_t pixel = 0xFF000000 | (r << 16) | (g << 8) | (b << 0);
+            uint32_t hr;
 
-            for(i=0; i<tomWidth * hiresRowScale; i++)
-               *currentLineBuffer++ = pixel;
+            for (hr = 0; hr < hiresRowScale; hr++)
+            {
+               uint32_t * currentLineBuffer = TOMCurrentLine + hr * screenPitch;
+
+               for(i=0; i<tomWidth * hiresRowScale; i++)
+                  *currentLineBuffer++ = pixel;
+            }
          }
       }
    }

--- a/src/tom/tom.h
+++ b/src/tom/tom.h
@@ -81,6 +81,24 @@ extern int32_t tomTimerCounter;
 extern uint32_t screenPitch;
 extern uint32_t * screenBuffer;
 
+/* RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE presentation-skip.
+ *
+ * Nonzero when the frontend has hinted (RETRO_AV_ENABLE_VIDEO clear) that it
+ * will discard this frame's video output -- set once per retro_run() in
+ * libretro.c, read by TOMExecHalfline().  It gates ONLY the final
+ * CRY/RGB16 -> host XRGB8888 store into screenBuffer (the
+ * scanline_render[]/tom_render_scanline_hires call and the border-colour
+ * fill), never the OP object-list dispatch or line-buffer writes that
+ * precede it in the same halfline: those touch tomRam8, which is real
+ * addressable Jaguar state (the OP line buffer at $F01800-$F01D9E, GPU
+ * synchronisation via OBF) a title could observe.  screenBuffer is a
+ * host-only presentation target no emulated processor can read back, so
+ * skipping stores into it changes nothing the machine can see. Default 0
+ * (render as normal), so a frontend that never calls the environment call
+ * -- or one that does and reports the bit set -- behaves exactly as
+ * before. */
+extern int tomSkipVideoPresent;
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/harness/harness.c
+++ b/test/harness/harness.c
@@ -451,6 +451,17 @@ static bool cb_environment(unsigned cmd, void *data)
     case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
         *(const char **)data = "/tmp";
         return true;
+    case RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE:
+        /* Only answer when a tool explicitly opted in (--av-skip-video);
+         * otherwise fall through to `default: return false`, which is
+         * exactly what every harness tool predating this option already
+         * gets -- the core then assumes no step may be skipped. */
+        if (active_cfg && active_cfg->av_skip_video) {
+            if (data)
+                *(enum retro_av_enable_flags *)data = RETRO_AV_ENABLE_AUDIO;
+            return true;
+        }
+        return false;
     case RETRO_ENVIRONMENT_GET_VARIABLE: {
         struct retro_variable *var = (struct retro_variable *)data;
         unsigned i;
@@ -499,6 +510,8 @@ bool harness_init_from_args(harness_config *cfg, int argc, char **argv)
             cfg->quiet = 1;
         } else if (strcmp(argv[i], "--mic-tone") == 0) {
             cfg->mic_tone = 1;
+        } else if (strcmp(argv[i], "--av-skip-video") == 0) {
+            cfg->av_skip_video = 1;
         } else if (strcmp(argv[i], "--frames") == 0 && i + 1 < argc) {
             cfg->frames = (unsigned)atoi(argv[++i]);
         } else if (strcmp(argv[i], "--snapshot-interval") == 0 && i + 1 < argc) {

--- a/test/harness/harness.h
+++ b/test/harness/harness.h
@@ -258,6 +258,15 @@ typedef struct {
      * voice-chat paths can be exercised without a real frontend mic. */
     int           mic_tone;
 
+    /* RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE presentation-skip test hook
+     * (--av-skip-video): when non-zero, the environment callback answers
+     * the call with RETRO_AV_ENABLE_VIDEO clear (audio bit still set), so
+     * a tool can A/B a run with the core's video-presentation-skip path
+     * active against one where it's not.  Default 0 leaves the call
+     * unanswered (returns false), matching every harness tool that
+     * predates this option -- see cb_environment() in harness.c. */
+    int           av_skip_video;
+
     /* Runtime state (set by harness) */
     void  *core_handle;
     unsigned current_frame;
@@ -306,6 +315,7 @@ typedef struct {
     .want_fb_hash = 0, \
     .last_fb_hash = 0, \
     .mic_tone = 0, \
+    .av_skip_video = 0, \
     .core_handle = NULL, \
     .current_frame = 0, \
     .audio = {0}, \

--- a/test/tools/test_benchmark.c
+++ b/test/tools/test_benchmark.c
@@ -43,6 +43,11 @@ static unsigned long long *(*pperf_counters_find)(const char *);
 /* Options state */
 static int bios_option_set = 0;
 static const char *blitter_value = "enabled"; /* default: fast blitter */
+/* --av-skip-video (perf measurement only): answers
+ * RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE with the video bit clear, so an
+ * A/B run can isolate the cost of the presentation stage this tool skips.
+ * Default 0 leaves the call unanswered, same as before this option existed. */
+static int av_skip_video = 0;
 
 /* High-resolution timer helpers */
 #ifdef __APPLE__
@@ -153,6 +158,14 @@ static bool environment_cb(unsigned cmd, void *data)
       case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
          *(const char **)data = "/tmp";
          return true;
+      case RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE:
+         if (av_skip_video)
+         {
+            if (data)
+               *(enum retro_av_enable_flags *)data = RETRO_AV_ENABLE_AUDIO;
+            return true;
+         }
+         return false;
       default:
          return false;
    }
@@ -196,7 +209,10 @@ static void print_usage(const char *progname)
       "  --load-srm file      Load EEPROM save data from file\n"
       "  --load-state file    Load a save state into the core after retro_load_game.\n"
       "                       Accepts raw retro_serialize() payloads or RetroArch\n"
-      "                       RASTATE container files (the MEM chunk is extracted).\n",
+      "                       RASTATE container files (the MEM chunk is extracted).\n"
+      "  --av-skip-video      Answer GET_AUDIO_VIDEO_ENABLE with the video bit\n"
+      "                       clear, so this run measures with the core's\n"
+      "                       presentation-skip path active.\n",
       progname);
 }
 
@@ -247,6 +263,8 @@ int main(int argc, char **argv)
          srm_load_path = argv[++i];
       else if (strcmp(argv[i], "--load-state") == 0 && i + 1 < argc)
          state_load_path = argv[++i];
+      else if (strcmp(argv[i], "--av-skip-video") == 0)
+         av_skip_video = 1;
       else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0)
       {
          print_usage(argv[0]);


### PR DESCRIPTION
## Summary

Implements `RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE`, but **only** the video-presentation-skip half (the audio bit is intentionally ignored — DSP/DAC output is untouched by this PR).

libretro.h's own doc comment on this call warns that a core emulating a platform which reads its own VRAM must keep rendering as normal unless it can prove the game isn't using display capture. The Jaguar does exactly that constantly — the blitter composites in main RAM and games read back what they drew — so this PR does **not** skip any emulated work: not the Object Processor, not GPU/DSP execution, not the blitter. Skipping those would desync emulation and break run-ahead determinism (the exact bug class fixed in #400).

## The gating boundary

`TOMExecHalfline()` (`src/tom/tom.c`) produces the emulated picture in two distinct steps per halfline:

1. `OPProcessList()` and the line-buffer BG clear — these read/write `tomRam8`, which is real, addressable Jaguar state (the OP line buffer at `$F01800-$F01D9E`). **Always runs, unconditionally, unchanged.**
2. The `scanline_render[]` / `tom_render_scanline_hires` call and the border-colour fill — these take the already-resolved line-buffer content (step 1's output) and convert/store host XRGB8888 pixels into `screenBuffer` (== `videoBuffer`). `screenBuffer` is a **host-only presentation surface** — no emulated processor (68K/GPU/DSP/blitter/OP) can read it back. **This is the only step gated by this PR.**

A new file-scope flag, `tomSkipVideoPresent` (declared in `tom.h`, defined in `tom.c`), gates exactly step 2. It's set once per `retro_run()` in `libretro.c` from the environment call result (video bit set → render as normal, which is also what happens when the call is unsupported — i.e. every existing frontend behaves exactly as before this PR).

Two more presentation-only spots are gated the same way, since they also only ever touch `videoBuffer`:
- the tail-row blanking fixup in `retro_run()` (issue #178's stale-row fix)
- `CrashDetectFrameTick()`'s framebuffer argument is passed `NULL` while skipping, so a long skip run (e.g. run-ahead's hidden re-executes) can't misread its frozen framebuffer as a `video_stall` false positive. GPU/DSP PC-escape and wedge detection — the checks that actually matter here — keep running unconditionally.

## Verification

- `make -j` — clean build.
- `make TEST_EXPORTS=1 test` — full suite passes (rebuilt on top of latest `develop`, build id `f8116f0-dirty`).
- `bash scripts/c89-lint.sh` on every touched core file (`libretro.c`, `src/tom/tom.c`, `src/tom/tom.h`) — passes (also auto-run by the local pre-commit hook).
- **Determinism (the acceptance bar):** `test/tools/hires_state_digest` — savestate FNV digests at frames 300/600/900 are **byte-identical** with the skip active vs inactive, on both `test/roms/yarc.j64` and `test/roms/jagniccc.j64`. This proves the machine cannot observe the skip.
- **Confirms the skip actually engages:** `test/tools/frame_hash_ab` shows the presented framebuffer freezes (nonblack-pixel count drops to 0, frame hash stops changing) when the skip is active, while the digest identity above still holds — i.e. presentation genuinely stops, emulation genuinely doesn't.
- Perf: A/B/B/A interleaved `test_benchmark` runs on `jagniccc.j64` (900 frames, 300 warmup) on a loaded machine (`uptime` load avg ~5.5, not idle) showed a small, directionally consistent ~1.5% throughput improvement (238.5/239.5 fps off vs 241.7/243.4 fps on). Given the load and effect size, I'm not confident enough in this number to present it as precise — reporting it directionally rather than as a clean measurement. The presentation stage this PR can skip (16bpp CRY scanline conversion for a ~326x241 frame) is a small fraction of total per-frame cost, which is dominated by 68K/GPU/DSP interpretation, so a small number here is expected.

## Test infra

Added an opt-in `--av-skip-video` flag to `test/harness/harness.c`/`.h` and `test/tools/test_benchmark.c` so tools can answer the environment call with the video bit cleared. Default behavior (the call is left unanswered, same as before this option existed) is unchanged for every existing harness-based test — confirmed by the full suite still passing.

## Test plan

- [x] `make -j$(getconf _NPROCESSORS_ONLN)` clean
- [x] `make TEST_EXPORTS=1 test` full suite green
- [x] `bash scripts/c89-lint.sh` on all touched core files
- [x] Savestate-digest equality (skip on vs off), two ROMs
- [x] Confirmed the skip mechanism actually fires (frame_hash_ab)
- [ ] Verify in RetroArch with a frontend that actually calls `GET_AUDIO_VIDEO_ENABLE` (e.g. during run-ahead) — no such frontend build was available in this environment; the harness-based A/B above is the available proxy.

---

No tracked GitHub issue covers this task (searched; nothing matched), so this PR carries the `no-issue` label per `docs/agent/github.md` rather than a `Closes #N` tag.

Refs #650
