### PR TITLE
docs(perf): ARM64/NEON SIMD delegation spec, per-chip tuning, hot-path followups

### DIFF
--- a/docs/perf-audit-2026-08.md
+++ b/docs/perf-audit-2026-08.md
@@ -40,6 +40,9 @@ promoted here.
    vjtrace compiled out of release, crash_detect 256-sample hash/frame, perf probes at slice
    granularity, OP `O(N²)` (teardown-only, 0% of frame), TOM LUT-driven scanline render.
 
+**Related:** ARM64/NEON SIMD tasks — [`perf-audit/simd-neon-arm64.md`](perf-audit/simd-neon-arm64.md); per-chip build tuning —
+[`perf-audit/arm-chip-tuning.md`](perf-audit/arm-chip-tuning.md); non-SIMD hot-path followups — [`perf-audit/hotpath-followups-2026-08.md`](perf-audit/hotpath-followups-2026-08.md).
+
 ## Evidence
 
 ### Host profiles (macOS arm64, `sample`, 12 s each, release `-O3 -g`, fast blitter)

--- a/docs/perf-audit/arm-chip-tuning.md
+++ b/docs/perf-audit/arm-chip-tuning.md
@@ -1,0 +1,360 @@
+# ARM per-chip tuning reference
+
+Pro-level per-chip build-tuning reference for this core's slowest targets (Apple A/M, Snapdragon
+handhelds, generic ARM64 Linux, 32-bit ARM). Shorthand, LLM-oriented. Companion to the SIMD task
+spec [`simd-neon-arm64.md`](simd-neon-arm64.md) (owned by a separate track — reference only, do
+not edit from here).
+
+**DOCUMENT ONLY.** Nothing here is applied. Every settings change is listed in §6 and marked
+**requires approval / not applied**. Ground rules that bind every proposal:
+
+- **#516:** the *last* `-O` wins; never append an `-O` in a platform block; never re-specify
+  platform flags on the command line ([`agent/build.md`](../agent/build.md)).
+- **#517:** no `-Ofast` / `-ffast-math` anywhere (determinism: run-ahead, netplay, savestates).
+- **#560:** per-SoC `-mcpu` is only justified where the platform name identifies the silicon
+  exactly (the `rpi*` model). Generic names get generic flags.
+
+**Provenance of claims.** Compiler behavior was verified on 2026-08-27 on the author's macOS
+host: Apple clang 17.0.0 (clang-1700.6.4.2), iPhoneOS 26.5 / AppleTVOS 26.5 SDKs, via
+`cc -E -dM` macro dumps and `--print-supported-cpus`. LLVM CPU feature sets read from
+`llvm-project` `AArch64.td`. NDK/ARM facts from developer.android.com and the Arm ARM. Anything
+not checked that way is marked **UNVERIFIED**. Linux-gcc cross checks could not run on this host
+(no `aarch64-linux-gnu-gcc` installed) — those are flagged inline.
+
+## What the build passes today (read from source, 2026-08-27)
+
+| Target | `Makefile` lines | Arch/CPU flags actually passed | NEON blitter |
+| --- | --- | --- | --- |
+| `osx` | 266–291 | none (`-arch` via `$(ARCHFLAGS)` only; no `-mcpu`/`-march`) | via `Makefile.common:218-219` host uname |
+| `ios-arm64` | 303–316 | `cc -arch arm64 -isysroot <iphoneos>` + `-miphoneos-version-min=8.0`; **no `-mcpu`** | `Makefile.common:158-159` |
+| `tvos-arm64` | 318–331 | `cc -arch arm64 -isysroot <appletvos>` + `-mappletvos-version-min=11.0`; **no `-mcpu`** | `Makefile.common:158-159` |
+| generic `arm64`/`aarch64` | 359–364 | **nothing** — no `-march`, no `-mcpu`; toolchain default (normally `armv8-a`) | `Makefile.common:162-163` via `ARCH=aarch64` |
+| `rpi0`–`rpi5_64` | 398–440 | per-SoC `-mcpu` (+ 32-bit `-mfpu`/`-mfloat-abi`) — see [`agent/build.md`](../agent/build.md) table | rpi2+ |
+| generic `armv*` | 442–455 | name-derived only; `HAVE_NEON` iff name contains `neon` | conditional |
+| `libnx` (Switch) | 467 | `-march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd` | via `armv8` name match |
+| Android (`jni/Android.mk`) | Android.mk 24–33, 52–54 | ndk-build ABI defaults (arm64-v8a ⇒ `armv8-a` baseline); `COREFLAGS` adds `-O3` + #569 visibility flags, **no `-march`/`-mcpu`** | Android.mk 25–28 |
+
+`-O3` for the Apple/unix/rpi rows comes from `OPT_O3_PLATFORMS` (`Makefile:70-71`), not the
+platform blocks (#516).
+
+---
+
+## 1. Apple A/M series (iOS, tvOS, macOS)
+
+### 1.1 Accepted `-mcpu` values (verified)
+
+Apple clang 17.0.0 `--print-supported-cpus` (host, 2026-08-27): `apple-a7` … `apple-a18`,
+`apple-m1` … `apple-m4`, `apple-s4` … `apple-s10`. `-mtune=apple-*` is also accepted (verified:
+`-mtune=apple-m1` compiles clean). `-mcpu` implies both ISA selection and tuning.
+
+### 1.2 What the repo's flags produce today (verified via `-E -dM`)
+
+| Build | Defined | NOT defined |
+| --- | --- | --- |
+| `ios-arm64` flags (`Makefile:303-316`) | `__aarch64__`, `__ARM_NEON`, `__ARM_FEATURE_AES/SHA2/CRYPTO`, `__ARM_ARCH 8` | `__ARM_FEATURE_CRC32`, `__ARM_FEATURE_ATOMICS`, `__ARM_FEATURE_DOTPROD` |
+| `tvos-arm64` flags (`Makefile:318-331`) | same | same |
+| `tvos` + `-mcpu=apple-a10` (experiment) | + `__ARM_FEATURE_CRC32` | still no `ATOMICS` |
+| `tvos` + `-mcpu=apple-a12` (experiment) | + `CRC32`, `ATOMICS`, `QRDMX` | — |
+| `osx` host arm64 default | `CRC32`, `ATOMICS`, `DOTPROD`, `NEON` | — |
+
+Read: with no `-mcpu`, Apple clang's device floor for `-arch arm64` iOS/tvOS is the **A7
+baseline** (ARMv8.0 + NEON + crypto, no CRC32, no LSE). macOS arm64 defaults to an
+apple-m1-class baseline, so the host build already gets CRC32/LSE/DotProd for free. This is why
+`simd-neon-arm64.md` T5's `__ARM_FEATURE_CRC32` guard is a no-op on today's iOS/tvOS builds and
+active on macOS — by design of the guard, not by accident.
+
+Note: [`simd-neon-arm64.md`](simd-neon-arm64.md) §Do-not-re-propose says per-SoC `-mcpu` is
+"Done — #560 (rpi4, ios-arm64, etc.)". For `ios-arm64` that is **not what the Makefile shows**
+(lines 303–316 carry no `-mcpu`); #560 gave iOS a correct platform block, not a CPU pin.
+
+### 1.3 Device floors and per-core features
+
+Feature columns verified against LLVM `AArch64.td` (`ProcAppleA7`/`A10`/`A11`…: A7/A8/A9 =
+NEON+crypto **without** `FeatureCRC`; A10 adds `FeatureCRC`+`RDM`+`PAN`+`LOR`+`VH` but **not**
+`FeatureLSE`; A11 = `HasV8_2aOps` ⇒ v8.1 LSE atomics mandatory; A12 = v8.3; A13 = v8.4;
+A14/M1 = v8.4+).
+
+| Chip | ISA class | NEON | crypto | CRC32 | LSE atomics |
+| --- | --- | --- | --- | --- | --- |
+| A7–A9 | v8.0 | yes | yes | **no** | no |
+| A10 (Fusion) | v8.0+ext | yes | yes | yes | **no** |
+| A10X | same as A10 | yes | yes | yes (per ProcAppleA10; A10X-specific entry not checked — UNVERIFIED) | no |
+| A11 | v8.2 | yes | yes | yes | yes |
+| A12 / A12X | v8.3 | yes | yes | yes | yes |
+| A13, A14/M1, A15/M2, … | v8.4+ | yes | yes | yes | yes |
+
+OS floors (verified via 2025-06 WWDC coverage; still current for the 26.x cycle):
+
+- **tvOS:** tvOS 26 still supports **Apple TV HD (2015, A8)** → tvOS floor = **A8 = no CRC32,
+  no LSE**. Apple TV 4K gen1 = A10X, gen2 (2021) = A12, gen3 (2022) = A15.
+- **iOS:** iOS 26 floor = **A13** (iPhone 11 / SE2). iPadOS 26 floor = A12.
+- The core's own `MINVERSION` (iOS 8.0 / tvOS 11.0, `Makefile:311/329`) is far below any
+  frontend's real floor. RetroArch's and Provenance's current deployment targets were **not
+  checked** (UNVERIFIED) — they, not this Makefile, define which chips can actually load the
+  dylib. **Do not raise `-mcpu` past the floor of the *loosest* frontend that ships this core.**
+
+Consequence: `-mcpu=apple-a10`+ on **tvOS** emits CRC32 instructions ⇒ SIGILL on Apple TV HD.
+`-mcpu=apple-a12`+ on **iOS** is safe only if every shipping frontend requires iOS 17+
+(A12 floor) — currently UNVERIFIED, so treated as unsafe.
+
+### 1.4 Why `-mcpu` matters less here anyway
+
+- **No ELF interposition problem:** Mach-O ld64 two-level namespace resolves same-image symbols
+  directly; the entire #569 GOT/PLT issue (audit P2) never applied to Apple targets
+  ([`agent/build.md`](../agent/build.md) §ELF visibility). The big Apple wins are algorithmic
+  (audit P1/P3/P9), not flags.
+- **Wide out-of-order cores:** every A10+ big core is a wide OoO design with large unified L2 and
+  aggressive prefetch; scheduling models (`-mtune`) move little on such cores compared to
+  in-order A53-class parts where `-mcpu` reorders dual-issue pairs. Expect ≤1-2% from tune-only
+  changes (estimate, UNVERIFIED — the measured #515 datum is that `-O3` itself was +5.5% on
+  macOS arm64).
+- **`-O3`, never `-Ofast`** (#517; `Makefile:33-71` comments).
+- The only *codegen-feature* upside of a CPU pin on iOS would be LSE atomics + CRC32; this core's
+  hot loops are single-threaded integer interpreters that use neither (atomics: see §3.2).
+
+### 1.5 Profiling pointer
+
+dsymutil/Instruments/`xctrace` recipe (incl. keeping `-O3 -g` via `RELEASE_DEBUG_INFO=1`, UUID
+match, `device_perf.sh`): [`device-profiling.md`](device-profiling.md); short form in
+[`perf-audit-2026-08.md`](../perf-audit-2026-08.md) §Measurement recipes.
+
+---
+
+## 2. Qualcomm Snapdragon (Android handhelds)
+
+### 2.1 SoCs in the wild
+
+Common Jaguar-capable Android gaming handhelds (device↔SoC verified from 2025-26 spec sheets for
+RP5/Odin 2; others widely reported, UNVERIFIED individually):
+
+| Device class | SoC | CPU config | Kryo name |
+| --- | --- | --- | --- |
+| AYN Odin 1 / Retroid Pocket 3+ era | SD 845 | 4×Kryo 385 Gold (Cortex-A75-derived) + 4×Kryo 385 Silver (A55-derived) | Kryo 385 |
+| Retroid Pocket 5 / Pocket Mini / Odin 1 Pro-class | SD 865 | 1×A77@2.84 + 3×A77@2.42 + 4×A55@1.8 (Kryo 585 = A77/A55-derived) — verified | Kryo 585 |
+| AYN Odin 2 / Odin 2 Mini/Portal | SD 8 Gen 2 | 1×Cortex-X3 + 2×A715 + 2×A710 + 3×A510 — verified | Kryo (unnumbered) |
+| 2025+ flagships | SD 8 Elite | Oryon custom cores; **no SVE, NEON only** (widely reported, UNVERIFIED) | — |
+| Retroid Pocket 4 Pro (not Snapdragon) | Dimensity 1100 | 4×A78 + 4×A55 (widely reported, UNVERIFIED) | — |
+
+Kryo 3xx/5xx are semi-custom Arm Cortex derivatives; there are **no** `-mcpu=kryo-585`-style
+names in GCC/Clang — you tune them as their underlying Cortex cores.
+
+### 2.2 `-mcpu`/`-mtune` values per generation (if you *could* pin one)
+
+GCC AArch64 accepts combined big.LITTLE tuning names — verified in GCC docs: permissible `-mtune`
+(and therefore `-mcpu`) values include `cortex-a75.cortex-a55`, `cortex-a76.cortex-a55` (GCC ≥ 8
+era; the a75/a76 pairs are listed from GCC 9+; exact first version UNVERIFIED). Clang does **not**
+accept the dotted pair names — use the big core alone.
+
+| SoC | GCC | Clang/NDK |
+| --- | --- | --- |
+| SD 845 | `-mcpu=cortex-a75.cortex-a55` (or `-mcpu=cortex-a75`) | `-mcpu=cortex-a75` |
+| SD 865 | `-mcpu=cortex-a77` (no dotted a77 pair in GCC docs read — UNVERIFIED whether one exists) | `-mcpu=cortex-a77` |
+| SD 8 Gen 2 | `-mcpu=cortex-x3` | `-mcpu=cortex-x3` |
+
+**But: none of this is shippable in the Android build.** See next.
+
+### 2.3 NDK reality (what is actually feasible)
+
+- `jni/Android.mk` builds whatever ABIs `APP_ABI` lists; there is no per-device axis. The
+  official ABI docs state **arm64-v8a is "Armv8.0 only"** (verified) — the NDK baseline is plain
+  `armv8-a`: no `+crc`, no `+crypto`, no LSE assumption at compile time.
+- CRC32 is **optional in ARMv8.0 and mandatory only from ARMv8.1** (verified, Arm ARM
+  DDI0596 CRC32 page). So `-march=armv8-a+crc` baked into a single Play/buildbot APK is a bet
+  that no v8.0 device without CRC ever loads it. In practice every Cortex-A53/A55-based Android
+  SoC ships CRC (UNVERIFIED as a universal claim — and Apple proved v8.0-without-CRC silicon
+  exists), so the safe engineering position is: **don't bake `+crc`, don't bake `+crypto`**
+  (crypto is a licensable option and known-absent on some older devices).
+- One APK, many chips ⇒ per-device `-mcpu` is off the table. What IS feasible:
+  1. **Keep baseline `armv8-a`** (today's state) — correct default.
+  2. **Runtime dispatch** for the few optional-ISA wins (only candidate in this codebase:
+     hardware CRC32, [`simd-neon-arm64.md`](simd-neon-arm64.md) T5 — cold path, load-time only):
+
+     ```c
+     #include <sys/auxv.h>
+     #ifndef HWCAP_CRC32
+     #define HWCAP_CRC32 (1UL << 7)   /* aarch64 AT_HWCAP bit */
+     #endif
+     use_hw = (getauxval(AT_HWCAP) & HWCAP_CRC32) != 0;
+     ```
+
+     plus a `__attribute__((target("+crc")))` (GCC/Clang AArch64, verified in GCC 14 docs) on
+     the HW-path function so only that function is compiled with the extension. Full
+     function-multi-versioning (`target_version`/`target_clones`, ifunc-based) also exists on
+     AArch64 (GCC 14+/Clang, verified) but is overkill for one cold CRC function — and ifunc
+     resolution order inside a `dlopen`ed core is an extra risk for zero gain. Prefer the
+     explicit `getauxval` branch.
+  3. **`-mtune=<core>` without `-mcpu`** would be ISA-safe (tuning only, no new instructions),
+     but there is no single right answer across A55/A77/X3 in one APK; generic tuning is the
+     NDK default for a reason. Not proposed.
+- On 32-bit `armeabi-v7a`: NEON is guaranteed by NDK r21+ defaults and r26 dropped non-NEON v7
+  entirely (`jni/Android.mk:18-19` comment; CI pins r26d). For AArch32 the CRC/AES hwcaps live
+  in `AT_HWCAP2`, not `AT_HWCAP` (verified, Arm blog) — T5 correctly stays `__aarch64__`-only.
+
+### 2.4 big.LITTLE scheduling
+
+A libretro core cannot set thread affinity or governor — it is a guest in the frontend process.
+Document for users instead:
+
+- RetroArch: threaded video off for this core (single hot thread), and on Android the frame
+  cadence lives or dies by whether the hot thread stays on a big core — that is the OS scheduler
+  + governor's decision, not ours.
+- User-side: "performance" governor / disable battery-saver / device gaming mode. Sustained
+  load on SD865-class handhelds with active cooling (RP5 has a fan) holds big-core clocks;
+  passively cooled devices (Odin 2) throttle later but from a faster baseline.
+- Frontend-side scheduling (RetroArch `sustained_performance_mode` on Android) exists; whether
+  current RetroArch builds expose it for cores is UNVERIFIED here.
+
+---
+
+## 3. Generic ARM64 Linux
+
+### 3.1 Today
+
+`Makefile:359-364`: the `arm64`/`aarch64` platform block sets linker/ARCH only — **no `-march`,
+no `-mcpu`**. Codegen = toolchain default, i.e. `-march=armv8-a` on standard
+`aarch64-linux-gnu` GCC (distros may configure higher; UNVERIFIED per-distro). NEON blitter is
+selected by platform/ARCH name (`Makefile.common:162-163`), and #569 gives it
+`-fvisibility=hidden -fno-semantic-interposition`. This is the libretro-buildbot target
+(`linux-aarch64.yml`), i.e. one binary for every ARM64 Linux device — the same
+single-binary constraint as Android. Baseline `armv8-a` is correct; per-chip tuning belongs to
+the `rpi*` names, which already have it.
+
+### 3.2 SVE / SVE2 — verdict: not applicable
+
+| Chip in scope | SVE/SVE2 |
+| --- | --- |
+| Pi 3/4/5 (A53/A72/A76) | none |
+| SD 865 (A77) | none |
+| SD 8 Gen 1/2/3 (X2/X3/A7xx, Armv9) | SVE2 @ VL=128 (X3/A715 verified); Android exposes via `HWCAP2_SVE2` (kernel mechanism verified; per-device kernel enablement UNVERIFIED) |
+| SD 8 Elite (Oryon) | none (widely reported, UNVERIFIED) |
+| Apple A-series, M1–M3 | none |
+| Apple M4 | SME/SME2, **not** SVE for NEON-style code (widely reported, UNVERIFIED against Apple docs) |
+
+So: of every device this core actually targets, only the SD 8 Gen 2-class handhelds have SVE2 at
+all, at VL=128 — the same 128-bit width as NEON, reached only via runtime dispatch inside a
+single binary, for kernels ([`simd-neon-arm64.md`](simd-neon-arm64.md) T1–T4) that are small,
+already NEON-shaped, and mostly ≤128-bit wide. **No SVE work is justified.** NEON-only
+intrinsics, compile-time guarded, remain the policy.
+
+### 3.3 outline-atomics
+
+`-moutline-atomics` is default-on for AArch64 GCC since 10.1, and default for Clang on
+Linux/Android targets since D93585 (Clang 12, requires libgcc ≥ 9.3.1 or compiler-rt) — both
+verified. It affects only `__atomic`/`_Atomic` operations (call into `__aarch64_ldadd*` etc.
+that pick LSE at runtime). This core's emulation path is single-threaded and its hot loops use
+no C atomics (netplay/voice paths use sockets, not shared-memory atomics — spot-checked, not
+exhaustively audited: UNVERIFIED as an absolute). Verdict: **irrelevant here; leave the default
+alone.** On `rpi5*`, `-mcpu=cortex-a76` already implies LSE so any atomic would inline anyway.
+
+---
+
+## 4. 32-bit ARM (rpi2/3 32-bit userland, armv7 Android)
+
+### 4.1 What changes vs AArch64 NEON
+
+- 32 × 64-bit D registers = 16 × 128-bit Q registers (vs 32 × 128-bit V on AArch64): heavier
+  register pressure in wide kernels; keep live vector counts small.
+- No float64 lanes (`float64x2_t` does not exist — verified: armv7 clang errors).
+- Intrinsics operate through the ACLE common subset; the A64-only additions below are simply
+  not declared for A32.
+- Alignment: `vld1q_u8`-family intrinsics have no alignment requirement on either ISA
+  (alignment-hinted encodings exist on A32 but intrinsics don't emit them unless the pointer
+  type promises it) — no porting hazard for the planned loads/stores.
+- `vrev16q_u8` **exists on ARMv7 NEON** (VREV16 is an ARMv7 Advanced-SIMD instruction) —
+  verified by compiling for `armv7-none-linux-gnueabihf`. The T3 scanline plan's byte-swap
+  approach is portable as written.
+
+**Compile check (2026-08-27, clang 17, `-target armv7-none-linux-gnueabihf -mfpu=neon`):** every
+intrinsic named in the parallel spec's code samples — `vld1_u8`, `vst1_u8`, `vbsl_u8`,
+`vceq_u16`, `vdup_n_u16`, `vrev16q_u8`, `vshrq_n_u16`, `vshll_n_u16`, `vld4_u8`, `vqaddq_s16`,
+`vld1q_s16`, `vst1q_s16`, `vdupq_n_s16` — **compiles for ARMv7**. The A64-only probes
+(`vaddvq_u32`, `vqtbl1q_u8`, `vzip1q_u32`, `vrbit_u8`, `float64x2_t`) all **fail** on the same
+target. GCC-armhf behavior assumed identical via ACLE (UNVERIFIED on this host — no cross gcc;
+re-check in the arm-linux-gnueabihf container per [`agent/build.md`](../agent/build.md)).
+
+### 4.2 AArch64-only intrinsics to avoid (so SIMD tasks stay rpi2/rpi3-32-bit portable)
+
+Families, not exhaustive (ACLE marks each as A64-only):
+
+| Family | Members | 32-bit replacement |
+| --- | --- | --- |
+| Horizontal reductions | `vaddv*`, `vaddlv*`, `vmaxv*`, `vminv*` | `vpadd`/`vpmax` pyramid + lane extract |
+| Full-width table lookup | `vqtbl1q`–`vqtbl4q`, `vqtbx*` | `vtbl1`–`vtbl4` (64-bit tables) |
+| One-instruction permutes | `vzip1/vzip2`, `vuzp1/vuzp2`, `vtrn1/vtrn2` (q and d forms) | A32 `vzip/vuzp/vtrn` (two-result struct forms) |
+| Scalar-pairwise f64 | `vpaddd_*`, `vpadds_*` | n/a — avoid |
+| Bit reverse | `vrbit*` | scalar `__builtin_bitreverse` or restructure |
+| f64 vectors | `float64x1_t`/`float64x2_t` + all `*_f64` | keep float math scalar (hot loops are integer anyway) |
+| Widening "high" ops | `vmovl_high_*`, `vaddl_high_*`, `vmull_high_*`, `vshll_high_n_*` | `vget_high_*` + the base op (2 intrinsics) |
+| Misc A64 | `vcopy*_lane*`, `vdupq_laneq_*`, `vrnd*` on f32 vectors (v8 FP rounding), `vsqrtq_f32`, `vcvt*_f64` | avoid / scalar |
+| CRC32 | `__crc32b/h/w/d` under `__ARM_FEATURE_CRC32` | already `__aarch64__`-gated in T5 — correct |
+
+Rule of thumb already followed by the parallel spec: if a NEON kernel compiles with
+`-target armv7-none-linux-gnueabihf -mfpu=neon`, it runs on everything from rpi2 up. Add that
+one-line compile check to any new `*_simd_neon.{c,h}` before review.
+
+---
+
+## 5. Feature detection matrix
+
+### Compile-time macros
+
+| Macro | Set by | Meaning / trap |
+| --- | --- | --- |
+| `__ARM_NEON` | GCC/Clang, both ISAs | AArch64: always. 32-bit: only with NEON `-mfpu`. (Legacy 32-bit spelling `__ARM_NEON__` also exists.) |
+| `__aarch64__` | GCC/Clang | 64-bit ISA (implies NEON) |
+| `_M_ARM64` | MSVC | 64-bit ARM Windows (buildbot MSVC rows, `Makefile.common:190`: no x86 intrinsics there; blitter NEON path uses GCC-style intrinsics — MSVC ARM64 currently lands scalar) |
+| `__ARM_FEATURE_CRC32` | flags say CRC is unconditionally available | today: macOS arm64 host, `rpi3+` (`-mcpu=cortex-a53+` — expected per GCC core defs, UNVERIFIED on this host), libnx (`+crc` explicit, `Makefile:467`). NOT iOS/tvOS/Android/generic-arm64. |
+| `__ARM_FEATURE_CRYPTO` | deprecated umbrella (AES+SHA2); prefer `__ARM_FEATURE_AES` / `__ARM_FEATURE_SHA2` | set on all Apple builds (A7 baseline includes crypto) |
+| `__ARM_FEATURE_ATOMICS` | LSE guaranteed | macOS host yes; iOS/tvOS default no (A7 floor) |
+| `__ARM_FEATURE_SVE` | SVE codegen enabled | never set on any target in scope (§3.2) |
+
+### Runtime detection
+
+| Platform | Mechanism |
+| --- | --- |
+| Linux / Android 64-bit | `getauxval(AT_HWCAP)` — `HWCAP_CRC32`, `HWCAP_AES`…; `AT_HWCAP2` for SVE2 etc. |
+| Linux / Android 32-bit process | ARMv8 features are in `AT_HWCAP2` (NEON in `AT_HWCAP`) — different split, easy to get wrong |
+| Apple | `sysctlbyname("hw.optional.armv8_crc32", …)` / newer `hw.optional.arm.FEAT_*` names (names widely documented; not exercised here — UNVERIFIED) |
+| Windows ARM64 | `IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE)` (UNVERIFIED) |
+
+### Which approach each planned task should use
+
+| Task ([`simd-neon-arm64.md`](simd-neon-arm64.md)) | Detection | Why |
+| --- | --- | --- |
+| T1 bswap, T2 OP phrase, T3 scanlines, T4 voice mix | **compile-time only** (`BLITTER_SIMD_HAVE_NEON` / `__ARM_NEON`) | builds are per-platform; NEON is a build-time fact on every target that gets these files (`Makefile.common:154-167`, `jni/Android.mk:25-28`); zero runtime cost, zero dispatch state |
+| T5 hardware CRC32 | compile-time `__ARM_FEATURE_CRC32 && __aarch64__` as specced — covers macOS + rpi3+. **If** Android/generic-arm64 coverage is ever wanted: add the §2.3 `getauxval` + `target("+crc")` branch; do NOT bake `+crc` into `-march` | single-binary targets can't promise CRC at compile time; cold path so a runtime branch costs nothing |
+| Anything SVE | none | rejected, §3.2 |
+
+---
+
+## 6. Recommended settings changes — **all: requires approval / not applied**
+
+Conservative by policy: #516 (flags live in platform blocks, last `-O` wins), #517 (no fast-math),
+#560 (`-mcpu` only where the name = the silicon). Every row is a *proposal*; nothing has been
+edited.
+
+| # | Change | Exact proposed diff | Recommendation | Status |
+| --- | --- | --- | --- | --- |
+| 1 | tvOS CPU pin | none — explicitly rejected: floor is Apple TV HD (A8); `-mcpu=apple-a10`+ emits CRC32 ⇒ SIGILL (§1.2/1.3) | keep as-is | rejected, do not apply |
+| 2 | iOS CPU pin | opt-in knob only, e.g. in the ios block (`Makefile:303-316`): `ifeq ($(IOS_MCPU),a12)` → `CFLAGS += -mcpu=apple-a12` | do NOT default until the shipping frontends' deployment floors are verified ≥ iOS 17 (A12); expected win small on OoO cores (§1.4) — measure with `device_perf.sh` first | requires approval / not applied |
+| 3 | tvOS/iOS tune-only | `CFLAGS += -mtune=apple-a10` (tvOS) — ISA-safe, changes scheduling only | only after an A/B on A8/A10X hardware shows a win; otherwise noise risk for zero verified gain | requires approval / not applied |
+| 4 | generic `arm64`/`aarch64` block | **stay `-march=armv8-a` (toolchain default)** — single-binary buildbot target; do not add `+crc`/`+crypto`/`-mcpu` | keep as-is | no change proposed |
+| 5 | `jni/Android.mk` `-march` extensions | none — arm64-v8a stays baseline `armv8-a` (§2.3). If T5-on-Android is wanted, that is a *source* change (getauxval dispatch), not a build-flag change | keep as-is | rejected for flags; source-side dispatch requires its own approval |
+| 6 | Switch (`libnx`) | note only: `Makefile:467` passes both `-mtune=cortex-a57` and `-mcpu=cortex-a57+crc+fp+simd`; `-mcpu` implies `-mtune`, so the pair is redundant (harmless — `-mcpu` wins for the overlapping part per GCC docs). Cleanup candidate, zero perf impact | optional cleanup | requires approval / not applied |
+| 7 | LTO default | unchanged — `LTO=1` knob stays opt-in until the Pi A/B ([`simd-neon-arm64.md`](simd-neon-arm64.md) T6; `Makefile:1046-1055`) | keep as-is | pending measurement |
+| 8 | New-file policy | any new `*_simd_neon.*` must pass the §4.2 armv7 compile check before review | process note, no build change | adopt in review checklist |
+
+If #2 or #3 is ever applied: the flag goes **inside the platform block** (never the command
+line), no `-O` is touched, and `test/tools/simd_matrix_check.sh` gains a row asserting the new
+flag — the same guard pattern the rpi rows use ([`agent/build.md`](../agent/build.md)).
+
+---
+
+## Related documents
+
+- [`simd-neon-arm64.md`](simd-neon-arm64.md) — the SIMD task specs this doc constrains (T1–T6).
+- [`perf-audit-2026-08.md`](../perf-audit-2026-08.md) — audit P1–P9; why algorithmic work
+  dominates flags on Apple targets.
+- [`agent/build.md`](../agent/build.md) — rpi per-SoC table, #516/#517/#569 detail, C89 exempt
+  list.
+- [`device-profiling.md`](device-profiling.md) — Instruments/xctrace on-device recipe.

--- a/docs/perf-audit/hotpath-followups-2026-08.md
+++ b/docs/perf-audit/hotpath-followups-2026-08.md
@@ -1,0 +1,328 @@
+# Non-SIMD hot-path followups — 2026-08-27
+
+Seven non-SIMD findings from a fresh hot-path hunt over the current tree (2026-08-27),
+ranked. Shorthand, LLM-oriented, same delegation format as
+[`simd-neon-arm64.md`](simd-neon-arm64.md) — each finding is self-contained. All impact
+tiers are **code-reading estimates, unprofiled**; audit **P1** (idle-loop fast-forward,
+[`perf-audit-2026-08.md`](../perf-audit-2026-08.md)) still dwarfs everything here.
+
+**Branch:** off `libretro/develop`. **C89 strict** (`bash scripts/c89-lint.sh` before
+pushing). **Test gates (every finding):** `make TEST_EXPORTS=1 test` + RetroArch smoke on
+a commercial title. Audio-path changes (F6, F7): **both** `test_audio_clipping` **and**
+`test_audio_presence` — clipping alone misses the silencing-regression class.
+
+---
+
+## F1 — Use `GET_CURRENT_SOFTWARE_FRAMEBUFFER` to skip the frontend frame copy
+
+| | |
+| --- | --- |
+| **Impact** | MED on Pi-class software-video drivers — **speculative, needs device A/B** |
+| **Risk** | MED — buffer lifetime/pitch handling; must fall back cleanly |
+| **Effort** | M |
+
+`RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER` is unused. The core renders into its
+own calloc'd buffer and hands it to `video_cb`; RetroArch's software video driver then
+copies it into a staging texture every frame (~300 KB/frame at 1x, ~1.2 MB at 2x).
+
+### Files and lines
+
+- `libretro.c:5049-5051` — allocation:
+
+  ```c
+  video_buffer_alloc_pixels =
+     VIDEO_BUFFER_PIXELS * shadowHiresN * shadowHiresN;
+  videoBuffer  = (uint32_t *)calloc(sizeof(uint32_t), video_buffer_alloc_pixels);
+  ```
+
+- `libretro.c:6213` — submit: `video_cb(videoBuffer, game_width, game_height, game_width << 2);`
+- `src/core/jaguar.c:1198-1209` — `JaguarSetScreenBuffer()` / `JaguarSetScreenPitch()`
+  (where TOM's render target is pointed).
+- `libretro.c:6144-6194` — tail-row blanking block (writes `videoBuffer` directly).
+
+### Mechanism
+
+Query the env call at the top of `retro_run` each frame. When the frontend offers a
+buffer with format XRGB8888 and compatible size/pitch, point `JaguarSetScreenBuffer()` /
+`JaguarSetScreenPitch()` at the frontend buffer for that frame; pass the same pointer to
+`video_cb`. Fall back to `videoBuffer` when the call is declined or the offer is
+incompatible. The tail-row blanking block (6144-6194) must target whichever buffer is
+active that frame (it currently hardcodes `videoBuffer`), as must
+`CrashDetectFrameTick`'s fb argument (6210).
+
+Worth nothing on GPU-accelerated video drivers, which decline the call — **A/B on a Pi
+with the software video driver before building this out.**
+
+### Test gates
+
+`make TEST_EXPORTS=1 test`; RetroArch smoke with both a driver that grants the call and
+one that declines it; savestate/rewind smoke (buffer swaps between frames).
+
+---
+
+## F2 — Memory Track: 128 KB memcpy per armed flash write
+
+| | |
+| --- | --- |
+| **Impact** | MED during in-game saves — certain |
+| **Risk** | LOW |
+| **Effort** | S |
+
+`mt_pack_save_buf` memcpys the whole 128 KB Memory Track (`MT_SAVE_SIZE`, defined
+`0x20000` at `libretro.c:189`) on **every** armed write. `mt_dirty_cb` fires from
+`MTWriteByte` / `MTWriteWord` per byte/word of the AT29C010 flash protocol, so an 8 KB
+save bursts ~1 GB of memcpy traffic.
+
+### Files and lines
+
+- `libretro.c:5431-5434`:
+
+  ```c
+  static void mt_pack_save_buf(void)
+  {
+     memcpy(eeprom_save_buf + MT_SAVE_OFFSET, mtMem, MT_SAVE_SIZE);
+  }
+  ```
+
+- `libretro.c:5096` — `mt_dirty_cb = mt_pack_save_buf;`
+- `src/core/memtrack.c:163-203` — `MTWriteByte` / `MTWriteWord` fire `mt_dirty_cb` at
+  170-171 and 199-200 (once per armed byte/word write).
+- `src/core/nvmbios.c:87-88` — NVM BIOS HLE write path also fires `mt_dirty_cb`.
+
+### Mechanism
+
+Set a dirty flag in `mt_dirty_cb`; do the memcpy once per frame in `retro_run` when the
+flag is set (then clear it). This matches the freshness contract the EEPROM path already
+provides — the save buffer only needs to be current when the frontend reads it, which
+happens between frames.
+
+### Test gates
+
+`make TEST_EXPORTS=1 test` (includes `test_memtrack`, `test_nvmbios`); RetroArch smoke:
+in-game save on a Jaguar CD title, exit, reload, verify the save survives.
+
+---
+
+## F3 — retro_serialize zero-fills ~350-450 KB of slack per call
+
+| | |
+| --- | --- |
+| **Impact** | LOW-MED when rewind/run-ahead active (they serialize every frame) |
+| **Risk** | LOW |
+| **Effort** | S |
+
+### Files and lines
+
+- `libretro.c:4132-4134`:
+
+  ```c
+  /* Zero-fill remaining bytes for deterministic save states */
+  if (written < STATE_SIZE)
+     memset(buf, 0, STATE_SIZE - written);
+  ```
+
+- `src/core/state.h:185` — `#define STATE_SIZE 0x280000` (2,621,440 bytes) vs a ~2.2 MB
+  payload.
+- `libretro.c:4118-4129` — the one-shot headroom log prints the true payload/slack.
+
+### Mechanism
+
+Query `RETRO_ENVIRONMENT_GET_SAVESTATE_CONTEXT` once (it is stable per session); skip the
+zero-fill for `RETRO_SAVESTATE_CONTEXT_ROLLBACK_NETPLAY` /
+`RETRO_SAVESTATE_CONTEXT_RUNAHEAD_SAME_INSTANCE` contexts, where the buffer never touches
+disk and slack bytes are never compared. Keep the zero-fill for normal (on-disk) states —
+deterministic bytes there are load-bearing for state-diff tooling.
+
+### Test gates
+
+`make TEST_EXPORTS=1 test` (savestate round-trip tests); RetroArch smoke with rewind and
+run-ahead enabled; save-to-disk / load-from-disk still byte-stable across two saves.
+
+---
+
+## F4 — Second unconditional per-frame `clock_gettime`
+
+| | |
+| --- | --- |
+| **Impact** | LOW — certain |
+| **Risk** | LOW |
+| **Effort** | S |
+
+Audit P8 flags the per-frame clock query inside `JLinkFrameTick`
+(`src/jerry/jlink.c:689-694`, called at `libretro.c:5957`). There is a **second** one:
+the netlink peer-picker rate-limit block calls `JLinkNowMs()` every frame even with
+netlink disabled. P8's "one clock query/frame" count is stale — it is two.
+
+### Files and lines
+
+- `libretro.c:6087-6098`:
+
+  ```c
+  {
+     uint32_t disc_now = JLinkNowMs();
+     if (JLinkDiscConsumeChanged())
+        netlink_peers_dirty = 1;
+     if (netlink_peers_dirty
+         && (uint32_t)(disc_now - netlink_last_rebuild_ms) >= 2000)
+     ...
+  ```
+
+- `src/jerry/jlink.c:82-91` — `JLinkNowMs()` → `clock_gettime(CLOCK_MONOTONIC)`.
+
+### Mechanism
+
+Guard the block on `JLinkMode() != JLINK_MODE_DISABLED || netlink_peers_dirty` so the
+clock read (and the `JLinkDiscConsumeChanged()` call) is skipped in the common
+netlink-off case. Fold into the P8 jlink gate when that lands — the sticky
+`netlink_peers_dirty` latch semantics (see the comment block at `libretro.c:6069-6086`)
+must be preserved: a change may be delayed, never lost.
+
+### Test gates
+
+`make TEST_EXPORTS=1 test` (includes `test_jlink_netpacket`, netlink witnesses);
+RetroArch smoke with netlink off and a two-instance netlink session.
+
+---
+
+## F5 — `LOG_DBG` has no compile-out (regression-proofing)
+
+| | |
+| --- | --- |
+| **Impact** | ~0 today — regression-proofing only |
+| **Risk** | LOW |
+| **Effort** | S |
+
+### Files and lines
+
+- `src/core/log.h:26-31` — `VJ_LOG` always evaluates args + makes an indirect call:
+
+  ```c
+  #define VJ_LOG(level, ...) do { \
+     if (vj_log_cb) vj_log_cb(level, __VA_ARGS__); \
+     else vj_log_stderr(__VA_ARGS__); \
+  } while (0)
+
+  #define LOG_DBG(...) VJ_LOG(RETRO_LOG_DEBUG, __VA_ARGS__)
+  ```
+
+- Current hot-path uses are all rate-capped or edge-gated, so today's cost is compares:
+  `src/core/jaguar.c:1176-1178` (edge-gated on one address), `src/jerry/dac.c:493-496`
+  (rate-capped), `src/jerry/dsp.c:606-612` (rate-capped).
+
+### Mechanism
+
+`#define LOG_DBG(...) do {} while (0)` under `NDEBUG` (or behind a `VJ_DEBUG_LOG` opt-in);
+keep `LOG_INF`/`LOG_WRN`/`LOG_ERR` live. Without this, any future `LOG_DBG` dropped into a
+per-access path ships at full argument-evaluation cost silently.
+
+### Test gates
+
+`make TEST_EXPORTS=1 test` on both a stock and an `NDEBUG`/opt-in build; grep that no
+release-relevant diagnostics (crash watchdog signatures) were downgraded to `LOG_DBG`.
+
+---
+
+## F6 — CDDA-DIAG residue in the hottest write funnels
+
+| | |
+| --- | --- |
+| **Impact** | LOW — certain; removal already sanctioned by the comments themselves |
+| **Risk** | LOW |
+| **Effort** | S |
+
+Diagnostic compares for the Primal Rage CDDA investigation sit in the DSP/Jaguar write
+funnels and are self-documented as removable once that investigation closes.
+
+### Files and lines
+
+- `src/jerry/dsp.c:606-612` — `DSPWriteWord` mailbox range compare:
+
+  ```c
+  if (offset >= 0xF1B270 && offset <= 0xF1B277)
+  {
+     static uint32_t mboxWrites = 0;
+     mboxWrites++;
+     if (mboxWrites <= 40 || (mboxWrites % 10000) == 0)
+        LOG_DBG("[CDDA] DSP mailbox write.w ...");
+  ```
+
+- `src/jerry/dsp.c:679-686` — the `DSPWriteLong` twin (same range compare).
+- `src/core/jaguar.c:1176-1178` — `JaguarWriteLong`:
+
+  ```c
+  if (addr == 0xF1B274 && data != 0)
+     LOG_DBG("[CDDA] DSP mailbox $F1B274 = %08X who=%u 68kpc=$%06X\n", ...);
+  ```
+
+### Mechanism
+
+Delete the three blocks (and the one-shot `VJ_CDDA_SNAPDIR` snapshot at
+`dsp.c:613-634`) when `docs/cd-diagnosis/primal-rage-cdda-diagnosis.md` closes. Bundle
+with the next `dsp.c` / `jaguar.c` perf PR — not worth a standalone one.
+
+### Test gates
+
+Audio-adjacent (DSP write path): **both** `test_audio_clipping` **and**
+`test_audio_presence`; `make TEST_EXPORTS=1 test`; RetroArch smoke on a music-heavy title.
+
+---
+
+## F7 — `GET_AUDIO_VIDEO_ENABLE` audio bit unused
+
+| | |
+| --- | --- |
+| **Impact** | LOW — only during fast-forward; likely not worth standalone |
+| **Risk** | LOW-MED (audio-path change → dual gate) |
+| **Effort** | S |
+
+### Files and lines
+
+- `libretro.c:5898-5912` — env query uses the video bit only (**correctly** — the DSP
+  must run every frame for determinism; only presentation may be skipped):
+
+  ```c
+  enum retro_av_enable_flags av_enable_flags = RETRO_AV_ENABLE_VIDEO;
+  environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &av_enable_flags);
+  tomSkipVideoPresent = (av_enable_flags & RETRO_AV_ENABLE_VIDEO) ? 0 : 1;
+  ```
+
+- Presentation stages that could honour the audio bit: `libretro.c:6106-6116`
+  (`DACPrepareFrame`, `VoiceChatMixInto`, `SoundCallback` call), with the resample loop
+  and the `audio_batch_cb` submit inside `SoundCallback` at `src/jerry/dac.c:376-425`.
+
+### Mechanism
+
+When the frontend clears `RETRO_AV_ENABLE_AUDIO` (fast-forward), skip the presentation
+stages only — the `SoundCallback` resample loop, `VoiceChatMixInto`, and the
+`audio_batch_cb` submit. DSP/DAC emulation stays untouched. Bundle only if already
+touching `dac.c`; the dual audio test gate makes a standalone PR not worthwhile.
+
+### Test gates
+
+**Both** `test_audio_clipping` **and** `test_audio_presence`; `make TEST_EXPORTS=1 test`;
+RetroArch smoke including fast-forward on/off transitions (no pops, audio resumes).
+
+---
+
+## Verified clean (do not re-hunt)
+
+Checked in the same 2026-08-27 pass; nothing to do:
+
+- No hot-path allocations — all buffers are load-time or opt-in.
+- No `time()` / `fflush` / `sprintf` / `fopen` / `getenv` in frame paths (`getenv`
+  results are latched to statics, e.g. `jlink.c` wait-debug, `dsp.c` snapshot dir).
+- Titlehook work is load-time only.
+- Memory Track **reads** are a 3-compare fast path (`memtrack.c`) — only writes have the
+  F2 issue.
+- `BUTCHExec` is gated and cheap when idle.
+- CHD access uses a single-hunk cache — fine.
+- JERRY / 68K dispatch is RAM-first.
+- The only per-frame heap-adjacent item (`branch_condition_table`) is already audit
+  **P4** ([`perf-audit-2026-08.md`](../perf-audit-2026-08.md)).
+
+## Related documents
+
+- [`perf-audit-2026-08.md`](../perf-audit-2026-08.md) — main audit (P1–P9); P1 dominates.
+- [`simd-neon-arm64.md`](simd-neon-arm64.md) — ARM64/NEON SIMD delegation tasks (T1–T6).
+- [`arm-chip-tuning.md`](arm-chip-tuning.md) — per-chip build tuning reference.
+- [`../agent/testing.md`](../agent/testing.md) — harness catalog, audio test pair, acid gate.

--- a/docs/perf-audit/simd-neon-arm64.md
+++ b/docs/perf-audit/simd-neon-arm64.md
@@ -1,0 +1,626 @@
+# ARM64 / NEON SIMD delegation spec
+
+Delegatable, per-task instructions for ARM64 and NEON optimizations in the Virtual
+Jaguar libretro core. Shorthand, LLM-oriented — each task is self-contained so a
+cheaper model can implement one without reading the others.
+
+**Audience:** implementers (human or agent) picking up a single task from this list.
+
+**Chip-tuning companion:** [`arm-chip-tuning.md`](arm-chip-tuning.md) — per-chip ISA
+floors, which feature macros each target actually defines (iOS/tvOS sit at the A7
+baseline — see §Do-not-re-propose), AArch64-only intrinsics to avoid, and the armv7
+portability compile check required below.
+
+**Branch:** off `libretro/develop` (GitFlow integration branch; local `develop` may be
+stale). PRs target `develop`, not `master`.
+
+**C89 / GNU89:** strict outside intrinsics files. No mid-block declarations, no C99
+(`for (int i…)`, compound literals, designated initializers, VLAs). New `*_simd_neon.c`
+/ `*_simd_neon.h` files go on the `scripts/c89-lint.sh::skip_file` list (same pattern as
+`src/tom/blitter_simd_neon.c`). Run `bash scripts/c89-lint.sh src/YOURFILE.c` before
+pushing.
+
+**Host builds on macOS:** prefix `DEVELOPER_DIR=/Library/Developer/CommandLineTools` on
+every `make`/`cc` invocation (see [`CLAUDE.md`](../../CLAUDE.md)).
+
+**Test gates (every task):**
+
+- `make TEST_EXPORTS=1 test` — full white-box suite (auto-relinks with wide ABI).
+- `test/tools/ir_ab.sh --ref libretro/develop HEAD` — instruction-count A/B vs base.
+- `make -C test/acid test` — acid gate (`check-baseline.py`; `Regressions: N` with N>0
+  is a failure).
+- Framebuffer A/B where noted: `test/tools/frame_hash_ab` ≥8,000 frames on Iron Soldier /
+  AvP / Doom / Tempest 2000 (see [`docs/profiling.md`](../profiling.md)).
+- Audio tasks under `src/jerry/`: **both** `test_audio_clipping` and `test_audio_presence`.
+- RetroArch smoke on at least one commercial title before claiming done (headless cannot
+  catch BIOS-mode crashes or judge music vs structured noise).
+- **armv7 portability check:** every new `*_simd_neon.*` file must compile-check against
+  `clang -target armv7-none-linux-gnueabihf -mfpu=neon` (or the documented equivalent in
+  the arm-linux-gnueabihf container, [`docs/agent/build.md`](../agent/build.md)) before
+  review, so it stays rpi2/rpi3-32-bit portable. AArch64-only intrinsics to avoid and the
+  verified-portable list: [`arm-chip-tuning.md`](arm-chip-tuning.md) §4.
+
+**Measurement (before claiming a device win):**
+
+- RPi: `test/tools/rpi_perf.sh` (`build` → `doctor` → `deploy` → `profile`).
+- iOS/tvOS: `test/tools/device_perf.sh` (`doctor` → `build` → `install` → `cfg` →
+  `capture` → `pull` → `report`).
+- macOS host: Instruments Time Profiler on `retro_run` hot paths.
+
+**NEON guards:** reuse `BLITTER_SIMD_HAVE_NEON` from
+[`src/tom/blitter_simd_arch.h`](../../src/tom/blitter_simd_arch.h). **rpi0 / rpi1 stay
+scalar** (ARM1176JZF-S has no NEON). Wire new arch files through `Makefile.common`'s
+`BLITTER_SIMD` selection pattern; only introduce a new `BUILD_AXES` flag if a task truly
+needs a compile-time knob beyond the existing capability macros.
+
+---
+
+## Do not re-propose
+
+These are already done, rejected, or superseded. Do not open duplicate PRs.
+
+| Item | Status |
+| --- | --- |
+| Accurate-blitter phrase ops (LFU, DCOMP, ZCOMP, byte merge, ADDARRAY) | **Done** — `src/tom/blitter_simd_neon.{c,h}`, `blitter_simd_sse2.c` |
+| Fast-blitter SIMD | **Rejected** — audit **F8** ([`perf-audit/blitter.md`](blitter.md) §F8): `blitter_generic` is per-pixel scalar; no natural 4-lane batch without a phrase-batched redesign (F3/F4 class) |
+| Audit **P3** (fast blitter per-pixel `JaguarRead*` dispatch) | **Plan of record** for blitter — see [`perf-audit-2026-08.md`](../perf-audit-2026-08.md) §P3 |
+| ELF `-fvisibility=hidden` / `-fno-semantic-interposition` | **Done** — #569 |
+| Per-SoC `-mcpu` flags | **Done for `rpi*` only** — #560 (`Makefile` 398–440). **NOT Apple targets:** the `ios-arm64`/`tvos-arm64` blocks (`Makefile` 303–331) pass only `-arch arm64` + min-version — no `-mcpu` — so those builds sit at the A7-class baseline (no `__ARM_FEATURE_CRC32`, no LSE). #560 gave iOS/tvOS correct platform blocks, not CPU pins. Detail: [`arm-chip-tuning.md`](arm-chip-tuning.md) §1 |
+| Frontend glue (`libretro.c`) | **Already optimal** — zero frame copies, one audio batch, geometry only on change |
+| Savestate `memcpy`, `crash_detect` 256-sample hash | **Already optimal** |
+| CRY 16bpp scanline LUT (`CRY16ToRGB32`) | **Rejected for NEON** — 64K-entry gather; no win (see T3) |
+| MOVEM batching in `src/m68000/cpuemu.c` | **Rejected** — 68K is 0.7–2.6% of frame |
+| DSP `mmult` / `div` vectorization | **Rejected** — ≤15 serial MACs / bit-serial divider |
+| `DSPSampleCallback` batching | **Rejected** — event-driven, no inner batch loop |
+| TOM CRY LUT replacement | **Rejected** — see T3 |
+
+---
+
+## Codegen probes (T1 / T3 verification)
+
+Run on **2026-08-27** on the author's macOS arm64 host
+(`DEVELOPER_DIR=/Library/Developer/CommandLineTools`). Cross-compilers
+(`aarch64-linux-gnu-gcc`, `arm-linux-gnueabihf-gcc`) were **not installed** on that
+machine; RPi/gcc-armhf numbers should be re-checked on a Linux box or in CI before
+closing T1 for 32-bit ARM.
+
+### GET32 / GET16 probe
+
+Isolated TUs compiled with `-O3 -S`. Current macros match
+[`src/core/vjag_memory.h`](../../src/core/vjag_memory.h) lines 83–85; proposed path uses
+`memcpy` + `__builtin_bswap32` / `__builtin_bswap16`.
+
+| Variant | Host clang -O3 (arm64) | Host gcc -O3 (arm64, Apple clang) |
+| --- | --- | --- |
+| `GET32` macro (4× byte load + shift/or) | **4× `ldrb` + `bfi`/`orr`** — **no `rev`** | Same as clang |
+| `GET32` bswap (`memcpy` + `__builtin_bswap32`) | **`ldr` + `rev`** | **`ldr` + `rev`** |
+| `GET16` macro (2× byte load + shift/or) | **2× `ldrb` + `bfi`** — **no `rev16`** | Same |
+| `GET16` bswap (`memcpy` + `__builtin_bswap16`) | **`ldrh` + `rev` + `lsr #16`** | Same |
+
+**Conclusion for T1:** on AArch64 host toolchains the macro path does **not** fuse to
+`rev`/`rev16`; the `__builtin_bswap*` path does. Task value on arm64 is fewer
+instructions and better ILP either way. On **arm-linux-gnueabihf GCC** (RPi 32-bit) the
+plan expected macro failure to `rev` — **re-verify there** before shrinking scope; Clang
+armhf often already fuses.
+
+Probe recipe (repeat after toolchain changes):
+
+```bash
+DEVELOPER_DIR=/Library/Developer/CommandLineTools clang -O3 -S -o - probe_get32.c \
+  | sed -n '/get32_macro/,/^$/p'
+DEVELOPER_DIR=/Library/Developer/CommandLineTools clang -O3 -S -o - probe_get32.c \
+  | sed -n '/get32_bswap/,/^$/p'
+```
+
+### BGEN clear probe
+
+Loop extracted from [`src/tom/tom.c`](../../src/tom/tom.c) lines 1602–1607 (719× u16
+constant fill after seeding bytes 0–1).
+
+| Compiler | Result |
+| --- | --- |
+| Host clang -O3 (arm64) | **Auto-vectorized:** `dup.8h` + `stur`/`stp q0` (128-bit stores), **no scalar `strh` loop** |
+| Host gcc -O3 (arm64) | Same vectorized output |
+
+**Conclusion for T3 BGEN:** **no hand-written NEON required** on AArch64 `-O3`; the
+compiler already widens the fill. Optional `VJ_RESTRICT` on the line-buffer pointer may
+help marginally on other targets. Do not spend effort on intrinsics here unless a
+`-O2`/armhf build disassembles to a scalar `strh` loop.
+
+Probe recipe:
+
+```bash
+DEVELOPER_DIR=/Library/Developer/CommandLineTools clang -O3 -S -o - probe_bgen_clear.c \
+  | sed -n '/bgen_clear_line:/,/\.Lfunc_end/p'
+```
+
+---
+
+## T1 — GET16/GET32/SET16/SET32 `__builtin_bswap` intrinsics
+
+| | |
+| --- | --- |
+| **Impact** | HIGH — macros run on every 68K/GPU/DSP/blitter memory access (`JaguarReadLong` et al. ≈8% of Iron Soldier host profile) |
+| **Risk** | LOW — byte-identical by construction if swap direction matches current shift-or semantics |
+| **Effort** | S |
+
+### Files and lines
+
+- [`src/core/vjag_memory.h`](../../src/core/vjag_memory.h) lines 73–85 — `SET64`/`GET64`/`SET32`/`GET32`/`SET16`/`GET16` macros.
+
+### Mechanism
+
+Replace hot `GET16`/`GET32`/`SET16`/`SET32` macros with `static INLINE` functions on
+GCC/Clang (`__GNUC__`): unaligned-safe `memcpy` load/store + `__builtin_bswap16` /
+`__builtin_bswap32`. Keep the existing shift-or macros as the portable fallback (MSVC:
+`_byteswap_ushort` / `_byteswap_ulong`). `GET64`/`SET64` are cold; optional same treatment
+or leave as macros.
+
+Codegen probe results are in §Codegen probes above.
+
+### Code sample (C89-compliant)
+
+Add near the top of `vjag_memory.h` (after includes, before macros):
+
+```c
+#include <string.h>
+
+#if defined(_MSC_VER)
+#  include <stdlib.h>
+#  define VJ_BSWAP16(v) ((uint16_t)_byteswap_ushort((unsigned short)(v)))
+#  define VJ_BSWAP32(v) ((uint32_t)_byteswap_ulong((unsigned long)(v)))
+#elif defined(__GNUC__)
+#  define VJ_BSWAP16(v) ((uint16_t)__builtin_bswap16((uint16_t)(v)))
+#  define VJ_BSWAP32(v) ((uint32_t)__builtin_bswap32((uint32_t)(v)))
+#endif
+
+#if defined(VJ_BSWAP32)
+static INLINE uint32_t vj_get32(const uint8_t *r, unsigned a)
+{
+   uint32_t v;
+   memcpy(&v, r + a, 4);
+   return VJ_BSWAP32(v);
+}
+
+static INLINE void vj_set32(uint8_t *r, unsigned a, uint32_t v)
+{
+   uint32_t be = VJ_BSWAP32(v);
+   memcpy(r + a, &be, 4);
+}
+
+static INLINE uint16_t vj_get16(const uint8_t *r, unsigned a)
+{
+   uint16_t v;
+   memcpy(&v, r + a, 2);
+   return VJ_BSWAP16(v);
+}
+
+static INLINE void vj_set16(uint8_t *r, unsigned a, uint16_t v)
+{
+   uint16_t be = VJ_BSWAP16(v);
+   memcpy(r + a, &be, 2);
+}
+
+#  define GET32(r, a)  vj_get32((const uint8_t *)(r), (unsigned)(a))
+#  define SET32(r, a, v) vj_set32((uint8_t *)(r), (unsigned)(a), (uint32_t)(v))
+#  define GET16(r, a)  vj_get16((const uint8_t *)(r), (unsigned)(a))
+#  define SET16(r, a, v) vj_set16((uint8_t *)(r), (unsigned)(a), (uint16_t)(v))
+#else
+/* existing shift-or macros unchanged */
+#endif
+```
+
+### Guards
+
+None beyond `__GNUC__` / MSVC split. No NEON required.
+
+### Test gates
+
+`make TEST_EXPORTS=1 test`, `test/tools/ir_ab.sh --ref libretro/develop HEAD`, acid gate.
+Optional: `test/tools/frame_hash_ab` on yarc.j64 (trivial sanity).
+
+### Measurement
+
+`ir_ab.sh` should show lower Ir on memory-heavy ROMs. Device: `rpi_perf.sh profile` on
+Iron Soldier; host: Instruments on `JaguarReadLong`.
+
+---
+
+## T2 — Object Processor 16bpp phrase NEON fast path
+
+| | |
+| --- | --- |
+| **Impact** | MED–HIGH — `OPProcessFixedBitmap` is 278–613 host samples/frame (same order as blitter) |
+| **Risk** | MED — bounds, transparency, shadow-FB hooks must match scalar byte-for-byte |
+| **Effort** | M |
+
+### Files and lines
+
+- [`src/tom/op.c`](../../src/tom/op.c) lines 1147–1216 — `OPProcessFixedBitmap`, `depth == 4` (16 BPP).
+- [`src/tom/op.c`](../../src/tom/op.c) lines 49–50 — `OP_LBUF_IN_BOUNDS`.
+- New: `src/tom/op_simd_neon.h` (or extend `blitter_simd_arch.h` only for guards).
+- [`scripts/c89-lint.sh`](../../scripts/c89-lint.sh) — add `op_simd_neon.h` to `skip_file` if it contains intrinsics.
+
+### Mechanism
+
+Inside the `while (i++ < 4)` inner loop (lines 1166–1211), add a guarded NEON fast path
+for one 4-pixel phrase when **all** of:
+
+- `depth == 4` (16 bpp) — already in this branch.
+- `!flagRMW`
+- `lbufDelta == 2` (no `OPFLAG_REFLECT`; REFLECT makes delta ≠ 2).
+- `OP_LBUF_IN_BOUNDS(currentLineBuffer, 8)` — whole phrase fits LBUF.
+- `!shadowFBActive && !shadowHiresActive` — shadow hooks at lines 1188–1200 must run scalar.
+
+Load 8 source bytes from the shifted `pixels` register (big-endian u16 lanes). Store 8 bytes
+to `currentLineBuffer` with transparency: skip lanes where both hi and lo bytes are zero
+when `flagTRANS`. Fall through to the existing scalar loop for RMW, REFLECT, shadow paths,
+and partial phrases (`firstPix` / `i` start mid-phrase).
+
+Reference NEON style: [`src/tom/blitter_simd_neon.h`](../../src/tom/blitter_simd_neon.h).
+
+### Code sample (intrinsics header — exempt from C89 lint)
+
+```c
+#include <arm_neon.h>
+#include <stdint.h>
+#include <string.h>
+
+static INLINE void op_store_phrase_16bpp_neon(
+      uint8_t *lbuf, uint64_t pixels, bool flagTRANS)
+{
+   uint8_t bytes[8];
+   uint8x8_t src;
+   uint8x8_t cur;
+   uint8x8_t mask;
+   uint16x4_t pix;
+   uint16x4_t zero;
+   uint16x4_t tmask;
+
+   bytes[0] = (uint8_t)(pixels >> 56);
+   bytes[1] = (uint8_t)(pixels >> 48);
+   bytes[2] = (uint8_t)(pixels >> 40);
+   bytes[3] = (uint8_t)(pixels >> 32);
+   bytes[4] = (uint8_t)(pixels >> 24);
+   bytes[5] = (uint8_t)(pixels >> 16);
+   bytes[6] = (uint8_t)(pixels >> 8);
+   bytes[7] = (uint8_t)(pixels);
+
+   src = vld1_u8(bytes);
+   if (!flagTRANS)
+   {
+      vst1_u8(lbuf, src);
+      return;
+   }
+
+   pix = vreinterpret_u16_u8(src);
+   zero = vdup_n_u16(0);
+   tmask = vceq_u16(pix, zero);
+   mask = vreinterpret_u8_u16(tmask);
+   cur = vld1_u8(lbuf);
+   src = vbsl_u8(mask, cur, src);
+   vst1_u8(lbuf, src);
+}
+```
+
+Call site sketch (C89 — vars at block top):
+
+```c
+#if defined(BLITTER_SIMD_HAVE_NEON)
+            if (!flagRMW && lbufDelta == 2
+                  && !shadowFBActive && !shadowHiresActive
+                  && OP_LBUF_IN_BOUNDS(currentLineBuffer, 8)
+                  && i == 0 && firstPix == 0)
+            {
+               op_store_phrase_16bpp_neon(currentLineBuffer, pixels, flagTRANS);
+               currentLineBuffer += 8;
+               i = 4;
+               continue;
+            }
+#endif
+```
+
+(Integrate carefully with `i`/`firstPix` control flow — the snippet is illustrative.)
+
+### Guards
+
+`#if defined(BLITTER_SIMD_HAVE_NEON)` — include `blitter_simd_arch.h`. Scalar path
+unchanged when undefined.
+
+### Test gates
+
+Framebuffer A/B ≥8,000 frames: Iron Soldier, AvP, Doom, Tempest 2000 (`frame_hash_ab`).
+`make TEST_EXPORTS=1 test`, acid gate, RetroArch smoke on a 16bpp-heavy title.
+
+### Measurement
+
+Host `sample` on `OPProcessFixedBitmap`; device `rpi_perf.sh` / `device_perf.sh` on AvP.
+
+---
+
+## T3 — TOM scanline converters, BGEN clear, `__restrict`
+
+| | |
+| --- | --- |
+| **Impact** | MED — concentrates on RGB-mode titles and 2×/true-colour configs (complements audit P9) |
+| **Risk** | LOW for scanlines; BGEN already vectorized at `-O3` (see probe) |
+| **Effort** | M |
+
+### Files and lines
+
+| Function | File:lines | Notes |
+| --- | --- | --- |
+| `tom_render_24bpp_scanline` | [`src/tom/tom.c`](../../src/tom/tom.c) 1227–1271 | G,R,pad,B → XRGB8888 |
+| `tom_render_16bpp_direct_scanline` | [`src/tom/tom.c`](../../src/tom/tom.c) 1276–1293 | BE u16 → `color >> 1` |
+| `tom_render_16bpp_rgb_scanline` | [`src/tom/tom.c`](../../src/tom/tom.c) 1311–1373 | `RGB16ToRGB32` LUT gather |
+| RGB expansion arithmetic (LUT source) | [`src/tom/tom.c`](../../src/tom/tom.c) 632–636 | RRRR RBBB BBGG GGGG → ARGB |
+| BGEN line clear | [`src/tom/tom.c`](../../src/tom/tom.c) 1587–1607 | 720× u16 fill |
+| Border fill | [`src/tom/tom.c`](../../src/tom/tom.c) 1670–1679 | scalar `uint32_t` stores |
+
+### Mechanism
+
+1. **`tom_render_16bpp_direct_scanline` (1276–1293):** when `pwidth_scale == 1`, NEON load
+   8 BE u16 (16 bytes as `uint8x16_t` + `vrev16q_u8`), `vshrq_n_u16` by 1, widen with
+   `vmovl_u16` / `vshll_n_u16`, store 8× `uint32_t`. Keep scalar loop for `pwidth_scale > 1`.
+
+2. **`tom_render_24bpp_scanline` (1257–1270):** treat 4 pixels as structure-of-bytes;
+   `vld4_u8` on interleaved G,R,?,B and `vst4_u8` into XRGB lanes with alpha `0xFF` (or
+   equivalent `uint32x4_t` pack). Guard: `pwidth_scale == 1`, no shadow hooks in this path.
+
+3. **`tom_render_16bpp_rgb_scanline` (1365–1372):** for `pwidth_scale == 1` and
+   `!shadowFBActive` (stock loop only), replace `RGB16ToRGB32[color]` gather with in-register
+   expansion matching lines 632–636:
+
+   ```c
+   /* per u16 color c (conceptual): */
+   r = (c & 0xF800) << 8;
+   g = (c & 0x003F) << 10;
+   b = (c & 0x07C0) >> 3;
+   out = 0xFF000000 | r | g | b;
+   ```
+
+   Process 4 or 8 pixels per vector. **Do not** vectorize the shadow/pack path (1347–1362).
+
+4. **CRY / `CRY16ToRGB32` / `tom_render_16bpp_cry_scanline`:** **rejected** — 64K LUT
+   gather dominates; NEON cannot beat L1 LUT latency.
+
+5. **BGEN clear (1602–1607):** codegen probe shows **compiler auto-vectorization** on arm64
+   `-O3` (`dup` + `stp`). **No intrinsics unless** armhf `-O2` disassembly shows scalar
+   `strh`. Optional: widen manually to `uint64_t` stores if needed on a specific target.
+
+6. **`VJ_RESTRICT` macro** (C89-safe): define in a shared header (e.g. `vjag_memory.h` or
+   `tom.h`):
+
+   ```c
+   #if defined(__GNUC__) || defined(__clang__)
+   #  define VJ_RESTRICT __restrict
+   #else
+   #  define VJ_RESTRICT
+   #endif
+   ```
+
+   Apply to `backbuffer`, `current_line_buffer` parameters in scanline functions to unlock
+   autovec independent of intrinsics.
+
+### Guards
+
+`#if defined(BLITTER_SIMD_HAVE_NEON)` around hand-written scanline kernels. BGEN: rely on
+`-O3` autovec first.
+
+### Test gates
+
+Framebuffer A/B byte-identical (`frame_hash_ab`) on AvP (RGB16), Iron Soldier (mixed), yarc,
+jagniccc. Full `make TEST_EXPORTS=1 test`, acid gate.
+
+### Measurement
+
+`device_perf.sh` on AvP with titledb 2× + true colour; compare `TOMExecHalfline` / scanline
+symbols before/after.
+
+---
+
+## T4 — `VoiceChatMixInto` saturating NEON mix
+
+| | |
+| --- | --- |
+| **Impact** | LOW–MED — only when voice chat enabled; 800–960 stereo pairs/frame at 48 kHz |
+| **Risk** | LOW if saturation matches scalar clamps |
+| **Effort** | S |
+
+### Files and lines
+
+- [`src/jerry/voicechat.c`](../../src/jerry/voicechat.c) lines 699–768 — `VoiceChatMixInto`.
+- [`src/jerry/voicechat.h`](../../src/jerry/voicechat.h) lines 26–31 — `VC_FRAME_SAMPLES`
+  (160), `VC_UPSAMPLE` (6), `VC_MAX_SPEAKERS` (3).
+
+### Mechanism
+
+The outer loop (723–765) upsamples 8 kHz far-end/monitor samples by 6×. For each group of
+6 output pairs, `mixed` is **constant** (lines 747–751). Vectorize the final add + saturate:
+
+- `vdupq_n_s16(mixed)` broadcast.
+- Load interleaved stereo with `vld1q_s16` (4 consecutive pairs = 8 lanes).
+- `vqaddq_s16` with existing buffer (saturating).
+- Store with `vst1q_s16`.
+
+Keep the scalar upsample / jitter pop logic (726–745) unchanged. Process 4 pairs per vector;
+tail scalar for `pairs % 4`.
+
+### Code sample (inside `VoiceChatMixInto`, C89 block)
+
+```c
+#if defined(BLITTER_SIMD_HAVE_NEON)
+#include <arm_neon.h>
+#endif
+/* ... */
+#if defined(BLITTER_SIMD_HAVE_NEON)
+         {
+            int16x8_t vm;
+            int16x8_t vbuf;
+            int16x8_t vout;
+            vm = vdupq_n_s16((int16_t)mixed);
+            for (; i + 4 <= pairs; i += 4)
+            {
+               vbuf = vld1q_s16(&stereo[i * 2]);
+               vout = vqaddq_s16(vbuf, vm);
+               vst1q_s16(&stereo[i * 2], vout);
+            }
+         }
+#endif
+         for (; i < pairs; i++)
+         {
+            /* existing scalar clamp loop */
+         }
+```
+
+(Integrate with the existing `for (i = 0; i < pairs; i++)` — refactor so the upsample
+block runs per `i`, vector block batches groups of 4 where `mixed` is stable.)
+
+### Guards
+
+`BLITTER_SIMD_HAVE_NEON` (or a jerry-local mirror if you prefer not to include tom headers
+in jerry — acceptable to include `blitter_simd_arch.h` from `voicechat.c`).
+
+### Test gates
+
+**Mandatory:** `test_audio_clipping` **and** `test_audio_presence`. Also:
+`test/test_voice_netpacket`, `test/test_voicechat`, `make TEST_EXPORTS=1 test`, acid gate,
+RetroArch voice-chat smoke.
+
+### Measurement
+
+Profile `VoiceChatMixInto` with voice chat enabled; negligible frame impact expected — goal
+is headroom on weak ARMs when chat is on.
+
+---
+
+## T5 — ARMv8 hardware CRC32 (optional)
+
+| | |
+| --- | --- |
+| **Impact** | LOW — ROM/CD load and titledb identification only, not `retro_run` frame time |
+| **Risk** | LOW — polynomial matches ISO-HDLC |
+| **Effort** | S |
+
+### Files and lines
+
+- [`src/core/crc32.c`](../../src/core/crc32.c) lines 55–63 — `crc32_calcCheckSum` table loop.
+
+### Mechanism
+
+Standard CRC-32/ISO-HDLC (poly `0xEDB88320`, reflected) matches ARMv8-A CRC32 extension
+(`__crc32b` / `__crc32w` with `__ARM_FEATURE_CRC32`). Guard:
+
+```c
+#if defined(__ARM_FEATURE_CRC32) && defined(__aarch64__)
+/* hardware path: crc = __crc32b(crc, *data++); etc. */
+#else
+/* existing crctable loop */
+#endif
+```
+
+`-mcpu=cortex-a53` and later expose `+crc` — today that means `rpi3`/`rpi3_64` and up
+(`Makefile` 398–440, #560) and the macOS arm64 host default. **Stock iOS/tvOS builds do
+NOT define `__ARM_FEATURE_CRC32`** — the `ios-arm64`/`tvos-arm64` blocks (`Makefile`
+303–331) pass no `-mcpu`, leaving the A7 baseline — so on those targets this guard
+compiles the table fallback and the hardware path is dead code (correct-by-guard, but
+know it). Coverage today: macOS host, `rpi3`+, and any build with an explicit `-mcpu`.
+Android / generic-arm64 Linux are single-binary targets that cannot promise CRC at
+compile time; if coverage there is ever wanted, use the runtime `getauxval(AT_HWCAP)` +
+`__attribute__((target("+crc")))` dispatch described in
+[`arm-chip-tuning.md`](arm-chip-tuning.md) §2.3 — do not bake `+crc` into `-march`.
+Bundle with T1/T3 if touching the tree anyway.
+
+### Guards
+
+`__ARM_FEATURE_CRC32` + `__aarch64__` (32-bit ARM CRC extension exists but is a separate
+feature bit — out of scope unless explicitly tested).
+
+### Test gates
+
+Any existing CRC consumers in `make TEST_EXPORTS=1 test`; titledb load smoke.
+
+### Measurement
+
+Time `crc32_calcCheckSum` on a multi-MiB ROM buffer — expect load-time QoL only.
+
+---
+
+## T6 — Compiler directives and explicit rejections
+
+| | |
+| --- | --- |
+| **Impact** | Variable (LTO); rejections prevent wasted effort |
+| **Risk** | LTO: MED — needs device A/B before default-on |
+| **Effort** | S (measurement only) |
+
+### LTO=1 A/B recipe
+
+Knob exists in [`Makefile`](../../Makefile) lines 1046–1055 (`make LTO=1` appends `-flto` to
+compile and link for GC-style GNU targets). **Never measured on real Pi hardware** per
+comment at 1046–1048.
+
+**RPi4 64-bit A/B/B/A:**
+
+```bash
+# A: baseline
+test/tools/rpi_perf.sh build --arch aarch64
+test/tools/rpi_perf.sh deploy pi@raspberrypi.local
+test/tools/rpi_perf.sh profile pi@raspberrypi.local --frames 1800 \
+  --make-args '' > /tmp/lto_a.txt
+
+# B: LTO=1
+test/tools/rpi_perf.sh build --arch aarch64 --make-args 'LTO=1'
+test/tools/rpi_perf.sh deploy pi@raspberrypi.local
+test/tools/rpi_perf.sh profile pi@raspberrypi.local --frames 1800 \
+  --make-args 'LTO=1' > /tmp/lto_b.txt
+
+# Repeat B then A to cancel thermal drift; compare mean frame μs from rpi_perf output.
+```
+
+Also run `make TEST_EXPORTS=1 test` and `ir_ab.sh` on both builds (LTO must not change
+emulation semantics).
+
+### Explicit rejections (do not implement)
+
+| Idea | Reason |
+| --- | --- |
+| Fast-blitter NEON | Audit F8 — no phrase batching in `blitter_generic` |
+| CRY LUT NEON gather | 64K table; memory-bound |
+| MOVEM batching (`cpuemu.c`) | 68K ≤2.6% frame |
+| DSP `mmult` / `div` SIMD | Too few ops per invocation |
+| `DSPSampleCallback` vectorization | No batch loop |
+| BGEN hand NEON on arm64 `-O3` | Probe: already `dup`/`stp` vectorized |
+| Default-on LTO | Needs T6 measurement first |
+
+### Test gates
+
+Same as LTO recipe; no code change required for this task.
+
+### Measurement
+
+`rpi_perf.sh profile` primary; optional `device_perf.sh` on A10X iPad if available.
+
+---
+
+## Execution order (suggested)
+
+1. **T1** — widest coverage, lowest risk.
+2. **T3** — scanline wins on RGB-heavy titles; skip BGEN intrinsics unless probe fails on target.
+3. **T2** — OP phrase path; needs framebuffer A/B discipline.
+4. **T4** — if voice chat is a shipping feature on ARM.
+5. **T5** — optional bundle.
+6. **T6** — parallel measurement track for LTO decision.
+
+---
+
+## Related documents
+
+- [`docs/perf-audit-2026-08.md`](../perf-audit-2026-08.md) — host/RPi audit (P1–P9).
+- [`docs/perf-audit/arm-chip-tuning.md`](arm-chip-tuning.md) — per-chip ISA floors,
+  feature-macro matrix, AArch64-only intrinsics, armv7 portability check.
+- [`docs/perf-audit/blitter.md`](blitter.md) — blitter F8, accurate-engine NEON.
+- [`docs/profiling.md`](../profiling.md) — `rpi_perf.sh`, `device_perf.sh`, `ir_ab.sh`,
+  `frame_hash_ab`.
+- [`docs/agent/build.md`](../agent/build.md) — C89 exempt list, `TEST_EXPORTS` relink.
+- [`docs/agent/testing.md`](../agent/testing.md) — audio test pair, acid gate.


### PR DESCRIPTION
## Summary

Research pass targeting the slowest hosts (Raspberry Pi, older iOS/tvOS, ARM Android handhelds). Documentation only — no emulator or build changes.

- **`docs/perf-audit/simd-neon-arm64.md`** — six delegable SIMD/ARM64 tasks (T1–T6): GET/SET byte-swap intrinsics (probe-confirmed: current macros emit 4x byte loads with no `rev`; the bswap form is `ldr`+`rev`), OP 16bpp phrase NEON fast path, TOM scanline converters, VoiceChatMixInto saturating mix, ARMv8 hardware CRC32, and LTO A/B recipe — each with code samples, guard conditions, test gates, and measurement recipes.
- **`docs/perf-audit/arm-chip-tuning.md`** — verified per-chip build-tuning reference (Apple A/M floors and `-mcpu` support, Snapdragon/Kryo handhelds, generic arm64, SVE/SVE2 verdict, armv7-NEON portability list, compile-time vs runtime feature-detection matrix). All proposed settings changes are marked requires-approval; none applied. Key finding: `ios-arm64`/`tvos-arm64` pass no `-mcpu`, so those builds run at an A7-class baseline (no CRC32/LSE); tvOS can never pin (Apple TV HD = A8).
- **`docs/perf-audit/hotpath-followups-2026-08.md`** — seven non-SIMD hot-path findings (unused `GET_CURRENT_SOFTWARE_FRAMEBUFFER`, 128 KB memcpy per Memory Track write, serialize slack memset under rewind/run-ahead, second per-frame `clock_gettime`, `LOG_DBG` NDEBUG gate, CDDA-DIAG residue, fast-forward audio-presentation skip) plus a verified-clean list.
- `docs/perf-audit-2026-08.md` gains a two-line Related pointer to the three new docs.

## Test plan

- [x] Docs-only change; no code or build-system edits (`git diff --stat` = 4 markdown files)
- [x] All file:line references verified against the current tree during the final review pass
- [x] Codegen probe results reproduced on macOS arm64 (clang + gcc, `-O3`)