### PR TITLE
perf(op): NEON fast path for 16bpp fixed-bitmap phrases

### DIFF
--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -34,6 +34,7 @@ skip_file() {
         # scalar ops and the arch header would redefine every one). They are
         # checked, with the right define and target, by check_simd_arch below.
         src/tom/blitter_simd_neon.c|src/tom/blitter_simd_sse2.c) return 0 ;;
+        src/tom/op_simd_neon.h) return 0 ;;
         # Depends on rcheevos headers fetched at runtime by the e2e shell wrapper.
         test/tools/test_rcheevos_e2e.c) return 0 ;;
         # Diagnostic tools — not part of the libretro core build.

--- a/src/tom/op.c
+++ b/src/tom/op.c
@@ -25,6 +25,7 @@
 #include "vjag_memory.h"
 #include "tom.h"
 #include "../core/vjtrace.h"
+#include "op_simd_neon.h"
 
 #define BLEND_Y(dst, src)	op_blend_y[(((uint16_t)dst<<8)) | ((uint16_t)(src))]
 #define BLEND_CR(dst, src)	op_blend_cr[(((uint16_t)dst)<<8) | ((uint16_t)(src))]
@@ -1162,6 +1163,23 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
          uint32_t sfbPhrase = data;
          pixels <<= firstPix;
          data += pitch;
+
+#if defined(BLITTER_SIMD_HAVE_NEON)
+         /* Full 4-pixel phrase, no RMW / REFLECT / shadow hooks, wholly
+          * inside LBUF. Partial firstPix/i phrases and every other mode
+          * keep the scalar loop below. */
+         if (!flagRMW && lbufDelta == 2
+               && !shadowFBActive && !shadowHiresActive
+               && OP_LBUF_IN_BOUNDS(currentLineBuffer, 8)
+               && i == 0 && firstPix == 0)
+         {
+            op_store_phrase_16bpp_neon(currentLineBuffer, pixels, flagTRANS);
+            currentLineBuffer += 8;
+            firstPix = 0;
+            i = 0;
+            continue;
+         }
+#endif
 
          while (i++ < 4)
          {

--- a/src/tom/op_simd_neon.h
+++ b/src/tom/op_simd_neon.h
@@ -1,0 +1,83 @@
+#ifndef OP_SIMD_NEON_H
+#define OP_SIMD_NEON_H
+
+/*
+ * Object Processor 16bpp phrase store — ARM NEON implementation
+ *
+ * Included by op.c. Capability comes from blitter_simd_arch.h
+ * (BLITTER_SIMD_HAVE_NEON) so this stays on the same rpi2+/AArch64
+ * set as the blitter kernels and stays scalar on rpi0/rpi1.
+ *
+ * Intrinsics are the ARMv7 Advanced-SIMD subset (vld1/vst1/vbsl/vceq)
+ * so the file remains portable to 32-bit rpi2/rpi3. Do not add
+ * AArch64-only ops here (vaddv*, vqtbl1q*, vzip1*, vrbit*, f64).
+ */
+
+#include "blitter_simd_arch.h"
+
+#if defined(BLITTER_SIMD_HAVE_NEON)
+
+#include <stdint.h>
+#include <boolean.h>
+#include <arm_neon.h>
+
+#if defined(_MSC_VER)
+#  define OP_SIMD_INLINE __forceinline
+#elif defined(__GNUC__) || defined(__clang__)
+#  define OP_SIMD_INLINE inline __attribute__((always_inline))
+#else
+#  define OP_SIMD_INLINE INLINE
+#endif
+
+/*
+ * Store one 16bpp phrase (4 pixels / 8 bytes) into LBUF.
+ *
+ * Byte order matches OPProcessFixedBitmap's scalar walk: bitsHi then
+ * bitsLo per pixel through a uint8_t* with lbufDelta == +2, which is
+ * pixels[63:56], [55:48], …, [7:0]. The explicit extract is host-
+ * endian independent (vcreate_u64 + vst1 would reverse on LE).
+ *
+ * flagTRANS: skip a u16 lane when both bytes are zero (same test as
+ * (bitsLo | bitsHi) == 0), keeping the existing LBUF bytes via vbsl.
+ * Opaque: straight 8-byte store. Caller has already gated RMW,
+ * REFLECT, shadow-FB hooks, and LBUF bounds.
+ */
+static OP_SIMD_INLINE void op_store_phrase_16bpp_neon(
+      uint8_t *lbuf, uint64_t pixels, bool flagTRANS)
+{
+   uint8_t bytes[8];
+   uint8x8_t src;
+   uint8x8_t cur;
+   uint8x8_t mask;
+   uint16x4_t pix;
+   uint16x4_t zero;
+   uint16x4_t tmask;
+
+   bytes[0] = (uint8_t)(pixels >> 56);
+   bytes[1] = (uint8_t)(pixels >> 48);
+   bytes[2] = (uint8_t)(pixels >> 40);
+   bytes[3] = (uint8_t)(pixels >> 32);
+   bytes[4] = (uint8_t)(pixels >> 24);
+   bytes[5] = (uint8_t)(pixels >> 16);
+   bytes[6] = (uint8_t)(pixels >> 8);
+   bytes[7] = (uint8_t)(pixels);
+
+   src = vld1_u8(bytes);
+   if (!flagTRANS)
+   {
+      vst1_u8(lbuf, src);
+      return;
+   }
+
+   pix = vreinterpret_u16_u8(src);
+   zero = vdup_n_u16(0);
+   tmask = vceq_u16(pix, zero);
+   mask = vreinterpret_u8_u16(tmask);
+   cur = vld1_u8(lbuf);
+   src = vbsl_u8(mask, cur, src);
+   vst1_u8(lbuf, src);
+}
+
+#endif /* BLITTER_SIMD_HAVE_NEON */
+
+#endif /* OP_SIMD_NEON_H */


### PR DESCRIPTION
## Summary

- NEON store of one 16bpp Object Processor phrase (4 pixels / 8 bytes) in `OPProcessFixedBitmap`, inlined from `src/tom/op_simd_neon.h` and gated on `BLITTER_SIMD_HAVE_NEON`.
- Taken only when `!flagRMW`, `lbufDelta == +2` (no REFLECT), the whole phrase is in LBUF (`OP_LBUF_IN_BOUNDS(..., 8)`), no shadow-FB/hi-res hooks, and `i == 0 && firstPix == 0`. Transparency is `vceq_u16` against zero with `vbsl`; opaque is a straight 8-byte store. Everything else keeps the scalar loop.
- Byte order matches the scalar hi-then-lo `uint8_t*` walk on little-endian hosts. Intrinsics are the ARMv7 Advanced-SIMD subset (no AArch64-only ops).

Closes #671

## Test plan

- [x] `bash scripts/c89-lint.sh src/tom/op.c` — passed
- [x] ARMv7 NEON compile probe of `op_simd_neon.h` (`clang -target armv7-none-linux-gnueabihf -mfpu=neon`) — passed
- [x] `DEVELOPER_DIR=… make -j8` clean build — succeeded (`-DBLITTER_SIMD_NEON`)
- [x] `DEVELOPER_DIR=… make TEST_EXPORTS=1 test` — 0 failed (3 skipped: LAN discovery pair, Fountain live abort, jagcd CUE→CHD)
- [x] `./test/regression_test.sh ./virtualjaguar_libretro.dylib` — 10 passed, 0 failed (yarc + jagniccc identical, plus determinism / frameskip / savestate / rewind)