### PR TITLE
perf(voicechat): NEON saturating mix

### DIFF
--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -36,6 +36,7 @@ skip_file() {
         src/tom/blitter_simd_neon.c|src/tom/blitter_simd_sse2.c) return 0 ;;
         src/tom/op_simd_neon.h) return 0 ;;
         src/tom/tom_scan_simd_neon.h) return 0 ;;
+        src/jerry/voicechat_simd_neon.h) return 0 ;;
         # Depends on rcheevos headers fetched at runtime by the e2e shell wrapper.
         test/tools/test_rcheevos_e2e.c) return 0 ;;
         # Diagnostic tools — not part of the libretro core build.

--- a/src/jerry/voicechat.c
+++ b/src/jerry/voicechat.c
@@ -5,8 +5,13 @@
 #include "voicechat.h"
 #include "jlink.h"
 #include "jlink_discover.h"
+#include "blitter_simd_arch.h"
 
 #include <string.h>
+
+#if defined(BLITTER_SIMD_HAVE_NEON)
+#include "voicechat_simd_neon.h"
+#endif
 
 #define VC_JITTER_FRAMES   8
 #define VC_JITTER_SAMPLES  (VC_JITTER_FRAMES * VC_FRAME_SAMPLES)
@@ -707,6 +712,9 @@ void VoiceChatMixInto(uint16_t *buf, unsigned pairs)
    int16_t holdFar[VC_MAX_SPEAKERS];
    int16_t holdMon;
    unsigned monIdx;
+   unsigned remain;
+   unsigned n;
+   unsigned k;
 
    if (!vcEnabled || !buf || pairs == 0)
       return;
@@ -720,7 +728,7 @@ void VoiceChatMixInto(uint16_t *buf, unsigned pairs)
    holdMon = 0;
    monIdx = 0;
 
-   for (i = 0; i < pairs; i++)
+   for (i = 0; i < pairs; )
    {
       /* 6× upsample: one 8 kHz sample every VC_UPSAMPLE output pairs. */
       if ((i % VC_UPSAMPLE) == 0)
@@ -750,18 +758,41 @@ void VoiceChatMixInto(uint16_t *buf, unsigned pairs)
       if (vcMonitor)
          mixed += ((int)holdMon * vol) / 100;
 
-      left = (int)stereo[i * 2 + 0] + mixed;
-      right = (int)stereo[i * 2 + 1] + mixed;
-      if (left > 32767)
-         left = 32767;
-      if (left < -32768)
-         left = -32768;
-      if (right > 32767)
-         right = 32767;
-      if (right < -32768)
-         right = -32768;
-      stereo[i * 2 + 0] = (int16_t)left;
-      stereo[i * 2 + 1] = (int16_t)right;
+      /* mixed is constant for this upsample group. */
+      remain = VC_UPSAMPLE - (i % VC_UPSAMPLE);
+      if (remain > pairs - i)
+         remain = pairs - i;
+      n = remain;
+
+#if defined(BLITTER_SIMD_HAVE_NEON)
+      /* vqaddq_s16 matches the scalar clamp iff mixed fits in int16. */
+      if (mixed >= -32768 && mixed <= 32767)
+      {
+         while (n >= 4)
+         {
+            voicechat_mix_sat4(&stereo[i * 2], (int16_t)mixed);
+            i += 4;
+            n -= 4;
+         }
+      }
+#endif
+
+      for (k = 0; k < n; k++)
+      {
+         left = (int)stereo[i * 2 + 0] + mixed;
+         right = (int)stereo[i * 2 + 1] + mixed;
+         if (left > 32767)
+            left = 32767;
+         if (left < -32768)
+            left = -32768;
+         if (right > 32767)
+            right = 32767;
+         if (right < -32768)
+            right = -32768;
+         stereo[i * 2 + 0] = (int16_t)left;
+         stereo[i * 2 + 1] = (int16_t)right;
+         i++;
+      }
    }
    if (vcMonitor)
       vcMonCount = 0;

--- a/src/jerry/voicechat_simd_neon.h
+++ b/src/jerry/voicechat_simd_neon.h
@@ -1,0 +1,33 @@
+#ifndef VOICECHAT_SIMD_NEON_H
+#define VOICECHAT_SIMD_NEON_H
+
+/*
+ * VoiceChatMixInto NEON saturating mix — 4 interleaved stereo pairs.
+ *
+ * Guarded by BLITTER_SIMD_HAVE_NEON (src/tom/blitter_simd_arch.h).
+ * Intrinsics are ARMv7-portable (vdupq_n_s16 / vld1q_s16 / vqaddq_s16 /
+ * vst1q_s16).  C89-lint skips this header; voicechat.c stays C89.
+ *
+ * mixed must already fit in int16.  vqaddq_s16 saturates each lane to
+ * [-32768, 32767], matching the scalar (int)add + clamp path when both
+ * addends are int16.  If mixed were truncated from a wider sum, the
+ * results would diverge (e.g. -32768 + 40000 = 7232 scalar vs sat-add
+ * of a truncated mixed).
+ */
+
+#include <stdint.h>
+#include <arm_neon.h>
+
+static void voicechat_mix_sat4(int16_t *stereo, int16_t mixed)
+{
+   int16x8_t vm;
+   int16x8_t vbuf;
+   int16x8_t vout;
+
+   vm = vdupq_n_s16(mixed);
+   vbuf = vld1q_s16(stereo);
+   vout = vqaddq_s16(vbuf, vm);
+   vst1q_s16(stereo, vout);
+}
+
+#endif /* VOICECHAT_SIMD_NEON_H */


### PR DESCRIPTION
## Summary

- Vectorize `VoiceChatMixInto`'s add+clamp over each 6-pair upsample group with `vdupq_n_s16` + `vqaddq_s16` (ARMv7-portable NEON). The far-end `mixed` value is constant for the group; 4 interleaved stereo pairs are saturating-added into the host buffer.
- `vqaddq_s16` matches the existing scalar clamp to [-32768, 32767] when `mixed` fits in int16 (verified with a host probe). Wider `mixed` (possible with several full-scale speakers) stays on the scalar path so truncation cannot diverge. Non-NEON builds and tail pairs (`remain % 4`) stay scalar.
- Intrinsics live in `src/jerry/voicechat_simd_neon.h`, guarded by `BLITTER_SIMD_HAVE_NEON` from `blitter_simd_arch.h`, and are on the C89-lint skip list. `voicechat.c` remains C89.

Closes #665

## Test plan

- [x] `bash scripts/c89-lint.sh src/jerry/voicechat.c` — passed
- [x] `clang -target armv7-none-linux-gnueabihf -mfpu=neon` syntax-check of the new header — OK
- [x] `DEVELOPER_DIR=/Library/Developer/CommandLineTools make -j8` — clean
- [x] `DEVELOPER_DIR=... make TEST_EXPORTS=1 test` — exit 0, 0 failed, 2 skipped (Fountain live abort, jagcd CUE→CHD; no CHSE chdman)
- [x] `test_audio_clipping` self-test: `PASS: dummy ROM stays silent`
- [x] `test_audio_clipping` Atari Karts: `PASS: no clipping signature in window` (0.000% saturated, RMS 410.6)
- [x] `test_audio_presence` Iron Soldier 1: `PASS: audio is present and within expected envelope`
- [x] `./test/test_voicechat` — ALL PASS (including `saturates near full scale without wrap` and three-speaker mix)
- [x] `./test/test_voice_netpacket` — OK (`PASS far-side audio mix shows voice energy`)

<!-- link-issue: #665 -->