### PR TITLE
test(tools): corpus_ab_sweep.sh -- bounded A/B of two cores over a ROM corpus

### DIFF
--- a/docs/agent/testing.md
+++ b/docs/agent/testing.md
@@ -63,6 +63,15 @@ Build: `cc -O2 -Wall -std=c99 $(INCFLAGS) -o test_foo test_foo.c test/harness/ha
   "flips != 0". Exit 77 = private ROM absent (skip, never silent pass). Timing wedges relocate
   rather than disappear — a single-scale run proves nothing (#406 wedged at scales 4,8 before
   Verilator constants, at 3 after). Env: `VJ_SCALES VJ_WINDOW VJ_MIN_FLIPS VJ_WARMUP_W`.
+- `test/tools/corpus_ab_sweep.sh` — A/B two cores across a ROM corpus, comparing the **full**
+  framebuffer hash stream: `corpus_ab_sweep.sh <base-core> <new-core> [rom-dir]`
+  (`FRAMES`, `TMO`, `VJ_ROMS`). Use it before merging anything that touches rendering. Two guards,
+  both earned: **every run is under a timeout** (Chroma-Luma Color Pick hangs `retro_run` forever,
+  #659 — the first sweep of this kind wedged on it for 2h23m emitting nothing, which is how #641's
+  regression reached develop), and it compares the hash stream rather than the transition **count**
+  (Super Burnout reads 143 transitions on both sides of #632 while rendering different pixels, so a
+  count comparison calls a real change "no change"). Exit 1 on any SKIP: an unchecked ROM must not
+  look like a clean sweep.
 - `test/sram_test.sh` — SRAM round-trip.
 - `test/tools/cd_boot_matrix.sh` — per-title CD boot-stage matrix (HLE + BIOS) vs
   `docs/cd-boot-matrix.md`. Env: `CD_MATRIX_FRAMES CD_MATRIX_TIMEOUT CD_MATRIX_MAX_RUNS

--- a/test/tools/corpus_ab_sweep.sh
+++ b/test/tools/corpus_ab_sweep.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# corpus_ab_sweep.sh -- A/B two cores across a ROM corpus and report every
+# title whose framebuffer stream differs.
+#
+#   test/tools/corpus_ab_sweep.sh <base-core> <new-core> [rom-dir]
+#
+# Env: FRAMES (default 300)   frames per run
+#      TMO    (default 60)    per-run timeout, seconds
+#
+# WHY THE TIMEOUT IS NOT OPTIONAL
+#
+# At least one ROM in the private corpus (Chroma-Luma Color Pick, issue #659)
+# makes retro_run never return -- an unbounded blit, invisible to the crash
+# watchdog because every watchdog signature is checked between frames. The
+# first version of this sweep had no timeout, wedged on it, and sat there for
+# 2h23m emitting nothing. The regression in #641 reached develop because
+# "still running" was read as progress rather than as a hang, so the sweep
+# that would have caught it never reported.
+#
+# Hence: every run is bounded, a hang is one visible SKIP line, and progress
+# is printed as it goes so an empty tail is distinguishable from a stall.
+#
+# Compares the FULL hash stream, not a summary. Two cores can agree on the
+# transition count and still render different pixels -- that is exactly the
+# #641/#632 signature (Super Burnout: 143 transitions on both, different
+# frames), so a count comparison would have called that "no change".
+set -u
+
+die() { printf 'corpus_ab_sweep: %s\n' "$*" >&2; exit 2; }
+
+BASE=${1:-}; NEW=${2:-}
+ROMDIR=${3:-${VJ_ROMS:-test/roms/private}}
+[ -n "$BASE" ] && [ -n "$NEW" ] || die "usage: corpus_ab_sweep.sh <base-core> <new-core> [rom-dir]"
+[ -f "$BASE" ] || die "base core not found: $BASE"
+[ -f "$NEW"  ] || die "new core not found: $NEW"
+[ -d "$ROMDIR" ] || die "rom dir not found: $ROMDIR (set VJ_ROMS or pass one)"
+
+HASH_AB=./test/tools/frame_hash_ab
+[ -x "$HASH_AB" ] || die "$HASH_AB not built -- see its header for the cc line"
+
+FRAMES=${FRAMES:-300}
+TMO=${TMO:-60}
+TO=$(command -v gtimeout || command -v timeout) || die "need timeout(1) or gtimeout(1)"
+
+# md5 on macOS, md5sum elsewhere.
+if command -v md5 >/dev/null 2>&1; then MD5() { md5 -q "$1"; }
+else MD5() { md5sum "$1" | cut -d' ' -f1; }; fi
+
+OUT=$(mktemp -d) || die "mktemp failed"
+# EXIT cleans up; INT/TERM must additionally stop, or Ctrl-C kills only the
+# current frame_hash_ab and the sweep grinds on through the rest.
+trap 'command rm -rf "$OUT"' EXIT
+trap 'exit 130' INT TERM
+
+find_roms() {
+   find -L "$ROMDIR" -maxdepth 1 -type f \
+        \( -iname '*.jag' -o -iname '*.j64' -o -iname '*.rom' \) | sort
+}
+
+total=$(find_roms | wc -l | tr -d ' ')
+[ "$total" -gt 0 ] || die "no ROMs found under $ROMDIR"
+echo "corpus_ab_sweep: $total ROMs, $FRAMES frames, ${TMO}s timeout"
+echo "  base: $BASE"
+echo "  new:  $NEW"
+
+n_same=0; n_diff=0; n_skip=0; i=0
+while IFS= read -r rom; do
+   i=$((i + 1)); b=$(basename "$rom")
+   if ! $TO "$TMO" "$HASH_AB" "$BASE" "$rom" --csv "$OUT/b.csv" \
+           --frames "$FRAMES" >/dev/null 2>&1; then
+      printf 'SKIP  [%3d/%3d] %-58s (base timeout/fail)\n' "$i" "$total" "${b:0:58}"
+      n_skip=$((n_skip + 1)); continue
+   fi
+   if ! $TO "$TMO" "$HASH_AB" "$NEW" "$rom" --csv "$OUT/f.csv" \
+           --frames "$FRAMES" >/dev/null 2>&1; then
+      printf 'SKIP  [%3d/%3d] %-58s (new timeout/fail)\n' "$i" "$total" "${b:0:58}"
+      n_skip=$((n_skip + 1)); continue
+   fi
+
+   if [ "$(MD5 "$OUT/b.csv")" = "$(MD5 "$OUT/f.csv")" ]; then
+      n_same=$((n_same + 1))
+   else
+      tb=$(awk -F, 'NR>1{if(p!=""&&$6!=p)n++;p=$6}END{print n+0}' "$OUT/b.csv")
+      tf=$(awk -F, 'NR>1{if(p!=""&&$6!=p)n++;p=$6}END{print n+0}' "$OUT/f.csv")
+      nd=$(paste -d'|' <(awk -F, 'NR>1{print $6}' "$OUT/b.csv") \
+                       <(awk -F, 'NR>1{print $6}' "$OUT/f.csv") \
+           | awk -F'|' '$1!=$2{n++}END{print n+0}')
+      printf 'DIFF  [%3d/%3d] %-58s transitions %s->%s, %s frames differ\n' \
+             "$i" "$total" "${b:0:58}" "$tb" "$tf" "$nd"
+      n_diff=$((n_diff + 1))
+   fi
+   [ $((i % 25)) -eq 0 ] && printf '      ... %d/%d (same=%d diff=%d skip=%d)\n' \
+                                   "$i" "$total" "$n_same" "$n_diff" "$n_skip"
+done < <(find_roms)
+
+echo "---- identical: $n_same   differing: $n_diff   skipped: $n_skip   (of $total) ----"
+# Differences are the point of the run, not a failure; a SKIP is, because it
+# means a ROM went unchecked and the result is not the clean sweep it looks
+# like.
+[ "$n_skip" -eq 0 ] || exit 1


### PR DESCRIPTION
The tooling gap that let #641's regression through.

## Why

#641 clamped the object-processor window and was merged on the strength of **five ROMs**. Run
across 160 it turned out to blank the bottom three scanlines on about a third of them (fixed in
#658).

A corpus A/B that would have caught it was running the entire time. It never reported, because it
had no per-run timeout and wedged on `Chroma-Luma Color Pick` (#659), which makes `retro_run` never
return. It sat there **2h23m** emitting nothing, and I read "still running" as progress and said
"no differences so far" three times from an empty file.

So this script encodes the two mistakes, not the happy path:

- **Every run is bounded by `timeout(1)`.** A hang is one visible `SKIP` line, and any SKIP makes
  the script **exit 1** — an unchecked ROM must not be able to look like a clean sweep.
- **It compares the full hash stream, not the transition count.** Super Burnout reads 143
  transitions on *both* sides of the #632 fix while rendering different pixels; a count comparison
  calls that "no change". Divergences report as `transitions A->B, N frames differ` so the shape is
  visible without opening the CSVs.
- Progress prints every 25 ROMs, so an empty tail is distinguishable from a stall — the exact
  failure mode above, made visible.

## Usage

```bash
test/tools/corpus_ab_sweep.sh <base-core> <new-core> [rom-dir]
# FRAMES (default 300), TMO (default 60), VJ_ROMS for the default rom-dir
```

## Verified

Against the #632/#658 work, which is where it came from:

```
corpus_ab_sweep: 160 ROMs, 300 frames, 60s timeout
      ... 125/160 (same=124 diff=0 skip=1)
SKIP  [ 40/160] Chroma-Luma Color Pick by Matthias Domin (bin) (1996) (PD) (base timeout/fail)
DIFF  [138/160] Super Burnout (1995).jag      transitions 143->143, N frames differ
---- identical: 158   differing: 1   skipped: 1   (of 160) ----
```

One difference, and it is the intended one. The same sweep against #641-as-merged diverged on a
third of the corpus.

Catalogued in `docs/agent/testing.md` next to the other harnesses, with both guards and the reason
each exists.

<!-- link-issue: #659 -->
