### PR TITLE
feat(debug): GDB remote stub Phase 1 — protocol engine, 68K target, loopback transport

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -592,7 +592,7 @@ jobs:
       shell: cmd
       run: |
         cl.exe /c /W3 /O2 /DNDEBUG /D_CRT_SECURE_NO_DEPRECATE ^
-          /I. /Isrc /Isrc\core /Isrc\tom /Isrc\jerry /Isrc\cd /Isrc\bios /Isrc\m68000 /Ilibretro-common\include ^
+          /I. /Isrc /Isrc\core /Isrc\tom /Isrc\jerry /Isrc\cd /Isrc\bios /Isrc\m68000 /Isrc\debug /Ilibretro-common\include ^
           /Ideps\libchdr\include /Ideps\libchdr\deps\lzma-25.01\include /Ideps\libchdr\deps\miniz-3.1.1 /Ideps\libchdr\deps\zstd-1.5.7 ^
           /D__LIBRETRO__ /DINLINE="_inline" /DBLITTER_SIMD_SCALAR ^
           /D_7ZIP_ST /DMINIZ_DEFLATE_APIS /DWANT_RAW_DATA_SECTOR=1 /DWANT_SUBCODE=1 /DVERIFY_BLOCK_CRC=1 ^
@@ -607,6 +607,7 @@ jobs:
           src\bios\jagbios_m.c ^
           src\bios\jagcdbios.c src\bios\jagdevcdbios.c ^
           src\m68000\m68kinterface.c ^
+          src\debug\gdbstub.c src\debug\gdbtarget.c src\debug\gdbsock.c ^
           src\tom\blitter_simd_scalar.c ^
           deps\libchdr\unity.c
 

--- a/Makefile
+++ b/Makefile
@@ -1292,7 +1292,7 @@ test: export VJ_EXPECT_BUILD := $(shell ./scripts/build-id.sh)
 # invocations get different values.
 test: EEPROM_GEN_TOOL := /tmp/vj_gen_eeprom_test_rom_$(shell echo $$PPID)
 test: EEPROM_FIXTURE := /tmp/vj_eeprom_lifecycle_$(shell echo $$PPID).j64
-test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_discover test/test_voicechat test/test_jlink_netpacket test/test_voicemodem_netpacket test/test_voice_netpacket test/test_uart_loopback test/test_jlink_negotiate test/test_blitter_simd test/test_dsp_mac40 test/test_titledb test/test_titlehook test/test_biosdb \
+test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlink test/test_jlink_tcp test/test_jlink_discover test/test_voicechat test/test_jlink_netpacket test/test_voicemodem_netpacket test/test_voice_netpacket test/test_uart_loopback test/test_jlink_negotiate test/test_blitter_simd test/test_dsp_mac40 test/test_titledb test/test_titlehook test/test_biosdb test/tools/test_gdbstub_proto \
 		$(TARGET) test/test_m68k_ops test/test_m68k_irq_ssp test/test_gpu_ops test/test_dsp_ops \
 		test/test_dsp_unit test/test_hle_bios test/test_subsystem_init \
 		test/test_subsystem_timeline test/test_irq_cascade test/test_boot_patterns \
@@ -1456,6 +1456,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	./test/test_biosdb
 	./test/test_cart_bios_loader
 	./test/test_titlehook
+	./test/tools/test_gdbstub_proto
 	./test/test_m68k_ops
 	./test/test_m68k_irq_ssp
 	./test/test_gpu_ops
@@ -1975,6 +1976,13 @@ test/test_titlehook: test/tools/test_titlehook.c src/core/titlehook.c \
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_titlehook.c src/core/titlehook.c \
 		src/core/titledb.c src/core/crc32.c
+
+# GDB Remote Serial Protocol engine (issue #652, Phase 1).  Pure protocol
+# unit tests: no emulator, no sockets. src/debug/gdbstub.c never calls
+# socket() and never dereferences a Jaguar global, so it links alone here.
+test/tools/test_gdbstub_proto: test/tools/test_gdbstub_proto.c src/debug/gdbstub.c
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/test_gdbstub_proto.c src/debug/gdbstub.c
 
 test/test_event_queue: test/test_event_queue.c src/core/event.c src/core/event.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile.common
+++ b/Makefile.common
@@ -105,7 +105,9 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/core/vjag_memory.c \
 	$(CORE_DIR)/src/core/vjtrace.c \
 	$(CORE_DIR)/src/core/universalhdr.c \
-	$(CORE_DIR)/src/jerry/wavetable.c
+	$(CORE_DIR)/src/jerry/wavetable.c \
+	$(CORE_DIR)/src/debug/gdbstub.c \
+	$(CORE_DIR)/src/debug/gdbtarget.c
 
 # SIMD-accelerated blitter operations: select arch-specific implementation.
 # BLITTER_SIMD may be set explicitly to one of: scalar, sse2, neon.

--- a/Makefile.common
+++ b/Makefile.common
@@ -107,7 +107,8 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/core/universalhdr.c \
 	$(CORE_DIR)/src/jerry/wavetable.c \
 	$(CORE_DIR)/src/debug/gdbstub.c \
-	$(CORE_DIR)/src/debug/gdbtarget.c
+	$(CORE_DIR)/src/debug/gdbtarget.c \
+	$(CORE_DIR)/src/debug/gdbsock.c
 
 # SIMD-accelerated blitter operations: select arch-specific implementation.
 # BLITTER_SIMD may be set explicitly to one of: scalar, sse2, neon.

--- a/Makefile.common
+++ b/Makefile.common
@@ -10,6 +10,7 @@ INCFLAGS := -I$(CORE_DIR) \
 				-I$(CORE_DIR)/src/cd \
 				-I$(CORE_DIR)/src/bios \
 				-I$(CORE_DIR)/src/m68000 \
+				-I$(CORE_DIR)/src/debug \
 				-I$(LIBRETRO_COMM_DIR)/include \
 				-I$(LIBCHDR_DIR)/include \
 				-I$(LIBCHDR_DIR)/deps/lzma-25.01/include \

--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,9 @@ let coreSources: [String] = [
     "src/core/universalhdr.c",
     "src/core/vjag_memory.c",
     "src/core/vjtrace.c",
+    "src/debug/gdbsock.c",
+    "src/debug/gdbstub.c",
+    "src/debug/gdbtarget.c",
     "src/jerry/axistune.c",
     "src/jerry/dac.c",
     "src/jerry/dsp.c",
@@ -165,6 +168,7 @@ let package = Package(
                 .headerSearchPath("src/cd"),
                 .headerSearchPath("src/bios"),
                 .headerSearchPath("src/m68000"),
+                .headerSearchPath("src/debug"),
                 .headerSearchPath("libretro-common/include"),
                 // src/cd/cdintf.c includes <libchdr/chd.h> unconditionally.
                 .headerSearchPath("deps/libchdr/include"),

--- a/docs/gdb-stub-design.md
+++ b/docs/gdb-stub-design.md
@@ -315,6 +315,16 @@ Five layers, in increasing cost:
    reason, register read, memory read, and bounds refusal; breakpoint/continue
    coverage waits for Phase 2, where breakpoints exist to test.
 
+   **This is not merely a stand-in for gdb being unavailable.** Phase 1's
+   `GDBHandlePacket` never sends the low-level `+`/`-` acknowledgement byte a
+   real GDB client requires for every packet before `QStartNoAckMode` is
+   negotiated (and that negotiation itself needs one such ack to complete).
+   `gdb_attach_probe.py` passes without noticing this because it never checks
+   for an ack. A real `m68k-elf-gdb`, brought by the user per Open Question 1,
+   would stall on its very first `qSupported`. Implementing the ack byte is
+   Phase 2 work, tracked alongside breakpoints -- until then, the scripted
+   probe is the only client Phase 1 actually supports end to end.
+
 ## Out of scope
 
 - **Tracepoints** (`QTDP` and the rest of GDB's tracepoint machinery).

--- a/docs/gdb-stub-design.md
+++ b/docs/gdb-stub-design.md
@@ -103,8 +103,12 @@ GDB threads map to processors:
 stop replies (`T05thread:N;`) name the thread that halted.
 
 Thread 1 is served with no target description at all, so GDB applies its own
-`m68k` architecture: full disassembly, source-level debugging with DWARF from
-`rln`, and backtraces come free.
+`m68k` architecture: full disassembly and backtraces come free. **Source-
+level debugging with DWARF does not** — see Open Question 2, answered during
+Phase 1 implementation: `rln` emits classic mc68k COFF, not ELF/DWARF, and its
+one debug-info flag (`-g`) produced byte-identical output to a build without
+it on a real test case. The honest claim is symbol-level (global symbol
+addresses via `rln -m`'s load map), not source-level.
 
 Threads 2 and 3 are served a custom description via `qXfer:features:read`,
 defining an `org.atari.jaguar.risc` feature with the 32 general registers and
@@ -304,7 +308,12 @@ Five layers, in increasing cost:
 5. **End-to-end against real GDB.** Drive `m68k-elf-gdb` (from the toolchain in
    #581, if it ships gdb — otherwise a scripted RSP client) against a test ROM:
    attach, set a breakpoint at a known symbol, continue, assert the stop reply
-   and PC, read a register, write memory, continue to exit.
+   and PC, read a register, write memory, continue to exit. **Answered during
+   Phase 1 implementation: it does not ship gdb** (see Open Question 1) — this
+   layer runs as `test/tools/gdb_attach_probe.py`, a scripted RSP client, for
+   as long as that remains true. It exercises attach, `qSupported`, halt
+   reason, register read, memory read, and bounds refusal; breakpoint/continue
+   coverage waits for Phase 2, where breakpoints exist to test.
 
 ## Out of scope
 
@@ -320,14 +329,43 @@ Five layers, in increasing cost:
 
 ## Open questions
 
-1. **Does the #581 toolchain include `m68k-elf-gdb`?** If not, test layer 5
-   needs a scripted RSP client instead, and the user-facing documentation needs
-   to tell people where to get a GDB that speaks m68k.
-2. **What DWARF, if any, does `rln` emit?** Source-level debugging of the 68K
-   is the headline benefit; if `rln` emits no usable debug info, the honest
-   claim is symbol-level, not source-level, and the docs must say so.
+1. **Does the #581 toolchain include `m68k-elf-gdb`?** **Answered 2026-08-26,
+   Phase 1 implementation: no.** `tools/jaguar-toolchain/PIN` pins exactly
+   five tools — `rmac`, `rln`, `lyxass`, `pc_jagcrypt`, `new_bjl` — and
+   `make jaguar-toolchain-build` was actually run to confirm: the built tree
+   (`tools/vendor/jaguar-toolchain/`) contains no `gdb` binary anywhere, and
+   none of the five tools is a debugger. There is no supported source of a
+   Jaguar-flavoured GDB in this repo's toolchain. Consequence: test layer 5 is
+   permanently a scripted RSP client (`test/tools/gdb_attach_probe.py`) rather
+   than a stopgap until gdb shows up, and the user-facing docs must tell
+   developers to bring their own `m68k-elf-gdb` (a stock `--target=m68k-elf`
+   GNU binutils/gdb build, e.g. from the m68k bare-metal toolchains
+   distributed for classic Mac/Amiga/Atari ST development, works against a
+   plain `m68k` architecture with no custom target description) rather than
+   implying this repo provides one.
+2. **What DWARF, if any, does `rln` emit?** **Answered 2026-08-26, Phase 1
+   implementation: none.** Verified by building the toolchain and actually
+   linking a test object: `rln -e` output identifies as `mc68k COFF object
+   not stripped` (`file`(1)) — a pre-ELF Atari-era object format, not ELF —
+   so `readelf -S` does not apply at all, and `objdump -h` (Xcode's
+   `llvm-objdump`) fails outright with "not recognized as a valid object
+   file" against it: no toolchain on this host can parse it as DWARF-bearing.
+   `rln`'s own `-g` flag ("output source-level debugging") produced a file
+   byte-for-byte identical (SHA-256) to the same link without `-g`, and
+   neither contains any string referencing the source filename or a
+   `.debug_*`-style section name. What Jaguar-era linking *does* give you is
+   `rln -m`'s load map: global symbol names resolved to segment-relative
+   addresses (confirmed working — see the TEXT/DATA/BSS-SEGMENT
+   RELOCATABLE SYMBOLS tables it printed for the smoke test). **Conclusion:
+   the honest claim is symbol-level debugging (breakpoints and reads by
+   symbol name/address, resolved from `rln -m`'s map or the object's own
+   symbol table), never source-level or line-level.** Every "source-level
+   debugging" claim in this document has been corrected accordingly; do not
+   reintroduce it without new evidence that some other tool in the chain
+   (not `rln`) emits real DWARF.
 3. **Register numbering for the RISC target descriptions.** Needs to be fixed
-   once and then never changed, since clients cache it.
+   once and then never changed, since clients cache it. Still open — GPU/DSP
+   threads are Phase 3, not Phase 1.
 
 ## Sequencing
 

--- a/libretro.c
+++ b/libretro.c
@@ -5180,7 +5180,17 @@ bool retro_load_game(const struct retro_game_info *info)
       port_var.key   = "virtualjaguar_gdb_port";
       port_var.value = NULL;
       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &port_var) && port_var.value)
-         gdb_stub_port = atoi(port_var.value);
+      {
+         /* The core-options UI only ever offers the four listed ports, so
+          * this only matters for a hand-edited config. atoi() on garbage
+          * returns 0, which GDBSockOpen() would take as "ask the OS for an
+          * ephemeral port" while the banner below kept reporting the
+          * bogus requested number -- reject it instead and keep the
+          * documented default. */
+         int parsed_port = atoi(port_var.value);
+         if (parsed_port > 0 && parsed_port <= 65535)
+            gdb_stub_port = parsed_port;
+      }
 
       if (gdb_stub_enabled)
       {

--- a/libretro.c
+++ b/libretro.c
@@ -59,6 +59,7 @@ int64_t rfread(void* buffer, size_t elem_size, size_t elem_count, RFILE* stream)
 #include "state.h"
 #include "titledb.h"
 #include "titlehook.h"
+#include "gdbstub.h"
 #include "log.h"
 /* CORE_VERSION.  scripts/gen-version-h.sh writes src/core/version.h with
  * the short git rev in it; the Makefile and jni/Android.mk both run it at
@@ -160,6 +161,151 @@ static void widescreen_reset(void)
 {
    widescreen_enabled          = false;
    widescreen_geometry_pending = false;
+}
+
+/* GDB remote debug stub (Phase 1, issue #652).  Developer-facing, off by
+ * default, latched once at content load exactly like the enhancement-hook
+ * gate above -- a "Restart" option must not be settable by a per-title DB
+ * row, so it is read raw via environ_cb, never through
+ * get_variable_pertitle().  File-scope statics, not retro_run()-local:
+ * iOS cannot dlclose the core, so a resident process must not carry a
+ * previous title's stub state (or half a buffered packet) into the next
+ * load -- reset alongside everything else in retro_unload_game() and
+ * retro_deinit(). */
+static bool gdb_stub_enabled     = false;
+static bool gdb_stub_socket_open = false;
+static int  gdb_stub_port        = 2345;
+static struct GDBSession gdb_session;
+static char gdb_rxbuf[GDB_PACKET_MAX];
+static int  gdb_rxlen = 0;
+
+/* Re-armed on every load/unload exactly like widescreen_reset() above:
+ * a fresh title must not inherit a half-received packet or a session
+ * struct pointed at the previous load's target ops. */
+static void gdb_stub_reset(void)
+{
+   gdb_stub_enabled     = false;
+   gdb_stub_socket_open = false;
+   gdb_stub_port        = 2345;
+   gdb_rxlen            = 0;
+}
+
+/* Serviced once per frame from the top of retro_run(), and only when the
+ * stub is enabled -- with no client attached this is one poll() and two
+ * cheap comparisons, bounded and non-blocking, per the design's "near-
+ * zero cost when disabled/idle" requirement.  Phase 1 has no breakpoints,
+ * so nothing here can block: every packet the engine understands gets an
+ * immediate reply, and the loop below terminates as soon as the receive
+ * buffer holds no further complete "$...#cs" packet. */
+static void gdb_stub_service(void)
+{
+   if (!gdb_stub_enabled || !gdb_stub_socket_open)
+      return;
+
+   GDBSockPoll();
+
+   /* Pull whatever is available into the tail of the accumulation
+    * buffer.  A single recv() rarely delivers more than one small RSP
+    * command, but nothing here assumes that -- partial packets are
+    * simply left in gdb_rxbuf for the next frame's call. */
+   for (;;)
+   {
+      int room = (int)sizeof(gdb_rxbuf) - gdb_rxlen;
+      int n;
+
+      if (room <= 0)
+      {
+         /* Buffer full with no packet boundary found: a malformed or
+          * hostile stream. Drop it and resync rather than wedging. */
+         gdb_rxlen = 0;
+         break;
+      }
+
+      n = GDBSockRecv(gdb_rxbuf + gdb_rxlen, room);
+      if (n < 0)
+      {
+         /* Client disconnected. */
+         gdb_rxlen = 0;
+         break;
+      }
+      if (n == 0)
+         break;
+
+      gdb_rxlen += n;
+   }
+
+   /* Dispatch every complete packet currently buffered. */
+   for (;;)
+   {
+      static char payload[GDB_PACKET_MAX];
+      static char reply[GDB_PACKET_MAX];
+      static char encoded[GDB_PACKET_MAX + 8];
+      int i;
+      int dollarAt = -1;
+      int hashAt   = -1;
+      int payLen, replyLen, encLen, consumed, remaining;
+
+      for (i = 0; i < gdb_rxlen; i++)
+      {
+         if (gdb_rxbuf[i] == '$')
+         {
+            dollarAt = i;
+            break;
+         }
+      }
+
+      if (dollarAt < 0)
+      {
+         /* No packet start in the buffer at all (e.g. a stray leading
+          * '+' ack byte with nothing after it yet): nothing to do. */
+         gdb_rxlen = 0;
+         break;
+      }
+
+      for (i = dollarAt + 1; i < gdb_rxlen; i++)
+      {
+         if (gdb_rxbuf[i] == '#')
+         {
+            hashAt = i;
+            break;
+         }
+      }
+
+      if (hashAt < 0 || (hashAt + 2) >= gdb_rxlen)
+      {
+         /* Incomplete packet: drop only the garbage before '$' (if any)
+          * so the scan above does not re-walk it every frame, and wait
+          * for more bytes next frame. */
+         if (dollarAt > 0)
+         {
+            remaining = gdb_rxlen - dollarAt;
+            memmove(gdb_rxbuf, gdb_rxbuf + dollarAt, (size_t)remaining);
+            gdb_rxlen = remaining;
+         }
+         break;
+      }
+
+      payLen = GDBDecodePacket(gdb_rxbuf + dollarAt, hashAt + 3 - dollarAt,
+                               payload, (int)sizeof(payload));
+      if (payLen >= 0)
+      {
+         replyLen = GDBHandlePacket(&gdb_session, payload, payLen,
+                                    reply, (int)sizeof(reply));
+         encLen = GDBEncodePacket(reply, replyLen, encoded,
+                                  (int)sizeof(encoded));
+         if (encLen > 0)
+            GDBSockSend(encoded, encLen);
+      }
+      /* A malformed packet (bad checksum, overflow) gets no reply at
+       * all here -- real GDB retransmits on a missing ack, and Phase 1
+       * does not implement the low-level +/- ack byte, so silence is
+       * the correct "I didn't understand that" for now. */
+
+      consumed  = hashAt + 3;
+      remaining = gdb_rxlen - consumed;
+      memmove(gdb_rxbuf, gdb_rxbuf + consumed, (size_t)remaining);
+      gdb_rxlen = remaining;
+   }
 }
 
 #ifdef VJ_TRACE
@@ -5018,6 +5164,60 @@ bool retro_load_game(const struct retro_game_info *info)
       hook_restart_notice_logged = 0;
    }
 
+   /* GDB remote debug stub (Phase 1, issue #652): same raw-read reasoning
+    * as the enhancement-hook gate immediately above -- a developer-facing
+    * "Restart" gate must not be settable by a per-title DB row. */
+   gdb_stub_reset();
+   {
+      struct retro_variable gdb_var;
+      struct retro_variable port_var;
+
+      gdb_var.key   = "virtualjaguar_gdb_stub";
+      gdb_var.value = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &gdb_var) && gdb_var.value)
+         gdb_stub_enabled = (strcmp(gdb_var.value, "enabled") == 0);
+
+      port_var.key   = "virtualjaguar_gdb_port";
+      port_var.value = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &port_var) && port_var.value)
+         gdb_stub_port = atoi(port_var.value);
+
+      if (gdb_stub_enabled)
+      {
+         if (GDBSockOpen(gdb_stub_port) == 0)
+         {
+            struct retro_message_ext gdb_msg;
+            char gdb_msg_text[96];
+
+            gdb_stub_socket_open = true;
+            GDBSessionInit(&gdb_session, GDBJaguarOps(), NULL);
+
+            snprintf(gdb_msg_text, sizeof(gdb_msg_text),
+                     "GDB stub listening on 127.0.0.1:%d", gdb_stub_port);
+            memset(&gdb_msg, 0, sizeof(gdb_msg));
+            gdb_msg.msg      = gdb_msg_text;
+            gdb_msg.duration = 4000;
+            gdb_msg.priority = 2;
+            gdb_msg.level    = RETRO_LOG_INFO;
+            gdb_msg.target   = RETRO_MESSAGE_TARGET_OSD;
+            gdb_msg.type     = RETRO_MESSAGE_TYPE_NOTIFICATION;
+            gdb_msg.progress = -1;
+            environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &gdb_msg);
+            LOG_INF("[GDB] stub listening on 127.0.0.1:%d\n", gdb_stub_port);
+         }
+         else
+         {
+            /* Bind failure (port in use, a second core instance under
+             * run-ahead, or no BSD sockets on this target) is logged once
+             * and the stub stays disabled for this session -- it must
+             * never fail content load. */
+            gdb_stub_enabled = false;
+            LOG_WRN("[GDB] stub enabled but failed to open port %d -- "
+                    "disabled for this session\n", gdb_stub_port);
+         }
+      }
+   }
+
    /* Known-bad (#464) warning latch: a fresh load starts with none warned,
     * even in-process on a platform that cannot dlclose (iOS). */
    titledb_reset_negative_warnings();
@@ -5361,6 +5561,11 @@ void retro_unload_game(void)
    TitleHookSetEnabled(0);
    TitleDBSetHooksForTest(NULL, 0);
    hook_restart_notice_logged = 0;
+   /* GDB stub (#652): close the listener/client so a stale socket does
+    * not linger into the next title, and re-latch the gate from the next
+    * load's option instead of carrying this session's state forward. */
+   GDBSockClose();
+   gdb_stub_reset();
    /* Known-bad negative entries (#464): same reasoning, same reset. */
    TitleDBSetNegativeForTest(NULL, 0);
    titledb_reset_negative_warnings();
@@ -5760,6 +5965,11 @@ void retro_deinit(void)
    TitleHookSetEnabled(0);
    TitleDBSetHooksForTest(NULL, 0);
    hook_restart_notice_logged = 0;
+   /* GDB stub (#652): belt-and-suspenders, matching retro_unload_game() --
+    * a frontend that calls deinit without unload first must not leave a
+    * listener bound past process teardown. */
+   GDBSockClose();
+   gdb_stub_reset();
    /* Known-bad negative entries (#464): same per-load re-arm as above. */
    TitleDBSetNegativeForTest(NULL, 0);
    titledb_reset_negative_warnings();
@@ -5859,6 +6069,12 @@ static void dbg_dump_frame(void)
 void retro_run(void)
 {
    bool updated = false;
+
+   /* GDB stub (#652): serviced first and unconditionally cheap when
+    * disabled -- gdb_stub_service() itself early-returns before touching
+    * a single byte if the option is off, which is the whole point of the
+    * "near-zero cost when disabled" requirement in the design doc. */
+   gdb_stub_service();
 
 #ifdef VJ_TRACE
    /* Stamp the frame number BEFORE the machine runs, so every event

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -580,6 +580,36 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "virtualjaguar_gdb_stub",
+      "GDB Debug Stub (Restart)",
+      NULL,
+      "Open a GDB remote debugging server on localhost so a debugger can inspect the emulated machine. Developer-facing; leave disabled for normal play. The server only ever listens on 127.0.0.1 -- it is not reachable from another machine. Requires a restart.",
+      NULL,
+      "diagnostics",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "virtualjaguar_gdb_port",
+      "GDB Stub Port (Restart)",
+      NULL,
+      "TCP port for the GDB debug stub. Change this only if another program already uses the default. Requires a restart.",
+      NULL,
+      "diagnostics",
+      {
+         { "2345", NULL },
+         { "2346", NULL },
+         { "2347", NULL },
+         { "3333", NULL },
+         { NULL, NULL },
+      },
+      "2345"
+   },
+   {
       "virtualjaguar_texdump_16bpp",
       "Texture Dump: 16bpp Preview",
       NULL,

--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -22,7 +22,7 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd)
 
 CC="${CC:-gcc}"
 CFLAGS="-fsyntax-only -std=gnu89 -Werror=declaration-after-statement"
-INCLUDES="-I. -Isrc -Isrc/core -Isrc/tom -Isrc/jerry -Isrc/cd -Isrc/bios -Isrc/m68000 -Ilibretro-common/include -Ideps/libchdr/include"
+INCLUDES="-I. -Isrc -Isrc/core -Isrc/tom -Isrc/jerry -Isrc/cd -Isrc/bios -Isrc/m68000 -Isrc/debug -Ilibretro-common/include -Ideps/libchdr/include"
 DEFINES='-D__LIBRETRO__ -DINLINE=inline'
 
 skip_file() {

--- a/src/debug/gdbsock.c
+++ b/src/debug/gdbsock.c
@@ -21,6 +21,9 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#ifdef _MSC_VER
+#pragma comment(lib, "ws2_32.lib")
+#endif
 typedef SOCKET gdb_sock_t;
 #define GDB_INVALID_SOCK  INVALID_SOCKET
 #define gdb_sock_valid(s) ((s) != INVALID_SOCKET)

--- a/src/debug/gdbsock.c
+++ b/src/debug/gdbsock.c
@@ -1,0 +1,167 @@
+/*
+ * gdbsock.c -- loopback-only TCP transport for the GDB stub.
+ *
+ * The socket layer mirrors src/jerry/jlink_tcp.c, which already solved
+ * the winsock/POSIX split for this codebase.
+ * Design: docs/gdb-stub-design.md (issue #652).
+ */
+#if !defined(_WIN32) && !defined(_DEFAULT_SOURCE)
+#define _DEFAULT_SOURCE 1
+#endif
+#include <string.h>
+#include "gdbstub.h"
+
+#if defined(_WIN32) || defined(__unix__) || defined(__APPLE__) || \
+    defined(__linux__) || defined(__ANDROID__)
+#define GDB_HAVE_TCP 1
+#endif
+
+#ifdef GDB_HAVE_TCP
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+typedef SOCKET gdb_sock_t;
+#define GDB_INVALID_SOCK  INVALID_SOCKET
+#define gdb_sock_valid(s) ((s) != INVALID_SOCKET)
+#define gdb_closesock(s)  closesocket(s)
+#define gdb_sockerr()     WSAGetLastError()
+#define GDB_EWOULDBLOCK   WSAEWOULDBLOCK
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+typedef int gdb_sock_t;
+#define GDB_INVALID_SOCK  (-1)
+#define gdb_sock_valid(s) ((s) >= 0)
+#define gdb_closesock(s)  close(s)
+#define gdb_sockerr()     errno
+#define GDB_EWOULDBLOCK   EWOULDBLOCK
+#endif
+
+static gdb_sock_t gdbListen = GDB_INVALID_SOCK;
+static gdb_sock_t gdbClient = GDB_INVALID_SOCK;
+
+static void GDBSetNonBlocking(gdb_sock_t s)
+{
+#ifdef _WIN32
+   u_long nb = 1;
+   ioctlsocket(s, FIONBIO, &nb);
+#else
+   int fl = fcntl(s, F_GETFL, 0);
+   if (fl >= 0)
+      fcntl(s, F_SETFL, fl | O_NONBLOCK);
+#endif
+}
+
+int GDBSockOpen(int port)
+{
+   struct sockaddr_in addr;
+   int yes = 1;
+
+   if (gdb_sock_valid(gdbListen))
+      return 0;
+
+   gdbListen = socket(AF_INET, SOCK_STREAM, 0);
+   if (!gdb_sock_valid(gdbListen))
+      return -1;
+
+   setsockopt(gdbListen, SOL_SOCKET, SO_REUSEADDR,
+              (const char *)&yes, sizeof(yes));
+
+   memset(&addr, 0, sizeof(addr));
+   addr.sin_family      = AF_INET;
+   addr.sin_port        = htons((unsigned short)port);
+   /* Loopback ONLY. Never INADDR_ANY -- this is a security invariant. */
+   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+   if (bind(gdbListen, (struct sockaddr *)&addr, sizeof(addr)) != 0 ||
+       listen(gdbListen, 1) != 0)
+   {
+      gdb_closesock(gdbListen);
+      gdbListen = GDB_INVALID_SOCK;
+      return -1;
+   }
+
+   GDBSetNonBlocking(gdbListen);
+   return 0;
+}
+
+void GDBSockClose(void)
+{
+   if (gdb_sock_valid(gdbClient))
+      gdb_closesock(gdbClient);
+   if (gdb_sock_valid(gdbListen))
+      gdb_closesock(gdbListen);
+
+   gdbClient = GDB_INVALID_SOCK;
+   gdbListen = GDB_INVALID_SOCK;
+}
+
+int GDBSockPoll(void)
+{
+   gdb_sock_t incoming;
+
+   if (!gdb_sock_valid(gdbListen))
+      return 0;
+
+   if (gdb_sock_valid(gdbClient))
+      return 1;
+
+   incoming = accept(gdbListen, NULL, NULL);
+   if (!gdb_sock_valid(incoming))
+      return 0;
+
+   GDBSetNonBlocking(incoming);
+   gdbClient = incoming;
+   return 1;
+}
+
+int GDBSockRecv(char *buf, int max)
+{
+   int n;
+
+   if (!gdb_sock_valid(gdbClient))
+      return 0;
+
+   n = (int)recv(gdbClient, buf, (size_t)max, 0);
+   if (n > 0)
+      return n;
+
+   if (n == 0)
+   {
+      gdb_closesock(gdbClient);
+      gdbClient = GDB_INVALID_SOCK;
+      return -1;
+   }
+
+   if (gdb_sockerr() == GDB_EWOULDBLOCK)
+      return 0;
+
+   gdb_closesock(gdbClient);
+   gdbClient = GDB_INVALID_SOCK;
+   return -1;
+}
+
+int GDBSockSend(const char *buf, int len)
+{
+   if (!gdb_sock_valid(gdbClient))
+      return -1;
+
+   return (int)send(gdbClient, buf, (size_t)len, 0);
+}
+
+#else /* no BSD sockets on this target */
+
+int  GDBSockOpen(int port) { (void)port; return -1; }
+void GDBSockClose(void)    { }
+int  GDBSockPoll(void)     { return 0; }
+int  GDBSockRecv(char *buf, int max) { (void)buf; (void)max; return 0; }
+int  GDBSockSend(const char *buf, int len) { (void)buf; (void)len; return -1; }
+
+#endif /* GDB_HAVE_TCP */

--- a/src/debug/gdbstub.c
+++ b/src/debug/gdbstub.c
@@ -123,6 +123,28 @@ int GDBExpandRLE(const char *in, int inLen, char *out, int outMax)
    return n;
 }
 
+int GDBParseHexU32(const char *s, int len, unsigned int *out)
+{
+   int i;
+   unsigned int v = 0;
+
+   if (len <= 0 || len > 8)
+      return -1;
+
+   for (i = 0; i < len; i++)
+   {
+      int d = GDBHexVal(s[i]);
+
+      if (d < 0)
+         return -1;
+
+      v = (v << 4) | (unsigned int)d;
+   }
+
+   *out = v;
+   return len;
+}
+
 void GDBSessionInit(struct GDBSession *s, const struct GDBTargetOps *ops,
                     void *user)
 {
@@ -159,6 +181,40 @@ int GDBHandlePacket(struct GDBSession *s, const char *pay, int payLen,
    {
       s->noAckMode = 1;
       return GDBCopyReply("OK", reply, replyMax);
+   }
+
+   if (pay[0] == 'm')
+   {
+      unsigned int addr = 0, len = 0;
+      int comma = -1;
+      int i, n;
+
+      if (!s->ops || !s->ops->readMemory)
+         return 0;
+
+      for (i = 1; i < payLen; i++)
+      {
+         if (pay[i] == ',')
+         {
+            comma = i;
+            break;
+         }
+      }
+
+      if (comma < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      if (GDBParseHexU32(pay + 1, comma - 1, &addr) < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      if (GDBParseHexU32(pay + comma + 1, payLen - comma - 1, &len) < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      n = s->ops->readMemory(s->user, addr, (int)len, reply, replyMax);
+      if (n < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      return n;
    }
 
    /* RSP: an empty reply means "I do not implement this packet". */

--- a/src/debug/gdbstub.c
+++ b/src/debug/gdbstub.c
@@ -1,0 +1,84 @@
+#include "gdbstub.h"
+
+static int GDBHexVal(char c)
+{
+   if (c >= '0' && c <= '9')
+      return c - '0';
+   if (c >= 'a' && c <= 'f')
+      return (c - 'a') + 10;
+   if (c >= 'A' && c <= 'F')
+      return (c - 'A') + 10;
+   return -1;
+}
+
+int GDBChecksum(const char *payload, int len)
+{
+   int i;
+   unsigned int sum = 0;
+
+   for (i = 0; i < len; i++)
+      sum += (unsigned char)payload[i];
+
+   return (int)(sum & 0xFF);
+}
+
+int GDBDecodePacket(const char *raw, int rawLen, char *out, int outMax)
+{
+   int i;
+   int hashAt = -1;
+   int payLen;
+   int hi, lo;
+
+   if (rawLen < 4 || raw[0] != '$')
+      return -1;
+
+   for (i = 1; i < rawLen; i++)
+   {
+      if (raw[i] == '#')
+      {
+         hashAt = i;
+         break;
+      }
+   }
+
+   if (hashAt < 0 || (hashAt + 2) >= rawLen)
+      return -1;
+
+   hi = GDBHexVal(raw[hashAt + 1]);
+   lo = GDBHexVal(raw[hashAt + 2]);
+   if (hi < 0 || lo < 0)
+      return -1;
+
+   payLen = hashAt - 1;
+   if (payLen > outMax)
+      return -3;
+
+   if (GDBChecksum(raw + 1, payLen) != ((hi << 4) | lo))
+      return -2;
+
+   for (i = 0; i < payLen; i++)
+      out[i] = raw[1 + i];
+
+   return payLen;
+}
+
+int GDBEncodePacket(const char *payload, int len, char *out, int outMax)
+{
+   static const char hexDigits[] = "0123456789abcdef";
+   int i;
+   int cs;
+
+   if ((len + 4) > outMax)
+      return -1;
+
+   out[0] = '$';
+   for (i = 0; i < len; i++)
+      out[1 + i] = payload[i];
+
+   cs = GDBChecksum(payload, len);
+   out[1 + len] = '#';
+   out[2 + len] = hexDigits[(cs >> 4) & 0xF];
+   out[3 + len] = hexDigits[cs & 0xF];
+
+   return len + 4;
+}

--- a/src/debug/gdbstub.c
+++ b/src/debug/gdbstub.c
@@ -217,6 +217,20 @@ int GDBHandlePacket(struct GDBSession *s, const char *pay, int payLen,
       return n;
    }
 
+   if (payLen == 1 && pay[0] == 'g')
+   {
+      int n;
+
+      if (!s->ops || !s->ops->readRegisters)
+         return 0;
+
+      n = s->ops->readRegisters(s->user, reply, replyMax);
+      if (n < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      return n;
+   }
+
    /* RSP: an empty reply means "I do not implement this packet". */
    return 0;
 }

--- a/src/debug/gdbstub.c
+++ b/src/debug/gdbstub.c
@@ -1,4 +1,5 @@
 #include "gdbstub.h"
+#include <string.h>
 
 static int GDBHexVal(char c)
 {
@@ -81,4 +82,85 @@ int GDBEncodePacket(const char *payload, int len, char *out, int outMax)
    out[3 + len] = hexDigits[cs & 0xF];
 
    return len + 4;
+}
+
+int GDBExpandRLE(const char *in, int inLen, char *out, int outMax)
+{
+   int i;
+   int n = 0;
+
+   for (i = 0; i < inLen; i++)
+   {
+      if (in[i] == '*')
+      {
+         int repeat;
+         char prev;
+
+         if (n == 0 || (i + 1) >= inLen)
+            return -1;
+
+         repeat = (int)(unsigned char)in[i + 1] - 29;
+         if (repeat < 0)
+            return -1;
+
+         prev = out[n - 1];
+         if ((n + repeat) > outMax)
+            return -1;
+
+         while (repeat-- > 0)
+            out[n++] = prev;
+
+         i++;
+         continue;
+      }
+
+      if (n >= outMax)
+         return -1;
+
+      out[n++] = in[i];
+   }
+
+   return n;
+}
+
+void GDBSessionInit(struct GDBSession *s, const struct GDBTargetOps *ops,
+                    void *user)
+{
+   s->ops       = ops;
+   s->user      = user;
+   s->noAckMode = 0;
+}
+
+static int GDBCopyReply(const char *text, char *reply, int replyMax)
+{
+   int len = (int)strlen(text);
+
+   if (len > replyMax)
+      return 0;
+
+   memcpy(reply, text, (size_t)len);
+   return len;
+}
+
+int GDBHandlePacket(struct GDBSession *s, const char *pay, int payLen,
+                    char *reply, int replyMax)
+{
+   if (payLen <= 0)
+      return 0;
+
+   if (pay[0] == '?')
+      return GDBCopyReply("S05", reply, replyMax);
+
+   /* Matches both the bare "qSupported" and the "qSupported:xxx" form. */
+   if (payLen >= 10 && memcmp(pay, "qSupported", 10) == 0)
+      return GDBCopyReply("PacketSize=1000;QStartNoAckMode+", reply, replyMax);
+
+   if (payLen == 15 && memcmp(pay, "QStartNoAckMode", 15) == 0)
+   {
+      s->noAckMode = 1;
+      return GDBCopyReply("OK", reply, replyMax);
+   }
+
+   /* RSP: an empty reply means "I do not implement this packet". */
+   return 0;
 }

--- a/src/debug/gdbstub.h
+++ b/src/debug/gdbstub.h
@@ -62,6 +62,8 @@ int GDBExpandRLE(const char *in, int inLen, char *out, int outMax);
 int GDBHandlePacket(struct GDBSession *s, const char *pay, int payLen,
                     char *reply, int replyMax);
 
+int GDBParseHexU32(const char *s, int len, unsigned int *out);
+
 /* Implemented in gdbtarget.c (Task 4). Declared here so libretro.c needs
  * only this one header. */
 const struct GDBTargetOps *GDBJaguarOps(void);

--- a/src/debug/gdbstub.h
+++ b/src/debug/gdbstub.h
@@ -1,0 +1,35 @@
+/*
+ * gdbstub.h -- GDB Remote Serial Protocol engine.
+ *
+ * This translation unit is deliberately free of sockets and of every
+ * Jaguar global, so test/tools/test_gdbstub_proto.c can link it alone.
+ * Design: docs/gdb-stub-design.md (issue #652).
+ */
+#ifndef __GDBSTUB_H__
+#define __GDBSTUB_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Modulo-256 sum of payload, as RSP defines it. */
+int GDBChecksum(const char *payload, int len);
+
+/*
+ * Decode "$payload#cs" from raw. Returns payload length written to out,
+ * or: -1 malformed framing, -2 checksum mismatch, -3 would overflow out.
+ * Never writes more than outMax bytes and never NUL-terminates.
+ */
+int GDBDecodePacket(const char *raw, int rawLen, char *out, int outMax);
+
+/*
+ * Encode payload as "$payload#cs" into out. Returns bytes written, or -1
+ * if out is too small. Never NUL-terminates.
+ */
+int GDBEncodePacket(const char *payload, int len, char *out, int outMax);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __GDBSTUB_H__ */

--- a/src/debug/gdbstub.h
+++ b/src/debug/gdbstub.h
@@ -28,6 +28,44 @@ int GDBDecodePacket(const char *raw, int rawLen, char *out, int outMax);
  */
 int GDBEncodePacket(const char *payload, int len, char *out, int outMax);
 
+#define GDB_PACKET_MAX 4096
+
+/*
+ * What the engine needs from a target. Phase 1 uses only readRegisters
+ * and readMemory; later phases add the rest. Every function may be NULL,
+ * in which case the engine replies "unsupported" rather than crashing.
+ */
+struct GDBTargetOps
+{
+   /* Serialise the register file as GDB expects it, hex, no separators.
+    * Returns chars written, or -1. */
+   int (*readRegisters)(void *user, char *out, int outMax);
+
+   /* Read len guest bytes at addr into out as hex. MUST bounds-check addr
+    * against the emulated map and return -1 on any out-of-range access. */
+   int (*readMemory)(void *user, unsigned int addr, int len,
+                     char *out, int outMax);
+};
+
+struct GDBSession
+{
+   const struct GDBTargetOps *ops;
+   void *user;
+   int noAckMode;
+};
+
+void GDBSessionInit(struct GDBSession *s, const struct GDBTargetOps *ops,
+                    void *user);
+
+int GDBExpandRLE(const char *in, int inLen, char *out, int outMax);
+
+int GDBHandlePacket(struct GDBSession *s, const char *pay, int payLen,
+                    char *reply, int replyMax);
+
+/* Implemented in gdbtarget.c (Task 4). Declared here so libretro.c needs
+ * only this one header. */
+const struct GDBTargetOps *GDBJaguarOps(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/debug/gdbstub.h
+++ b/src/debug/gdbstub.h
@@ -68,6 +68,19 @@ int GDBParseHexU32(const char *s, int len, unsigned int *out);
  * only this one header. */
 const struct GDBTargetOps *GDBJaguarOps(void);
 
+/*
+ * Loopback-only TCP transport, implemented in gdbsock.c (Task 5). Binds
+ * 127.0.0.1 only -- never INADDR_ANY -- and accepts a single client.
+ * On platforms without BSD sockets, GDBSockOpen() always fails and the
+ * rest are inert, so the caller degrades to "stub unavailable" rather
+ * than failing content load.
+ */
+int GDBSockOpen(int port);
+void GDBSockClose(void);
+int GDBSockPoll(void);
+int GDBSockRecv(char *buf, int max);
+int GDBSockSend(const char *buf, int len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/debug/gdbtarget.c
+++ b/src/debug/gdbtarget.c
@@ -1,0 +1,96 @@
+/*
+ * gdbtarget.c -- adapts the Jaguar to the GDB stub's target vtable.
+ * Design: docs/gdb-stub-design.md (issue #652).
+ *
+ * NOTE on the "who" argument to JaguarReadByte(): the plan that specified
+ * this file named the constant DEBUG, but src/core/vjag_memory.h's who
+ * enum spells this enumerator DEBUGGER, not DEBUG -- deliberately, per
+ * that header's comment: Xcode's stock Debug configuration defines the
+ * preprocessor macro DEBUG=1, which would otherwise mangle the enumerator
+ * list on every Xcode/SwiftPM consumer. The wire value (9) is unchanged.
+ * Verified non-perturbing: every who-gated side effect in the read path
+ * (DSP HLE sound-engine auto-ack and DSPGO auto-clear in src/jerry/dsp.c,
+ * the busArbiter OP charge in jaguar.c, the GPU/DSP-specific branches in
+ * vjtrace.c) is gated on who == M68K / GPU / DSP / OP specifically, none
+ * of which equals DEBUGGER (9), so a debugger read triggers none of them.
+ */
+#include <string.h>
+#include "gdbstub.h"
+#include "m68kinterface.h"
+#include "jaguar.h"
+
+static const char gdbHex[] = "0123456789abcdef";
+
+static void GDBPutHex32(char *out, unsigned int v)
+{
+   int i;
+
+   for (i = 0; i < 8; i++)
+      out[i] = gdbHex[(v >> ((7 - i) * 4)) & 0xF];
+}
+
+static int GDBReadRegs68K(void *user, char *out, int outMax)
+{
+   int i;
+
+   (void)user;
+
+   if (outMax < 144)
+      return -1;
+
+   for (i = 0; i < 8; i++)
+      GDBPutHex32(out + (i * 8),
+                  m68k_get_reg(NULL, (m68k_register_t)(M68K_REG_D0 + i)));
+
+   for (i = 0; i < 8; i++)
+      GDBPutHex32(out + ((8 + i) * 8),
+                  m68k_get_reg(NULL, (m68k_register_t)(M68K_REG_A0 + i)));
+
+   GDBPutHex32(out + (16 * 8), m68k_get_reg(NULL, M68K_REG_SR));
+   GDBPutHex32(out + (17 * 8), m68k_get_reg(NULL, M68K_REG_PC));
+
+   return 144;
+}
+
+/*
+ * The Jaguar bus is 24-bit. Anything above 0xFFFFFF cannot be addressed
+ * and is refused outright rather than silently wrapped -- a debugger that
+ * asks for a wild address must be told no, not handed mirrored data.
+ */
+#define GDB_GUEST_LIMIT 0x1000000U
+
+static int GDBReadMem68K(void *user, unsigned int addr, int len,
+                         char *out, int outMax)
+{
+   int i;
+
+   (void)user;
+
+   if (len <= 0)
+      return -1;
+   if (addr >= GDB_GUEST_LIMIT)
+      return -1;
+   if ((unsigned int)len > (GDB_GUEST_LIMIT - addr))
+      return -1;
+   if ((len * 2) > outMax)
+      return -1;
+
+   for (i = 0; i < len; i++)
+   {
+      unsigned int b = JaguarReadByte(addr + (unsigned int)i, DEBUGGER);
+
+      out[i * 2]       = gdbHex[(b >> 4) & 0xF];
+      out[(i * 2) + 1] = gdbHex[b & 0xF];
+   }
+
+   return len * 2;
+}
+
+const struct GDBTargetOps *GDBJaguarOps(void)
+{
+   static struct GDBTargetOps ops;
+
+   ops.readRegisters = GDBReadRegs68K;
+   ops.readMemory    = GDBReadMem68K;
+   return &ops;
+}

--- a/src/debug/gdbtarget.c
+++ b/src/debug/gdbtarget.c
@@ -8,11 +8,23 @@
  * that header's comment: Xcode's stock Debug configuration defines the
  * preprocessor macro DEBUG=1, which would otherwise mangle the enumerator
  * list on every Xcode/SwiftPM consumer. The wire value (9) is unchanged.
- * Verified non-perturbing: every who-gated side effect in the read path
- * (DSP HLE sound-engine auto-ack and DSPGO auto-clear in src/jerry/dsp.c,
- * the busArbiter OP charge in jaguar.c, the GPU/DSP-specific branches in
- * vjtrace.c) is gated on who == M68K / GPU / DSP / OP specifically, none
- * of which equals DEBUGGER (9), so a debugger read triggers none of them.
+ * Verified for RAM/ROM and for every who-GATED side effect this audit
+ * found (DSP HLE sound-engine auto-ack and DSPGO auto-clear in
+ * src/jerry/dsp.c, the busArbiter OP charge in jaguar.c, the GPU/DSP-
+ * specific branches in vjtrace.c): all of them test who == M68K / GPU /
+ * DSP / OP specifically, none of which equals DEBUGGER (9), so a
+ * debugger read triggers none of them.
+ *
+ * NOT claimed: that every memory-mapped register in the map is free of
+ * read side effects regardless of who asks. A handful of hardware
+ * registers are read-sensitive by design on real silicon (e.g. CD
+ * BUTCH+2's DSCNTRL ack semantics in src/cd/cdrom.c, reached only via
+ * the 16/32-bit read path, not the byte path this file calls) -- a
+ * debugger peeking at those would legitimately perturb interrupt/FIFO
+ * state exactly as touching them from any processor does. GDBReadMem68K
+ * reads one byte at a time via JaguarReadByte(), which for MMIO ranges
+ * is honest about that: it inherits whatever the byte-granular handler
+ * defines, same as the emulated machine's own 68K would see.
  */
 #include <string.h>
 #include "gdbstub.h"

--- a/test/tools/gdb_attach_probe.py
+++ b/test/tools/gdb_attach_probe.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Minimal RSP client: attach to the core's GDB stub and validate Phase 1."""
+import socket, sys
+
+def cksum(payload: bytes) -> int:
+    return sum(payload) & 0xFF
+
+def pack(payload: str) -> bytes:
+    b = payload.encode()
+    return b"$" + b + b"#" + ("%02x" % cksum(b)).encode()
+
+def recv_packet(sock) -> str:
+    buf = b""
+    while b"#" not in buf or len(buf.split(b"#")[-1]) < 2:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise RuntimeError("stub closed the connection")
+        buf += chunk
+    body = buf[buf.index(b"$") + 1 : buf.rindex(b"#")]
+    want = int(buf[buf.rindex(b"#") + 1 : buf.rindex(b"#") + 3], 16)
+    if cksum(body) != want:
+        raise RuntimeError("checksum mismatch from stub")
+    return body.decode()
+
+def main(port: int) -> int:
+    s = socket.create_connection(("127.0.0.1", port), timeout=5)
+    s.sendall(b"+")
+
+    s.sendall(pack("qSupported:multiprocess+"))
+    sup = recv_packet(s)
+    assert "PacketSize=" in sup, f"qSupported lacked PacketSize: {sup!r}"
+
+    s.sendall(pack("?"))
+    assert recv_packet(s) == "S05"
+
+    s.sendall(pack("g"))
+    regs = recv_packet(s)
+    assert len(regs) == 144, f"g returned {len(regs)} chars, want 144"
+    int(regs, 16)                      # must be pure hex
+
+    s.sendall(pack("m0,10"))
+    mem = recv_packet(s)
+    assert len(mem) == 32, f"m0,10 returned {len(mem)} chars, want 32"
+    int(mem, 16)
+
+    # A wild address must be refused, not mirrored.
+    s.sendall(pack("mffffffff,4"))
+    assert recv_packet(s) == "E01"
+
+    s.close()
+    print("PASS: attach, qSupported, halt reason, registers, memory, bounds refusal")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main(int(sys.argv[1]) if len(sys.argv) > 1 else 2345))

--- a/test/tools/test_gdbstub_proto.c
+++ b/test/tools/test_gdbstub_proto.c
@@ -101,6 +101,70 @@ TEST(encode_refuses_to_overflow_output) {
     ASSERT_EQ(GDBEncodePacket("OK", 2, out, sizeof(out)), -1);
 }
 
+/* ------------------------------------------------------------------ */
+/* Task 2: run-length decode and command dispatch                      */
+/* ------------------------------------------------------------------ */
+
+TEST(rle_expands_star_runs) {
+    char out[64];
+    /* '0' then '*' with ' ' (0x20 = 32) -> repeat previous 32-29 = 3 more */
+    int n = GDBExpandRLE("0* ", 3, out, sizeof(out));
+    ASSERT_EQ(n, 4);
+    out[n] = '\0';
+    ASSERT_STR(out, "0000");
+}
+
+TEST(rle_passes_through_plain_text) {
+    char out[64];
+    int n = GDBExpandRLE("qSupported", 10, out, sizeof(out));
+    ASSERT_EQ(n, 10);
+}
+
+TEST(rle_rejects_leading_star) {
+    char out[64];
+    ASSERT_EQ(GDBExpandRLE("* ", 2, out, sizeof(out)), -1);
+}
+
+TEST(rle_refuses_to_overflow_output) {
+    char out[4];
+    ASSERT_EQ(GDBExpandRLE("0*~", 3, out, sizeof(out)), -1);
+}
+
+/* --- dispatch --- */
+static struct GDBSession g_sess;
+
+static void setup_session(void) {
+    static struct GDBTargetOps ops;
+    memset(&ops, 0, sizeof(ops));
+    GDBSessionInit(&g_sess, &ops, NULL);
+}
+
+TEST(qsupported_advertises_packet_size) {
+    char reply[256];
+    int n;
+    setup_session();
+    n = GDBHandlePacket(&g_sess, "qSupported:multiprocess+", 24, reply, sizeof(reply));
+    ASSERT(n > 0);
+    reply[n] = '\0';
+    ASSERT(strstr(reply, "PacketSize=") != NULL);
+}
+
+TEST(unknown_command_returns_empty_reply) {
+    char reply[256];
+    setup_session();
+    ASSERT_EQ(GDBHandlePacket(&g_sess, "zzUnknown", 9, reply, sizeof(reply)), 0);
+}
+
+TEST(halt_reason_reports_sigtrap) {
+    char reply[256];
+    int n;
+    setup_session();
+    n = GDBHandlePacket(&g_sess, "?", 1, reply, sizeof(reply));
+    ASSERT(n > 0);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "S05");
+}
+
 int main(void) {
     SUITE("gdbstub framing");
     RUN(checksum_is_modulo_256_sum);
@@ -114,5 +178,12 @@ int main(void) {
     RUN(decode_refuses_to_overflow_output);
     RUN(encode_wraps_payload_with_checksum);
     RUN(encode_refuses_to_overflow_output);
+    RUN(rle_expands_star_runs);
+    RUN(rle_passes_through_plain_text);
+    RUN(rle_rejects_leading_star);
+    RUN(rle_refuses_to_overflow_output);
+    RUN(qsupported_advertises_packet_size);
+    RUN(unknown_command_returns_empty_reply);
+    RUN(halt_reason_reports_sigtrap);
     return REPORT();
 }

--- a/test/tools/test_gdbstub_proto.c
+++ b/test/tools/test_gdbstub_proto.c
@@ -1,0 +1,118 @@
+/*
+ * test_gdbstub_proto.c -- unit tests for the GDB RSP protocol engine
+ * (src/debug/gdbstub.c) against a fake in-memory transport and a fake
+ * target. No emulator, no sockets.
+ *
+ * Design: docs/gdb-stub-design.md (issue #652).
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "../../src/debug/gdbstub.h"
+
+/* ------------------------------------------------------------------ */
+/* Minimal test runner (copied verbatim from test/test_boot_config.c) */
+/* ------------------------------------------------------------------ */
+
+static int tf_pass = 0, tf_fail = 0, tf_skip = 0;
+static const char *tf_suite = "";
+static const char *tf_name = "";
+static bool tf_failed = false;
+
+#define SUITE(n) do { tf_suite = (n); tf_pass = tf_fail = tf_skip = 0; \
+    fprintf(stderr, "\n=== %s ===\n", tf_suite); } while(0)
+#define TEST(n) static void test_##n(void)
+#define RUN(n) do { tf_name = #n; tf_failed = false; test_##n(); \
+    if (tf_failed) tf_fail++; \
+    else { tf_pass++; fprintf(stderr, "  PASS  %s\n", #n); } } while(0)
+#define SKIP(n, r) do { tf_skip++; fprintf(stderr, "  SKIP  %s (%s)\n", #n, r); } while(0)
+#define REPORT() (fprintf(stderr, "\n--- %s: %d passed, %d failed, %d skipped ---\n\n", \
+    tf_suite, tf_pass, tf_fail, tf_skip), tf_fail)
+#define FAIL(fmt, ...) do { fprintf(stderr, "  FAIL  %s:%d: " fmt "\n", \
+    tf_name, __LINE__, ##__VA_ARGS__); tf_failed = true; return; } while(0)
+#define ASSERT(cond) do { if (!(cond)) FAIL("expected true: %s", #cond); } while(0)
+#define ASSERT_EQ(a, b) do { int _a=(int)(a), _b=(int)(b); \
+    if (_a != _b) FAIL("%s == %s: got %d, want %d", #a, #b, _a, _b); } while(0)
+#define ASSERT_STR(a, b) do { if (strcmp((a),(b))!=0) \
+    FAIL("%s == %s: got \"%s\"", #a, #b, (a)); } while(0)
+
+TEST(checksum_is_modulo_256_sum) {
+    /* 'O','K' = 0x4F + 0x4B = 0x9A */
+    ASSERT_EQ(GDBChecksum("OK", 2), 0x9A);
+}
+
+TEST(checksum_wraps_at_256) {
+    /* 0xFF + 0x02 = 0x101 -> 0x01 */
+    char buf[2]; buf[0] = (char)0xFF; buf[1] = (char)0x02;
+    ASSERT_EQ(GDBChecksum(buf, 2), 0x01);
+}
+
+TEST(decode_extracts_payload) {
+    char out[64];
+    int n = GDBDecodePacket("$OK#9a", 6, out, sizeof(out));
+    ASSERT_EQ(n, 2);
+    out[n] = '\0';
+    ASSERT_STR(out, "OK");
+}
+
+TEST(decode_accepts_uppercase_checksum) {
+    char out[64];
+    ASSERT_EQ(GDBDecodePacket("$OK#9A", 6, out, sizeof(out)), 2);
+}
+
+TEST(decode_rejects_bad_checksum) {
+    char out[64];
+    ASSERT_EQ(GDBDecodePacket("$OK#00", 6, out, sizeof(out)), -2);
+}
+
+TEST(decode_rejects_missing_dollar) {
+    char out[64];
+    ASSERT_EQ(GDBDecodePacket("OK#9a", 5, out, sizeof(out)), -1);
+}
+
+TEST(decode_rejects_missing_hash) {
+    char out[64];
+    ASSERT_EQ(GDBDecodePacket("$OK9a", 5, out, sizeof(out)), -1);
+}
+
+TEST(decode_rejects_truncated_checksum) {
+    char out[64];
+    ASSERT_EQ(GDBDecodePacket("$OK#9", 5, out, sizeof(out)), -1);
+}
+
+TEST(decode_refuses_to_overflow_output) {
+    char out[4];
+    /* payload is 8 bytes, out holds 4 */
+    ASSERT_EQ(GDBDecodePacket("$AAAAAAAA#c0", 12, out, sizeof(out)), -3);
+}
+
+TEST(encode_wraps_payload_with_checksum) {
+    char out[64];
+    int n = GDBEncodePacket("OK", 2, out, sizeof(out));
+    ASSERT_EQ(n, 6);
+    out[n] = '\0';
+    ASSERT_STR(out, "$OK#9a");
+}
+
+TEST(encode_refuses_to_overflow_output) {
+    char out[4];
+    ASSERT_EQ(GDBEncodePacket("OK", 2, out, sizeof(out)), -1);
+}
+
+int main(void) {
+    SUITE("gdbstub framing");
+    RUN(checksum_is_modulo_256_sum);
+    RUN(checksum_wraps_at_256);
+    RUN(decode_extracts_payload);
+    RUN(decode_accepts_uppercase_checksum);
+    RUN(decode_rejects_bad_checksum);
+    RUN(decode_rejects_missing_dollar);
+    RUN(decode_rejects_missing_hash);
+    RUN(decode_rejects_truncated_checksum);
+    RUN(decode_refuses_to_overflow_output);
+    RUN(encode_wraps_payload_with_checksum);
+    RUN(encode_refuses_to_overflow_output);
+    return REPORT();
+}

--- a/test/tools/test_gdbstub_proto.c
+++ b/test/tools/test_gdbstub_proto.c
@@ -249,6 +249,43 @@ TEST(read_memory_without_target_op_is_unsupported) {
     ASSERT_EQ(GDBHandlePacket(&g_sess, "m0,2", 4, reply, sizeof(reply)), 0);
 }
 
+/* ------------------------------------------------------------------ */
+/* Task 4: 68000 register serialisation                                */
+/* ------------------------------------------------------------------ */
+
+static int fake_read_regs(void *user, char *out, int outMax) {
+    /* d0=1, everything else 0, sr=0x2700, pc=0x802000 */
+    static const char *s =
+      "00000001" "00000000" "00000000" "00000000"
+      "00000000" "00000000" "00000000" "00000000"
+      "00000000" "00000000" "00000000" "00000000"
+      "00000000" "00000000" "00000000" "00000000"
+      "00002700" "00802000";
+    int n = (int)strlen(s);
+    (void)user;
+    if (n > outMax) return -1;
+    memcpy(out, s, (size_t)n);
+    return n;
+}
+
+TEST(read_registers_returns_144_hex_chars) {
+    char reply[512]; int n;
+    static struct GDBTargetOps ops;
+    memset(&ops, 0, sizeof(ops));
+    ops.readRegisters = fake_read_regs;
+    GDBSessionInit(&g_sess, &ops, NULL);
+    n = GDBHandlePacket(&g_sess, "g", 1, reply, sizeof(reply));
+    ASSERT_EQ(n, 144);
+    ASSERT_EQ(memcmp(reply, "00000001", 8), 0);          /* d0 first */
+    ASSERT_EQ(memcmp(reply + 136, "00802000", 8), 0);    /* pc last  */
+}
+
+TEST(read_registers_without_target_op_is_unsupported) {
+    char reply[512];
+    setup_session();
+    ASSERT_EQ(GDBHandlePacket(&g_sess, "g", 1, reply, sizeof(reply)), 0);
+}
+
 int main(void) {
     SUITE("gdbstub framing");
     RUN(checksum_is_modulo_256_sum);
@@ -276,5 +313,7 @@ int main(void) {
     RUN(read_memory_wild_address_is_refused);
     RUN(read_memory_absurd_length_is_refused);
     RUN(read_memory_without_target_op_is_unsupported);
+    RUN(read_registers_returns_144_hex_chars);
+    RUN(read_registers_without_target_op_is_unsupported);
     return REPORT();
 }

--- a/test/tools/test_gdbstub_proto.c
+++ b/test/tools/test_gdbstub_proto.c
@@ -165,6 +165,90 @@ TEST(halt_reason_reports_sigtrap) {
     ASSERT_STR(reply, "S05");
 }
 
+/* ------------------------------------------------------------------ */
+/* Task 3: bounds-checked memory reads                                 */
+/* ------------------------------------------------------------------ */
+
+static unsigned char fake_mem[256];
+
+static int fake_read_mem(void *user, unsigned int addr, int len,
+                         char *out, int outMax) {
+    static const char hx[] = "0123456789abcdef";
+    int i;
+    (void)user;
+    if (addr > sizeof(fake_mem) || len < 0) return -1;
+    if ((addr + (unsigned int)len) > sizeof(fake_mem)) return -1;  /* the invariant */
+    if ((len * 2) > outMax) return -1;
+    for (i = 0; i < len; i++) {
+        out[i*2]   = hx[(fake_mem[addr+i] >> 4) & 0xF];
+        out[i*2+1] = hx[fake_mem[addr+i] & 0xF];
+    }
+    return len * 2;
+}
+
+static void setup_mem_session(void) {
+    static struct GDBTargetOps ops;
+    memset(&ops, 0, sizeof(ops));
+    ops.readMemory = fake_read_mem;
+    GDBSessionInit(&g_sess, &ops, NULL);
+    fake_mem[0] = 0xDE; fake_mem[1] = 0xAD;
+}
+
+TEST(parse_hex_u32_reads_value) {
+    unsigned int v = 0;
+    ASSERT_EQ(GDBParseHexU32("f00d", 4, &v), 4);
+    ASSERT_EQ((int)v, 0xF00D);
+}
+
+TEST(parse_hex_u32_rejects_non_hex) {
+    unsigned int v = 0;
+    ASSERT_EQ(GDBParseHexU32("zz", 2, &v), -1);
+}
+
+TEST(read_memory_returns_hex) {
+    char reply[256]; int n;
+    setup_mem_session();
+    n = GDBHandlePacket(&g_sess, "m0,2", 4, reply, sizeof(reply));
+    ASSERT_EQ(n, 4);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "dead");
+}
+
+TEST(read_memory_past_end_is_refused) {
+    char reply[256]; int n;
+    setup_mem_session();
+    /* 0xFF + 4 bytes overruns the 256-byte fake guest */
+    n = GDBHandlePacket(&g_sess, "mff,4", 5, reply, sizeof(reply));
+    ASSERT(n > 0);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "E01");
+}
+
+TEST(read_memory_wild_address_is_refused) {
+    char reply[256]; int n;
+    setup_mem_session();
+    n = GDBHandlePacket(&g_sess, "mffffffff,4", 11, reply, sizeof(reply));
+    ASSERT(n > 0);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "E01");
+}
+
+TEST(read_memory_absurd_length_is_refused) {
+    char reply[64]; int n;
+    setup_mem_session();
+    /* len would overflow the caller's reply buffer even if in range */
+    n = GDBHandlePacket(&g_sess, "m0,1000", 7, reply, sizeof(reply));
+    ASSERT(n > 0);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "E01");
+}
+
+TEST(read_memory_without_target_op_is_unsupported) {
+    char reply[256];
+    setup_session();   /* ops.readMemory == NULL */
+    ASSERT_EQ(GDBHandlePacket(&g_sess, "m0,2", 4, reply, sizeof(reply)), 0);
+}
+
 int main(void) {
     SUITE("gdbstub framing");
     RUN(checksum_is_modulo_256_sum);
@@ -185,5 +269,12 @@ int main(void) {
     RUN(qsupported_advertises_packet_size);
     RUN(unknown_command_returns_empty_reply);
     RUN(halt_reason_reports_sigtrap);
+    RUN(parse_hex_u32_reads_value);
+    RUN(parse_hex_u32_rejects_non_hex);
+    RUN(read_memory_returns_hex);
+    RUN(read_memory_past_end_is_refused);
+    RUN(read_memory_wild_address_is_refused);
+    RUN(read_memory_absurd_length_is_refused);
+    RUN(read_memory_without_target_op_is_unsupported);
     return REPORT();
 }


### PR DESCRIPTION
Phase 1 of #652, implementing `docs/gdb-stub-design.md` (merged in #653). Off by default; **no hot-path code is touched** — breakpoints and the armed-flag gate are Phase 2.

## What works

A scripted RSP client attaches over loopback, negotiates `qSupported`, reads all 18 68000 registers and emulated memory, and detaches.

- `src/debug/gdbstub.c` — RSP engine: framing, checksums, run-length decode, dispatch. Contains no socket call and dereferences no Jaguar global, which is what makes it unit-testable standalone.
- `src/debug/gdbtarget.c` — 68K register serialisation and bounds-checked memory reads.
- `src/debug/gdbsock.c` — loopback-only TCP, one client, non-blocking.
- `test/tools/test_gdbstub_proto.c` — 27 tests, including adversarial out-of-range and overflow cases.

## Read this before reviewing: a real GDB cannot attach yet

**The `+`/`-` acknowledgement byte is not implemented.** `gdb_attach_probe.py` passes because it never checks for an ack; a real `m68k-elf-gdb` would stall on its very first `qSupported`. This is documented as a named Phase 2 gap in the design doc rather than left to be discovered. Phase 1's honest claim is that the scripted probe is the only client it supports end to end.

Two related findings, both now corrected in the design doc rather than left overclaiming:

- **The toolchain ships no `m68k-elf-gdb`.** `make jaguar-toolchain-build` was actually run; the built tree contains no debugger among its five tools. Users must bring their own.
- **`rln` emits mc68k COFF, not DWARF.** `objdump`/`readelf` cannot parse it, and `rln -g` produced a byte-identical link. **Every "source-level debugging" claim in the design doc is corrected to symbol-level.**

## Verified independently, not just reported

I re-ran all of this myself on the rebased branch rather than accepting the implementation report:

| Check | Result |
|---|---|
| `make -j8` production build | clean, no warnings from any `src/debug` file |
| `make TEST_EXPORTS=1 test` (sequential) | exit 0, zero FAIL lines |
| `test_gdbstub_proto` | 27 passed, 0 failed |
| `c89-lint.sh` on every touched `src/` file | clean |
| **Loopback bind, by observation** | `netstat` shows `127.0.0.1.2347 LISTEN` — never `*.2347` |
| **Determinism** | `hires_state_digest` over 900 frames, stub disabled vs enabled-and-idle: **byte-identical** (`afc8ea96e322f156…`) |
| SPM manifest | `src/debug/*.c` added; `scripts/check-package-sources.sh` clean |
| iOS static reset | `GDBSockClose()` + `gdb_stub_reset()` in both `retro_unload_game` and `retro_deinit` |

Determinism is the acceptance bar here, not a nicety — the stub must be invisible to emulation, and #400 is what happens when host-side state leaks into the emulated machine.

## Security posture

Binds `htonl(INADDR_LOOPBACK)` only, with no option to change it. One client at a time. No GDB file I/O (`vFile`) — not now, not later. Every guest address is bounds-checked against the 24-bit bus before any read, with adversarial unit tests (wild addresses, absurd lengths, output-buffer overflow) covering that invariant directly.

## Two things found in passing

- `scripts/c89-lint.sh` was missing `-Isrc/debug`; fixed.
- `Package.swift`'s `coreSources` had already drifted from `Makefile.common` — the exact class of bug `check-package-sources.sh` exists to catch. Fixed and now clean.
- `swift build` still fails on a **pre-existing, unrelated** manifest error (`defaultLocalization not set`), reproduced on the untouched manifest before any change here. Left out of scope; worth its own issue.

Refs #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)