### PR TITLE
perf(tom): NEON scanline converters for direct/24bpp/RGB16 modes

### DIFF
--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -34,6 +34,7 @@ skip_file() {
         # scalar ops and the arch header would redefine every one). They are
         # checked, with the right define and target, by check_simd_arch below.
         src/tom/blitter_simd_neon.c|src/tom/blitter_simd_sse2.c) return 0 ;;
+        src/tom/tom_scan_simd_neon.h) return 0 ;;
         # Depends on rcheevos headers fetched at runtime by the e2e shell wrapper.
         test/tools/test_rcheevos_e2e.c) return 0 ;;
         # Diagnostic tools — not part of the libretro core build.

--- a/src/core/vjag_memory.h
+++ b/src/core/vjag_memory.h
@@ -9,6 +9,14 @@
 
 #include <stdint.h>
 
+/* C89-safe restrict.  Unlocks autovec on scanline src/dst independently of
+ * the NEON kernels; empty on compilers without a restrict spelling. */
+#if defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER)
+#  define VJ_RESTRICT __restrict
+#else
+#  define VJ_RESTRICT
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -254,6 +254,7 @@
 //	------------------------------------------------------------
 
 #include "tom.h"
+#include "tom_scan_simd_neon.h"
 
 #include <string.h>								// For memset()
 #include "blitter.h"
@@ -446,9 +447,9 @@ typedef void (render_xxx_scanline_fn)(uint32_t *);
 // Private function prototypes
 
 void tom_render_16bpp_cry_scanline(uint32_t * backbuffer);
-void tom_render_24bpp_scanline(uint32_t * backbuffer);
-void tom_render_16bpp_direct_scanline(uint32_t * backbuffer);
-void tom_render_16bpp_rgb_scanline(uint32_t * backbuffer);
+void tom_render_24bpp_scanline(uint32_t * VJ_RESTRICT backbuffer);
+void tom_render_16bpp_direct_scanline(uint32_t * VJ_RESTRICT backbuffer);
+void tom_render_16bpp_rgb_scanline(uint32_t * VJ_RESTRICT backbuffer);
 void tom_render_16bpp_cry_rgb_mix_scanline(uint32_t * backbuffer);
 uint16_t TOMIRQControlReg(void);
 
@@ -1224,12 +1225,12 @@ static void tom_render_scanline_hires(uint32_t * backbuffer)
 }
 
 // 24 BPP mode rendering
-void tom_render_24bpp_scanline(uint32_t * backbuffer)
+void tom_render_24bpp_scanline(uint32_t * VJ_RESTRICT backbuffer)
 {
    unsigned i;
    uint8_t s;
    uint16_t width = tomWidth;
-   uint8_t * current_line_buffer = (uint8_t *)&tomRam8[0x1800];
+   uint8_t * VJ_RESTRICT current_line_buffer = (uint8_t *)&tomRam8[0x1800];
    uint8_t pwidth = ((GET16(tomRam8, VMODE) & PWIDTH) >> 9) + 1;
    uint8_t pwidth_scale = (pwidth >= 8) ? (pwidth / 4) : 1;
    int16_t startPos = GET16(tomRam8, HDB1) - (int16_t)TOMGetLeftVisibleHC();
@@ -1255,6 +1256,16 @@ void tom_render_24bpp_scanline(uint32_t * backbuffer)
 #endif
 
    width = tom_clamp_line_buffer_width(current_line_buffer, width, 4, pwidth_scale);
+#if defined(BLITTER_SIMD_HAVE_NEON)
+   if (pwidth_scale == 1)
+   {
+      unsigned n;
+      n = tom_scan_neon_24bpp(current_line_buffer, backbuffer, width);
+      current_line_buffer += n * 4;
+      backbuffer += n;
+      width = (uint16_t)(width - n);
+   }
+#endif
    while (width >= pwidth_scale)
    {
       uint32_t b;
@@ -1273,15 +1284,25 @@ void tom_render_24bpp_scanline(uint32_t * backbuffer)
 //Seems to me that this is NOT a valid mode--the JTRM seems to imply that you would need
 //extra hardware outside of the Jaguar console to support this!
 // 16 BPP direct mode rendering
-void tom_render_16bpp_direct_scanline(uint32_t * backbuffer)
+void tom_render_16bpp_direct_scanline(uint32_t * VJ_RESTRICT backbuffer)
 {
    uint8_t s;
    uint16_t width = tomWidth;
-   uint8_t * current_line_buffer = (uint8_t *)&tomRam8[0x1800];
+   uint8_t * VJ_RESTRICT current_line_buffer = (uint8_t *)&tomRam8[0x1800];
    uint8_t pwidth = ((GET16(tomRam8, VMODE) & PWIDTH) >> 9) + 1;
    uint8_t pwidth_scale = (pwidth >= 8) ? (pwidth / 4) : 1;
 
    width = tom_clamp_line_buffer_width(current_line_buffer, width, 2, pwidth_scale);
+#if defined(BLITTER_SIMD_HAVE_NEON)
+   if (pwidth_scale == 1)
+   {
+      unsigned n;
+      n = tom_scan_neon_16bpp_direct(current_line_buffer, backbuffer, width);
+      current_line_buffer += n * 2;
+      backbuffer += n;
+      width = (uint16_t)(width - n);
+   }
+#endif
    while (width >= pwidth_scale)
    {
       uint16_t color = (*current_line_buffer++) << 8;
@@ -1308,12 +1329,12 @@ void tom_render_16bpp_direct_scanline(uint32_t * backbuffer)
  *
  * Only pack art substitutes here, never a true-color CRY
  * reconstruction; see TomLinePackRGB above. */
-void tom_render_16bpp_rgb_scanline(uint32_t * backbuffer)
+void tom_render_16bpp_rgb_scanline(uint32_t * VJ_RESTRICT backbuffer)
 {
    unsigned i;
    uint8_t s;
    uint16_t width = tomWidth;
-   uint8_t * current_line_buffer = (uint8_t *)&tomRam8[0x1800];
+   uint8_t * VJ_RESTRICT current_line_buffer = (uint8_t *)&tomRam8[0x1800];
    uint8_t pwidth = ((GET16(tomRam8, VMODE) & PWIDTH) >> 9) + 1;
    uint8_t pwidth_scale = (pwidth >= 8) ? (pwidth / 4) : 1;
    int16_t startPos = GET16(tomRam8, HDB1) - (int16_t)TOMGetLeftVisibleHC();
@@ -1362,6 +1383,16 @@ void tom_render_16bpp_rgb_scanline(uint32_t * backbuffer)
       return;
    }
 
+#if defined(BLITTER_SIMD_HAVE_NEON)
+   if (pwidth_scale == 1)
+   {
+      unsigned n;
+      n = tom_scan_neon_16bpp_rgb(current_line_buffer, backbuffer, width);
+      current_line_buffer += n * 2;
+      backbuffer += n;
+      width = (uint16_t)(width - n);
+   }
+#endif
    while (width >= pwidth_scale)
    {
       uint32_t color = (*current_line_buffer++) << 8;
@@ -1581,7 +1612,7 @@ void TOMExecHalfline(uint16_t halfline, bool render)
    {
       if (render)
       {
-         uint8_t * current_line_buffer = (uint8_t *)&tomRam8[0x1800];
+         uint8_t * VJ_RESTRICT current_line_buffer = (uint8_t *)&tomRam8[0x1800];
          uint8_t bgHI = tomRam8[BG], bgLO = tomRam8[BG + 1];
 
          // Clear line buffer with BG
@@ -1595,8 +1626,10 @@ void TOMExecHalfline(uint16_t halfline, bool render)
              * endian-corrected value, so it is safe on any host byte
              * order -- see the paletteRAM16 comment in op.c for the same
              * "OK for direct copies, not for endian-corrected data"
-             * pattern applied to this exact line buffer. */
-            uint16_t * current_line_buffer16 = (uint16_t *)current_line_buffer;
+             * pattern applied to this exact line buffer.
+             * No hand-written NEON: clang/gcc -O3 already emit dup+stp.
+             * VJ_RESTRICT helps autovec on other targets. */
+            uint16_t * VJ_RESTRICT current_line_buffer16 = (uint16_t *)current_line_buffer;
             uint16_t bgPixel;
 
             current_line_buffer[0] = bgHI;

--- a/src/tom/tom_scan_simd_neon.h
+++ b/src/tom/tom_scan_simd_neon.h
@@ -1,0 +1,156 @@
+/*
+ * TOM scanline converters — ARM NEON implementation.
+ *
+ * Guarded by BLITTER_SIMD_HAVE_NEON from blitter_simd_arch.h (capability,
+ * not a new BUILD_AXES flag).  Kernels use only the ARMv7 Advanced-SIMD
+ * subset so rpi2 / rpi3-32-bit stay portable: vget_high_* + vmovl_* rather
+ * than vmovl_high_*, no vaddv / vqtbl1q / vzip1.  Included from tom.c;
+ * keep this file C89 (vars at top of each block).
+ */
+
+#ifndef TOM_SCAN_SIMD_NEON_H
+#define TOM_SCAN_SIMD_NEON_H
+
+#include "blitter_simd_arch.h"
+
+#if defined(BLITTER_SIMD_HAVE_NEON)
+
+#include <arm_neon.h>
+#include <stdint.h>
+
+#ifndef VJ_RESTRICT
+#if defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER)
+#  define VJ_RESTRICT __restrict
+#else
+#  define VJ_RESTRICT
+#endif
+#endif
+
+#ifndef INLINE
+#define INLINE
+#endif
+
+/* 8 BE u16 pixels -> XRGB8888 via (color >> 1), matching
+ * tom_render_16bpp_direct_scanline.  Returns pixels written (multiple of 8). */
+static INLINE unsigned tom_scan_neon_16bpp_direct(
+   const uint8_t * VJ_RESTRICT src,
+   uint32_t * VJ_RESTRICT dst,
+   unsigned n)
+{
+   unsigned i;
+   unsigned done;
+   uint8x16_t raw;
+   uint16x8_t pix;
+   uint32x4_t lo;
+   uint32x4_t hi;
+
+   done = n & ~7u;
+   for (i = 0; i < done; i += 8)
+   {
+      raw = vld1q_u8(src + (i * 2));
+      pix = vshrq_n_u16(vreinterpretq_u16_u8(vrev16q_u8(raw)), 1);
+      lo = vmovl_u16(vget_low_u16(pix));
+      hi = vmovl_u16(vget_high_u16(pix));
+      vst1q_u32(dst + i, lo);
+      vst1q_u32(dst + i + 4, hi);
+   }
+   return done;
+}
+
+/* 8 Jaguar 24bpp pixels (G,R,pad,B) -> XRGB8888
+ * 0xFF000000 | (r << 16) | (g << 8) | b.  Returns pixels written (multiple of 8). */
+static INLINE unsigned tom_scan_neon_24bpp(
+   const uint8_t * VJ_RESTRICT src,
+   uint32_t * VJ_RESTRICT dst,
+   unsigned n)
+{
+   unsigned i;
+   unsigned done;
+   uint8x8x4_t in;
+   uint16x8_t r16;
+   uint16x8_t g16;
+   uint16x8_t b16;
+   uint32x4_t r;
+   uint32x4_t g;
+   uint32x4_t b;
+   uint32x4_t out;
+   uint32x4_t alpha;
+
+   done = n & ~7u;
+   alpha = vdupq_n_u32(0xFF000000u);
+   for (i = 0; i < done; i += 8)
+   {
+      in = vld4_u8(src + (i * 4));
+      /* in.val[0]=G, [1]=R, [2]=pad, [3]=B */
+      g16 = vmovl_u8(in.val[0]);
+      r16 = vmovl_u8(in.val[1]);
+      b16 = vmovl_u8(in.val[3]);
+
+      r = vshlq_n_u32(vmovl_u16(vget_low_u16(r16)), 16);
+      g = vshlq_n_u32(vmovl_u16(vget_low_u16(g16)), 8);
+      b = vmovl_u16(vget_low_u16(b16));
+      out = vorrq_u32(alpha, vorrq_u32(r, vorrq_u32(g, b)));
+      vst1q_u32(dst + i, out);
+
+      r = vshlq_n_u32(vmovl_u16(vget_high_u16(r16)), 16);
+      g = vshlq_n_u32(vmovl_u16(vget_high_u16(g16)), 8);
+      b = vmovl_u16(vget_high_u16(b16));
+      out = vorrq_u32(alpha, vorrq_u32(r, vorrq_u32(g, b)));
+      vst1q_u32(dst + i + 4, out);
+   }
+   return done;
+}
+
+/* 8 Jaguar RGB16 pixels (RBG 556: RRRRR BBBBB GGGGGG) -> XRGB8888, bit-
+ * identical to RGB16ToRGB32[] filled by TOMFillLookupTables:
+ *   0xFF000000 | ((c & 0xF800) << 8) | ((c & 0x003F) << 10) | ((c & 0x07C0) >> 3)
+ * Returns pixels written (multiple of 8). */
+static INLINE unsigned tom_scan_neon_16bpp_rgb(
+   const uint8_t * VJ_RESTRICT src,
+   uint32_t * VJ_RESTRICT dst,
+   unsigned n)
+{
+   unsigned i;
+   unsigned done;
+   uint8x16_t raw;
+   uint16x8_t c;
+   uint32x4_t c32;
+   uint32x4_t r;
+   uint32x4_t g;
+   uint32x4_t b;
+   uint32x4_t out;
+   uint32x4_t alpha;
+   uint32x4_t mask_r;
+   uint32x4_t mask_g;
+   uint32x4_t mask_b;
+
+   done = n & ~7u;
+   alpha = vdupq_n_u32(0xFF000000u);
+   mask_r = vdupq_n_u32(0xF800u);
+   mask_g = vdupq_n_u32(0x003Fu);
+   mask_b = vdupq_n_u32(0x07C0u);
+   for (i = 0; i < done; i += 8)
+   {
+      raw = vld1q_u8(src + (i * 2));
+      c = vreinterpretq_u16_u8(vrev16q_u8(raw));
+
+      c32 = vmovl_u16(vget_low_u16(c));
+      r = vshlq_n_u32(vandq_u32(c32, mask_r), 8);
+      g = vshlq_n_u32(vandq_u32(c32, mask_g), 10);
+      b = vshrq_n_u32(vandq_u32(c32, mask_b), 3);
+      out = vorrq_u32(alpha, vorrq_u32(r, vorrq_u32(g, b)));
+      vst1q_u32(dst + i, out);
+
+      c32 = vmovl_u16(vget_high_u16(c));
+      r = vshlq_n_u32(vandq_u32(c32, mask_r), 8);
+      g = vshlq_n_u32(vandq_u32(c32, mask_g), 10);
+      b = vshrq_n_u32(vandq_u32(c32, mask_b), 3);
+      out = vorrq_u32(alpha, vorrq_u32(r, vorrq_u32(g, b)));
+      vst1q_u32(dst + i + 4, out);
+   }
+   return done;
+}
+
+#endif /* BLITTER_SIMD_HAVE_NEON */
+
+#endif /* TOM_SCAN_SIMD_NEON_H */


### PR DESCRIPTION
## Summary

- NEON kernels for TOM's `pwidth_scale == 1` 16bpp-direct, 24bpp, and RGB16 scanline converters (`src/tom/tom_scan_simd_neon.h`), ARMv7-portable and guarded by `BLITTER_SIMD_HAVE_NEON`.
- RGB16 expansion is arithmetic, bit-identical to `RGB16ToRGB32[]` (all 65536 values checked). CRY LUT paths are untouched (documented T3 rejection).
- C89-safe `VJ_RESTRICT` in `vjag_memory.h` applied to scanline src/dst. BGEN clear stays compiler auto-vectorized (`dup`+`stp` at `-O3`); only restrict was added there.

Closes #668

## Test plan

- [x] `bash scripts/c89-lint.sh src/tom/tom.c` — passed
- [x] ARMv7 NEON compile probe of `tom_scan_simd_neon.h` (`clang -target armv7-none-linux-gnueabihf -mfpu=neon`) — passed
- [x] RGB16/direct/24bpp identity probe vs scalar/LUT formulas — 0 mismatches
- [x] `DEVELOPER_DIR=… make -j8` clean build — succeeded (`-DBLITTER_SIMD_NEON`)
- [x] `DEVELOPER_DIR=… make TEST_EXPORTS=1 test` — 0 failed (2 skipped: Fountain live abort, jagcd CUE→CHD)
- [x] `./test/regression_test.sh ./virtualjaguar_libretro.dylib` — 10 passed, 0 failed (yarc + jagniccc identical, plus determinism / frameskip / savestate / rewind)