### PR TITLE
ci(pr-issue-link): put the auto-linking job on master, where the event reads it from

### DIFF
--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -16,8 +16,27 @@ name: PR issue link
 # the issue *looks* connected while the Development panel stays empty, so
 # the issue never shows which release or pre-release tag contains the work.
 #
-# There is no public API to create that link, so it has to be done in the
-# UI -- this job's only job is to make forgetting it visible.
+# WHAT CHANGED (2026-08-26)
+#
+# This job used to only *complain*, on the stated grounds that "there is no
+# public API to create that link, so it has to be done in the UI".  That is
+# no longer true -- and the cost of it being stale was that every new PR
+# went red on creation for a step that cannot be performed until after the
+# PR exists.
+#
+# The GraphQL mutation `addCloseIssueReferences` ("Adds one or more pull
+# requests as manually linked closing references on an issue") is exactly
+# the Development-panel link, and it is idempotent.  So this job now *makes*
+# the link from a tag in the PR body instead of demanding a manual step,
+# and only fails when there is no tag to act on.
+#
+# Tag the PR body with any of (case-insensitive):
+#
+#     Closes #123 / Fixes #123 / Resolves #123 / Refs #123
+#     <!-- link-issue: #123 -->      (invisible in the rendered body)
+#
+# The keyword forms still do nothing on GitHub's side; scripts/pr-link-issue.sh
+# is what gives them effect, and that script is also runnable by hand.
 #
 # Opt out for a genuinely issue-less PR by adding the `no-issue` label.
 
@@ -27,6 +46,7 @@ on:
 
 permissions:
   contents: read
+  issues: write          # addCloseIssueReferences mutates the ISSUE
   pull-requests: read
 
 concurrency:
@@ -38,52 +58,55 @@ jobs:
     name: PR is linked to an issue
     runs-on: ubuntu-latest
     steps:
-      - name: Check the Development panel for a linked issue
+      # pull_request_target: check out the BASE ref (the default for this
+      # event), never the PR head.  The script below runs with a write token,
+      # so it must be the trusted copy from the target branch and not a
+      # version the PR itself could have edited.
+      - uses: actions/checkout@v4
+
+      - name: Link the PR to its issue, or explain what is missing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
 
-          # `no-issue` opt-out.
           if gh pr view "$PR" --repo "$REPO" --json labels \
                 --jq '.labels[].name' | grep -qx 'no-issue'; then
             echo "::notice::'no-issue' label present -- skipping the linked-issue check."
             exit 0
           fi
 
-          linked=$(gh pr view "$PR" --repo "$REPO" \
-                      --json closingIssuesReferences \
-                      --jq '.closingIssuesReferences | length')
-
-          if [ "$linked" -gt 0 ]; then
-            gh pr view "$PR" --repo "$REPO" --json closingIssuesReferences \
-              --jq '.closingIssuesReferences[] | "linked: #\(.number)"'
+          # Already linked -> reports and exits 0.  Tag in the body -> links
+          # it and exits 0.  Neither -> exits non-zero, message on stderr.
+          if out=$(./scripts/pr-link-issue.sh "$PR" --repo "$REPO" 2>&1); then
+            echo "$out"
+            echo "✅ $out" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-
-          # Not linked.  If the body mentions an issue, name it in the error --
-          # that is the number the author almost certainly meant to link.
-          body=$(gh pr view "$PR" --repo "$REPO" --json body --jq '.body // ""')
-          guess=$(printf '%s' "$body" \
-                  | grep -oiE '(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed))[[:space:]]+#[0-9]+' \
-                  | grep -oE '#[0-9]+' | head -1 || true)
+          echo "$out"
 
           {
             echo "### ❌ This PR is not linked to an issue"
             echo
-            echo "No entry in the **Development** panel."
-            if [ -n "$guess" ]; then
-              echo
-              echo "The body says it closes \`$guess\`, but **that keyword does nothing here**:"
-              echo "GitHub only creates the link when a PR targets the default branch"
-              echo "(\`master\`), and this PR targets \`develop\`."
-            fi
+            echo "No entry in the **Development** panel, and no link tag in the body"
+            echo "for CI to act on."
             echo
-            echo "**Fix it in the UI:** open the PR → **Development** (right sidebar) →"
-            echo "gear icon → pick the issue. There is no public API for this, so it"
-            echo "cannot be automated."
+            echo "**Fix it by editing the PR description** -- add one of:"
+            echo
+            echo '```'
+            echo "Closes #123        Fixes #123        Resolves #123        Refs #123"
+            echo "<!-- link-issue: #123 -->     (invisible in the rendered body)"
+            echo '```'
+            echo
+            echo "Editing the description re-runs this job, which will then create the"
+            echo "link for you. The Development panel by hand still works, and so does"
+            echo "\`scripts/pr-link-issue.sh $PR --repo $REPO\` from a terminal."
+            echo
+            echo "Note the keywords do **not** link on their own here: GitHub only honours"
+            echo "them when a PR targets the default branch (\`master\`), and this PR targets"
+            echo "\`develop\`. The tag is a marker for this job, not for GitHub."
             echo
             echo "Without the link the issue never shows which release or pre-release"
             echo "tag contains the work, which is the whole point of linking."
@@ -91,5 +114,5 @@ jobs:
             echo "Genuinely no issue? Add the \`no-issue\` label."
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "::error::PR #$PR has no linked issue. Link it in the Development panel, or add the 'no-issue' label."
+          echo "::error::PR #$PR has no linked issue and no link tag in its body. Add 'Refs #N' to the description (that re-runs this job and creates the link), or add the 'no-issue' label."
           exit 1

--- a/scripts/pr-link-issue.sh
+++ b/scripts/pr-link-issue.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Link a pull request to an issue in the GitHub **Development** panel.
+#
+#   scripts/pr-link-issue.sh <pr-number> [issue-number] [--repo owner/name]
+#
+# With no issue number, the PR body is scanned for a link tag (see below) and
+# that issue is used.
+#
+# WHY THIS SCRIPT EXISTS
+#
+# Every PR here must be linked to an issue, and `Closes #N` does not do it:
+# GitHub only creates the relationship from a closing keyword when the PR
+# targets the repository's DEFAULT branch.  This repo's default is `master`
+# and virtually every PR targets `develop`, so keywords create no link at all.
+#
+# That used to mean the link could only be made by hand in the web UI, which
+# is what .github/workflows/pr-issue-link.yml said.  That is no longer true:
+# the GraphQL mutation `addCloseIssueReferences` -- "Adds one or more pull
+# requests as manually linked closing references on an issue" -- is exactly
+# the Development-panel link, and it is idempotent, so re-running is safe.
+#
+# LINK TAGS accepted in the PR body (case-insensitive):
+#
+#   Closes #123 / Fixes #123 / Resolves #123 / Refs #123
+#   <!-- link-issue: #123 -->      (invisible in the rendered body)
+#
+# The keyword forms still do nothing on GitHub's side here; this script is
+# what gives them effect.
+set -euo pipefail
+
+# Guard the file-mutating and network helpers against interactive shell
+# aliases (`rm -i` and friends block forever with no TTY).
+die() { printf 'pr-link-issue: %s\n' "$*" >&2; exit 1; }
+
+PR=""; ISSUE=""; REPO=""
+while [ $# -gt 0 ]; do
+   case "$1" in
+      --repo) REPO=${2:-}; shift 2 ;;
+      -h|--help) sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+      *) if [ -z "$PR" ]; then PR=$1; elif [ -z "$ISSUE" ]; then ISSUE=$1;
+         else die "unexpected argument '$1'"; fi; shift ;;
+   esac
+done
+
+[ -n "$PR" ] || die "usage: pr-link-issue.sh <pr-number> [issue-number] [--repo owner/name]"
+case "$PR" in ''|*[!0-9]*) die "PR must be a number, got '$PR'" ;; esac
+
+if [ -z "$REPO" ]; then
+   REPO=$(command gh repo view --json nameWithOwner --jq .nameWithOwner) \
+      || die "not in a GitHub repo and --repo not given"
+fi
+OWNER=${REPO%%/*}; NAME=${REPO#*/}
+
+# Already linked?  Nothing to do -- report it and stop, so this is safe to
+# run unconditionally from CI or a hook.
+existing=$(command gh pr view "$PR" --repo "$REPO" \
+              --json closingIssuesReferences \
+              --jq '[.closingIssuesReferences[].number] | join(",")')
+if [ -n "$existing" ]; then
+   echo "PR #$PR is already linked to: #${existing//,/, #}"
+   exit 0
+fi
+
+# Strip fenced code blocks and inline code spans before scanning.  A PR that
+# *documents* this feature quotes the tag syntax, and an unstripped scan
+# happily links the example: PR #644 explained the tags with `#123` in a
+# fenced block and got linked to issue #123 instead of the #643 tag at the
+# bottom of the same body.  Anything inside code is a sample, not an
+# instruction.
+strip_code() {
+   awk '
+      /^[[:space:]]*```/ { fence = !fence; next }
+      fence { next }
+      { gsub(/`[^`]*`/, ""); print }
+   '
+}
+
+# No issue given: scan the body for a link tag.  Hidden HTML-comment form
+# wins over the keyword forms, so a PR can point at one issue in prose and
+# link a different one deliberately.
+if [ -z "$ISSUE" ]; then
+   body=$(command gh pr view "$PR" --repo "$REPO" --json body --jq '.body // ""' \
+          | strip_code)
+   ISSUE=$(printf '%s' "$body" \
+           | grep -oiE '<!--[[:space:]]*link-issue:[[:space:]]*#?[0-9]+[[:space:]]*-->' \
+           | grep -oE '[0-9]+' | head -1 || true)
+   if [ -z "$ISSUE" ]; then
+      ISSUE=$(printf '%s' "$body" \
+              | grep -oiE '(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed)|refs?)[[:space:]]+#[0-9]+' \
+              | grep -oE '[0-9]+' | head -1 || true)
+   fi
+   [ -n "$ISSUE" ] || die "PR #$PR body has no link tag (Closes/Fixes/Resolves/Refs #N, or <!-- link-issue: #N -->) and no issue number was given"
+fi
+case "$ISSUE" in ''|*[!0-9]*) die "issue must be a number, got '$ISSUE'" ;; esac
+
+# The mutation refuses a PR as its target, but the error is opaque; check
+# here so the message is useful.
+kind=$(command gh api "repos/$REPO/issues/$ISSUE" \
+          --jq 'if .pull_request then "pr" else "issue" end' 2>/dev/null) \
+   || die "#$ISSUE does not exist in $REPO"
+[ "$kind" = issue ] || die "#$ISSUE is a pull request, not an issue"
+
+ids=$(command gh api graphql \
+   -f query='query($o:String!,$n:String!,$p:Int!,$i:Int!){
+      repository(owner:$o,name:$n){
+        pullRequest(number:$p){ id }
+        issue(number:$i){ id }
+      }}' \
+   -f o="$OWNER" -f n="$NAME" -F p="$PR" -F i="$ISSUE" \
+   --jq '"\(.data.repository.pullRequest.id) \(.data.repository.issue.id)"')
+pr_id=${ids%% *}; issue_id=${ids##* }
+
+command gh api graphql \
+   -f query='mutation($i:ID!,$p:[ID!]!){
+      addCloseIssueReferences(input:{issueId:$i, pullRequestIds:$p}){
+        clientMutationId
+      }}' \
+   -f i="$issue_id" -f p="$pr_id" >/dev/null
+
+# Verify rather than trust the mutation's empty success payload.
+now=$(command gh pr view "$PR" --repo "$REPO" \
+         --json closingIssuesReferences \
+         --jq '[.closingIssuesReferences[].number] | join(",")')
+[ -n "$now" ] || die "mutation reported success but PR #$PR still has no linked issue"
+echo "PR #$PR -> linked to #${now//,/, #}"


### PR DESCRIPTION
#644 landed the auto-linking job on `develop` and it had **no effect**. The very next PR (#654)
still failed the check — and its [job log](https://github.com/libretro/virtualjaguar-libretro/actions/runs/33036782247/job/98401062960)
shows the *old* script running, still printing "There is no public API for this, so it cannot be
automated."

## Why

`pull_request_target` reads its workflow definition from the repository's **default branch**, not
from the PR's base branch. Default here is `master`, and master is **45 commits behind develop** —
so the job that actually runs on every PR is master's copy. Merging a `pull_request_target`
workflow to `develop` changes nothing at all.

This is the same trap the job exists to work around — default branch is `master` while all work
targets `develop` — one level up, in the CI configuration instead of in issue linking.

## Change

Exactly two files cherry-picked onto master, nothing else:

```
.github/workflows/pr-issue-link.yml
scripts/pr-link-issue.sh
```

Both are already merged on `develop` (#644), so this does not introduce anything unreviewed — it
puts the reviewed thing where the event can see it.

## Audit of the other `pull_request_target` workflows

Same failure mode applies to all of them, so I checked:

| workflow | master vs develop |
|---|---|
| `close-referenced-issues.yml` | in sync |
| `labeler.yml` | in sync |
| `warn-pr-base.yml` | in sync |
| **`pr-issue-link.yml`** | **differs — runs the stale copy** |

Only this one was stale.

## Base branch

Targets `master` deliberately, as `hotfix/*` per the GitFlow rule in `CLAUDE.md`. A
`pull_request_target` workflow cannot take effect on any other branch, so there is no
develop-first path for this one.

## After this merges

The next PR opened with a link tag in its body should link itself and go green with no manual step
— which is what #643 asked for and what #644 could not deliver on its own.

<!-- link-issue: #643 -->
