### PR TITLE
perf(core): byte-swap intrinsics for GET/SET macros

### DIFF
--- a/src/core/vjag_memory.h
+++ b/src/core/vjag_memory.h
@@ -8,6 +8,7 @@
 #define __MEMORY_H__
 
 #include <stdint.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,7 +70,85 @@ extern const char * whoName[10];
 
 // Some handy macros to help converting native endian to big endian (jaguar native)
 // & vice versa
+//
+// On little-endian GCC/Clang/MSVC, memcpy + bswap compiles to a fused load/store
+// plus rev (arm64 probe 2026-08-27: the shift-or form is 4x ldrb with no rev).
+// memcpy + bswap is wrong on MSB_FIRST: a native load is already BE, so bswap
+// would invert.  Shift-or stays the portable fallback.
 
+#if !defined(MSB_FIRST)
+#if defined(_MSC_VER)
+#  include <stdlib.h>
+#  define VJ_BSWAP16(v) ((uint16_t)_byteswap_ushort((unsigned short)(v)))
+#  define VJ_BSWAP32(v) ((uint32_t)_byteswap_ulong((unsigned long)(v)))
+#  define VJ_BSWAP64(v) ((uint64_t)_byteswap_uint64((unsigned __int64)(v)))
+#elif defined(__GNUC__)
+#  define VJ_BSWAP16(v) ((uint16_t)__builtin_bswap16((uint16_t)(v)))
+#  define VJ_BSWAP32(v) ((uint32_t)__builtin_bswap32((uint32_t)(v)))
+#  define VJ_BSWAP64(v) ((uint64_t)__builtin_bswap64((uint64_t)(v)))
+#endif
+#endif
+
+#ifndef INLINE
+#  if defined(_MSC_VER)
+#    define INLINE __inline
+#  elif defined(__GNUC__)
+#    define INLINE __inline__
+#  else
+#    define INLINE
+#  endif
+#endif
+
+#if defined(VJ_BSWAP32)
+static INLINE uint32_t vj_get32(const uint8_t *r, unsigned a)
+{
+   uint32_t v;
+   memcpy(&v, r + a, 4);
+   return VJ_BSWAP32(v);
+}
+
+static INLINE void vj_set32(uint8_t *r, unsigned a, uint32_t v)
+{
+   uint32_t be;
+   be = VJ_BSWAP32(v);
+   memcpy(r + a, &be, 4);
+}
+
+static INLINE uint16_t vj_get16(const uint8_t *r, unsigned a)
+{
+   uint16_t v;
+   memcpy(&v, r + a, 2);
+   return VJ_BSWAP16(v);
+}
+
+static INLINE void vj_set16(uint8_t *r, unsigned a, uint16_t v)
+{
+   uint16_t be;
+   be = VJ_BSWAP16(v);
+   memcpy(r + a, &be, 2);
+}
+
+static INLINE uint64_t vj_get64(const uint8_t *r, unsigned a)
+{
+   uint64_t v;
+   memcpy(&v, r + a, 8);
+   return VJ_BSWAP64(v);
+}
+
+static INLINE void vj_set64(uint8_t *r, unsigned a, uint64_t v)
+{
+   uint64_t be;
+   be = VJ_BSWAP64(v);
+   memcpy(r + a, &be, 8);
+}
+
+#  define GET32(r, a)    vj_get32((const uint8_t *)(r), (unsigned)(a))
+#  define SET32(r, a, v) vj_set32((uint8_t *)(r), (unsigned)(a), (uint32_t)(v))
+#  define GET16(r, a)    vj_get16((const uint8_t *)(r), (unsigned)(a))
+#  define SET16(r, a, v) vj_set16((uint8_t *)(r), (unsigned)(a), (uint16_t)(v))
+#  define GET64(r, a)    vj_get64((const uint8_t *)(r), (unsigned)(a))
+#  define SET64(r, a, v) vj_set64((uint8_t *)(r), (unsigned)(a), (uint64_t)(v))
+#else
 #define SET64(r, a, v) 	r[(a)] = ((v) & 0xFF00000000000000) >> 56, r[(a)+1] = ((v) & 0x00FF000000000000) >> 48, \
 						r[(a)+2] = ((v) & 0x0000FF0000000000) >> 40, r[(a)+3] = ((v) & 0x000000FF00000000) >> 32, \
 						r[(a)+4] = ((v) & 0xFF000000) >> 24, r[(a)+5] = ((v) & 0x00FF0000) >> 16, \
@@ -83,6 +162,7 @@ extern const char * whoName[10];
 #define GET32(r, a)		((r[(a)] << 24) | (r[(a)+1] << 16) | (r[(a)+2] << 8) | r[(a)+3])
 #define SET16(r, a, v)	r[(a)] = ((v) & 0xFF00) >> 8, r[(a)+1] = (v) & 0xFF
 #define GET16(r, a)		((r[(a)] << 8) | r[(a)+1])
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Closes #667

## Summary
- Replace `GET16`/`GET32`/`SET16`/`SET32` (and `GET64`/`SET64`) shift-or byte-composition macros in `src/core/vjag_memory.h` with `static INLINE` `memcpy` + `__builtin_bswap*` (MSVC: `_byteswap_*`) so AArch64 compiles to `ldr`+`rev` instead of 4× `ldrb`.
- Keep the existing shift-or macros as the portable fallback (`MSB_FIRST` / non-GCC/MSVC). Drop-in compatible with every call site; SET macros were statement-level (no preprocessor-dependent uses).
- Byte-identical by construction. Standalone tests that include this header without `-DINLINE` get a local `INLINE` fallback.

## Test plan
- [x] `bash scripts/c89-lint.sh src/core/vjag_memory.h src/core/jaguar.c` passed
- [x] `DEVELOPER_DIR=/Library/Developer/CommandLineTools make -j8` builds clean
- [x] `DEVELOPER_DIR=... make TEST_EXPORTS=1 test` — 0 failed (2 skipped: Fountain live abort, jagcd CUE→CHD; 1 in-harness skip)
- [x] `./test/regression_test.sh ./virtualjaguar_libretro.dylib` — 10 passed, 0 failed (yarc + jagniccc identical, plus determinism/frameskip/savestate/rewind)
- [x] `test/tools/ir_ab.sh --ref libretro/develop HEAD` (podman `vj-cachegrind`, jagniccc 300 frames): **Ir −1.974%** (18,524,791,816 → 18,159,084,911); frame-hash CSVs identical

Probe (host clang -O3 arm64): macro `GET32` = 4× `ldrb`+`bfi`/`orr`; bswap = `ldr`+`rev`. Unaligned offset-1 runtime match.