### PR TITLE
build(arm): iOS/tvOS mtune, LTO default for ELF targets, libnx cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,36 @@ ifeq ($(origin OPT_LEVEL),undefined)
    endif
 endif
 
+# LTO default.  Resolved here (before BUILD_AXES) so the stamp records the
+# effective value, not the empty command-line origin.
+#
+# GNU-ld ELF targets (unix, rpi*, generic arm64/aarch64/armv*) default ON;
+# opt out with LTO=0.  win (PE/COFF) and qnx (unverified gcc floor) stay off.
+# Mach-O (osx/ios/tvos) stays off unless LTO=1 is passed explicitly -- Apple
+# ld64 LTO is a different pipeline than the #569 ELF GOT/PLT win, and host
+# A/B numbers are indicative only.  classic_armv7_a7 is not in this list: it
+# already runs its own -flto=4 -fwhole-program pipeline.
+#
+# The FLAGS append is still gated on GC_STYLE below; this only picks the
+# default so `make` and `make LTO=1` stamp the same on unix/rpi*.
+LTO_DEFAULT_PLATFORMS := unix rpi0 rpi1 rpi2 rpi3 rpi3_64 rpi4 rpi4_64 rpi5 rpi5_64 \
+                         arm64 aarch64
+ifeq ($(origin LTO),undefined)
+   ifneq ($(filter $(platform),$(LTO_DEFAULT_PLATFORMS)),)
+      LTO := 1
+   else ifneq (,$(filter armv%,$(platform)))
+      LTO := 1
+   else
+      LTO := 0
+   endif
+endif
+
+# Opt-in iOS -mcpu pin.  Empty by default: stock ios-arm64 is -mtune only
+# (ISA-safe for the RetroArch iOS 9 / A7 floor).  For an iOS 17+ deploy
+# that can assume A12+: `make platform=ios-arm64 IOS_MCPU=apple-a12`.
+# MUST stay in BUILD_AXES -- it changes object content.
+IOS_MCPU ?=
+
 # system platform
 system_platform = unix
 ifeq ($(shell uname -a),)
@@ -208,7 +238,7 @@ MACHO_EXPORTS_FLAGS := -Wl,-exported_symbols_list,$(MACHO_EXPORTS)
 # CFLAGS contains -DINLINE="inline".
 BUILD_AXES := TEST_EXPORTS BENCH_PROFILE DEBUG BLITTER_TRACE COVERAGE \
               RELEASE_DEBUG_INFO DEBUG_PRESENTATION STATIC_LINKING platform \
-              OPT_LEVEL LTO
+              OPT_LEVEL LTO IOS_MCPU
 BUILD_CONFIG := $(strip $(foreach v,$(BUILD_AXES),$(v)=$($(v))))
 BUILD_CONFIG_STAMP := .build-config
 # Superseded .link-mode, which tracked TEST_EXPORTS alone; removed by the
@@ -303,6 +333,17 @@ else ifneq (,$(findstring ios,$(platform)))
 ifeq ($(platform),ios-arm64)
    CC = cc -arch arm64 -isysroot $(IOSSDK)
    CXX = clang++ -arch arm64 -isysroot $(IOSSDK)
+   # ISA-safe schedule model.  RetroArch's ios-arm64 floor is iOS 9 = A7;
+   # -mtune does not change the ISA so A7 devices still run the binary.
+   # Do NOT default -mcpu: apple-a10+ emits CRC32, apple-a11+ emits LSE,
+   # and either SIGILLs on A7/A8/A9.  Opt in for iOS 17+ deploys:
+   #   make platform=ios-arm64 IOS_MCPU=apple-a12
+   CFLAGS += -mtune=apple-a10
+   CXXFLAGS += -mtune=apple-a10
+   ifneq ($(IOS_MCPU),)
+      CFLAGS += -mcpu=$(IOS_MCPU)
+      CXXFLAGS += -mcpu=$(IOS_MCPU)
+   endif
 else
    CC = cc -arch armv7 -isysroot $(IOSSDK)
    CXX = clang++ -arch armv7 -isysroot $(IOSSDK)
@@ -327,6 +368,10 @@ else ifeq ($(platform), tvos-arm64)
         CC = cc -arch arm64 -isysroot $(IOSSDK)
         CXX = clang++ -arch arm64 -isysroot $(IOSSDK)
         MINVERSION = -mappletvos-version-min=11.0
+        # ISA-safe schedule model for Apple TV HD (A8), the tvOS floor.
+        # -mcpu is forbidden here: apple-a10+ emits CRC32 => SIGILL on A8.
+        CFLAGS += -mtune=apple-a8
+        CXXFLAGS += -mtune=apple-a8
         SHARED += $(MINVERSION)
         CFLAGS += $(MINVERSION)
 
@@ -464,7 +509,8 @@ else ifeq ($(platform), libnx)
 	# possibly speed up are integer-only regardless of target architecture,
 	# so the x86_64/arm64 A/B null result (see the FLAGS block below)
 	# generalizes here without needing a Switch-specific measurement.
-	CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd
+	# -mcpu implies -mtune, so a separate -mtune=cortex-a57 was redundant.
+	CFLAGS += -march=armv8-a -mtp=soft -mcpu=cortex-a57+crc+fp+simd
 	CXXFLAGS := $(ASFLAGS) $(CFLAGS)
 	STATIC_LINKING = 1
 
@@ -1043,17 +1089,29 @@ ifneq ($(platform),win)
       FLAGS += -fvisibility=hidden
    endif
 
-   # Opt-in LTO (issue #569). Deliberately NOT default-on -- it wants an
-   # A/B on real Pi hardware first (test/tools/rpi_perf.sh exists for
-   # exactly that), same caution as the -O3 rollout above (#515/#516).
-   # `make LTO=1` (add `platform=rpi4_64` etc.) appends -flto to both
-   # the compile and link lines for every GC_STYLE=gnu target except
-   # `win` (see above).
+   # LTO (issue #569).  Default-on for these GNU-ld ELF targets; opt out
+   # with LTO=0.  macOS host A/B is indicative only; Linux/Pi CI + device
+   # `rpi_perf.sh` is the final arbiter.  `win` is excluded by the outer
+   # ifneq; `qnx` is excluded here (unverified gcc floor -- the same
+   # reason it is carved out of -fno-semantic-interposition).
+   # `make LTO=1 platform=rpi4_64` still works (now a no-op vs default).
+   ifneq ($(platform),qnx)
+      ifeq ($(LTO),1)
+         FLAGS   += -flto
+         LDFLAGS += -flto
+      endif
+   endif
+endif
+endif
+
+# Explicit LTO=1 on Mach-O (osx/ios/tvos): same knob, default-off.  Lets
+# a macOS host A/B the flag; Apple ld64 LTO is not the #569 ELF win and
+# is not default-on.
+ifeq ($(GC_STYLE),macho)
    ifeq ($(LTO),1)
       FLAGS   += -flto
       LDFLAGS += -flto
    endif
-endif
 endif
 # ----------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,16 @@ ifeq ($(origin LTO),undefined)
    endif
 endif
 
+# gcov + -flto is known-broken on GCC: the computed-goto dispatch tables in
+# dsp.c/gpu.c become .data.rel.local arrays of .L label addresses, and the
+# coverage instrumentation strands those local symbols across LTO partitions
+# ("undefined reference to `.L106'" at link).  Coverage wants unmerged,
+# per-line attribution anyway, so force LTO off -- even over an explicit
+# LTO=1 -- whenever COVERAGE=1.
+ifeq ($(COVERAGE),1)
+   override LTO := 0
+endif
+
 # Opt-in iOS -mcpu pin.  Empty by default: stock ios-arm64 is -mtune only
 # (ISA-safe for the RetroArch iOS 9 / A7 floor).  For an iOS 17+ deploy
 # that can assume A12+: `make platform=ios-arm64 IOS_MCPU=apple-a12`.

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -156,6 +156,10 @@ platforms are explicitly carved back out:
   `-flto=4 -fwhole-program` pipeline in its platform block. Host A/B numbers are
   indicative only — Linux/Pi CI + `test/tools/rpi_perf.sh` on device is the final
   arbiter. `LTO` is in `BUILD_AXES` since it changes object content.
+  **`COVERAGE=1` force-disables LTO** (even an explicit `LTO=1`): GCC's gcov
+  instrumentation turns the dsp.c/gpu.c computed-goto dispatch tables into
+  `.data.rel.local` arrays of `.L` label addresses that don't survive LTO
+  partitioning (`undefined reference to `.L106'` at link).
 - **iOS/tvOS `-mtune`:** `ios-arm64` adds `-mtune=apple-a10`, `tvos-arm64` adds
   `-mtune=apple-a8`. These are ISA-safe (scheduling only) for RetroArch's iOS 9 / A7
   and tvOS Apple TV HD / A8 floors. Do **not** default `-mcpu` there — that would emit

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -89,7 +89,7 @@ full rebuild per flip (~21s at `-j8` without ccache).
 
 Stamp covers **every** compile-affecting switch (`BUILD_AXES`: `TEST_EXPORTS BENCH_PROFILE
 DEBUG BLITTER_TRACE COVERAGE RELEASE_DEBUG_INFO DEBUG_PRESENTATION STATIC_LINKING platform
-OPT_LEVEL LTO`).
+OPT_LEVEL LTO IOS_MCPU`).
 **Adding a new CFLAGS-affecting switch means adding it to that list** — forgetting = silent
 chimera binary, not a build error. It stamps variable *names*, not `$(CFLAGS)` (`DEBUG=1`
 injects a per-second `-DBUILD_TIMESTAMP`, so stamping flags would flush every build).
@@ -148,17 +148,26 @@ platforms are explicitly carved back out:
   attribute already present on an earlier declaration governs the later definition, so
   `libretro.c`'s definitions (which never repeat `RETRO_API`) inherit it from the header
   they include.
-- **`LTO=1` opt-in knob:** `make LTO=1` (combine with `platform=` as usual) appends
-  `-flto` to both compile and link lines for every `GC_STYLE=gnu` target except `win`
-  (see above). Deliberately **not** default-on — it needs an A/B on real Pi hardware first
-  (`test/tools/rpi_perf.sh`), the same caution the `-O3` rollout used (#515/#516).
-  `classic_armv7_a7` is unaffected either way: it already runs its own
-  `-flto=4 -fwhole-program` pipeline in its platform block, independent of this knob.
-  `LTO` is in `BUILD_AXES` since it changes object content.
+- **`LTO` default-on for GNU-ld ELF:** unix, `rpi*`, generic `arm64`/`aarch64`/`armv*`
+  now pass `-flto` unless you opt out with `LTO=0`. `win` (PE/COFF) and `qnx`
+  (unverified gcc floor) stay excluded even with `LTO=1`. Mach-O (`osx`/`ios*`/`tvos*`)
+  stays default-off; explicit `make LTO=1` on those is honoured so a macOS host can A/B
+  the flag. `classic_armv7_a7` is unaffected: it already runs its own
+  `-flto=4 -fwhole-program` pipeline in its platform block. Host A/B numbers are
+  indicative only — Linux/Pi CI + `test/tools/rpi_perf.sh` on device is the final
+  arbiter. `LTO` is in `BUILD_AXES` since it changes object content.
+- **iOS/tvOS `-mtune`:** `ios-arm64` adds `-mtune=apple-a10`, `tvos-arm64` adds
+  `-mtune=apple-a8`. These are ISA-safe (scheduling only) for RetroArch's iOS 9 / A7
+  and tvOS Apple TV HD / A8 floors. Do **not** default `-mcpu` there — that would emit
+  CRC32 (A10+) / LSE (A11+) and SIGILL on the floor chips. Opt-in pin for iOS 17+
+  deploys: `make platform=ios-arm64 IOS_MCPU=apple-a12` (appends `-mcpu=$(IOS_MCPU)`;
+  `IOS_MCPU` is in `BUILD_AXES`).
 - **Android (`jni/Android.mk`):** `ndk-build` never includes `Makefile`, only
   `Makefile.common`, so it inherited none of the desktop optimisation flags. `COREFLAGS`
   now also carries `-O3 -DNDEBUG -fvisibility=hidden -fno-stack-protector
-  -fomit-frame-pointer -fno-semantic-interposition` by hand.
+  -fomit-frame-pointer -fno-semantic-interposition` by hand. No `-march` extensions
+  (single-APK arm64-v8a baseline is `armv8-a`). No `-flto`: the chip-tuning note did
+  not propose it, and this host cannot run `ndk-build` to verify.
 - **Issue #516 does not apply here:** neither `-fvisibility=hidden` nor
   `-fno-semantic-interposition` is an `-O`, so neither can silently shift a platform's
   resolved optimisation level.

--- a/test/tools/simd_matrix_check.sh
+++ b/test/tools/simd_matrix_check.sh
@@ -79,10 +79,16 @@ dump() {
    # calling make happens to carry.  The explicit empty assignments pin the
    # rest of BUILD_AXES for the same reason -- a future `make test` variant
    # that sets DEBUG=1 would otherwise silently move the answer again.
-   env -u MAKEFLAGS -u MFLAGS -u MAKELEVEL \
+   #
+   # LTO is un-set rather than pinned to empty: `LTO=` on the command line
+   # is origin=command / value empty, which the Makefile treats as off and
+   # would hide the ELF default-on.  `env -u LTO` drops a parent
+   # `make LTO=1 test` export so origin is undefined and the default applies.
+   env -u MAKEFLAGS -u MFLAGS -u MAKELEVEL -u LTO \
       make -n -f Makefile -f "$PROBE" vjsimd platform="$plat" \
            COVERAGE= DEBUG= TEST_EXPORTS= BENCH_PROFILE= BLITTER_TRACE= \
            RELEASE_DEBUG_INFO= DEBUG_PRESENTATION= STATIC_LINKING= \
+           IOS_MCPU= \
            "$@" 2>/dev/null \
       | tr -d '"' | sed -n 's/.*\(SIMD=.*\)/\1/p' | head -1
 }
@@ -259,8 +265,57 @@ expect_tune rpi5_64  -O3 cortex-a76   no
 # The target #516 was actually about: -Ofast must survive to the end.
 expect_tune classic_armv7_a7 -Ofast - yes
 # Non-Pi ARM must NOT acquire -mcpu -- we do not know their silicon.
+# ios-arm64 / tvos-arm64: -mtune is ISA-safe; -mcpu is not (A7 / A8 floors).
+expect_tune ios-arm64  -O3 - no
 expect_tune tvos-arm64 -O3 - no
 expect_tune vita       -O2 - no
+
+# expect_mtune <platform> <expected-mtune|->
+expect_mtune() {
+   local plat="$1" want="$2"; shift 2
+   local got cflags mtune
+
+   checked=$((checked + 1))
+   got="$(dump "$plat" "$@")"
+   cflags="$(printf '%s' "$got" | sed -n 's/.*CFLAGS=//p')"
+   mtune="$(printf '%s' "$cflags" | tr ' ' '\n' | grep -E '^-mtune=' | tail -1)"
+
+   if [ -z "$cflags" ]; then
+      printf 'FAIL  %-42s could not read CFLAGS\n' "$plat"; fail=$((fail + 1)); return
+   fi
+   if [ "$want" = "-" ]; then
+      if [ -n "$mtune" ]; then
+         printf 'FAIL  %-42s unexpected %s\n' "$plat" "$mtune"; fail=$((fail + 1)); return
+      fi
+   elif [ "$mtune" != "-mtune=$want" ]; then
+      printf 'FAIL  %-42s -mtune is %s, expected -mtune=%s\n' "$plat" "${mtune:-none}" "$want"
+      fail=$((fail + 1)); return
+   fi
+   [ "$VERBOSE" = 1 ] && printf 'ok    %-42s %s\n' "$plat" "${mtune:-(no -mtune)}"
+   return 0
+}
+
+echo
+echo "simd_matrix_check: Apple -mtune (ISA-safe; no default -mcpu)"
+expect_mtune ios-arm64  apple-a10
+expect_mtune tvos-arm64 apple-a8
+# 32-bit ios9 must not pick up the arm64 tune value.
+expect_mtune ios9 -
+# rpi rows use -mcpu (implies -mtune); they must not also pass -mtune.
+expect_mtune rpi4_64 -
+# Opt-in IOS_MCPU appends -mcpu without dropping -mtune.
+got="$(dump ios-arm64 IOS_MCPU=apple-a12)"
+cflags="$(printf '%s' "$got" | sed -n 's/.*CFLAGS=//p')"
+checked=$((checked + 1))
+mcpu="$(printf '%s' "$cflags" | tr ' ' '\n' | grep -E '^-mcpu=' | tail -1)"
+mtune="$(printf '%s' "$cflags" | tr ' ' '\n' | grep -E '^-mtune=' | tail -1)"
+if [ "$mcpu" != "-mcpu=apple-a12" ] || [ "$mtune" != "-mtune=apple-a10" ]; then
+   printf 'FAIL  %-42s IOS_MCPU=apple-a12 => mtune=%s mcpu=%s\n' \
+      "ios-arm64 IOS_MCPU=apple-a12" "${mtune:-none}" "${mcpu:-none}"
+   fail=$((fail + 1))
+elif [ "$VERBOSE" = 1 ]; then
+   printf 'ok    %-42s %s %s\n' "ios-arm64 IOS_MCPU=apple-a12" "$mtune" "$mcpu"
+fi
 
 echo
 
@@ -323,6 +378,46 @@ expect_vis osx      no  no
 # there expands to __attribute__((__dllexport__)), not the visibility
 # attribute, so it is explicitly excluded from both flags in the Makefile.
 expect_vis win       no  no
+
+# expect_lto <platform> <expect-flto:yes|no> [extra make vars...]
+expect_lto() {
+   local plat="$1" want="$2"; shift 2
+   local got cflags has_lto label
+
+   checked=$((checked + 1))
+   label="$plat${1:+ $1}"
+   got="$(dump "$plat" "$@")"
+   cflags="$(printf '%s' "$got" | sed -n 's/.*CFLAGS=//p')"
+
+   if [ -z "$cflags" ]; then
+      printf 'FAIL  %-42s could not read CFLAGS\n' "$label"; fail=$((fail + 1)); return
+   fi
+   has_lto="$(printf '%s' "$cflags" | tr ' ' '\n' | grep -cE '^-flto$')"
+   if [ "$want" = yes ] && [ "$has_lto" -eq 0 ]; then
+      printf 'FAIL  %-42s missing -flto\n' "$label"; fail=$((fail + 1)); return
+   fi
+   if [ "$want" = no ] && [ "$has_lto" -ne 0 ]; then
+      printf 'FAIL  %-42s unexpectedly has -flto\n' "$label"; fail=$((fail + 1)); return
+   fi
+   [ "$VERBOSE" = 1 ] && printf 'ok    %-42s lto=%s\n' "$label" "$want"
+   return 0
+}
+
+echo
+echo "simd_matrix_check: LTO default (issue #569; ELF on, Mach-O/win/qnx off)"
+# GNU-ld ELF defaults on; LTO=0 opts out.
+expect_lto unix     yes
+expect_lto rpi4_64  yes
+expect_lto rpi1     yes
+expect_lto arm64    yes
+expect_lto unix     no  LTO=0
+# Mach-O default-off; explicit LTO=1 is honoured for host A/B.
+expect_lto osx      no
+expect_lto osx      yes LTO=1
+expect_lto ios-arm64 no
+# win (PE) and qnx stay excluded even with LTO=1.
+expect_lto win      no  LTO=1
+expect_lto qnx      no  LTO=1
 
 echo
 if [ "$fail" -ne 0 ]; then

--- a/test/tools/simd_matrix_check.sh
+++ b/test/tools/simd_matrix_check.sh
@@ -418,6 +418,10 @@ expect_lto ios-arm64 no
 # win (PE) and qnx stay excluded even with LTO=1.
 expect_lto win      no  LTO=1
 expect_lto qnx      no  LTO=1
+# gcov coverage forces LTO off (GCC computed-goto .L refs break LTO link),
+# even over an explicit LTO=1.
+expect_lto unix     no  COVERAGE=1
+expect_lto unix     no  COVERAGE=1 LTO=1
 
 echo
 if [ "$fail" -ne 0 ]; then


### PR DESCRIPTION
## Summary

- **iOS/tvOS `-mtune` (ISA-safe):** `ios-arm64` gets `-mtune=apple-a10`, `tvos-arm64` gets `-mtune=apple-a8`. No default `-mcpu` (that would emit CRC32/LSE and SIGILL on RetroArch's iOS 9 / A7 and tvOS Apple TV HD / A8 floors). Opt-in `make platform=ios-arm64 IOS_MCPU=apple-a12` appends `-mcpu=$(IOS_MCPU)` for iOS 17+ deploys. `IOS_MCPU` is in `BUILD_AXES`.
- **LTO default-on for GNU-ld ELF** (`unix`, `rpi*`, generic `arm64`/`aarch64`/`armv*`); opt out with `LTO=0`. `win` (PE/COFF) and `qnx` stay excluded even with `LTO=1`. Mach-O stays default-off; explicit `LTO=1` is honoured for host A/B. `classic_armv7_a7` is unchanged (its own `-flto=4` pipeline).
- **libnx:** drop redundant `-mtune=cortex-a57` next to `-mcpu=cortex-a57+crc+fp+simd` (zero codegen impact).
- **Android `jni/Android.mk`:** no change. Chip-tuning doc rejected `-march` extensions (single-APK `armv8-a` baseline) and did not propose `-flto`; this host cannot run `ndk-build` to verify.

Closes #678

## mtune probe results

Apple clang 21.0.0, iPhoneOS 26.5 / AppleTVOS 26.5 SDKs, `xcrun --sdk iphoneos|appletvos clang -arch arm64`:

| flag | iphoneos | appletvos |
| --- | --- | --- |
| `-mtune=apple-a7` … `apple-a13` | ACCEPT | ACCEPT (probed a7/a8/a9/a10/a12) |
| `-mtune=apple-a10` (ios-arm64) | ACCEPT | — |
| `-mtune=apple-a8` (tvos-arm64) | — | ACCEPT |
| `-mcpu=apple-a10/a12/a13/a14` | ACCEPT | — |
| combined `-mtune=apple-a10 -mcpu=apple-a12` | ACCEPT | — |

No fallback was needed; the recommended values compiled against the real SDKs.

`make platform=ios-arm64 -n` shows `-mtune=apple-a10` and no `-mcpu`. `IOS_MCPU=apple-a12` adds `-mcpu=apple-a12`. `make platform=tvos-arm64 -n` shows `-mtune=apple-a8`.

## LTO A/B (macOS arm64 host — indicative only)

`test/tools/test_benchmark`, 900 frames / 300 warmup, fast blitter, public ROMs, A/B/B/A order. A = `LTO=0`, B = `LTO=1` (Mach-O ld64 LTO, **not** the ELF GOT/PLT win). Binary size 2,282,016 → 2,217,584 (−2.8%).

| ROM | A1 ms/f | B1 ms/f | B2 ms/f | A2 ms/f | A mean | B mean |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| jagniccc.j64 (GPU/DSP/blitter mix) | 6.003 | 6.215 | 6.530 | 6.222 | 6.113 | 6.373 |
| yarc.j64 (GPU spin; noisy) | 9.702 | 11.002 | 9.719 | 6.308 | 8.005 | 10.361 |

jagniccc is the load-bearing row (~4% slower under Mach-O LTO). yarc A1 vs A2 already disagrees by 50%+, so that row is thermal/noise, not a verdict.

**Decision:** default-on for GNU-ld ELF only. Mach-O stays opt-in (`LTO=1`) because this A/B is Apple ld64, not the #569 ELF interposition win, and it was not faster here. **Linux/Pi CI + `test/tools/rpi_perf.sh` on device is the final arbiter**; revert with `LTO=0` if a Pi row regresses.

## Test plan

- [x] `test/tools/simd_matrix_check.sh` OK (58 rows), including Apple `-mtune`, `IOS_MCPU`, LTO default on/off, and no leak from parent `LTO=1`
- [x] `make platform=ios-arm64 -n` / `tvos-arm64 -n` / `IOS_MCPU=apple-a12` flag sanity
- [x] `make -j8 LTO=0` and `make -j8 LTO=1` host builds clean
- [x] `make TEST_EXPORTS=1 LTO=1 test` — 0 failed
- [x] `make TEST_EXPORTS=1 test` (osx default = LTO off) — 0 failed
- [x] `make -j8` production rebuild after the TEST_EXPORTS flip
- [ ] Linux CI (`c-cpp.yml`) and Pi device `rpi_perf.sh` A/B (not run here)