### PR TITLE
fix(spm): exclude tools/ so a fetched Jaguar toolchain doesn't break the manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -142,9 +142,18 @@ let package = Package(
             name: "virtualjaguar",
             dependencies: ["virtualjaguar-libretro-common", "virtualjaguar-libchdr"],
             path: ".",
-            // Directories owned by the other two targets. SPM rejects
-            // overlapping target paths without this.
-            exclude: ["libretro-common", "deps"],
+            // libretro-common and deps are owned by the other two targets;
+            // SPM rejects overlapping target paths without excluding them.
+            //
+            // tools/ is here for a different reason: SPM scans the whole target
+            // path for RESOURCES independently of the `sources` list above, and
+            // tools/vendor/jaguar-toolchain (fetched by tools/jaguar-toolchain/
+            // setup.sh, gitignored) ships a macOS helper .app carrying an
+            // English.lproj.  SPM reads that as a localized resource and fails
+            // the manifest with "defaultLocalization not set" -- so `swift
+            // build` breaks for anyone who has fetched the Jaguar toolchain,
+            // and only for them.
+            exclude: ["libretro-common", "deps", "tools"],
             sources: coreSources,
             publicHeadersPath: "src/core",
             cSettings: coreDefines + [


### PR DESCRIPTION
Refs #614

## The bug

`swift build --target virtualjaguar` fails outright:

```
error: 'virtualjaguar-libretro': manifest property 'defaultLocalization' not set;
it is required in the presence of localized resources
```

**But only on machines that have run `tools/jaguar-toolchain/setup.sh`.** That fetch lands a macOS helper `.app` carrying an `English.lproj`:

```
tools/vendor/jaguar-toolchain/new_bjl/macos_helper/launcher.app/Contents/Resources/English.lproj/InfoPlist.strings
```

SPM reads that `.lproj` as a localized resource and hard-errors the manifest before a single file compiles. Nothing downstream can consume the package on such a machine.

## Why the existing comment was wrong

The comment this replaces claimed:

> The explicit `sources` list means SPM compiles only what is named, so the rest of the repo (docs, tests, scripts) is ignored.

That is true for **compilation** and false for **resources**. SPM walks the entire target `path` looking for resources *independently of* the `sources:` array, and `exclude:` is the only thing that stops it. With `path: "."` that scan covers the whole repository, so any `.lproj` outside the exclude list breaks the build.

## Why `exclude`, not `defaultLocalization: "en"`

`defaultLocalization` is the fix the SPM docs reach for, and it does silence the error — but it silences it by making SPM **accept** the toolchain's `InfoPlist.strings` as a resource of the core C library, producing a resource bundle the core has no business carrying. Excluding the directory makes SPM ignore it, which is what we actually want.

I verified the resource scan does respect `exclude` before choosing, rather than assuming it — so `defaultLocalization` here would be not merely redundant but worse. The two are not stacked.

Scope kept to the one demonstrated offender. A defensive sweep of `docs/`, `site/`, `test/` etc. would add entries with no demonstrated cause and would not close the class anyway: a `.lproj` under `src/` would still break it, and `src/` cannot be excluded.

## Verification

macOS, Xcode toolchain, `DEVELOPER_DIR` unset. Each run used a fresh `--cache-path`/`--scratch-path`, so none of these came from a cached package graph — the first clean run I did passed, and it took recreating the path to prove causation rather than infer it.

| State | Result |
|---|---|
| offending path present, before fix | the `defaultLocalization` error |
| offending path present, after fix | `Build of target: 'virtualjaguar' complete!` |
| offending path absent, after fix | `Build of target: 'virtualjaguar' complete!` |
| `scripts/check-package-sources.sh` | `OK -- 66 core + 13 libretro-common sources agree` |

The test fixture was removed afterwards; `tools/vendor` does not exist in the tree.

## CI cannot catch this class

Worth stating plainly rather than assuming a green check means covered: `/tools/vendor/` is gitignored, and the `spm-consumer` job resolves this package by version from a clean tree. The directory that triggers the failure never exists in CI. This surfaces only locally, and only for developers who have fetched the assembler toolchain — which is why it sat in a shipped manifest.

Linked to #614 as another manifest defect in that track rather than filed as its own issue; happy to split it out if you'd rather keep the one-issue-per-fix pattern of #612 / #615 / #617 / #619 / #621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)