### PR TITLE
fix(op): clamp the object window to the visible window, not VBB (fixes #641 regression)

### DIFF
--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -1552,22 +1552,28 @@ void TOMExecHalfline(uint16_t halfline, bool render)
        * Super Burnout (#632) is the case that exposed this.  It sets
        * VDB=25, VDE=$7FF, VP=523, VBB=500, VI=521, and rebuilds the
        * display list in its vertical-interrupt handler.  The OP then ran
-       * once more at halfline 522 -- 22 halflines into blanking, one
-       * halfline after VI -- consuming line 0 of the freshly written HUD
-       * object.  The visible result was the top scanline missing from the
-       * whole first HUD text row, so LAP rendered as LHP and POSITION as
-       * POSTTTON, identically on both blitters because the blitter was
-       * never involved.
+       * once more at halfline 522 -- one halfline after VI -- consuming
+       * line 0 of the freshly written HUD object.  The visible result was
+       * the top scanline missing from the whole first HUD text row, so LAP
+       * rendered as LHP and POSITION as POSTTTON, identically on both
+       * blitters because the blitter was never involved.
        *
-       * Clamping to VBB is the narrow reading: blanking begins there, so
-       * that is where the object list stops being displayed.  It applies
-       * only on this branch -- a title with a real in-range VDE keeps
-       * exactly the window it asked for, including one that deliberately
-       * extends past VBB. */
+       * Clamp to the VISIBLE window, which is where the line-copy loop
+       * below stops reading: a pass at or past bottomVisible produces a
+       * line buffer nobody ever copies out, so declining to run it cannot
+       * change the picture, while running it can corrupt the next field.
+       *
+       * Not VBB.  Clamping to VBB was the first attempt and it was wrong:
+       * blanking begins before the display window ends on this hardware
+       * (NTSC VBB=500 against a visible window running to 511), so it cut
+       * the bottom three scanlines off every title using the VDE=$FFFF
+       * idiom -- about a third of the private corpus, including Hover
+       * Strike, JSSDemo and JagFest Demo.  "Only Super Burnout does this"
+       * was measured on five ROMs and did not survive 160. */
       {
-         uint16_t vbb = GET16(tomRam8, VBB);
-         if (vbb > 0 && vbb < endingHalfline)
-            endingHalfline = vbb;
+         uint16_t visible_end = TOMGetBottomVisible();
+         if (visible_end > 0 && visible_end < endingHalfline)
+            endingHalfline = visible_end;
       }
    }
 


### PR DESCRIPTION
**#641 introduced a regression on roughly a third of the corpus. This fixes it and keeps #632 fixed.**

## What went wrong

#641 clamped `endingHalfline` to `VBB` when `VDE` is past the end of the field. On NTSC, blanking
begins at **VBB=500** while the visible window runs to **511** — so the clamp stopped object
processing five halflines (about three scanlines) *before the display actually ends*.

Measured against the pre-#641 core across the private corpus at 300 frames: about a third diverged.
Every divergence I sampled had the same signature — the last rows of the frame, and fewer non-black
pixels:

| title | differing rows | non-black, base → #641 |
|---|---|---:|
| Hover Strike (652×480, 2x) | **474–479** | 57196 → 56286 |
| JagFest Demo (326×240) | **237–239** | 19082 → 18842 |
| JSSDemo (326×240) | **237–239** | 7209 → 6973 |

The bottom three scanlines stopped being drawn.

## The fix

Clamp to `TOMGetBottomVisible()` instead — the same value the line-copy loop further down that
function uses to decide when to stop reading.

That makes it correct by construction rather than by measurement: a pass at or past
`bottomVisible` fills a line buffer nobody ever copies out, so declining to run it **cannot** change
the picture, while running it *can* corrupt the next field. There is no gap to tune.

Super Burnout's `VDE=$7FF` resolves to the NTSC fallback of 511 — still well below the halfline-522
pass that was eating its HUD object's first line, so #632 stays fixed.

## Verification

| check | result |
|---|---|
| Super Burnout HUD | all seven rows — `LAP`, not `LHP` |
| Hover Strike | byte-identical to pre-#641 |
| JagFest Demo | byte-identical to pre-#641 |
| JSSDemo | byte-identical to pre-#641 |
| Iron Soldier | byte-identical to pre-#641 |

## What I got wrong in #641, and why

#641 states "Super Burnout is the only title in the corpus that sets `VDE` past the end of the
field." That was measured on **five ROMs**, and it did not survive 160. `docs/jtrm-register-map.md`
calls `VDE=$FFFF` *standard practice* — it is common, not rare. I had the sentence that contradicted
me in the tree already and read it as background instead of as a population estimate.

The corpus sweep that would have caught this before merge was running the whole time and produced
nothing: it wedged on `Chroma-Luma Color Pick (PD).jag`, which hangs `frame_hash_ab` indefinitely,
and sat there for 2h23m with no timeout. I should have treated "still running" as a result worth
checking rather than as progress. The sweep now runs every case under `timeout` and prints progress
— worth folding into a reusable script separately, along with an issue for the ROM that hangs the
core.

<!-- link-issue: #632 -->
