### PR TITLE
feat(libretro): support RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -245,6 +245,11 @@ static bool show_input_options = true;
  * the options menu is complete before any content is loaded (the type is
  * unknown then, and the user may be configuring ahead of loading). */
 static bool content_loaded         = false;
+/* No-content boot (RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, issue #646):
+ * there is no cartridge, so there is no EEPROM chip for RETRO_MEMORY_SAVE_RAM
+ * to expose.  Gates retro_get_memory_size()/retro_get_memory_data() only --
+ * everything else keys off jaguar_cd_mode / jaguarCartInserted as before. */
+static bool no_game_active         = false;
 static bool show_cd_options        = true;
 static bool show_cart_bios_option  = true;
 /* 16bpp preview interpretation only matters while texture dump is on
@@ -1265,6 +1270,14 @@ void retro_set_environment(retro_environment_t cb)
    voicechat_query_mic_iface();
 
    environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS, &achievements);
+
+   /* No-content boot (issue #646): retro_load_game(NULL) boots the bare
+    * console -- real boot ROM, no cartridge, matching what a real Jaguar
+    * does with an empty cart slot.  See cd_boot_strategy_none. */
+   {
+      bool no_content = true;
+      environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_content);
+   }
 
    /* CD extensions are declared path-loaded (env 65).  DELIBERATELY the
     * inverse of the usual pattern: hybrid cart+disc cores (Genesis Plus GX,
@@ -4900,10 +4913,12 @@ bool retro_load_game(const struct retro_game_info *info)
       { 0 },
    };
 
-   if (!info)
-      return false;
-
-   is_cd_content = info->path && (has_extension(info->path, "cue")
+   /* info == NULL is a no-content boot (RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME,
+    * issue #646): the bare console, no cartridge.  Handled by threading the
+    * NULL through every info-dependent branch below (is_cd_content is
+    * unconditionally false; apply_cart_bios_autodetect() already NULL-checks
+    * info on its own) rather than an early return. */
+   is_cd_content = info && info->path && (has_extension(info->path, "cue")
                                   || has_extension(info->path, "cdi")
                                   || has_extension(info->path, "chd")
                                   || has_extension(info->path, "iso"));
@@ -4934,7 +4949,7 @@ bool retro_load_game(const struct retro_game_info *info)
     * over disc bytes either way. v1 only covers cartridge CRCs, and hashing
     * a disc image would find nothing this table knows about while risking a
     * collision handing a CD title some cartridge's per-title overrides. */
-   if (info->data && !is_cd_content)
+   if (info && info->data && !is_cd_content)
    {
       TitleDBSetContent((const uint8_t *)info->data, info->size);
       /* A patched ROM (RetroArch soft patching, or a pre-patched dump)
@@ -5105,10 +5120,26 @@ bool retro_load_game(const struct retro_game_info *info)
       apply_cart_bios_autodetect(info);
 
    /* Resolve boot configuration — single source of truth for which
-    * strategy (cart / HLE / real BIOS) we will dispatch to below. */
-   ResolveBootConfig(&bootConfig, jaguar_cd_mode, cd_bios_loaded_externally,
-                     vjs.cdBootMode, vjs.useJaguarBIOS);
-   vjs.useJaguarBIOS = bootConfig.showBootROM;
+    * strategy (cart / HLE / real BIOS / no-content) we will dispatch to
+    * below.  ResolveBootConfig() only knows about cart/CD content, so a
+    * no-content boot (info == NULL, issue #646) is resolved directly:
+    * there is no 68K program anywhere for HLE to jump into, so the real
+    * boot ROM is the only sane strategy -- exactly what real hardware
+    * shows with an empty cart slot. */
+   if (!info)
+   {
+      vjs.useJaguarBIOS          = true;
+      bootConfig.isCDGame        = false;
+      bootConfig.showBootROM     = true;
+      bootConfig.cdBiosAvailable = false;
+      bootConfig.strategy        = &cd_boot_strategy_none;
+   }
+   else
+   {
+      ResolveBootConfig(&bootConfig, jaguar_cd_mode, cd_bios_loaded_externally,
+                        vjs.cdBootMode, vjs.useJaguarBIOS);
+      vjs.useJaguarBIOS = bootConfig.showBootROM;
+   }
 
    /* check_variables() ran above, before bootConfig existed, so the blit
     * memo could not tell cartridge from CD content then.  Re-apply the
@@ -5185,7 +5216,7 @@ bool retro_load_game(const struct retro_game_info *info)
     * boot strategies handle their own JaguarReset() ordering internally
     * so the post-boot state is preserved.  We only need to do an extra
     * reset+reload here for the RAM-loaded path. */
-   if (!jaguarCartInserted && !jaguar_cd_mode)
+   if (info && !jaguarCartInserted && !jaguar_cd_mode)
    {
       JaguarReset();
       if (!JaguarLoadFile((uint8_t*)info->data, info->size))
@@ -5242,6 +5273,7 @@ bool retro_load_game(const struct retro_game_info *info)
 
    /* Content type is now known — refresh which options apply to it. */
    content_loaded = true;
+   no_game_active = (info == NULL);
    update_option_visibility();
 
    /* Memory Track NVM BIOS module: on hardware the CD BIOS boot installs
@@ -5271,6 +5303,7 @@ void retro_unload_game(void)
    cd_image_path[0]  = '\0';
    /* Content type is unknown again — restore the full option list. */
    content_loaded    = false;
+   no_game_active    = false;
    update_option_visibility();
    JaguarDone();
 
@@ -5422,6 +5455,9 @@ void *retro_get_memory_data(unsigned type)
       return jaguarMainRAM;
    if (type == RETRO_MEMORY_SAVE_RAM)
    {
+      /* No-content boot (#646): no cartridge means no EEPROM chip. */
+      if (no_game_active)
+         return NULL;
       /* Memory Track cart uses 128K NVRAM directly */
       if (jaguarMainROMCRC32 == 0xFDF37F47)
          return mtMem;
@@ -5437,6 +5473,11 @@ size_t retro_get_memory_size(unsigned type)
       return 0x200000;
    if (type == RETRO_MEMORY_SAVE_RAM)
    {
+      /* No-content boot (#646): no cartridge means no EEPROM chip -- report
+       * zero so frontends don't create a meaningless .srm for a bare BIOS
+       * session. */
+      if (no_game_active)
+         return 0;
       if (jaguarMainROMCRC32 == 0xFDF37F47)
          return MT_SAVE_SIZE;
       /* CD discs share the cart EEPROM with their CD-side EEPROM bank

--- a/src/cd/jagcd_boot.h
+++ b/src/cd/jagcd_boot.h
@@ -21,6 +21,18 @@ extern const CDBootStrategy cd_boot_strategy_hle;
 extern const CDBootStrategy cd_boot_strategy_bios;
 extern const CDBootStrategy cd_boot_strategy_cart;
 
+/* No-content boot (RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME): the frontend
+ * launched the core with no cartridge or disc at all.  Real hardware still
+ * runs the boot ROM off the reset vector with an empty cart slot -- it
+ * shows the boot animation and then sits, because the ROM's own
+ * cart-header check never finds anything to jump to.  This strategy
+ * mirrors that: it clears the cart ROM window (so a previous title's image
+ * can't survive a same-process reload) and always forces the real boot ROM
+ * path, since there is no 68K program anywhere for HLE to jump into.
+ * Selected directly in retro_load_game() when info == NULL; never produced
+ * by ResolveBootConfig(), which only knows about cart/CD content. */
+extern const CDBootStrategy cd_boot_strategy_none;
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cd/jagcd_cart.c
+++ b/src/cd/jagcd_cart.c
@@ -7,11 +7,13 @@
 
 #include "jagcd_boot.h"
 #include "file.h"
+#include "jaggd.h"          /* JGD_AUTO_THRESHOLD -- size of the flat cart window */
 #include "jaguar.h"
 #include "log.h"
 #include "vjag_memory.h"
 
 #include <stdlib.h>
+#include <string.h>
 #include <streams/file_stream.h>
 
 RFILE* rfopen(const char *path, const char *mode);
@@ -94,4 +96,45 @@ const CDBootStrategy cd_boot_strategy_cart = {
     cart_boot,
     NULL,
     cart_reset
+};
+
+/* No-content boot -- see the declaration comment in jagcd_boot.h. */
+static bool none_boot(const struct retro_game_info *info)
+{
+    (void)info;
+
+    /* Clear the flat cart window ($800000-$DFFEFF) so a previous title's
+     * image cannot survive a same-process reload (iOS never dlcloses the
+     * core) and be mistaken for an inserted cartridge.  jaguarROMSize and
+     * the CRC follow suit so titledb / enhancement-hook / Memory-Track
+     * lookups all see "no content" instead of the last title's values. */
+    memset(jaguarMainROM, 0, JGD_AUTO_THRESHOLD);
+    jaguarROMSize      = 0;
+    jaguarMainROMCRC32 = 0;
+
+    /* jaguarCartInserted here means "JaguarReset() must take the real
+     * boot-ROM vector path" (copy SSP/PC from the staged boot ROM and park
+     * illegal-fetch traps there), not "there is a valid program at
+     * $800000" -- the window above is zeroed, so the boot ROM's own
+     * cart-header check finds nothing, exactly like a real console with an
+     * empty cart slot. */
+    jaguarCartInserted = true;
+
+    JaguarReset();
+
+    LOG_INF("[BOOT] Boot path: no cartridge (bare console boot)\n");
+    return true;
+}
+
+static void none_reset(void)
+{
+}
+
+/* instruction_hook is NULL for the same reason cart_boot's is: nothing to
+ * trap on an empty cart slot, and jaguar.c already NULL-checks it. */
+const CDBootStrategy cd_boot_strategy_none = {
+    "none",
+    none_boot,
+    NULL,
+    none_reset
 };

--- a/test/test_boot_config.c
+++ b/test/test_boot_config.c
@@ -91,22 +91,27 @@ static struct BootConfig *p_bootConfig;
 static const CDBootStrategy *p_strategy_hle;
 static const CDBootStrategy *p_strategy_bios;
 static const CDBootStrategy *p_strategy_cart;
+static const CDBootStrategy *p_strategy_none;
 
 #define IS_HLE(c)  ((c).strategy == p_strategy_hle)
 #define IS_BIOS(c) ((c).strategy == p_strategy_bios)
 #define IS_CART(c)  ((c).strategy == p_strategy_cart)
+#define IS_NONE(c)  ((c).strategy == p_strategy_none)
 
 static void (*p_retro_init)(void);
 static void (*p_retro_deinit)(void);
 static bool (*p_retro_load_game)(const struct retro_game_info *);
 static void (*p_retro_unload_game)(void);
 static void (*p_retro_run)(void);
+static void (*p_retro_reset)(void);
 static void (*p_retro_set_environment)(retro_environment_t);
 static void (*p_retro_set_video_refresh)(retro_video_refresh_t);
 static void (*p_retro_set_audio_sample)(retro_audio_sample_t);
 static void (*p_retro_set_audio_sample_batch)(retro_audio_sample_batch_t);
 static void (*p_retro_set_input_poll)(retro_input_poll_t);
 static void (*p_retro_set_input_state)(retro_input_state_t);
+static void *(*p_retro_get_memory_data)(unsigned);
+static size_t (*p_retro_get_memory_size)(unsigned);
 
 #define LOAD_SYM(name) do { \
     p_##name = dlsym(g_handle, #name); \
@@ -132,7 +137,8 @@ static bool load_core(void)
     p_strategy_hle  = dlsym(g_handle, "cd_boot_strategy_hle");
     p_strategy_bios = dlsym(g_handle, "cd_boot_strategy_bios");
     p_strategy_cart = dlsym(g_handle, "cd_boot_strategy_cart");
-    if (!p_strategy_hle || !p_strategy_bios || !p_strategy_cart)
+    p_strategy_none = dlsym(g_handle, "cd_boot_strategy_none");
+    if (!p_strategy_hle || !p_strategy_bios || !p_strategy_cart || !p_strategy_none)
     { fprintf(stderr, "FATAL: dlsym(strategies)\n"); return false; }
 
     LOAD_SYM(retro_init);
@@ -147,6 +153,9 @@ static bool load_core(void)
     p_retro_load_game = dlsym(g_handle, "retro_load_game");
     p_retro_unload_game = dlsym(g_handle, "retro_unload_game");
     p_retro_run = dlsym(g_handle, "retro_run");
+    p_retro_reset = dlsym(g_handle, "retro_reset");
+    p_retro_get_memory_data = dlsym(g_handle, "retro_get_memory_data");
+    p_retro_get_memory_size = dlsym(g_handle, "retro_get_memory_size");
 
     return true;
 }
@@ -539,6 +548,99 @@ TEST(integration_hle_bios_setting_off)
 }
 
 /* ------------------------------------------------------------------ */
+/* Part 3: No-content boot (RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME,      */
+/*          issue #646) -- retro_load_game(NULL).  Needs no ROM/disc,  */
+/*          so these always run (never gated on the private corpus).   */
+/* ------------------------------------------------------------------ */
+
+static bool g_saw_no_game_env = false;
+
+static bool env_callback_no_game(unsigned cmd, void *data)
+{
+    if ((cmd & 0xFF) == RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME)
+    {
+        g_saw_no_game_env = *(const bool *)data;
+        return true;
+    }
+    return env_callback(cmd, data);
+}
+
+static void core_init_no_game(void)
+{
+    g_saw_no_game_env = false;
+    p_retro_set_environment(env_callback_no_game);
+    p_retro_set_video_refresh(stub_video);
+    p_retro_set_audio_sample(stub_audio);
+    p_retro_set_audio_sample_batch(stub_audio_batch);
+    p_retro_set_input_poll(stub_input_poll);
+    p_retro_set_input_state(stub_input_state);
+    p_retro_init();
+}
+
+TEST(no_game_env_declared)
+{
+    core_init_no_game();
+    ASSERT_EQ(g_saw_no_game_env, true);
+    p_retro_deinit();
+}
+
+TEST(no_game_boot_selects_none_strategy)
+{
+    bool loaded;
+
+    core_init_no_game();
+    loaded = p_retro_load_game(NULL);
+    if (!loaded) FAIL("retro_load_game(NULL) failed");
+
+    fprintf(stderr, "        bootConfig: isCDGame=%d showBootROM=%d strategy=%s\n",
+            p_bootConfig->isCDGame, p_bootConfig->showBootROM,
+            p_bootConfig->strategy ? p_bootConfig->strategy->name : "null");
+
+    ASSERT_EQ(p_bootConfig->isCDGame, false);
+    ASSERT_EQ(p_bootConfig->showBootROM, true);
+    ASSERT(IS_NONE(*p_bootConfig));
+    core_teardown();
+}
+
+TEST(no_game_save_ram_is_empty)
+{
+    bool loaded;
+
+    core_init_no_game();
+    loaded = p_retro_load_game(NULL);
+    if (!loaded) FAIL("retro_load_game(NULL) failed");
+
+    /* No cartridge -> no EEPROM chip.  A frontend must not be handed a
+     * meaningless .srm for a bare-BIOS session. */
+    ASSERT_EQ(p_retro_get_memory_size(RETRO_MEMORY_SAVE_RAM), 0);
+    ASSERT(p_retro_get_memory_data(RETRO_MEMORY_SAVE_RAM) == NULL);
+    core_teardown();
+}
+
+TEST(no_game_runs_and_resets_without_crashing)
+{
+    bool loaded;
+    int i;
+
+    core_init_no_game();
+    loaded = p_retro_load_game(NULL);
+    if (!loaded) FAIL("retro_load_game(NULL) failed");
+
+    /* Real hardware boots the ROM (cube animation) and then sits with an
+     * empty cart slot; run long enough to clear the animation and settle,
+     * then reset and do it again.  A crash here is the whole point of the
+     * test -- there is no assertion beyond "the process is still alive". */
+    for (i = 0; i < 120; i++)
+        p_retro_run();
+    if (p_retro_reset)
+        p_retro_reset();
+    for (i = 0; i < 60; i++)
+        p_retro_run();
+
+    core_teardown();
+}
+
+/* ------------------------------------------------------------------ */
 /* Main                                                                */
 /* ------------------------------------------------------------------ */
 
@@ -604,6 +706,14 @@ int main(int argc, char *argv[])
             SKIP(integration_auto_mode_with_bios, "no CD BIOS file");
         }
     }
+    total_fail += REPORT();
+
+    /* ---- Part 3: No-content boot (never gated -- needs no ROM) ---- */
+    SUITE("No-Content Boot (RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME)");
+    RUN(no_game_env_declared);
+    RUN(no_game_boot_selects_none_strategy);
+    RUN(no_game_save_ram_is_empty);
+    RUN(no_game_runs_and_resets_without_crashing);
     total_fail += REPORT();
 
     if (g_handle) dlclose(g_handle);


### PR DESCRIPTION
## Summary

- `retro_load_game(NULL)` now boots the bare console: real boot ROM, no cartridge inserted -- exactly what real hardware shows with an empty cart slot (boot animation, then it sits).
- New `cd_boot_strategy_none` (`src/cd/jagcd_cart.c` / `src/cd/jagcd_boot.h`), selected directly in `retro_load_game()` when `info == NULL` -- `ResolveBootConfig()` only resolves cart/CD content, and there is no 68K program anywhere for HLE to jump into, so the real boot ROM is the only sane strategy. The strategy clears the flat cart window (`$800000`-`$DFFEFF`) so a previous title's image can't survive a same-process reload (iOS never dlcloses the core).
- Threaded the `NULL` case through every `info`-dependent branch in `retro_load_game` (titledb CRC feed, CD-content detection, cart-BIOS autodetect, the RAM-loaded-executable reload path) instead of the previous unconditional `if (!info) return false;`.
- `RETRO_MEMORY_SAVE_RAM` now reports size 0 / `NULL` data for a no-content session -- there is no cartridge, so there is no EEPROM chip to expose.

## Verification

- `make -j8` (clean, production ABI) -- passes, no warnings besides the pre-existing vendored libchdr `Byte` typedef note.
- `make TEST_EXPORTS=1 test` -- full suite passes (0 failed) on top of `libretro/develop` @ `d0c0ce8`, including the 4 new tests below.
- `bash scripts/c89-lint.sh` on every touched file -- passes (also re-verified by the repo's pre-commit hook).
- New tests in `test/test_boot_config.c` (Part 3, no ROM required, so they always run in CI): `no_game_env_declared`, `no_game_boot_selects_none_strategy`, `no_game_save_ram_is_empty`, `no_game_runs_and_resets_without_crashing`.
- Manually exercised the no-content path headlessly with a scratch dlopen harness (not committed): `retro_load_game(NULL)` returns true; the boot animation actually renders (framebuffer goes from black to a fully-painted screen between frames ~38-69) and then settles into a stable spin from frame ~300 through frame 1800+ (30 seconds) with zero crash-watchdog trips; `retro_reset()` re-runs the same sequence; a full savestate serialize/unserialize round-trip succeeds.

## CD / disk-control finding (explicitly out of scope)

This core has no `RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE`/`_EXT` implementation at all. That means a frontend has no way to hand the core a disc image *after* a no-game launch, so CD boot (HLE or real CD BIOS) cannot be reached from the no-content path today. Making CD reachable from `retro_load_game(NULL)` is a separate, larger feature (disk-control interface + swap handling) and is intentionally not attempted here.

## Test plan

- [x] `make -j8`
- [x] `make TEST_EXPORTS=1 test`
- [x] `bash scripts/c89-lint.sh` on every touched file
- [x] Headless no-content boot exercised manually (see above)
- [ ] Verify in RetroArch with "Start Core" / no-content launch (not done in this sandbox -- headless verification above is thorough but real-frontend confirmation is still worth doing before release)

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)