### PR TITLE
fix(blitter): log the refused nested blit, stubbing vj_log_cb in the unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2105,10 +2105,14 @@ test/test_pit_clock_rate: test/test_pit_clock_rate.c \
 		src/jerry/jerry.c src/tom/tom.c
 	$(CC) -O2 -Wall -std=c99 -o $@ test/test_pit_clock_rate.c
 
+# -DINLINE=inline because this compiles a core source STANDALONE, outside
+# CFLAGS: blitter_mmio.c includes src/core/log.h, which declares
+# `static INLINE`, and every other build of that file gets INLINE from the
+# core's own -DINLINE="inline".  log.h's vj_log_cb is stubbed in the test.
 test/test_blitter_mmio: test/test_blitter_mmio.c src/tom/blitter_mmio.c \
 		src/tom/blitter_internal.h src/tom/blitter.h src/core/vjag_memory.h \
-		src/core/settings.h
-	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		src/core/settings.h src/core/log.h
+	$(CC) -O2 -Wall -std=c99 -DINLINE=inline $(INCFLAGS) \
 		-o $@ test/test_blitter_mmio.c src/tom/blitter_mmio.c
 
 test/test_tom_visible_window: test/test_tom_visible_window.c src/tom/tom.c \

--- a/src/tom/blitter_mmio.c
+++ b/src/tom/blitter_mmio.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include "bus_arbiter.h"
 #include "gpu.h"
+#include "../core/log.h"
 #include "settings.h"
 #include "vjag_memory.h"
 
@@ -354,16 +355,28 @@ void BlitterWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
        * between frames, and so has no savestate surface at all. */
       static int blit_in_progress = 0;
 
-      /* Silent on purpose.  A warning here would be genuinely useful --
-       * a title that reaches this is misprogramming its destination --
-       * but this file is compiled STANDALONE by test/test_blitter_mmio,
-       * outside CFLAGS and without linking the core.  src/core/log.h
-       * needs -DINLINE and resolves to vj_log_cb, so including it turns
-       * that target into a link error.  Keeping blitter_mmio.c free of
-       * core dependencies is the existing design; do not add logging
-       * here without giving that test a stub. */
+      /* Warn once.  A title reaching this is misprogramming its blit
+       * destination and the user wants to know why the picture is wrong,
+       * but a runaway blit can arrive here on every pixel, so this must
+       * never become a per-pixel log.
+       *
+       * NOTE for anyone touching the includes: this file is also compiled
+       * STANDALONE by test/test_blitter_mmio, outside CFLAGS and without
+       * linking the core.  src/core/log.h needs -DINLINE (supplied by that
+       * Makefile rule) and resolves to vj_log_cb (stubbed in the test's
+       * existing stub block).  Both are required together. */
       if (blit_in_progress)
+      {
+         static int warned = 0;
+         if (!warned)
+         {
+            warned = 1;
+            LOG_WRN("[blitter] B_CMD written while a blit is running "
+                    "(destination overlaps $F022xx) -- refusing the nested "
+                    "blit; see issue #659\n");
+         }
          return;
+      }
 
       if (vjs.blitterTiming)
          busClks = BlitDurationSysclks();

--- a/test/test_blitter_mmio.c
+++ b/test/test_blitter_mmio.c
@@ -14,6 +14,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "libretro.h"
+
 #include "vjag_memory.h"
 #include "settings.h"
 #include "blitter.h"
@@ -23,6 +25,10 @@ uint8_t blitter_ram[0x100];
 
 /* Stubs for dependencies we don't need */
 struct VJSettings vjs = { 0 };
+/* blitter_mmio.c logs a refused nested blit (#659) through src/core/log.h.
+ * NULL here makes VJ_LOG fall back to its vj_log_stderr path, so the warning
+ * still works standalone instead of the include becoming a link error. */
+retro_log_printf_t vj_log_cb = NULL;
 int BlitterCompareIsEnabled(void) { return 0; }
 void BlitterRunComparison(void) {}
 void blitter_blit(uint32_t cmd) { (void)cmd; }


### PR DESCRIPTION
Restores the diagnostic that #663 had to drop. Follow-up to #659.

## Why it was missing

#663 landed the blitter re-entrancy guard **silent**. A title that reaches it is misprogramming its
blit destination, so the user sees garbage rendering with nothing in the log to explain it.

It went in silent because a bare `#include "../core/log.h"` broke every CI build:
`test/test_blitter_mmio` compiles `blitter_mmio.c` **standalone** — outside `CFLAGS`, without
linking the core. It failed first at compile:

```
src/tom/../core/log.h:14:8: error: unknown type name 'INLINE'
```

and then, once `-DINLINE=inline` was supplied, at link:

```
Undefined symbols: "_vj_log_cb", referenced from: _BlitterWriteWord
```

I read that as `blitter_mmio.c` being deliberately dependency-free and dropped the log line. That
was the wrong read — the test already carries a *"Stubs for dependencies we don't need"* block with
eight entries in it. This is the ninth, not an exception.

## The three pieces

They only work together, and the code says so in both places so nobody removes one alone:

| file | change |
|---|---|
| `test/test_blitter_mmio.c` | `retro_log_printf_t vj_log_cb = NULL;` beside the existing stubs |
| `Makefile` | `-DINLINE=inline` on that rule + `src/core/log.h` as a prerequisite |
| `src/tom/blitter_mmio.c` | the include, and a warn-once `LOG_WRN` |

`NULL` is not a disabled log: `VJ_LOG` falls through to its own `vj_log_stderr` path, so the warning
works in the standalone test too.

## Warn-once is load-bearing

A runaway blit can arrive at this branch on **every pixel**, so this must never become a per-pixel
log. Verified against Chroma-Luma Color Pick — the line appears exactly once in a 60-frame run:

```
[blitter] B_CMD written while a blit is running (destination overlaps $F022xx)
          -- refusing the nested blit; see issue #659
```

## Verification

| check | result |
|---|---|
| `make test` | **exit 0** — 147 cheat tests 0 failed, every suite 0 failed |
| `test/test_blitter_mmio` standalone | builds, `All tests passed.` |
| core build | exit 0, no new warnings |
| `scripts/c89-lint.sh` | passes |
| warning occurrences in a 60-frame run | exactly **1** |

Ran `make test` before pushing this time — skipping it is what put #663 red in the first place.

<!-- link-issue: #659 -->
