### PR TITLE
perf(tom/op): NEON wave 2 — 24bpp phrases and 2x hi-res box-replicate

### DIFF
--- a/src/tom/op.c
+++ b/src/tom/op.c
@@ -1251,6 +1251,22 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
          pixels <<= firstPix;
          data += pitch;
 
+#if defined(BLITTER_SIMD_HAVE_NEON)
+         /* Full 2-pixel phrase, no REFLECT, wholly inside LBUF.
+          * 24bpp has no RMW path and no shadow-FB hooks. Partial
+          * firstPix/i phrases keep the scalar loop below. */
+         if (!flagRMW && lbufDelta == 4
+               && OP_LBUF_IN_BOUNDS(currentLineBuffer, 8)
+               && i == 0 && firstPix == 0)
+         {
+            op_store_phrase_24bpp_neon(currentLineBuffer, pixels, flagTRANS);
+            currentLineBuffer += 8;
+            firstPix = 0;
+            i = 0;
+            continue;
+         }
+#endif
+
          while (i++ < 2)
          {
             // We don't use a 32-bit var here because of endian issues...!

--- a/src/tom/op_simd_neon.h
+++ b/src/tom/op_simd_neon.h
@@ -2,7 +2,7 @@
 #define OP_SIMD_NEON_H
 
 /*
- * Object Processor 16bpp phrase store — ARM NEON implementation
+ * Object Processor 16bpp / 24bpp phrase store — ARM NEON implementation
  *
  * Included by op.c. Capability comes from blitter_simd_arch.h
  * (BLITTER_SIMD_HAVE_NEON) so this stays on the same rpi2+/AArch64
@@ -73,6 +73,54 @@ static OP_SIMD_INLINE void op_store_phrase_16bpp_neon(
    zero = vdup_n_u16(0);
    tmask = vceq_u16(pix, zero);
    mask = vreinterpret_u8_u16(tmask);
+   cur = vld1_u8(lbuf);
+   src = vbsl_u8(mask, cur, src);
+   vst1_u8(lbuf, src);
+}
+
+/*
+ * Store one 24bpp phrase (2 pixels / 8 bytes) into LBUF.
+ *
+ * Byte order matches OPProcessFixedBitmap's scalar walk: bits3..bits0
+ * per pixel through a uint8_t* with lbufDelta == +4. The 24bpp loop
+ * never applies RMW or shadow-FB hooks (RMW is 16bpp CRY-only); the
+ * caller still gates REFLECT, partial firstPix/i, and LBUF bounds.
+ *
+ * flagTRANS: skip a u32 lane when all four bytes are zero (same test
+ * as (bits3 | bits2 | bits1 | bits0) == 0). Opaque: straight 8-byte
+ * store.
+ */
+static OP_SIMD_INLINE void op_store_phrase_24bpp_neon(
+      uint8_t *lbuf, uint64_t pixels, bool flagTRANS)
+{
+   uint8_t bytes[8];
+   uint8x8_t src;
+   uint8x8_t cur;
+   uint8x8_t mask;
+   uint32x2_t pix;
+   uint32x2_t zero;
+   uint32x2_t tmask;
+
+   bytes[0] = (uint8_t)(pixels >> 56);
+   bytes[1] = (uint8_t)(pixels >> 48);
+   bytes[2] = (uint8_t)(pixels >> 40);
+   bytes[3] = (uint8_t)(pixels >> 32);
+   bytes[4] = (uint8_t)(pixels >> 24);
+   bytes[5] = (uint8_t)(pixels >> 16);
+   bytes[6] = (uint8_t)(pixels >> 8);
+   bytes[7] = (uint8_t)(pixels);
+
+   src = vld1_u8(bytes);
+   if (!flagTRANS)
+   {
+      vst1_u8(lbuf, src);
+      return;
+   }
+
+   pix = vreinterpret_u32_u8(src);
+   zero = vdup_n_u32(0);
+   tmask = vceq_u32(pix, zero);
+   mask = vreinterpret_u8_u32(tmask);
    cur = vld1_u8(lbuf);
    src = vbsl_u8(mask, cur, src);
    vst1_u8(lbuf, src);

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -1196,6 +1196,9 @@ static void tom_render_scanline_hires(uint32_t * backbuffer)
    unsigned w = (tomWidth < 1024) ? tomWidth : 1024;
    uint32_t *dst;
    uint32_t px;
+#if defined(BLITTER_SIMD_HAVE_NEON)
+   unsigned neon_done;
+#endif
 
    if (fn == tom_render_16bpp_cry_scanline)
    {
@@ -1209,13 +1212,39 @@ static void tom_render_scanline_hires(uint32_t * backbuffer)
       return;
    }
 
-   for (i = 0; i < w; i++)
-      tomHiresScratch[i] = backbuffer[i * n];
+#if defined(BLITTER_SIMD_HAVE_NEON)
+   /* n==2 is Stage 1. Compiler autovec of the runtime-n loops only
+    * fires for n==1 (gather) or n>7 (expand); the common 2x path
+    * stays scalar without this. */
+   if (n == 2u)
+   {
+      neon_done = tom_scan_neon_hires_gather_n2(backbuffer, tomHiresScratch, w);
+      for (i = neon_done; i < w; i++)
+         tomHiresScratch[i] = backbuffer[i * n];
+   }
+   else
+#endif
+   {
+      for (i = 0; i < w; i++)
+         tomHiresScratch[i] = backbuffer[i * n];
+   }
    fn(tomHiresScratch);
    for (r = 0; r < n; r++)
    {
       dst = backbuffer + r * screenPitch;
-      for (i = 0; i < w; i++)
+#if defined(BLITTER_SIMD_HAVE_NEON)
+      if (n == 2u)
+      {
+         neon_done = tom_scan_neon_hires_expand_n2(tomHiresScratch, dst, w);
+         dst += neon_done * 2u;
+         i = neon_done;
+      }
+      else
+         i = 0;
+#else
+      i = 0;
+#endif
+      for (; i < w; i++)
       {
          px = tomHiresScratch[i];
          for (s = 0; s < n; s++)

--- a/src/tom/tom_scan_simd_neon.h
+++ b/src/tom/tom_scan_simd_neon.h
@@ -151,6 +151,51 @@ static INLINE unsigned tom_scan_neon_16bpp_rgb(
    return done;
 }
 
+/* Strided gather of every 2nd uint32: dst[i] = src[i * 2].
+ * Matches tom_render_scanline_hires's seed of tomHiresScratch from the
+ * existing Nx row.  Returns source pixels written (multiple of 4). */
+static INLINE unsigned tom_scan_neon_hires_gather_n2(
+   const uint32_t * VJ_RESTRICT src,
+   uint32_t * VJ_RESTRICT dst,
+   unsigned n)
+{
+   unsigned i;
+   unsigned done;
+   uint32x4x2_t t;
+
+   done = n & ~3u;
+   for (i = 0; i < done; i += 4)
+   {
+      t = vld2q_u32(src + (i * 2));
+      vst1q_u32(dst + i, t.val[0]);
+   }
+   return done;
+}
+
+/* 2x box-replicate: dst[2*i] = dst[2*i+1] = src[i].
+ * ARMv7 vzipq (struct form), not A64 vzip1/vzip2.  Returns source
+ * pixels expanded (multiple of 4). */
+static INLINE unsigned tom_scan_neon_hires_expand_n2(
+   const uint32_t * VJ_RESTRICT src,
+   uint32_t * VJ_RESTRICT dst,
+   unsigned n)
+{
+   unsigned i;
+   unsigned done;
+   uint32x4_t a;
+   uint32x4x2_t z;
+
+   done = n & ~3u;
+   for (i = 0; i < done; i += 4)
+   {
+      a = vld1q_u32(src + i);
+      z = vzipq_u32(a, a);
+      vst1q_u32(dst + (i * 2), z.val[0]);
+      vst1q_u32(dst + (i * 2) + 4, z.val[1]);
+   }
+   return done;
+}
+
 #endif /* BLITTER_SIMD_HAVE_NEON */
 
 #endif /* TOM_SCAN_SIMD_NEON_H */


### PR DESCRIPTION
## Summary

- **OP 24bpp fixed-bitmap phrase store** (`op_store_phrase_24bpp_neon`): same guard as the 16bpp path — full 2-pixel / 8-byte phrase, `lbufDelta == +4` (no REFLECT), wholly inside LBUF. 24bpp has no RMW and no shadow-FB hooks (verified in `OPProcessFixedBitmap`). TRANS skips a zero `u32` lane via `vceq_u32`/`vbsl`; opaque is a straight 8-byte store. Used by Iron Soldier.
- **Stage-1 2x hi-res gather + box-replicate** (`tom_scan_neon_hires_gather_n2` / `_expand_n2`): `vld2q_u32` gathers every other pixel into `tomHiresScratch`; ARMv7 `vzipq_u32` (struct form, not A64 `vzip1`/`vzip2`) expands to `AA BB CC DD`. Clang `-O3` auto-vectorizes the *runtime-n* loops only for `n==1` (gather) or `n>7` (expand), so the common 2x path stayed scalar.
- Stacked on #672 (OP 16bpp) and #670 (TOM scanlines). `#672` / `#670` have **not** merged to `develop` yet; rebase onto `libretro/develop` after they land so this diff is just the two wave-2 commits.

Closes #681

## Skipped (with rationale)

| Candidate | Why skipped |
| --- | --- |
| `OPProcessScaledBitmap` 16bpp | Dest run length is `ceil((hscale - remainder) / 0x20)`, not a constant `hscale` run. Only exact multiples of `$20` with remainder 0 give a stable vdup store; 1.0x (`hscale==$20`, the common case) is run-length 1. Phrase wrap, TRANS skip-but-advance, and shadow peeks sit in the dest-pixel loop — structure does not fall out. |
| Border fill (`TOMExecHalfline` ~1711) | clang `-O3` already emits `dup.4s` + `stp q0, q0` (same BGEN-clear precedent). |
| 8bpp opaque phrase | CLUT gather dominates. `-O3` is 8× `ldrb`/`ldrh`/`strh`; no ARMv7 gather, and pairing the 8 stores into one `vst1q` does not move the needle. |
| CRY LUT / fast-blitter SIMD / DSP mmult / MOVEM | Already on the rejection list. |

## clang-tidy note

`op_simd_neon.h` and `tom_scan_simd_neon.h` are already on `scripts/c89-lint.sh`'s `skip_file` list. The clang-tidy job's grep in `.github/workflows/c-cpp.yml` still only excludes `blitter_simd_(neon|sse2|scalar).(c|h)`, so these include-only NEON headers can fail a standalone tidy pass the same way the blitter headers used to. Another PR is fixing that CI regex; this one does not.

## Test plan

- [x] `bash scripts/c89-lint.sh src/tom/op.c src/tom/tom.c` — passed
- [x] ARMv7 NEON compile probe of both headers (`clang -target armv7-none-linux-gnueabihf -mfpu=neon -fsyntax-only`) — passed
- [x] `DEVELOPER_DIR=… make -j8` clean build — succeeded (`-DBLITTER_SIMD_NEON`)
- [x] `DEVELOPER_DIR=… make TEST_EXPORTS=1 test` — 0 failed (2 skipped: Fountain live abort, jagcd CUE→CHD)
- [x] `./test/regression_test.sh ./virtualjaguar_libretro.dylib` — **10 passed, 0 failed** (yarc + jagniccc 0 pixels differ, plus determinism / frameskip / savestate / rewind)
- [x] Iron Soldier `iron_soldier_v104_f2400.state` frame_hash_ab A/B vs merge-base, 180 frames — **identical** (181 CSV rows)
- [x] yarc `internal_resolution=2x` frame_hash_ab A/B, 180 frames — **identical**