### PR TITLE
feat(debug): GDB remote stub Phase 2/3/4 -- breakpoints, GPU/DSP threads, docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ test/tools/paddle_decode_test
 test/tools/procontroller_decode_test
 test/tools/sixd_decode_test
 test/tools/tuning_identity
+test/tools/gdb_determinism_probe
 # vjtrace flight-recorder analyzer/smoke tools -- built on demand by
 # test/tools/vjtrace_selftest.sh (and by hand per each tool's own header
 # comment); never tracked, same Mach-O-on-Linux-CI hazard as above.

--- a/docs/gdb-stub-design.md
+++ b/docs/gdb-stub-design.md
@@ -310,20 +310,34 @@ Five layers, in increasing cost:
    attach, set a breakpoint at a known symbol, continue, assert the stop reply
    and PC, read a register, write memory, continue to exit. **Answered during
    Phase 1 implementation: it does not ship gdb** (see Open Question 1) — this
-   layer runs as `test/tools/gdb_attach_probe.py`, a scripted RSP client, for
-   as long as that remains true. It exercises attach, `qSupported`, halt
-   reason, register read, memory read, and bounds refusal; breakpoint/continue
-   coverage waits for Phase 2, where breakpoints exist to test.
+   layer runs as scripted RSP clients under `test/tools/`, for as long as that
+   remains true.
 
    **This is not merely a stand-in for gdb being unavailable.** Phase 1's
-   `GDBHandlePacket` never sends the low-level `+`/`-` acknowledgement byte a
+   `GDBHandlePacket` never sent the low-level `+`/`-` acknowledgement byte a
    real GDB client requires for every packet before `QStartNoAckMode` is
    negotiated (and that negotiation itself needs one such ack to complete).
-   `gdb_attach_probe.py` passes without noticing this because it never checks
-   for an ack. A real `m68k-elf-gdb`, brought by the user per Open Question 1,
-   would stall on its very first `qSupported`. Implementing the ack byte is
-   Phase 2 work, tracked alongside breakpoints -- until then, the scripted
-   probe is the only client Phase 1 actually supports end to end.
+   Phase 1's `gdb_attach_probe.py` passed without noticing this because it
+   never checked for an ack — a real `m68k-elf-gdb` would have stalled on its
+   very first `qSupported`.
+
+   **Phase 2 closed that gap and extended this layer:**
+   `test/tools/gdb_attach_probe.py` now verifies a `+` precedes every reply in
+   ack mode, and that acks stop arriving after `QStartNoAckMode` — including
+   the off-by-one (the `OK` reply to `QStartNoAckMode` itself is still acked;
+   only packets after it are not). `test/tools/gdb_breakpoint_probe.py` is new:
+   it launches the core headlessly (via `test/tools/gdb_determinism_probe` as
+   a free-running host process), halts it at boot (`virtualjaguar_gdb_wait`),
+   injects a single real 68K instruction (`BRA.S *`, a branch-to-self loop)
+   into scratch RAM via `M`, redirects PC to it via `G`, arms a `Z0` there,
+   continues, and asserts the stop reply names thread 1 and a fresh register
+   read shows PC still at that exact address — a real breakpoint actually
+   halting real (if synthetic) execution, not just a protocol-level OK reply.
+   The gdb_wait halt is load-bearing, not just convenient: an early version of
+   this script picked an arbitrary "probably unused" RAM address without
+   halting first, and the ROM's own boot code overwrote the injected
+   instruction before the CPU fetched it, within a single frame — confirmed
+   by reading the address back and finding the ROM's own data there instead.
 
 ## Out of scope
 
@@ -373,19 +387,96 @@ Five layers, in increasing cost:
    debugging" claim in this document has been corrected accordingly; do not
    reintroduce it without new evidence that some other tool in the chain
    (not `rln`) emits real DWARF.
-3. **Register numbering for the RISC target descriptions.** Needs to be fixed
-   once and then never changed, since clients cache it. Still open — GPU/DSP
-   threads are Phase 3, not Phase 1.
+3. **Register numbering for the RISC target descriptions.** **Answered
+   2026-08-27, Phase 3 implementation: R0-R31 = index 0-31, PC = 32,
+   FLAGS = 33 (34 registers total), identical for the GPU and DSP
+   descriptions.** Fixed now — do not renumber; see "GPU/DSP register
+   files" below.
+
+## Phase 2/3 implementation notes (2026-08-27)
+
+Phases 2-4 landed together. A few things resolved or turned out different
+from how this document originally described them:
+
+- **The `ALPINE_FUNCTIONS` six-site claim ("Watchpoints") was verified
+  true, but not for the reason it looked true at first.** `ALPINE_FUNCTIONS`
+  is not a build-system flag passed by any Makefile target — it is
+  `#define`d unconditionally near the top of `src/core/jaguar.c` itself
+  (line 80), so the six `m68k_read/write_memory_{8,16,32}` sites really are
+  compiled into every build, exactly as this document said. (An earlier
+  pass at this implementation grepped only the Makefiles for
+  `-DALPINE_FUNCTIONS`, found nothing, and nearly reported this as a design-
+  doc inaccuracy before re-checking the source directly and finding the
+  `#define` in `jaguar.c`.) What *was* true is that the six sites were
+  functionally dead: `bpmActive` was default-`false` and nothing in the
+  tree ever set it, and the six sites' only consumer, `M68KDebugHalt()`,
+  sets `SPCFLAG_DEBUGGER`, which makes `m68k_execute()` return early
+  (unwind) rather than block — and nothing ever called the matching
+  `M68KDebugResume()`, so the pre-existing "feature" would have wedged the
+  68K forever if anything had ever armed it. The six sites now call
+  `GDBMemWatchHit()` instead of `M68KDebugHalt()`; this module is the
+  first and only thing that ever sets `bpmActive`/`bpmAddress1`.
+- **Single watchpoint slot, not a table.** "Watchpoints ride the existing
+  exported memory-access breakpoint vars" was implemented literally: one
+  slot, matching `bpmAddress1`'s singular shape. A second `Z2`/`Z3`/`Z4`
+  while one is already armed at a different address is refused (E01)
+  rather than silently displacing it or growing a table. Documented as a
+  known limitation in the user guide.
+- **Stepping does NOT use the 68K's `SPCFLAG_DEBUGGER` path**, contrary to
+  what this document originally specified. All three processors' stepping
+  (and `monitor halt <target>`, and the `gdb_wait` boot halt) share one
+  one-shot primitive on the same per-target breakpoint-table structure
+  `GDBCheckPC()` already uses: arm a flag that matches unconditionally on
+  that processor's very next instruction hook, consumed immediately on
+  match. Reasoning for the deviation: `SPCFLAG_DEBUGGER` makes
+  `m68k_execute()` return early to its *caller* rather than block in
+  place, so something outside the hook would have to notice "a step just
+  completed" and re-invoke `GDBHalt()` — an extra layer of scheduler
+  plumbing the one-shot primitive doesn't need, and which wasn't worth the
+  risk of getting subtly wrong under time pressure when a uniform
+  mechanism across all three processors was available and already
+  necessary for the GPU/DSP anyway. `SPCFLAG_DEBUGGER`/`M68KDebugHalt`/
+  `M68KDebugResume` remain unused by this module.
+- **GPU/DSP register/PC/flags accessors needed adding or un-gating.**
+  `GPUGetReg`/`GPUGetPC` predate this feature (issue #406) and were
+  already unconditional; `GPUGetFlags` and `DSPGetReg` existed but were
+  `#ifdef VJ_TRACE`-only and are now unconditional (matching `GPUGetReg`'s
+  existing precedent, not a new exception). `DSPGetPC`, and the write side
+  of all of these (`GPUSetReg`/`GPUSetPC`/`GPUSetFlags`/`DSPSetReg`/
+  `DSPSetPC`/`DSPSetFlags`), plus read-only `GPUGetControl`/`DSPGetControl`
+  for `monitor regs`, did not exist at all and were added. The writes are
+  raw pokes (like `m68k_set_reg`), not simulated MMIO writes, specifically
+  so that GDB setting PC or FLAGS does not also trigger a G_CTRL/D_CTRL-
+  style side effect (e.g. toggling GPUGO) as a surprise side effect of a
+  register-inspection action.
+- **The RISC disassembler is genuinely shared, not just "not duplicated
+  in spirit."** `src/debug/gdbdisasm.h` is a header-only module included
+  by both `src/debug/gdbtarget.c` (`monitor disasm`, live) and
+  `test/tools/gpu_disasm_dump.c` (offline, dlsym-based) — the latter was
+  refactored to drop its own inline copy of the mnemonic table and operand
+  decode logic in favour of the shared one.
+- **Multi-architecture GDB sessions (native m68k thread 1 + custom-
+  description threads 2/3 in one inferior) are implemented to the RSP
+  specification and covered by this repo's own scripted test client, but
+  never verified against a real `gdb` binary** — consistent with Open
+  Question 1's answer (no `m68k-elf-gdb` ships anywhere in this repo's
+  toolchain). Documented as an explicit caveat in the user guide rather
+  than claimed as verified.
 
 ## Sequencing
 
 Each phase is independently useful and independently abandonable.
 
 1. **Protocol layer + 68K target, no breakpoints.** Attach, read registers,
-   read memory, detach. Proves the transport and framing.
+   read memory, detach. Proves the transport and framing. **Shipped**
+   (issue #652, PR #662).
 2. **68K breakpoints, watchpoints and stepping**, on the armed-flag gate. Run
    test layer 4 here — this is the go/no-go for the whole shipped-by-default
-   premise.
-3. **GPU and DSP threads**, XML descriptions, `monitor disasm`.
+   premise. **Shipped** — see the PR for this phase for the perf
+   measurement's result and the machine load it was (or wasn't) taken
+   under; do not treat this document as the record of that number.
+3. **GPU and DSP threads**, XML descriptions, `monitor disasm`. **Shipped**,
+   with the multi-architecture-session caveat above.
 4. **Documentation**: a user guide covering attaching, the frontend-freeze
-   behaviour, and the RISC disassembly limitation.
+   behaviour, and the RISC disassembly limitation. **Shipped** as
+   `docs/gdb-stub-guide.md`.

--- a/docs/gdb-stub-guide.md
+++ b/docs/gdb-stub-guide.md
@@ -1,0 +1,201 @@
+# GDB remote debugging — user guide
+
+Issue [#652](https://github.com/libretro/virtualjaguar-libretro/issues/652). Design rationale,
+architecture, and the invariants this feature must never violate live in
+[`gdb-stub-design.md`](gdb-stub-design.md) — read that first if you are changing this feature,
+not just using it. This page is for the developer on the other end of the socket.
+
+## What this is, in one paragraph
+
+The core can open a TCP socket that speaks GDB's Remote Serial Protocol (RSP), so a real debugger
+— `gdb`, `lldb`, VS Code, or any RSP-speaking tool — can inspect and control the emulated Jaguar:
+set breakpoints, read and write registers and memory, single-step, and watch memory addresses.
+All three processors are exposed: the 68000 as a native GDB target, and the GPU and DSP RISC
+cores as two additional GDB "threads" with a custom register description. It is off by default,
+developer-facing, and never reachable from another machine.
+
+## Quick start
+
+1. In core options, set **GDB Debug Stub** to `enabled` (category: Diagnostics) and restart
+   content — this option is read once at load, like the other developer-facing "Restart" options
+   in this core.
+2. Optionally set **GDB Stub Port** if the default (2345) collides with something else on your
+   machine.
+3. Load your content. You should see an on-screen message: `GDB stub listening on
+   127.0.0.1:2345 -- halts will freeze this frontend`.
+4. Point your debugger at `127.0.0.1:<port>`. With `gdb`:
+
+   ```
+   (gdb) target remote 127.0.0.1:2345
+   ```
+
+   You'll see a second on-screen banner (`GDB client attached...`) the moment the socket accepts
+   your connection.
+5. Set a breakpoint and continue, same as debugging any other target:
+
+   ```
+   (gdb) break *0x802000
+   (gdb) continue
+   ```
+
+When the breakpoint hits, the emulator freezes exactly at that instruction — see "Halts freeze
+the frontend" below before you rely on this in a session you care about.
+
+## The three targets (GDB threads)
+
+| GDB thread | Processor | What GDB knows about it |
+|---|---|---|
+| 1 | 68000 (main CPU) | Native `m68k` architecture — GDB already understands it. Full register names, disassembly, and backtraces work exactly as they would for any other m68k target. |
+| 2 | GPU RISC (TOM) | A custom 34-register description (`R0`-`R31`, `PC`, `FLAGS`) served over `qXfer:features:read`. GDB can display and set these registers by name and place breakpoints on them. It **cannot** disassemble this processor — see below. |
+| 3 | DSP RISC (JERRY) | Same custom description as the GPU (same underlying RISC core, different opcode table from R32 up — see `monitor disasm`). Same disassembly limitation. |
+
+Switch threads in `gdb` with `thread 2` / `thread 3`, or address a specific one with `Hg`/`Hc` at
+the protocol level if you're driving the socket by hand.
+
+Register numbering for threads 2/3 is fixed permanently (clients cache it across a session):
+index 0-31 are `R0`-`R31`, 32 is `PC`, 33 is `FLAGS`.
+
+**Multi-architecture caveat:** mixing one native-architecture thread (68K) with two
+custom-description threads (GPU/DSP) in a single GDB session is not a mainstream use of RSP, and
+this repo has no way to test it against a real `gdb` binary (see "No shipped `m68k-elf-gdb`"
+below). The protocol-level pieces (register numbering, XML shape, thread enumeration) are
+implemented to the RSP specification and covered by this repo's own scripted test client, but
+real GDB's behavior when a target description changes mid-session between threads has not been
+verified end to end. If you find a `gdb` build that handles this cleanly (or doesn't), the
+project would like to know.
+
+## Breakpoints and watchpoints
+
+- `break`/`hbreak` (GDB's `Z0`/`Z1`) set an execution breakpoint on any of the three processors.
+  Software and hardware breakpoint requests are treated identically: **this stub never patches
+  emulated memory** to implement a breakpoint (see the design doc for why — the short version is
+  that patched instruction bytes would leak into savestates). Up to 64 breakpoints per processor.
+- `watch`/`rwatch`/`awatch` (GDB's `Z2`/`Z3`/`Z4`) set a memory watchpoint on the 68000's bus.
+  **Only one memory watchpoint can be armed at a time** — this rides a single-slot mechanism
+  that predates the GDB stub (an old, previously-unused breakpoint-on-memory-access hook in the
+  core). Setting a second watchpoint while one is already armed at a different address is
+  refused. Watchpoints are 68K-bus-scoped only; they are not available on the GPU/DSP threads.
+- Stepping (`stepi`/`step`, or `s` at the protocol level) works on all three processors. The GPU
+  and DSP do **not** use the real hardware single-step bit (`G_CTRL`/`D_CTRL` bit 3) for this —
+  that bit is guest-visible state a game can read, and toggling it from the debugger would be an
+  observable perturbation of the emulated machine. Stepping is implemented as a one-shot internal
+  breakpoint instead.
+
+## `monitor` commands
+
+GDB forwards `monitor <text>` to the stub verbatim. Available commands:
+
+```
+monitor disasm <gpu|dsp> <addr> [count]   RISC disassembly (see below)
+monitor regs [gpu|dsp]                    full register + control-register dump
+monitor halt <68k|gpu|dsp>                halt one processor without a breakpoint
+monitor trace                             dump the 68K PC traceback ring (issue #542)
+monitor watch [<addr> [r|w]]              set/clear the memory watchpoint (same slot as Z2-Z4)
+```
+
+`monitor trace` is worth knowing about even outside a GDB session: the traceback ring it dumps is
+already maintained unconditionally by the core (it backs the crash-detection watchdog), so this
+command is free to use after any wild jump or crash to see where the 68K had been.
+
+## The RISCs have no GDB disassembly
+
+GDB ships disassemblers for real-world architectures. The Jaguar's GPU and DSP are a bespoke
+RISC ISA with no GDB (or LLVM, or binutils) backend, and none is coming. When you `disassemble` a
+function on thread 2 or 3, GDB will fail or print garbage — this is not a bug in the stub, it is
+GDB correctly telling you it doesn't know this instruction set.
+
+`monitor disasm <gpu|dsp> <addr> [count]` fills that gap using this repo's own RISC
+disassembler (the same one `test/tools/gpu_disasm_dump` uses offline — there is exactly one
+implementation of this disassembler in the tree, not two that could drift apart). Output is
+plain text, one instruction per line, e.g.:
+
+```
+(gdb) monitor disasm gpu f03410 8
+$F03410: 8442  move            r2, r18
+$F03412: E840  jr               T, +0 -> $F03414
+...
+```
+
+## Halts freeze the frontend
+
+This is the single most important thing to understand before attaching to something you care
+about: **when a breakpoint or watchpoint hits, the entire emulator freezes** — video, audio, and
+input all stop, because the halt is implemented by blocking the same thread `retro_run()` runs
+on. This is a deliberate design choice (see the design doc's "Architecture" section): freezing
+in place, with every processor's state coherent at the exact point of the fault, is what makes
+inspecting an emulator with a real debugger useful in the first place. The alternative — winding
+back through savestates to approximate where a bug happened — is the status quo this feature
+replaces.
+
+Consequences:
+
+- **The frontend UI will appear hung** for as long as you're halted. This is expected, not a
+  crash. Resume with `continue`/`c`, `stepi`/`s`, or disconnect your debugger.
+- **Disconnecting your debugger while halted resumes the machine immediately** and disarms every
+  breakpoint and watchpoint. A dead or closed debugger connection can never leave the machine
+  wedged.
+- If you forget you're attached and walk away, two core options help:
+  - **GDB Stub: Halt Timeout** — after N seconds halted with no client activity, the core
+    auto-resumes and logs it loudly. Off by default: silently resuming a machine you're
+    debugging is a worse surprise than a frozen frontend, for the audience this feature is built
+    for. Note that auto-resuming does **not** disarm the breakpoint that triggered the halt — if
+    execution reaches the same address again, expect the same halt (and the same log line) to
+    repeat.
+  - **GDB Stub: Halt At Boot** — halts before the 68000's very first instruction, so you can
+    attach before anything has run. Without this, a boot-time fault may already be long past by
+    the time you connect.
+
+## Symbol-level, not source-level, debugging
+
+Be precise about what this feature gives you. `rln`, the Jaguar toolchain's linker (see the
+`tools/jaguar-toolchain` fetch in this repo), emits classic `mc68k COFF` object files — a
+pre-ELF, Atari-era format, not ELF/DWARF. There is no line-number or source-file information
+anywhere in that chain, and `rln`'s own `-g` ("output source-level debugging") flag was verified
+during this feature's design to produce byte-identical output to a build without it. **This
+repository cannot offer source-level debugging for Jaguar homebrew, and no future version of this
+document should claim otherwise without new evidence that some other tool in the chain emits real
+DWARF.**
+
+What you do get: `rln -m`'s load map resolves your program's global symbol names to addresses,
+so you can set breakpoints and read memory by the symbol names your own code defines, and GDB's
+disassembly (on the 68K thread — see above for the RISC threads) shows raw instructions annotated
+with whatever symbols it can resolve from the binary. That is a long way from a source debugger,
+but it is a long way ahead of "reason about a hex dump," which was the alternative before this
+feature existed.
+
+## No shipped `m68k-elf-gdb`
+
+This project's toolchain (`tools/jaguar-toolchain`, see the fetch script referenced from the
+design doc) pins exactly five tools — `rmac`, `rln`, `lyxass`, `pc_jagcrypt`, `new_bjl` — and
+none of them is a debugger. **You bring your own `m68k-elf-gdb`.** A stock GNU binutils/gdb build
+targeting `m68k-elf` (the kind distributed for classic Mac/Amiga/Atari ST bare-metal development)
+works against a plain `m68k` architecture with no custom target description needed for thread 1.
+This repository's own test coverage for the wire protocol uses a small scripted Python RSP client
+(`test/tools/gdb_attach_probe.py`, `test/tools/gdb_breakpoint_probe.py`) rather than a real `gdb`
+binary, for exactly this reason — there wasn't one to test against. If something in this guide
+doesn't match what your particular `gdb` build does, the scripted client is the ground truth this
+implementation was actually verified against; please file an issue with what you saw.
+
+## Security notes (short version — see the design doc for the full reasoning)
+
+- The listener binds `127.0.0.1` only, always. There is no option to change this. If you need to
+  reach it from another machine, forward the port yourself (e.g. `ssh -L`).
+- Only one client at a time; a second connection attempt is closed immediately.
+- Every memory read and write is bounds-checked against the emulated map — a malformed or
+  hostile packet cannot read or write outside emulated space.
+- Register and memory writes issued through the debugger genuinely change emulated state (that's
+  the point of a debugger). A savestate taken after such a write reflects it. This is intentional
+  and not guarded against.
+
+## Known limitations
+
+- One memory watchpoint at a time (see "Breakpoints and watchpoints" above).
+- No debugging across a savestate load: breakpoints stay armed at addresses that may no longer
+  mean anything once new content or a different program state loads.
+- No support for run-ahead: a second core instance under run-ahead will simply fail to bind the
+  port, and that instance's stub stays disabled — debugging with run-ahead active is not
+  supported.
+- Non-stop mode is not implemented. All three processors halt together; you cannot halt the 68K
+  while leaving the GPU running.
+- Tracepoints (`QTDP` and friends) and GDB's file-I/O extension (`vFile`) are not implemented, and
+  the latter never will be — see the design doc's "Out of scope".

--- a/libretro.c
+++ b/libretro.c
@@ -163,149 +163,65 @@ static void widescreen_reset(void)
    widescreen_geometry_pending = false;
 }
 
-/* GDB remote debug stub (Phase 1, issue #652).  Developer-facing, off by
- * default, latched once at content load exactly like the enhancement-hook
- * gate above -- a "Restart" option must not be settable by a per-title DB
+/* GDB remote debug stub (issue #652).  Developer-facing, off by default,
+ * latched once at content load exactly like the enhancement-hook gate
+ * above -- a "Restart" option must not be settable by a per-title DB
  * row, so it is read raw via environ_cb, never through
  * get_variable_pertitle().  File-scope statics, not retro_run()-local:
  * iOS cannot dlclose the core, so a resident process must not carry a
- * previous title's stub state (or half a buffered packet) into the next
- * load -- reset alongside everything else in retro_unload_game() and
- * retro_deinit(). */
+ * previous title's stub state into the next load -- reset alongside
+ * everything else in retro_unload_game() and retro_deinit().
+ *
+ * Phase 2 moved the session, receive buffer, breakpoint tables and the
+ * blocking halt loop into src/debug/gdbtarget.c (GDBTargetOpen/Close/
+ * ServicePoll/ResetState) -- this file now owns only what genuinely
+ * needs environ_cb: option parsing, the socket lifecycle, and the two
+ * OSD banners the design calls out ("shown when the stub is enabled and
+ * again when a client attaches -- both are moments we can still reach
+ * the frontend"). */
 static bool gdb_stub_enabled     = false;
 static bool gdb_stub_socket_open = false;
 static int  gdb_stub_port        = 2345;
-static struct GDBSession gdb_session;
-static char gdb_rxbuf[GDB_PACKET_MAX];
-static int  gdb_rxlen = 0;
+static bool gdb_stub_wait_at_boot = false;
+
+/* Defined further down, right after environ_cb itself is declared --
+ * forward-declared here so gdb_stub_service() below can call it. */
+static void gdb_stub_show_banner(const char *text);
 
 /* Re-armed on every load/unload exactly like widescreen_reset() above:
- * a fresh title must not inherit a half-received packet or a session
- * struct pointed at the previous load's target ops. */
+ * a fresh title must not inherit a previous session's socket or armed
+ * breakpoints. Does NOT call GDBTargetClose() itself -- callers that
+ * need the Jaguar-side state disarmed too (unload/deinit) call that
+ * explicitly, since a bind-failure path needs only the option flags
+ * reset, not a full target-state wipe of a target that was never
+ * opened. */
 static void gdb_stub_reset(void)
 {
-   gdb_stub_enabled     = false;
-   gdb_stub_socket_open = false;
-   gdb_stub_port        = 2345;
-   gdb_rxlen            = 0;
+   gdb_stub_enabled      = false;
+   gdb_stub_socket_open  = false;
+   gdb_stub_port         = 2345;
+   gdb_stub_wait_at_boot = false;
 }
 
 /* Serviced once per frame from the top of retro_run(), and only when the
- * stub is enabled -- with no client attached this is one poll() and two
- * cheap comparisons, bounded and non-blocking, per the design's "near-
- * zero cost when disabled/idle" requirement.  Phase 1 has no breakpoints,
- * so nothing here can block: every packet the engine understands gets an
- * immediate reply, and the loop below terminates as soon as the receive
- * buffer holds no further complete "$...#cs" packet. */
+ * stub is enabled -- with no client attached this is one poll() and a
+ * handful of cheap comparisons, bounded and non-blocking, per the
+ * design's "near-zero cost when disabled/idle" requirement. Firing a
+ * breakpoint does NOT return through here: GDBHalt() (src/debug/
+ * gdbtarget.c) blocks in place, deep inside JaguarExecuteNew(), and this
+ * function is simply never reached for the remainder of that retro_run()
+ * call. The "client attached" banner is fired here, on the edge
+ * GDBTargetServicePoll() reports, because this is the only place in the
+ * whole stub that can still reach environ_cb. */
 static void gdb_stub_service(void)
 {
    if (!gdb_stub_enabled || !gdb_stub_socket_open)
       return;
 
-   GDBSockPoll();
+   GDBTargetServicePoll();
 
-   /* Pull whatever is available into the tail of the accumulation
-    * buffer.  A single recv() rarely delivers more than one small RSP
-    * command, but nothing here assumes that -- partial packets are
-    * simply left in gdb_rxbuf for the next frame's call. */
-   for (;;)
-   {
-      int room = (int)sizeof(gdb_rxbuf) - gdb_rxlen;
-      int n;
-
-      if (room <= 0)
-      {
-         /* Buffer full with no packet boundary found: a malformed or
-          * hostile stream. Drop it and resync rather than wedging. */
-         gdb_rxlen = 0;
-         break;
-      }
-
-      n = GDBSockRecv(gdb_rxbuf + gdb_rxlen, room);
-      if (n < 0)
-      {
-         /* Client disconnected. */
-         gdb_rxlen = 0;
-         break;
-      }
-      if (n == 0)
-         break;
-
-      gdb_rxlen += n;
-   }
-
-   /* Dispatch every complete packet currently buffered. */
-   for (;;)
-   {
-      static char payload[GDB_PACKET_MAX];
-      static char reply[GDB_PACKET_MAX];
-      static char encoded[GDB_PACKET_MAX + 8];
-      int i;
-      int dollarAt = -1;
-      int hashAt   = -1;
-      int payLen, replyLen, encLen, consumed, remaining;
-
-      for (i = 0; i < gdb_rxlen; i++)
-      {
-         if (gdb_rxbuf[i] == '$')
-         {
-            dollarAt = i;
-            break;
-         }
-      }
-
-      if (dollarAt < 0)
-      {
-         /* No packet start in the buffer at all (e.g. a stray leading
-          * '+' ack byte with nothing after it yet): nothing to do. */
-         gdb_rxlen = 0;
-         break;
-      }
-
-      for (i = dollarAt + 1; i < gdb_rxlen; i++)
-      {
-         if (gdb_rxbuf[i] == '#')
-         {
-            hashAt = i;
-            break;
-         }
-      }
-
-      if (hashAt < 0 || (hashAt + 2) >= gdb_rxlen)
-      {
-         /* Incomplete packet: drop only the garbage before '$' (if any)
-          * so the scan above does not re-walk it every frame, and wait
-          * for more bytes next frame. */
-         if (dollarAt > 0)
-         {
-            remaining = gdb_rxlen - dollarAt;
-            memmove(gdb_rxbuf, gdb_rxbuf + dollarAt, (size_t)remaining);
-            gdb_rxlen = remaining;
-         }
-         break;
-      }
-
-      payLen = GDBDecodePacket(gdb_rxbuf + dollarAt, hashAt + 3 - dollarAt,
-                               payload, (int)sizeof(payload));
-      if (payLen >= 0)
-      {
-         replyLen = GDBHandlePacket(&gdb_session, payload, payLen,
-                                    reply, (int)sizeof(reply));
-         encLen = GDBEncodePacket(reply, replyLen, encoded,
-                                  (int)sizeof(encoded));
-         if (encLen > 0)
-            GDBSockSend(encoded, encLen);
-      }
-      /* A malformed packet (bad checksum, overflow) gets no reply at
-       * all here -- real GDB retransmits on a missing ack, and Phase 1
-       * does not implement the low-level +/- ack byte, so silence is
-       * the correct "I didn't understand that" for now. */
-
-      consumed  = hashAt + 3;
-      remaining = gdb_rxlen - consumed;
-      memmove(gdb_rxbuf, gdb_rxbuf + consumed, (size_t)remaining);
-      gdb_rxlen = remaining;
-   }
+   if (GDBSockHasClientAttachEvent())
+      gdb_stub_show_banner("GDB client attached -- halts will freeze this frontend");
 }
 
 #ifdef VJ_TRACE
@@ -357,6 +273,23 @@ static retro_input_state_t input_state_cb;
 static retro_environment_t environ_cb;
 retro_audio_sample_batch_t audio_batch_cb;
 retro_log_printf_t vj_log_cb = NULL;
+
+/* GDB stub OSD banner (issue #652) -- see the forward declaration and
+ * gdb_stub_service() above for why this lives here, after environ_cb. */
+static void gdb_stub_show_banner(const char *text)
+{
+   struct retro_message_ext gdb_msg;
+
+   memset(&gdb_msg, 0, sizeof(gdb_msg));
+   gdb_msg.msg      = text;
+   gdb_msg.duration = 4000;
+   gdb_msg.priority = 2;
+   gdb_msg.level    = RETRO_LOG_INFO;
+   gdb_msg.target   = RETRO_MESSAGE_TARGET_OSD;
+   gdb_msg.type     = RETRO_MESSAGE_TYPE_NOTIFICATION;
+   gdb_msg.progress = -1;
+   environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &gdb_msg);
+}
 
 static bool libretro_supports_bitmasks = false;
 static bool save_data_needs_unpack = false;
@@ -5196,13 +5129,16 @@ bool retro_load_game(const struct retro_game_info *info)
       hook_restart_notice_logged = 0;
    }
 
-   /* GDB remote debug stub (Phase 1, issue #652): same raw-read reasoning
-    * as the enhancement-hook gate immediately above -- a developer-facing
+   /* GDB remote debug stub (issue #652): same raw-read reasoning as the
+    * enhancement-hook gate immediately above -- a developer-facing
     * "Restart" gate must not be settable by a per-title DB row. */
    gdb_stub_reset();
    {
       struct retro_variable gdb_var;
       struct retro_variable port_var;
+      struct retro_variable wait_var;
+      struct retro_variable timeout_var;
+      int halt_timeout_seconds = 0;
 
       gdb_var.key   = "virtualjaguar_gdb_stub";
       gdb_var.value = NULL;
@@ -5224,28 +5160,48 @@ bool retro_load_game(const struct retro_game_info *info)
             gdb_stub_port = parsed_port;
       }
 
+      /* virtualjaguar_gdb_wait: halt at the very first 68K instruction so
+       * a developer can attach before anything has run -- see the design
+       * doc's note that debugging a boot-time fault is impossible if the
+       * machine has already run past it. Read here (not latched
+       * separately) since it only matters once, at this same load. */
+      wait_var.key   = "virtualjaguar_gdb_wait";
+      wait_var.value = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &wait_var) && wait_var.value)
+         gdb_stub_wait_at_boot = (strcmp(wait_var.value, "enabled") == 0);
+
+      /* virtualjaguar_gdb_halt_timeout: "off" (0) by default -- silently
+       * resuming a debugged machine is worse than a freeze for this
+       * audience, per the design doc. */
+      timeout_var.key   = "virtualjaguar_gdb_halt_timeout";
+      timeout_var.value = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &timeout_var) && timeout_var.value
+            && strcmp(timeout_var.value, "off") != 0)
+      {
+         int parsed_timeout = atoi(timeout_var.value);
+         if (parsed_timeout > 0)
+            halt_timeout_seconds = parsed_timeout;
+      }
+
       if (gdb_stub_enabled)
       {
          if (GDBSockOpen(gdb_stub_port) == 0)
          {
-            struct retro_message_ext gdb_msg;
             char gdb_msg_text[96];
 
             gdb_stub_socket_open = true;
-            GDBSessionInit(&gdb_session, GDBJaguarOps(), NULL);
+            GDBTargetOpen();
+            GDBTargetSetHaltTimeout(halt_timeout_seconds);
+            if (gdb_stub_wait_at_boot)
+               GDBTargetArmWaitAtBoot();
 
             snprintf(gdb_msg_text, sizeof(gdb_msg_text),
-                     "GDB stub listening on 127.0.0.1:%d", gdb_stub_port);
-            memset(&gdb_msg, 0, sizeof(gdb_msg));
-            gdb_msg.msg      = gdb_msg_text;
-            gdb_msg.duration = 4000;
-            gdb_msg.priority = 2;
-            gdb_msg.level    = RETRO_LOG_INFO;
-            gdb_msg.target   = RETRO_MESSAGE_TARGET_OSD;
-            gdb_msg.type     = RETRO_MESSAGE_TYPE_NOTIFICATION;
-            gdb_msg.progress = -1;
-            environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &gdb_msg);
-            LOG_INF("[GDB] stub listening on 127.0.0.1:%d\n", gdb_stub_port);
+                     "GDB stub listening on 127.0.0.1:%d -- halts will "
+                     "freeze this frontend", gdb_stub_port);
+            gdb_stub_show_banner(gdb_msg_text);
+            LOG_INF("[GDB] stub listening on 127.0.0.1:%d%s%s\n", gdb_stub_port,
+                    gdb_stub_wait_at_boot ? " (halting at boot)" : "",
+                    halt_timeout_seconds > 0 ? " (halt-timeout armed)" : "");
          }
          else
          {
@@ -5672,10 +5628,14 @@ void retro_unload_game(void)
    TitleHookSetEnabled(0);
    TitleDBSetHooksForTest(NULL, 0);
    hook_restart_notice_logged = 0;
-   /* GDB stub (#652): close the listener/client so a stale socket does
-    * not linger into the next title, and re-latch the gate from the next
-    * load's option instead of carrying this session's state forward. */
+   /* GDB stub (#652): close the listener/client and disarm every
+    * breakpoint/watchpoint/step (GDBTargetClose(), src/debug/
+    * gdbtarget.c) so a stale socket -- or worse, an armed breakpoint at
+    * an address that means nothing in the next title -- never lingers
+    * into the next load. Re-latch the gate from the next load's option
+    * instead of carrying this session's state forward. */
    GDBSockClose();
+   GDBTargetClose();
    gdb_stub_reset();
    /* Known-bad negative entries (#464): same reasoning, same reset. */
    TitleDBSetNegativeForTest(NULL, 0);
@@ -6098,8 +6058,9 @@ void retro_deinit(void)
    hook_restart_notice_logged = 0;
    /* GDB stub (#652): belt-and-suspenders, matching retro_unload_game() --
     * a frontend that calls deinit without unload first must not leave a
-    * listener bound past process teardown. */
+    * listener bound, or a breakpoint armed, past process teardown. */
    GDBSockClose();
+   GDBTargetClose();
    gdb_stub_reset();
    /* Known-bad negative entries (#464): same per-load re-arm as above. */
    TitleDBSetNegativeForTest(NULL, 0);

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -610,6 +610,36 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "2345"
    },
    {
+      "virtualjaguar_gdb_wait",
+      "GDB Stub: Halt At Boot (Restart)",
+      NULL,
+      "Halt the 68000 before its very first instruction and wait for a GDB client to attach, so a boot-time fault can be debugged instead of running to completion before you connect. Only takes effect while the GDB Debug Stub option above is enabled. Requires a restart.",
+      NULL,
+      "diagnostics",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "virtualjaguar_gdb_halt_timeout",
+      "GDB Stub: Halt Timeout",
+      NULL,
+      "If the machine is halted at a breakpoint with no client activity for this long, resume automatically and log it loudly, so a forgotten debug session does not look like a hang forever. 'Off' means a halt waits indefinitely -- the default, because silently resuming a debugged machine is worse than a freeze for the developers this option is for.",
+      NULL,
+      "diagnostics",
+      {
+         { "off", NULL },
+         { "30",  "30 seconds" },
+         { "60",  "60 seconds" },
+         { "300", "5 minutes" },
+         { NULL, NULL },
+      },
+      "off"
+   },
+   {
       "virtualjaguar_texdump_16bpp",
       "Texture Dump: 16bpp Preview",
       NULL,

--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -49,6 +49,7 @@ skip_file() {
         test/tools/frame_hash_ab.c) return 0 ;;
         test/tools/hires_box_check.c) return 0 ;;
         test/tools/hires_state_digest.c) return 0 ;;
+        test/tools/gdb_determinism_probe.c) return 0 ;;
         test/tools/hires_shot.c) return 0 ;;
         test/tools/blit_memo_verify.c) return 0 ;;
         test/tools/op_list_dump.c) return 0 ;;

--- a/src/core/jaguar.c
+++ b/src/core/jaguar.c
@@ -43,6 +43,7 @@
 #include "settings.h"
 #include "tom.h"
 #include "vjtrace.h"
+#include "gdbstub.h"
 
 static bool frameDone;
 
@@ -384,6 +385,26 @@ void M68KInstructionHook(void)
    pcQPtr++;
    pcQPtr &= 0x3FF;
 
+#ifndef VJ_GDB_STUB_DISABLE_HOOKS
+   /* GDB stub (issue #652): one load of a hot global, one never-taken
+    * branch when no 68K breakpoint/step is armed -- see
+    * docs/gdb-stub-design.md "Breakpoint detection" and its cited
+    * vjtrace evidence that a predicted-not-taken branch on a hot global
+    * is free. GDBHalt() blocks in place (does not unwind this hook, or
+    * m68k_execute()'s caller) until the client continues, steps, or
+    * disconnects -- placed before the odd-PC check below so a runaway
+    * 68K that fetched an odd address while a breakpoint happens to sit
+    * exactly there still stops instead of silently returning.
+    *
+    * VJ_GDB_STUB_DISABLE_HOOKS exists ONLY for the Phase 2 A/B
+    * perf measurement (docs/gdb-stub-design.md Testing item 4) that
+    * proves this branch is free when unarmed -- it must never be
+    * defined in a shipped build; the stub ships enabled-by-default
+    * with this hook always compiled in. */
+   if (gdbArmed68K && GDBCheckPC(GDB_TGT_68K, m68kPC))
+      GDBHalt(GDB_TGT_68K, GDB_STOP_BREAKPOINT, m68kPC);
+#endif
+
    if (m68kPC & 0x01)		// Oops! We're fetching an odd address!
       return;
 
@@ -514,9 +535,13 @@ static void M68KGPURAMSyncRead(unsigned int address, unsigned int length)
 unsigned int m68k_read_memory_8(unsigned int address)
 {
 #ifdef ALPINE_FUNCTIONS
-   // Check if breakpoint on memory is active, and deal with it
-   if (bpmActive && address == bpmAddress1)
-      M68KDebugHalt();
+   /* GDB stub (issue #652): rides this pre-existing memory-breakpoint
+    * gate rather than adding a new one. bpmActive/bpmAddress1 are owned
+    * exclusively by the stub (src/debug/gdbtarget.c) -- nothing else in
+    * the tree ever arms them, so this is a single global-bool check,
+    * false in every session without an attached debugger. isWrite=0. */
+   if (bpmActive)
+      GDBMemWatchHit(address, 0);
 #endif
 
    // Musashi does this automagically for you, UAE core does not :-P
@@ -562,9 +587,9 @@ void gpu_dump_registers(void);
 unsigned int m68k_read_memory_16(unsigned int address)
 {
 #ifdef ALPINE_FUNCTIONS
-   // Check if breakpoint on memory is active, and deal with it
-   if (bpmActive && address == bpmAddress1)
-      M68KDebugHalt();
+   /* GDB stub (issue #652): see m68k_read_memory_8 above. isWrite=0. */
+   if (bpmActive)
+      GDBMemWatchHit(address, 0);
 #endif
 
    // Musashi does this automagically for you, UAE core does not :-P
@@ -609,9 +634,9 @@ unsigned int m68k_read_memory_16(unsigned int address)
 unsigned int m68k_read_memory_32(unsigned int address)
 {
 #ifdef ALPINE_FUNCTIONS
-   // Check if breakpoint on memory is active, and deal with it
-   if (bpmActive && address == bpmAddress1)
-      M68KDebugHalt();
+   /* GDB stub (issue #652): see m68k_read_memory_8 above. isWrite=0. */
+   if (bpmActive)
+      GDBMemWatchHit(address, 0);
 #endif
 
    // Musashi does this automagically for you, UAE core does not :-P
@@ -777,9 +802,9 @@ static bool M68KRiscWordLatch(unsigned int address, unsigned int value)
 void m68k_write_memory_8(unsigned int address, unsigned int value)
 {
 #ifdef ALPINE_FUNCTIONS
-   // Check if breakpoint on memory is active, and deal with it
-   if (bpmActive && address == bpmAddress1)
-      M68KDebugHalt();
+   /* GDB stub (issue #652): see m68k_read_memory_8 above. isWrite=1. */
+   if (bpmActive)
+      GDBMemWatchHit(address, 1);
 #endif
 
    // Musashi does this automagically for you, UAE core does not :-P
@@ -831,9 +856,9 @@ void m68k_write_memory_8(unsigned int address, unsigned int value)
 void m68k_write_memory_16(unsigned int address, unsigned int value)
 {
 #ifdef ALPINE_FUNCTIONS
-   // Check if breakpoint on memory is active, and deal with it
-   if (bpmActive && address == bpmAddress1)
-      M68KDebugHalt();
+   /* GDB stub (issue #652): see m68k_read_memory_8 above. isWrite=1. */
+   if (bpmActive)
+      GDBMemWatchHit(address, 1);
 #endif
 
    // Musashi does this automagically for you, UAE core does not :-P
@@ -901,9 +926,9 @@ void m68k_write_memory_16(unsigned int address, unsigned int value)
 void m68k_write_memory_32(unsigned int address, unsigned int value)
 {
 #ifdef ALPINE_FUNCTIONS
-   // Check if breakpoint on memory is active, and deal with it
-   if (bpmActive && address == bpmAddress1)
-      M68KDebugHalt();
+   /* GDB stub (issue #652): see m68k_read_memory_8 above. isWrite=1. */
+   if (bpmActive)
+      GDBMemWatchHit(address, 1);
 #endif
 
    // Musashi does this automagically for you, UAE core does not :-P

--- a/src/debug/gdbdisasm.h
+++ b/src/debug/gdbdisasm.h
@@ -1,0 +1,199 @@
+/*
+ * gdbdisasm.h -- the one and only GPU/DSP RISC disassembler in this tree.
+ *
+ * Header-only and self-contained (no Jaguar globals, no I/O) so it can be
+ * included both by src/debug/gdbtarget.c (`monitor disasm`, live, in the
+ * running core) and by test/tools/gpu_disasm_dump.c (offline, dlsym-based)
+ * without either one inventing its own copy. Design: docs/gdb-stub-design.md
+ * (issue #652) -- "reuse our own disassembly tooling... do not write a
+ * second disassembler."
+ *
+ * GPU and DSP share the RISC core for opcodes 0-31 (arithmetic/logic/shift/
+ * compare) but diverge from opcode 32 onward: the GPU has pixel ops
+ * (LOADP/STOREP) the DSP has no use for, and the DSP has audio-saturation
+ * ops (SAT16S/SAT32S/SUBQMOD/ADDQMOD/MIRROR) the GPU has no use for. The
+ * mnemonic tables below are transcribed directly from the two dispatch
+ * tables that actually execute the opcodes -- src/tom/gpu.c's executeOpcode
+ * switch and src/jerry/dsp.c's dsp_dispatch[] in dsp_executeOpcode() -- so a
+ * future opcode change there must be mirrored here by hand; nothing here is
+ * derived automatically.
+ *
+ * C89/GNU89, like the rest of the core. Every accumulating snprintf() below
+ * clamps its running offset to outMax immediately, so out+n is never
+ * advanced past one-past-the-end even if the caller hands in a tiny buffer
+ * -- pointer arithmetic past that is undefined behaviour in C regardless of
+ * whether the result is ever dereferenced.
+ */
+#ifndef __GDBDISASM_H__
+#define __GDBDISASM_H__
+
+#include <stdio.h>
+
+static const char * const GDBDisasmGPUMnemonics[64] =
+{
+   "add",       "addc",      "addq",      "addqt",
+   "sub",       "subc",      "subq",      "subqt",
+   "neg",       "and",       "or",        "xor",
+   "not",       "btst",      "bset",      "bclr",
+   "mult",      "imult",     "imultn",    "resmac",
+   "imacn",     "div",       "abs",       "sh",
+   "shlq",      "shrq",      "sha",       "sharq",
+   "ror",       "rorq",      "cmp",       "cmpq",
+   "sat8",      "sat16",     "move",      "moveq",
+   "moveta",    "movefa",    "movei",     "loadb",
+   "loadw",     "load",      "loadp",     "load(r14+n)",
+   "load(r15+n)","storeb",   "storew",    "store",
+   "storep",    "store(r14+n)","store(r15+n)","move pc",
+   "jump",      "jr",        "mmult",     "mtoi",
+   "normi",     "nop",       "load(r14+rn)","load(r15+rn)",
+   "store(r14+rn)","store(r15+rn)","sat24","pack"
+};
+
+static const char * const GDBDisasmDSPMnemonics[64] =
+{
+   "add",       "addc",      "addq",      "addqt",
+   "sub",       "subc",      "subq",      "subqt",
+   "neg",       "and",       "or",        "xor",
+   "not",       "btst",      "bset",      "bclr",
+   "mult",      "imult",     "imultn",    "resmac",
+   "imacn",     "div",       "abs",       "sh",
+   "shlq",      "shrq",      "sha",       "sharq",
+   "ror",       "rorq",      "cmp",       "cmpq",
+   "subqmod",   "sat16s",    "move",      "moveq",
+   "moveta",    "movefa",    "movei",     "loadb",
+   "loadw",     "load",      "sat32s",    "load(r14+n)",
+   "load(r15+n)","storeb",   "storew",    "store",
+   "mirror",    "store(r14+n)","store(r15+n)","move pc",
+   "jump",      "jr",        "mmult",     "mtoi",
+   "normi",     "nop",       "load(r14+rn)","load(r15+rn)",
+   "store(r14+rn)","store(r15+rn)","illegal","addqmod"
+};
+
+/* Clamp n into [0, cap] -- shared by GDBDisasmCC and GDBDisasmOne so an
+ * accumulated snprintf() offset can never walk out+n past one-past-end. */
+static int GDBDisasmClamp(int n, int cap)
+{
+   if (n < 0)
+      return 0;
+   if (n > cap)
+      return cap;
+   return n;
+}
+
+/* jr/jump condition-code decode -- mirrors build_branch_condition_table()
+ * in src/tom/gpu.c (shared by the DSP, same encoding). The 5-bit field is
+ * NOT simply "cc[n&7]": bit 4 selects the N flag instead of C for the
+ * carry-style tests in bits 2-3 (issue #406). Writes into out, returns
+ * bytes written (never NUL-terminates; caller owns termination). */
+static int GDBDisasmCC(unsigned j, char *out, int outMax)
+{
+   int n = 0;
+   int needSep = 0;
+
+   if (outMax <= 0)
+      return 0;
+
+   if (j == 0)
+   {
+      out[0] = 'T';
+      return 1;
+   }
+
+   if (j & 1)
+   {
+      n += snprintf(out + n, (size_t)(outMax - n), "NZ");
+      n = GDBDisasmClamp(n, outMax);
+      needSep = 1;
+   }
+   if (j & 2)
+   {
+      n += snprintf(out + n, (size_t)(outMax - n), "%sZ", needSep ? " " : "");
+      n = GDBDisasmClamp(n, outMax);
+      needSep = 1;
+   }
+   if (j & 4)
+   {
+      n += snprintf(out + n, (size_t)(outMax - n), "%s%s",
+                    needSep ? " " : "", (j & 0x10) ? "NN" : "NC");
+      n = GDBDisasmClamp(n, outMax);
+      needSep = 1;
+   }
+   if (j & 8)
+   {
+      n += snprintf(out + n, (size_t)(outMax - n), "%s%s",
+                    needSep ? " " : "", (j & 0x10) ? "N" : "C");
+      n = GDBDisasmClamp(n, outMax);
+      needSep = 1;
+   }
+   if (!needSep)
+      n = GDBDisasmClamp(snprintf(out, (size_t)outMax, "cc%u", j), outMax);
+
+   return n;
+}
+
+/*
+ * Decode one RISC instruction at `addr` (word w, plus the two following
+ * words w2/w3 for the movei 32-bit-immediate case) into out as a single
+ * line of text, no trailing newline. `mnemonics` is one of the two tables
+ * above. Returns bytes written, clamped to outMax (may fill the buffer
+ * completely with no room for a NUL if outMax is small -- callers that
+ * need a C string reserve one extra byte, same convention as GDBDisasmCC).
+ */
+static int GDBDisasmOne(const char * const mnemonics[64], unsigned int addr,
+                        unsigned short w, unsigned short w2, unsigned short w3,
+                        char *out, int outMax)
+{
+   unsigned op  = (unsigned)(w >> 10);
+   unsigned r1  = (unsigned)((w >> 5) & 0x1F);
+   unsigned r2  = (unsigned)(w & 0x1F);
+   int n;
+
+   if (outMax <= 0)
+      return 0;
+
+   n = GDBDisasmClamp(
+          snprintf(out, (size_t)outMax, "$%06X: %04X  %-14s", addr, w, mnemonics[op]),
+          outMax);
+
+   if (op == 53)                        /* jr */
+   {
+      int disp = (int)((r1 & 0x10) ? (int)r1 - 32 : (int)r1);
+      n += snprintf(out + n, (size_t)(outMax - n), " ");
+      n = GDBDisasmClamp(n, outMax);
+      n += GDBDisasmCC(r2, out + n, outMax - n);
+      n = GDBDisasmClamp(n, outMax);
+      n += snprintf(out + n, (size_t)(outMax - n), ", %+d -> $%06X",
+                    disp, addr + 2 + disp * 2);
+      n = GDBDisasmClamp(n, outMax);
+   }
+   else if (op == 52)                   /* jump */
+   {
+      n += snprintf(out + n, (size_t)(outMax - n), " ");
+      n = GDBDisasmClamp(n, outMax);
+      n += GDBDisasmCC(r2, out + n, outMax - n);
+      n = GDBDisasmClamp(n, outMax);
+      n += snprintf(out + n, (size_t)(outMax - n), ", (r%u)", r1);
+      n = GDBDisasmClamp(n, outMax);
+   }
+   else if (op == 38)                   /* movei -- 32-bit immediate follows */
+   {
+      n += snprintf(out + n, (size_t)(outMax - n), " #$%08X, r%u",
+                    ((unsigned int)w3 << 16) | (unsigned int)w2, r2);
+      n = GDBDisasmClamp(n, outMax);
+   }
+   else if (op == 2 || op == 6 || op == 31 || op == 35 || op == 24 || op == 25)
+   {
+      /* addq/subq/cmpq/moveq/shlq/shrq: r1 is a 5-bit immediate, 0 means 32 */
+      n += snprintf(out + n, (size_t)(outMax - n), " #%u, r%u", r1 ? r1 : 32, r2);
+      n = GDBDisasmClamp(n, outMax);
+   }
+   else
+   {
+      n += snprintf(out + n, (size_t)(outMax - n), " r%u, r%u", r1, r2);
+      n = GDBDisasmClamp(n, outMax);
+   }
+
+   return n;
+}
+
+#endif /* __GDBDISASM_H__ */

--- a/src/debug/gdbsock.c
+++ b/src/debug/gdbsock.c
@@ -159,6 +159,11 @@ int GDBSockSend(const char *buf, int len)
    return (int)send(gdbClient, buf, (size_t)len, 0);
 }
 
+int GDBSockHasClient(void)
+{
+   return gdb_sock_valid(gdbClient) ? 1 : 0;
+}
+
 #else /* no BSD sockets on this target */
 
 int  GDBSockOpen(int port) { (void)port; return -1; }
@@ -166,5 +171,6 @@ void GDBSockClose(void)    { }
 int  GDBSockPoll(void)     { return 0; }
 int  GDBSockRecv(char *buf, int max) { (void)buf; (void)max; return 0; }
 int  GDBSockSend(const char *buf, int len) { (void)buf; (void)len; return -1; }
+int  GDBSockHasClient(void) { return 0; }
 
 #endif /* GDB_HAVE_TCP */

--- a/src/debug/gdbstub.c
+++ b/src/debug/gdbstub.c
@@ -1,5 +1,6 @@
 #include "gdbstub.h"
 #include <string.h>
+#include <stdio.h>
 
 static int GDBHexVal(char c)
 {
@@ -145,12 +146,44 @@ int GDBParseHexU32(const char *s, int len, unsigned int *out)
    return len;
 }
 
-void GDBSessionInit(struct GDBSession *s, const struct GDBTargetOps *ops,
-                    void *user)
+void GDBSessionInit(struct GDBSession *s, const struct GDBTargetOps *ops68k,
+                    void *user68k)
 {
-   s->ops       = ops;
-   s->user      = user;
+   int i;
+
+   for (i = 0; i < GDB_NUM_TARGETS; i++)
+   {
+      s->ops[i]  = NULL;
+      s->user[i] = NULL;
+   }
+
+   s->ops[GDB_TGT_68K]  = ops68k;
+   s->user[GDB_TGT_68K] = user68k;
    s->noAckMode = 0;
+   s->threadG   = 1;
+   s->threadC   = 1;
+}
+
+void GDBSessionSetTargetOps(struct GDBSession *s, int target,
+                            const struct GDBTargetOps *ops, void *user)
+{
+   if (target < 0 || target >= GDB_NUM_TARGETS)
+      return;
+
+   s->ops[target]  = ops;
+   s->user[target] = user;
+}
+
+/* Resolves an RSP thread number (1-based; 0 or -1 mean "any", treated as
+ * thread 1 -- this stub never runs more than one processor's worth of
+ * "current thread" logic at a time) to a target index. */
+static int GDBThreadToTarget(int threadId)
+{
+   if (threadId <= 0)
+      return GDB_TGT_68K;
+   if (threadId > GDB_NUM_TARGETS)
+      return GDB_TGT_68K;
+   return threadId - 1;
 }
 
 static int GDBCopyReply(const char *text, char *reply, int replyMax)
@@ -164,18 +197,100 @@ static int GDBCopyReply(const char *text, char *reply, int replyMax)
    return len;
 }
 
-int GDBHandlePacket(struct GDBSession *s, const char *pay, int payLen,
-                    char *reply, int replyMax)
+/* qRcmd's command text arrives hex-encoded (one byte per two hex
+ * digits); decode it into a NUL-terminated C string. Returns the decoded
+ * length (excluding the NUL), or -1 on malformed hex / overflow. */
+static int GDBHexDecodeToText(const char *hex, int hexLen, char *out, int outMax)
 {
+   int i, n = 0;
+
+   if (hexLen & 1)
+      return -1;
+
+   for (i = 0; i < hexLen; i += 2)
+   {
+      unsigned int byte;
+
+      if (n >= outMax)
+         return -1;
+      if (GDBParseHexU32(hex + i, 2, &byte) < 0)
+         return -1;
+
+      out[n++] = (char)byte;
+   }
+
+   if (n < outMax)
+      out[n] = '\0';
+
+   return n;
+}
+
+/* The inverse: plain text -> hex, for qRcmd's reply (GDB decodes and
+ * prints it). Returns hex chars written, or -1 if out is too small. */
+static int GDBHexEncodeText(const char *text, int textLen, char *out, int outMax)
+{
+   static const char hexDigits[] = "0123456789abcdef";
+   int i;
+
+   if ((textLen * 2) > outMax)
+      return -1;
+
+   for (i = 0; i < textLen; i++)
+   {
+      unsigned char b = (unsigned char)text[i];
+
+      out[i * 2]     = hexDigits[(b >> 4) & 0xF];
+      out[i * 2 + 1] = hexDigits[b & 0xF];
+   }
+
+   return textLen * 2;
+}
+
+/* Scans a "vCont;action[:tid];action[:tid]..." payload for whether any
+ * action is a step ('s') -- if so the caller treats the whole batch as a
+ * step, otherwise a continue. Good enough for this stub's halt-everyone-
+ * together model: only ever one processor is actually halted, so only
+ * its own action (however GDB addressed it) matters, and GDBHalt() acts
+ * on behalf of whichever processor is blocked, not on a thread ID parsed
+ * here. */
+static int GDBVContHasStep(const char *pay, int payLen)
+{
+   int i;
+
+   for (i = 0; i < payLen; i++)
+   {
+      if (pay[i] == ';' && i + 1 < payLen && pay[i + 1] == 's')
+         return 1;
+   }
+
+   return 0;
+}
+
+int GDBHandlePacket(struct GDBSession *s, const char *pay, int payLen,
+                    char *reply, int replyMax,
+                    int *resumeRequested, int *resumeIsStep)
+{
+   int targetG;
+   static const char qxferPrefix[] = "qXfer:features:read:";
+   const int qxferPrefixLen = (int)sizeof(qxferPrefix) - 1;
+
+   *resumeRequested = 0;
+   *resumeIsStep     = 0;
+
    if (payLen <= 0)
       return 0;
+
+   targetG = GDBThreadToTarget(s->threadG);
 
    if (pay[0] == '?')
       return GDBCopyReply("S05", reply, replyMax);
 
    /* Matches both the bare "qSupported" and the "qSupported:xxx" form. */
    if (payLen >= 10 && memcmp(pay, "qSupported", 10) == 0)
-      return GDBCopyReply("PacketSize=1000;QStartNoAckMode+", reply, replyMax);
+      return GDBCopyReply(
+         "PacketSize=1000;QStartNoAckMode+;swbreak+;hwbreak+"
+         ";qXfer:features:read+;vContSupported+",
+         reply, replyMax);
 
    if (payLen == 15 && memcmp(pay, "QStartNoAckMode", 15) == 0)
    {
@@ -183,13 +298,69 @@ int GDBHandlePacket(struct GDBSession *s, const char *pay, int payLen,
       return GDBCopyReply("OK", reply, replyMax);
    }
 
+   /* qC -- report the current general thread. */
+   if (payLen == 2 && pay[0] == 'q' && pay[1] == 'C')
+   {
+      char buf[16];
+      sprintf(buf, "QC%x", (s->threadG > 0) ? s->threadG : 1);
+      return GDBCopyReply(buf, reply, replyMax);
+   }
+
+   /* qfThreadInfo/qsThreadInfo -- the roster is fixed and small enough to
+    * report in one shot: 1=68K, 2=GPU, 3=DSP, always, whether or not GPU/
+    * DSP ops are registered (an unregistered target just answers "g"/"m"
+    * etc. as unsupported for its own thread, same as any other missing
+    * ops function). */
+   if (payLen == 12 && memcmp(pay, "qfThreadInfo", 12) == 0)
+      return GDBCopyReply("m1,2,3", reply, replyMax);
+   if (payLen == 12 && memcmp(pay, "qsThreadInfo", 12) == 0)
+      return GDBCopyReply("l", reply, replyMax);
+
+   /* Hg<tid> / Hc<tid> -- select the thread subsequent g/G/m/M/Z/z (Hg) or
+    * c/s/vCont (Hc) apply to. Thread IDs are hex, optionally "-1" for
+    * "all threads". */
+   if (payLen >= 2 && pay[0] == 'H' && (pay[1] == 'g' || pay[1] == 'c'))
+   {
+      unsigned int tid = 0;
+      int neg = 0;
+      int off = 2;
+
+      if (off < payLen && pay[off] == '-')
+      {
+         neg = 1;
+         off++;
+      }
+
+      if (payLen - off > 0)
+      {
+         if (GDBParseHexU32(pay + off, payLen - off, &tid) < 0)
+            return GDBCopyReply("E01", reply, replyMax);
+      }
+
+      if (pay[1] == 'g')
+         s->threadG = neg ? -1 : (int)tid;
+      else
+         s->threadC = neg ? -1 : (int)tid;
+
+      return GDBCopyReply("OK", reply, replyMax);
+   }
+
+   /* T<tid> -- thread-alive query (a bare hex thread id, or "-1"; not to
+    * be confused with any 'q'/'Q'-prefixed tracepoint packet, which this
+    * stub does not implement at all -- see "Out of scope"). All three of
+    * our threads always exist for the lifetime of the session. */
+   if (payLen >= 2 && pay[0] == 'T' &&
+       (pay[1] == '-' || (pay[1] >= '0' && pay[1] <= '9') ||
+        (pay[1] >= 'a' && pay[1] <= 'f') || (pay[1] >= 'A' && pay[1] <= 'F')))
+      return GDBCopyReply("OK", reply, replyMax);
+
    if (pay[0] == 'm')
    {
       unsigned int addr = 0, len = 0;
       int comma = -1;
       int i, n;
 
-      if (!s->ops || !s->ops->readMemory)
+      if (!s->ops[targetG] || !s->ops[targetG]->readMemory)
          return 0;
 
       for (i = 1; i < payLen; i++)
@@ -210,25 +381,262 @@ int GDBHandlePacket(struct GDBSession *s, const char *pay, int payLen,
       if (GDBParseHexU32(pay + comma + 1, payLen - comma - 1, &len) < 0)
          return GDBCopyReply("E01", reply, replyMax);
 
-      n = s->ops->readMemory(s->user, addr, (int)len, reply, replyMax);
+      n = s->ops[targetG]->readMemory(s->user[targetG], addr, (int)len, reply, replyMax);
       if (n < 0)
          return GDBCopyReply("E01", reply, replyMax);
 
       return n;
    }
 
+   if (pay[0] == 'M')
+   {
+      unsigned int addr = 0, len = 0;
+      int comma = -1, colon = -1;
+      int i, rc;
+
+      if (!s->ops[targetG] || !s->ops[targetG]->writeMemory)
+         return 0;
+
+      for (i = 1; i < payLen; i++)
+      {
+         if (pay[i] == ',' && comma < 0)
+            comma = i;
+         else if (pay[i] == ':' && comma >= 0)
+         {
+            colon = i;
+            break;
+         }
+      }
+
+      if (comma < 0 || colon < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      if (GDBParseHexU32(pay + 1, comma - 1, &addr) < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      if (GDBParseHexU32(pay + comma + 1, colon - comma - 1, &len) < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      if ((unsigned int)(payLen - colon - 1) != len * 2)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      rc = s->ops[targetG]->writeMemory(s->user[targetG], addr, (int)len,
+                                         pay + colon + 1, (int)len * 2);
+      if (rc < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      return GDBCopyReply("OK", reply, replyMax);
+   }
+
    if (payLen == 1 && pay[0] == 'g')
    {
       int n;
 
-      if (!s->ops || !s->ops->readRegisters)
+      if (!s->ops[targetG] || !s->ops[targetG]->readRegisters)
          return 0;
 
-      n = s->ops->readRegisters(s->user, reply, replyMax);
+      n = s->ops[targetG]->readRegisters(s->user[targetG], reply, replyMax);
       if (n < 0)
          return GDBCopyReply("E01", reply, replyMax);
 
       return n;
+   }
+
+   if (payLen >= 1 && pay[0] == 'G')
+   {
+      int rc;
+
+      if (!s->ops[targetG] || !s->ops[targetG]->writeRegisters)
+         return 0;
+
+      rc = s->ops[targetG]->writeRegisters(s->user[targetG], pay + 1, payLen - 1);
+      if (rc < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      return GDBCopyReply("OK", reply, replyMax);
+   }
+
+   if (pay[0] == 'Z' || pay[0] == 'z')
+   {
+      int insert = (pay[0] == 'Z');
+      unsigned int type = 0, addr = 0, kind = 0;
+      int c1 = -1, c2 = -1;
+      int i, rc;
+      const struct GDBTargetOps *ops = s->ops[targetG];
+
+      if (payLen < 3 || pay[1] < '0' || pay[1] > '4')
+         return 0;
+
+      type = (unsigned int)(pay[1] - '0');
+
+      /* Format is fixed: "Z<type-digit>,<addr-hex>,<kind-hex>[;...]" --
+       * the first comma is always right after the single type digit. */
+      if (pay[2] != ',')
+         return GDBCopyReply("E01", reply, replyMax);
+      c1 = 2;
+
+      for (i = c1 + 1; i < payLen; i++)
+      {
+         if (pay[i] == ',')
+         {
+            c2 = i;
+            break;
+         }
+      }
+
+      if (c2 < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      if (GDBParseHexU32(pay + c1 + 1, c2 - c1 - 1, &addr) < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      /* The kind field may be followed by ";cond_list"/";cmds" (agent
+       * expressions / conditional breakpoints) we don't implement --
+       * stop at the first ';' rather than failing the whole packet. */
+      {
+         int kindEnd = payLen;
+
+         for (i = c2 + 1; i < payLen; i++)
+         {
+            if (pay[i] == ';')
+            {
+               kindEnd = i;
+               break;
+            }
+         }
+
+         if (GDBParseHexU32(pay + c2 + 1, kindEnd - c2 - 1, &kind) < 0)
+            return GDBCopyReply("E01", reply, replyMax);
+      }
+
+      if (!ops || (insert ? !ops->insertBreak : !ops->removeBreak))
+         return 0;
+
+      rc = insert ? ops->insertBreak(s->user[targetG], (int)type, addr, kind)
+                  : ops->removeBreak(s->user[targetG], (int)type, addr, kind);
+
+      if (rc == -1)
+         return 0;
+      if (rc == -2)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      return GDBCopyReply("OK", reply, replyMax);
+   }
+
+   /* 'c'/'s' with an optional resume-address argument (unsupported --
+    * we never relocate PC on resume) are both handled the same way: no
+    * immediate reply. The eventual stop reply is sent later, out of
+    * band, by GDBHalt() when the processor actually halts again. */
+   if (pay[0] == 'c' || pay[0] == 's')
+   {
+      *resumeRequested = 1;
+      *resumeIsStep     = (pay[0] == 's');
+      return 0;
+   }
+
+   if (payLen >= 5 && memcmp(pay, "vCont", 5) == 0)
+   {
+      if (payLen == 6 && pay[5] == '?')
+         return GDBCopyReply("vCont;c;s", reply, replyMax);
+
+      if (payLen >= 6 && pay[5] == ';')
+      {
+         *resumeRequested = 1;
+         *resumeIsStep     = GDBVContHasStep(pay, payLen);
+         return 0;
+      }
+
+      return 0;
+   }
+
+   if (payLen > 6 && memcmp(pay, "qRcmd,", 6) == 0)
+   {
+      char cmd[256];
+      char text[512];
+      int cmdLen, textLen, hexLen;
+
+      cmdLen = GDBHexDecodeToText(pay + 6, payLen - 6, cmd, (int)sizeof(cmd) - 1);
+      if (cmdLen < 0)
+         return GDBCopyReply("E01", reply, replyMax);
+
+      if (!s->ops[GDB_TGT_68K] || !s->ops[GDB_TGT_68K]->monitorCmd)
+         return 0;
+
+      textLen = s->ops[GDB_TGT_68K]->monitorCmd(s->user[GDB_TGT_68K], cmd,
+                                                text, (int)sizeof(text));
+      if (textLen <= 0)
+         return GDBCopyReply("OK", reply, replyMax);
+
+      hexLen = GDBHexEncodeText(text, textLen, reply, replyMax);
+      if (hexLen < 0)
+         return 0;
+
+      return hexLen;
+   }
+
+   if (payLen > qxferPrefixLen && memcmp(pay, qxferPrefix, (size_t)qxferPrefixLen) == 0)
+   {
+      const struct GDBTargetOps *ops = s->ops[targetG];
+      const char *rest = pay + qxferPrefixLen;
+      int restLen = payLen - qxferPrefixLen;
+      int colonAt = -1, commaAt = -1;
+      unsigned int off = 0, len = 0;
+      const char *xml;
+      int xmlLen = 0;
+      int chunk;
+      int i;
+
+      /* rest is "<annex>:<offset>,<length>"; we serve one document per
+       * target so the annex is accepted but not inspected. */
+      for (i = 0; i < restLen; i++)
+      {
+         if (rest[i] == ':')
+         {
+            colonAt = i;
+            break;
+         }
+      }
+      if (colonAt < 0)
+         return GDBCopyReply("E00", reply, replyMax);
+
+      for (i = colonAt + 1; i < restLen; i++)
+      {
+         if (rest[i] == ',')
+         {
+            commaAt = i;
+            break;
+         }
+      }
+      if (commaAt < 0)
+         return GDBCopyReply("E00", reply, replyMax);
+
+      if (GDBParseHexU32(rest + colonAt + 1, commaAt - colonAt - 1, &off) < 0)
+         return GDBCopyReply("E00", reply, replyMax);
+      if (GDBParseHexU32(rest + commaAt + 1, restLen - commaAt - 1, &len) < 0)
+         return GDBCopyReply("E00", reply, replyMax);
+
+      if (!ops || !ops->targetXML)
+         return 0;
+
+      xml = ops->targetXML(s->user[targetG], &xmlLen);
+      if (!xml || xmlLen <= 0)
+         return 0;
+
+      if ((int)off >= xmlLen)
+         return GDBCopyReply("l", reply, replyMax);
+
+      chunk = xmlLen - (int)off;
+      if (chunk > (int)len)
+         chunk = (int)len;
+      if (chunk > replyMax - 1)
+         chunk = replyMax - 1;
+      if (chunk < 0)
+         chunk = 0;
+
+      reply[0] = ((int)off + chunk >= xmlLen) ? 'l' : 'm';
+      memcpy(reply + 1, xml + off, (size_t)chunk);
+
+      return chunk + 1;
    }
 
    /* RSP: an empty reply means "I do not implement this packet". */

--- a/src/debug/gdbstub.h
+++ b/src/debug/gdbstub.h
@@ -30,10 +30,41 @@ int GDBEncodePacket(const char *payload, int len, char *out, int outMax);
 
 #define GDB_PACKET_MAX 4096
 
+/* GDB thread numbers (1-based, RSP convention) map 1:1 to processors.
+ * Fixed forever -- clients cache thread identity across a session.
+ * GDB_TGT_* below are the 0-based equivalents used for arrays/indexing;
+ * thread number == GDB_TGT_* + 1. */
+#define GDB_TGT_68K       0
+#define GDB_TGT_GPU       1
+#define GDB_TGT_DSP       2
+#define GDB_NUM_TARGETS   3
+
+/* Register numbering within the GPU/DSP custom target description
+ * (org.atari.jaguar.risc): R0-R31, then PC, then FLAGS. Fixed once
+ * shipped -- see docs/gdb-stub-design.md Open Question 3. */
+#define GDB_RISC_REG_PC     32
+#define GDB_RISC_REG_FLAGS  33
+#define GDB_RISC_NUM_REGS   34
+
+/* Stop reasons, used to build the stop-reply and for logging. */
+#define GDB_STOP_BREAKPOINT 0
+#define GDB_STOP_WATCHPOINT 1
+#define GDB_STOP_STEP       2
+#define GDB_STOP_USER       3
+
+/* Z/z packet break/watch types, as GDB defines them on the wire. */
+#define GDB_BP_SOFTWARE   0
+#define GDB_BP_HARDWARE   1
+#define GDB_BP_WATCH_WR   2
+#define GDB_BP_WATCH_RD   3
+#define GDB_BP_WATCH_RW   4
+
 /*
- * What the engine needs from a target. Phase 1 uses only readRegisters
- * and readMemory; later phases add the rest. Every function may be NULL,
- * in which case the engine replies "unsupported" rather than crashing.
+ * What the engine needs from a target. Every function pointer may be
+ * NULL, in which case the engine replies "unsupported" (or the
+ * packet-specific error) rather than crashing. One instance per
+ * processor (68K/GPU/DSP); register a target with
+ * GDBSessionSetTargetOps() below.
  */
 struct GDBTargetOps
 {
@@ -41,32 +72,153 @@ struct GDBTargetOps
     * Returns chars written, or -1. */
    int (*readRegisters)(void *user, char *out, int outMax);
 
+   /* Parse GDB's "G" payload (hex, no separators, same layout as
+    * readRegisters's output) and apply it. Returns 0 on success, -1 on
+    * malformed input. */
+   int (*writeRegisters)(void *user, const char *hex, int hexLen);
+
    /* Read len guest bytes at addr into out as hex. MUST bounds-check addr
     * against the emulated map and return -1 on any out-of-range access. */
    int (*readMemory)(void *user, unsigned int addr, int len,
                      char *out, int outMax);
+
+   /* Write len guest bytes at addr from hex (2*len hex chars). MUST
+    * bounds-check identically to readMemory. Returns 0 on success, -1 on
+    * any out-of-range access or malformed hex. */
+   int (*writeMemory)(void *user, unsigned int addr, int len,
+                      const char *hex, int hexLen);
+
+   /* Z/z packet handling. type is one of GDB_BP_*. Returns 0 (OK), -1
+    * (unsupported -- empty reply), or -2 (out of resources -- E01, e.g.
+    * the breakpoint table is full or a watchpoint slot is already
+    * taken). insert/remove are idempotent: removing an address that was
+    * never inserted is not an error. */
+   int (*insertBreak)(void *user, int type, unsigned int addr, unsigned int kind);
+   int (*removeBreak)(void *user, int type, unsigned int addr, unsigned int kind);
+
+   /* qXfer:features:read target: return a pointer to a static,
+    * NUL-terminated XML blob (annex is ignored -- each target has
+    * exactly one description) and its length. NULL (xmlLen set to 0)
+    * means "this target has no custom description" (thread 1 / 68K: GDB
+    * already knows the m68k architecture natively). */
+   const char * (*targetXML)(void *user, int *xmlLen);
+
+   /* qRcmd ("monitor ..."), cmd already hex-decoded and NUL-terminated.
+    * Appends plain (not hex-encoded -- the engine does that) text to
+    * out. Returns bytes written. */
+   int (*monitorCmd)(void *user, const char *cmd, char *out, int outMax);
 };
 
 struct GDBSession
 {
-   const struct GDBTargetOps *ops;
-   void *user;
+   const struct GDBTargetOps *ops[GDB_NUM_TARGETS];
+   void *user[GDB_NUM_TARGETS];
    int noAckMode;
+   /* Hg/Hc thread selection, RSP thread numbers (1-based); 0 means
+    * "any"/unset and is treated as thread 1. */
+   int threadG;
+   int threadC;
 };
 
-void GDBSessionInit(struct GDBSession *s, const struct GDBTargetOps *ops,
-                    void *user);
+void GDBSessionInit(struct GDBSession *s, const struct GDBTargetOps *ops68k,
+                    void *user68k);
+
+/* Registers (or clears, with ops==NULL) the ops/user pair for one
+ * non-68K target. Safe to call before any packet is processed. */
+void GDBSessionSetTargetOps(struct GDBSession *s, int target,
+                            const struct GDBTargetOps *ops, void *user);
 
 int GDBExpandRLE(const char *in, int inLen, char *out, int outMax);
 
+/*
+ * Handle one decoded RSP payload and produce a reply payload (NOT yet
+ * framed with $...#cs -- the caller encodes it). Returns the reply
+ * length, which may legitimately be 0 (RSP's "I don't implement this"
+ * convention for most packets, but ALSO the correct reply-suppression
+ * for 'c'/'s'/vCont: those never get an immediate reply, the eventual
+ * stop-reply is sent later, out of band, by GDBHalt()). Check
+ * *resumeRequested after every call: nonzero means the caller (the halt
+ * loop) should stop servicing packets and let the halted processor run;
+ * *resumeIsStep distinguishes step from continue. Both are 0 on entry
+ * and only ever set, never read, by this function -- caller clears them
+ * before the next call.
+ */
 int GDBHandlePacket(struct GDBSession *s, const char *pay, int payLen,
-                    char *reply, int replyMax);
+                    char *reply, int replyMax,
+                    int *resumeRequested, int *resumeIsStep);
 
 int GDBParseHexU32(const char *s, int len, unsigned int *out);
 
-/* Implemented in gdbtarget.c (Task 4). Declared here so libretro.c needs
- * only this one header. */
+/* Implemented in gdbtarget.c. Declared here so libretro.c needs only this
+ * one header. */
 const struct GDBTargetOps *GDBJaguarOps(void);
+const struct GDBTargetOps *GDBGpuOps(void);
+const struct GDBTargetOps *GDBDspOps(void);
+
+/*
+ * Per-target armed-breakpoint counters -- the whole "near zero cost when
+ * disabled" premise (docs/gdb-stub-design.md, "Breakpoint detection").
+ * Defined in gdbtarget.c; read by the hot paths in src/core/jaguar.c,
+ * src/tom/gpu.c, src/jerry/dsp.c. Each is the count of armed execution
+ * breakpoints (Z0/Z1) for that processor PLUS 1 while a one-shot single
+ * step is pending for it -- either way, nonzero means "call GDBCheckPC",
+ * zero means "one load, one never-taken branch, done".
+ */
+extern int gdbArmed68K;
+extern int gdbArmedGPU;
+extern int gdbArmedDSP;
+
+/* Called only when the matching gdbArmedXXX counter above is nonzero.
+ * Consults a 256-entry direct-mapped cache first; a miss falls through
+ * to a linear scan of the (small, capped) breakpoint table. Returns
+ * nonzero if pc is an armed breakpoint or the pending one-shot step
+ * target for that processor. */
+int GDBCheckPC(int target, unsigned int pc);
+
+/*
+ * Blocks. Freezes the calling processor's forward progress by servicing
+ * RSP packets in a loop until a continue/step is issued or the client
+ * disconnects (which disarms every breakpoint/watchpoint and resumes
+ * immediately -- a dead debugger must never leave the machine wedged).
+ * Called from inside M68KInstructionHook()/GPUExec()/DSPExec() --
+ * deliberately does NOT unwind the call stack, so every processor's
+ * state is frozen exactly where it stopped. pc is the address to report
+ * in the stop reply.
+ */
+void GDBHalt(int target, int reason, unsigned int pc);
+
+/*
+ * Called from the memory-access breakpoint sites in src/core/jaguar.c
+ * (m68k_read/write_memory_{8,16,32}), guarded there by "if (bpmActive)"
+ * -- bpmActive/bpmAddress1 (src/core/jaguar.c) are owned exclusively by
+ * this module; nothing else in the tree ever sets them. isWrite is 1 for
+ * a write access, 0 for a read. A no-op unless the single armed
+ * watchpoint's kind (write/read/access) matches and the address matches.
+ */
+void GDBMemWatchHit(unsigned int address, int isWrite);
+
+/* Disarms every breakpoint/watchpoint/step and resets thread/halt state,
+ * without touching the socket. Called on client disconnect (mid-halt or
+ * not), on halt-timeout auto-continue, and from the reset paths so a
+ * fresh content load never inherits a previous session's armed state. */
+void GDBTargetResetState(void);
+
+/* Called once, right after GDBSockOpen() succeeds: builds the session
+ * and registers all three targets' ops, then resets armed state. */
+void GDBTargetOpen(void);
+
+/* Called on content unload/deinit (or a bind failure that leaves the
+ * stub disabled for this session): resets all Jaguar-side state. Does
+ * NOT touch the socket -- callers close that separately with
+ * GDBSockClose() first, matching the existing Phase 1 lifecycle. */
+void GDBTargetClose(void);
+
+/* Edge-triggered: true the first time this is called after a new client
+ * has accepted, false otherwise. Lets libretro.c fire the "client
+ * attached" OSD banner (docs/gdb-stub-design.md "The halt loop and
+ * retro_run()") from retro_run() without this module needing to reach
+ * environ_cb itself. */
+int GDBSockHasClientAttachEvent(void);
 
 /*
  * Loopback-only TCP transport, implemented in gdbsock.c (Task 5). Binds
@@ -80,6 +232,32 @@ void GDBSockClose(void);
 int GDBSockPoll(void);
 int GDBSockRecv(char *buf, int max);
 int GDBSockSend(const char *buf, int len);
+/* True iff a client is currently connected (accept()ed, not yet
+ * dropped). Lets libretro.c fire the "client attached" OSD banner on
+ * the accept edge without owning any socket state itself. */
+int GDBSockHasClient(void);
+
+/*
+ * Non-blocking, called once per retro_run() frame while the stub is
+ * enabled. Drains whatever the socket has, dispatches every complete
+ * packet currently buffered, and returns -- never loops waiting for
+ * more data. This is also the low-level pump GDBHalt() calls
+ * repeatedly (with a short sleep between calls) while blocked.
+ */
+void GDBTargetServicePoll(void);
+
+/* Optional halt timeout in seconds (virtualjaguar_gdb_halt_timeout); 0
+ * means "off" (the documented default -- silently resuming a debugged
+ * machine is worse than a freeze for this audience). Set by libretro.c
+ * from the core option. */
+void GDBTargetSetHaltTimeout(int seconds);
+
+/* Halt-at-boot support (virtualjaguar_gdb_wait): when armed, the very
+ * first M68KInstructionHook() call after content load halts
+ * unconditionally, exactly like a breakpoint at the reset vector, so a
+ * developer can attach before anything has executed. Self-clearing:
+ * fires at most once per content load. */
+void GDBTargetArmWaitAtBoot(void);
 
 #ifdef __cplusplus
 }

--- a/src/debug/gdbtarget.c
+++ b/src/debug/gdbtarget.c
@@ -1,35 +1,54 @@
 /*
- * gdbtarget.c -- adapts the Jaguar to the GDB stub's target vtable.
+ * gdbtarget.c -- adapts the Jaguar to the GDB stub's target vtable, owns
+ * the per-target breakpoint/watchpoint state, and runs the halt loop.
  * Design: docs/gdb-stub-design.md (issue #652).
  *
- * NOTE on the "who" argument to JaguarReadByte(): the plan that specified
- * this file named the constant DEBUG, but src/core/vjag_memory.h's who
- * enum spells this enumerator DEBUGGER, not DEBUG -- deliberately, per
- * that header's comment: Xcode's stock Debug configuration defines the
- * preprocessor macro DEBUG=1, which would otherwise mangle the enumerator
- * list on every Xcode/SwiftPM consumer. The wire value (9) is unchanged.
- * Verified for RAM/ROM and for every who-GATED side effect this audit
- * found (DSP HLE sound-engine auto-ack and DSPGO auto-clear in
- * src/jerry/dsp.c, the busArbiter OP charge in jaguar.c, the GPU/DSP-
- * specific branches in vjtrace.c): all of them test who == M68K / GPU /
- * DSP / OP specifically, none of which equals DEBUGGER (9), so a
- * debugger read triggers none of them.
+ * NOTE on the "who" argument to JaguarReadByte()/JaguarWriteByte(): the
+ * plan that specified this file named the constant DEBUG, but
+ * src/core/vjag_memory.h's who enum spells this enumerator DEBUGGER, not
+ * DEBUG -- deliberately, per that header's comment: Xcode's stock Debug
+ * configuration defines the preprocessor macro DEBUG=1, which would
+ * otherwise mangle the enumerator list on every Xcode/SwiftPM consumer.
+ * The wire value (9) is unchanged. Verified for RAM/ROM and for every
+ * who-GATED side effect this audit found (DSP HLE sound-engine auto-ack
+ * and DSPGO auto-clear in src/jerry/dsp.c, the busArbiter OP charge in
+ * jaguar.c, the GPU/DSP-specific branches in vjtrace.c): all of them test
+ * who == M68K / GPU / DSP / OP specifically, none of which equals
+ * DEBUGGER (9), so a debugger read/write triggers none of them.
  *
  * NOT claimed: that every memory-mapped register in the map is free of
- * read side effects regardless of who asks. A handful of hardware
- * registers are read-sensitive by design on real silicon (e.g. CD
- * BUTCH+2's DSCNTRL ack semantics in src/cd/cdrom.c, reached only via
- * the 16/32-bit read path, not the byte path this file calls) -- a
- * debugger peeking at those would legitimately perturb interrupt/FIFO
- * state exactly as touching them from any processor does. GDBReadMem68K
- * reads one byte at a time via JaguarReadByte(), which for MMIO ranges
- * is honest about that: it inherits whatever the byte-granular handler
- * defines, same as the emulated machine's own 68K would see.
+ * read/write side effects regardless of who asks. A handful of hardware
+ * registers are read/write-sensitive by design on real silicon (e.g. CD
+ * BUTCH+2's DSCNTRL ack semantics in src/cd/cdrom.c, reached only via the
+ * 16/32-bit read path, not the byte path this file calls) -- a debugger
+ * poking at those would legitimately perturb interrupt/FIFO state
+ * exactly as touching them from any processor does.
  */
 #include <string.h>
+#include <stdio.h>
+#include <time.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "gdbstub.h"
+#include "gdbdisasm.h"
 #include "m68kinterface.h"
 #include "jaguar.h"
+#include "gpu.h"
+#include "dsp.h"
+#include "log.h"
+
+/* pcQueue/pcQPtr (src/core/jaguar.c, issue #542's 68K PC traceback ring)
+ * have no header declaration -- test/tools dlsym them by name instead.
+ * gdbtarget.c is linked into the same binary (not dlsym-based), so it
+ * needs a plain extern, same ad hoc pattern src/core/vjtrace.c already
+ * uses for GPUGetReg/DSPGetReg. */
+extern uint32_t pcQueue[0x400];
+extern uint32_t pcQPtr;
 
 static const char gdbHex[] = "0123456789abcdef";
 
@@ -40,6 +59,21 @@ static void GDBPutHex32(char *out, unsigned int v)
    for (i = 0; i < 8; i++)
       out[i] = gdbHex[(v >> ((7 - i) * 4)) & 0xF];
 }
+
+static int GDBGetHexVal(char c)
+{
+   if (c >= '0' && c <= '9')
+      return c - '0';
+   if (c >= 'a' && c <= 'f')
+      return (c - 'a') + 10;
+   if (c >= 'A' && c <= 'F')
+      return (c - 'A') + 10;
+   return -1;
+}
+
+/* ------------------------------------------------------------------ */
+/* 68000 registers and memory                                          */
+/* ------------------------------------------------------------------ */
 
 static int GDBReadRegs68K(void *user, char *out, int outMax)
 {
@@ -62,6 +96,45 @@ static int GDBReadRegs68K(void *user, char *out, int outMax)
    GDBPutHex32(out + (17 * 8), m68k_get_reg(NULL, M68K_REG_PC));
 
    return 144;
+}
+
+/* "G" -- write all 18 68K registers back, same layout readRegisters
+ * produced (D0-D7, A0-A7, SR, PC; 8 hex chars each, no separators). A
+ * raw poke via m68k_set_reg(), same as any debugger register write --
+ * no simulated instruction, no side effect beyond the register itself. */
+static int GDBWriteRegs68K(void *user, const char *hex, int hexLen)
+{
+   unsigned int v;
+   int i;
+
+   (void)user;
+
+   if (hexLen < 144)
+      return -1;
+
+   for (i = 0; i < 8; i++)
+   {
+      if (GDBParseHexU32(hex + (i * 8), 8, &v) < 0)
+         return -1;
+      m68k_set_reg((m68k_register_t)(M68K_REG_D0 + i), v);
+   }
+
+   for (i = 0; i < 8; i++)
+   {
+      if (GDBParseHexU32(hex + ((8 + i) * 8), 8, &v) < 0)
+         return -1;
+      m68k_set_reg((m68k_register_t)(M68K_REG_A0 + i), v);
+   }
+
+   if (GDBParseHexU32(hex + (16 * 8), 8, &v) < 0)
+      return -1;
+   m68k_set_reg(M68K_REG_SR, v);
+
+   if (GDBParseHexU32(hex + (17 * 8), 8, &v) < 0)
+      return -1;
+   m68k_set_reg(M68K_REG_PC, v);
+
+   return 0;
 }
 
 /*
@@ -98,11 +171,974 @@ static int GDBReadMem68K(void *user, unsigned int addr, int len,
    return len * 2;
 }
 
+/* "M" -- write len bytes at addr from 2*len hex chars. Bounds-checked
+ * identically to GDBReadMem68K -- this is the single most important
+ * invariant in the whole stub (docs/gdb-stub-design.md "Security"): a
+ * malformed or hostile M/X packet must never write outside emulated
+ * space. GPU and DSP threads share this same function (GDBGpuOps()/
+ * GDBDspOps() below point readMemory/writeMemory at the identical
+ * functions the 68K uses) because the local RISC RAMs are memory-mapped
+ * into the same unified 24-bit bus JaguarReadByte/JaguarWriteByte already
+ * decode -- there is no separate GPU/DSP address space to model. */
+static int GDBWriteMem68K(void *user, unsigned int addr, int len,
+                          const char *hex, int hexLen)
+{
+   int i;
+
+   (void)user;
+
+   if (len <= 0)
+      return -1;
+   if (addr >= GDB_GUEST_LIMIT)
+      return -1;
+   if ((unsigned int)len > (GDB_GUEST_LIMIT - addr))
+      return -1;
+   if (hexLen != len * 2)
+      return -1;
+
+   for (i = 0; i < len; i++)
+   {
+      int hi = GDBGetHexVal(hex[i * 2]);
+      int lo = GDBGetHexVal(hex[(i * 2) + 1]);
+
+      if (hi < 0 || lo < 0)
+         return -1;
+
+      JaguarWriteByte(addr + (unsigned int)i,
+                      (uint8_t)((hi << 4) | lo), DEBUGGER);
+   }
+
+   return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Per-target breakpoint tables, direct-mapped PC cache, armed counters */
+/* docs/gdb-stub-design.md "Breakpoint detection"                       */
+/* ------------------------------------------------------------------ */
+
+#define GDB_MAX_BP        64
+#define GDB_BP_CACHE_SIZE 256
+#define GDB_BP_CACHE_MASK (GDB_BP_CACHE_SIZE - 1)
+#define GDB_BP_EMPTY      0xFFFFFFFFu
+
+struct GDBBpTarget
+{
+   unsigned int addr[GDB_MAX_BP];
+   int used[GDB_MAX_BP];
+   int count;
+   unsigned int cache[GDB_BP_CACHE_SIZE];
+   /* Armed for exactly the next instruction on this processor -- used by
+    * both single-step (`s`/`vCont;s`) and `monitor halt <target>`/the
+    * gdb_wait boot halt. Consumed (cleared) the moment it matches. */
+   int oneShot;
+   int oneShotReason;
+};
+
+static struct GDBBpTarget gdbBp[GDB_NUM_TARGETS];
+static int gdbLastReason[GDB_NUM_TARGETS];
+
+int gdbArmed68K = 0;
+int gdbArmedGPU = 0;
+int gdbArmedDSP = 0;
+
+static void GDBRecomputeArmed(int target)
+{
+   int n = gdbBp[target].count + (gdbBp[target].oneShot ? 1 : 0);
+
+   if (target == GDB_TGT_68K)
+      gdbArmed68K = n;
+   else if (target == GDB_TGT_GPU)
+      gdbArmedGPU = n;
+   else if (target == GDB_TGT_DSP)
+      gdbArmedDSP = n;
+}
+
+int GDBCheckPC(int target, unsigned int pc)
+{
+   struct GDBBpTarget *t;
+   unsigned int idx;
+   int i;
+
+   if (target < 0 || target >= GDB_NUM_TARGETS)
+      return 0;
+
+   t = &gdbBp[target];
+
+   if (t->oneShot)
+   {
+      t->oneShot = 0;
+      gdbLastReason[target] = t->oneShotReason;
+      GDBRecomputeArmed(target);
+      return 1;
+   }
+
+   idx = (pc >> 1) & GDB_BP_CACHE_MASK;
+   if (t->cache[idx] == pc)
+   {
+      gdbLastReason[target] = GDB_STOP_BREAKPOINT;
+      return 1;
+   }
+
+   for (i = 0; i < GDB_MAX_BP; i++)
+   {
+      if (t->used[i] && t->addr[i] == pc)
+      {
+         t->cache[idx] = pc;
+         gdbLastReason[target] = GDB_STOP_BREAKPOINT;
+         return 1;
+      }
+   }
+
+   return 0;
+}
+
+static int GDBInsertExecBp(int target, unsigned int addr)
+{
+   struct GDBBpTarget *t = &gdbBp[target];
+   int i;
+
+   for (i = 0; i < GDB_MAX_BP; i++)
+   {
+      if (t->used[i] && t->addr[i] == addr)
+         return 0;   /* already armed: idempotent */
+   }
+
+   for (i = 0; i < GDB_MAX_BP; i++)
+   {
+      if (!t->used[i])
+      {
+         t->used[i] = 1;
+         t->addr[i] = addr;
+         t->count++;
+         GDBRecomputeArmed(target);
+         return 0;
+      }
+   }
+
+   return -2;   /* table full */
+}
+
+static int GDBRemoveExecBp(int target, unsigned int addr)
+{
+   struct GDBBpTarget *t = &gdbBp[target];
+   int i;
+
+   for (i = 0; i < GDB_MAX_BP; i++)
+   {
+      if (t->used[i] && t->addr[i] == addr)
+      {
+         t->used[i] = 0;
+         t->count--;
+         /* Direct-mapped: this address can only ever have landed in one
+          * cache line. Clearing it is enough -- a stale hit for a
+          * DIFFERENT still-armed address at the same line would simply
+          * be re-populated on its next miss. */
+         t->cache[(addr >> 1) & GDB_BP_CACHE_MASK] = GDB_BP_EMPTY;
+         GDBRecomputeArmed(target);
+         return 0;
+      }
+   }
+
+   return 0;   /* not found: idempotent, per RSP convention */
+}
+
+/* ------------------------------------------------------------------ */
+/* Memory watchpoints -- single slot, ridden on jaguar.c's bpmActive/    */
+/* bpmAddress1 (docs/gdb-stub-design.md "Watchpoints"). This module is   */
+/* their only writer anywhere in the tree.                              */
+/* ------------------------------------------------------------------ */
+
+static int gdbWatchArmed    = 0;
+static unsigned int gdbWatchAddr = 0;
+static int gdbWatchKindMask = 0;   /* bit0 = write, bit1 = read */
+
+static int GDBWatchMaskForType(int type)
+{
+   if (type == GDB_BP_WATCH_WR)
+      return 1;
+   if (type == GDB_BP_WATCH_RD)
+      return 2;
+   return 3;   /* GDB_BP_WATCH_RW (access) */
+}
+
+static int GDBInsertWatch(unsigned int addr, int type)
+{
+   int mask = GDBWatchMaskForType(type);
+
+   if (gdbWatchArmed && gdbWatchAddr != addr)
+      return -2;   /* single slot -- see docs/gdb-stub-design.md */
+
+   gdbWatchAddr      = addr;
+   gdbWatchKindMask  |= mask;
+   gdbWatchArmed     = 1;
+   bpmAddress1       = addr;
+   bpmActive         = true;
+
+   return 0;
+}
+
+static int GDBRemoveWatch(unsigned int addr, int type)
+{
+   if (!gdbWatchArmed || gdbWatchAddr != addr)
+      return 0;   /* idempotent */
+
+   gdbWatchKindMask &= ~GDBWatchMaskForType(type);
+   if (gdbWatchKindMask == 0)
+   {
+      gdbWatchArmed = 0;
+      bpmActive     = false;
+   }
+
+   return 0;
+}
+
+void GDBMemWatchHit(unsigned int address, int isWrite)
+{
+   int need = isWrite ? 1 : 2;
+
+   if (!gdbWatchArmed || address != gdbWatchAddr)
+      return;
+   if (!(gdbWatchKindMask & need))
+      return;
+
+   GDBHalt(GDB_TGT_68K, GDB_STOP_WATCHPOINT, address);
+}
+
+/* ------------------------------------------------------------------ */
+/* Per-target insertBreak/removeBreak (Z/z packet backends)             */
+/* ------------------------------------------------------------------ */
+
+static int GDB68KInsertBreak(void *user, int type, unsigned int addr, unsigned int kind)
+{
+   (void)user;
+   (void)kind;
+
+   if (type == GDB_BP_SOFTWARE || type == GDB_BP_HARDWARE)
+      return GDBInsertExecBp(GDB_TGT_68K, addr);
+   if (type == GDB_BP_WATCH_WR || type == GDB_BP_WATCH_RD || type == GDB_BP_WATCH_RW)
+      return GDBInsertWatch(addr, type);
+
+   return -1;
+}
+
+static int GDB68KRemoveBreak(void *user, int type, unsigned int addr, unsigned int kind)
+{
+   (void)user;
+   (void)kind;
+
+   if (type == GDB_BP_SOFTWARE || type == GDB_BP_HARDWARE)
+      return GDBRemoveExecBp(GDB_TGT_68K, addr);
+   if (type == GDB_BP_WATCH_WR || type == GDB_BP_WATCH_RD || type == GDB_BP_WATCH_RW)
+      return GDBRemoveWatch(addr, type);
+
+   return -1;
+}
+
+/* GPU/DSP execution breakpoints only -- this stub's memory watchpoints
+ * ride the 68K bus access functions exclusively (see the comment above
+ * GDBMemWatchHit / docs/gdb-stub-design.md), so a Z2/Z3/Z4 against GDB
+ * thread 2 or 3 is refused as unsupported rather than silently aliased
+ * onto the 68K's single watch slot. */
+static int GDBGpuInsertBreak(void *user, int type, unsigned int addr, unsigned int kind)
+{
+   (void)user;
+   (void)kind;
+   if (type == GDB_BP_SOFTWARE || type == GDB_BP_HARDWARE)
+      return GDBInsertExecBp(GDB_TGT_GPU, addr);
+   return -1;
+}
+
+static int GDBGpuRemoveBreak(void *user, int type, unsigned int addr, unsigned int kind)
+{
+   (void)user;
+   (void)kind;
+   if (type == GDB_BP_SOFTWARE || type == GDB_BP_HARDWARE)
+      return GDBRemoveExecBp(GDB_TGT_GPU, addr);
+   return -1;
+}
+
+static int GDBDspInsertBreak(void *user, int type, unsigned int addr, unsigned int kind)
+{
+   (void)user;
+   (void)kind;
+   if (type == GDB_BP_SOFTWARE || type == GDB_BP_HARDWARE)
+      return GDBInsertExecBp(GDB_TGT_DSP, addr);
+   return -1;
+}
+
+static int GDBDspRemoveBreak(void *user, int type, unsigned int addr, unsigned int kind)
+{
+   (void)user;
+   (void)kind;
+   if (type == GDB_BP_SOFTWARE || type == GDB_BP_HARDWARE)
+      return GDBRemoveExecBp(GDB_TGT_DSP, addr);
+   return -1;
+}
+
+/* ------------------------------------------------------------------ */
+/* GPU/DSP register files (org.atari.jaguar.risc: R0-R31, PC, FLAGS)    */
+/* ------------------------------------------------------------------ */
+
+static int GDBReadRegsRISC(uint32_t (*getReg)(int), uint32_t pc, uint32_t flags,
+                           char *out, int outMax)
+{
+   int i;
+
+   if (outMax < GDB_RISC_NUM_REGS * 8)
+      return -1;
+
+   for (i = 0; i < 32; i++)
+      GDBPutHex32(out + (i * 8), getReg(i));
+
+   GDBPutHex32(out + (GDB_RISC_REG_PC * 8), pc);
+   GDBPutHex32(out + (GDB_RISC_REG_FLAGS * 8), flags);
+
+   return GDB_RISC_NUM_REGS * 8;
+}
+
+static int GDBWriteRegsRISC(void (*setReg)(int, uint32_t),
+                            void (*setPC)(uint32_t), void (*setFlags)(uint32_t),
+                            const char *hex, int hexLen)
+{
+   unsigned int v;
+   int i;
+
+   if (hexLen < GDB_RISC_NUM_REGS * 8)
+      return -1;
+
+   for (i = 0; i < 32; i++)
+   {
+      if (GDBParseHexU32(hex + (i * 8), 8, &v) < 0)
+         return -1;
+      setReg(i, v);
+   }
+
+   if (GDBParseHexU32(hex + (GDB_RISC_REG_PC * 8), 8, &v) < 0)
+      return -1;
+   setPC(v);
+
+   if (GDBParseHexU32(hex + (GDB_RISC_REG_FLAGS * 8), 8, &v) < 0)
+      return -1;
+   setFlags(v);
+
+   return 0;
+}
+
+static int GDBReadRegsGPU(void *user, char *out, int outMax)
+{
+   (void)user;
+   return GDBReadRegsRISC(GPUGetReg, GPUGetPC(), GPUGetFlags(), out, outMax);
+}
+
+static int GDBWriteRegsGPU(void *user, const char *hex, int hexLen)
+{
+   (void)user;
+   return GDBWriteRegsRISC(GPUSetReg, GPUSetPC, GPUSetFlags, hex, hexLen);
+}
+
+static int GDBReadRegsDSP(void *user, char *out, int outMax)
+{
+   (void)user;
+   return GDBReadRegsRISC(DSPGetReg, DSPGetPC(), DSPGetFlags(), out, outMax);
+}
+
+static int GDBWriteRegsDSP(void *user, const char *hex, int hexLen)
+{
+   (void)user;
+   return GDBWriteRegsRISC(DSPSetReg, DSPSetPC, DSPSetFlags, hex, hexLen);
+}
+
+/* ------------------------------------------------------------------ */
+/* qXfer:features:read -- custom target descriptions for GPU/DSP        */
+/* Register numbering (R0-R31=0-31, PC=32, FLAGS=33) is fixed forever   */
+/* once shipped -- docs/gdb-stub-design.md Open Question 3.             */
+/* ------------------------------------------------------------------ */
+
+static char gdbGpuXML[2048];
+static char gdbDspXML[2048];
+static int gdbGpuXMLLen = -1;
+static int gdbDspXMLLen = -1;
+
+static int GDBBuildRiscXML(const char *featureName, char *buf, int bufMax)
+{
+   int n = 0;
+   int i;
+
+   n += snprintf(buf + n, (size_t)(bufMax - n),
+      "<?xml version=\"1.0\"?>\n"
+      "<!DOCTYPE target SYSTEM \"gdb-target.dtd\">\n"
+      "<target>\n"
+      "  <feature name=\"%s\">\n", featureName);
+
+   for (i = 0; i < 32; i++)
+      n += snprintf(buf + n, (size_t)(bufMax - n),
+         "    <reg name=\"r%d\" bitsize=\"32\" type=\"uint32\"/>\n", i);
+
+   n += snprintf(buf + n, (size_t)(bufMax - n),
+      "    <reg name=\"pc\" bitsize=\"32\" type=\"code_ptr\"/>\n"
+      "    <reg name=\"flags\" bitsize=\"32\" type=\"uint32\"/>\n"
+      "  </feature>\n"
+      "</target>\n");
+
+   if (n < 0)
+      return 0;
+   return (n >= bufMax) ? bufMax - 1 : n;
+}
+
+static const char *GDBGpuTargetXML(void *user, int *xmlLen)
+{
+   (void)user;
+   if (gdbGpuXMLLen < 0)
+      gdbGpuXMLLen = GDBBuildRiscXML("org.atari.jaguar.gpu", gdbGpuXML,
+                                     (int)sizeof(gdbGpuXML));
+   *xmlLen = gdbGpuXMLLen;
+   return gdbGpuXML;
+}
+
+static const char *GDBDspTargetXML(void *user, int *xmlLen)
+{
+   (void)user;
+   if (gdbDspXMLLen < 0)
+      gdbDspXMLLen = GDBBuildRiscXML("org.atari.jaguar.dsp", gdbDspXML,
+                                     (int)sizeof(gdbDspXML));
+   *xmlLen = gdbDspXMLLen;
+   return gdbDspXML;
+}
+
+/* ------------------------------------------------------------------ */
+/* monitor commands (qRcmd) -- 68K ops only; internally dispatches to   */
+/* whichever processor the command names. docs/gdb-stub-design.md       */
+/* "monitor commands": reuses the ONE disassembler (gdbdisasm.h), does  */
+/* not write a second one.                                              */
+/* ------------------------------------------------------------------ */
+
+static uint16_t GDBRiscReadWord(int target, uint32_t addr)
+{
+   if (target == GDB_TGT_GPU)
+      return GPUReadWord(addr, DEBUGGER);
+   return DSPReadWord(addr, DEBUGGER);
+}
+
+static int GDBMonitorDisasm(const char *args, char *out, int outMax)
+{
+   char which[8];
+   unsigned int addr = 0, count = 4;
+   int target;
+   const char * const *mnemonics;
+   int n = 0;
+   unsigned int i;
+
+   if (sscanf(args, "%7s %x %u", which, &addr, &count) < 2)
+      return snprintf(out, (size_t)outMax,
+         "usage: monitor disasm <gpu|dsp> <addr> [count]\n");
+
+   if (strcmp(which, "gpu") == 0)
+   {
+      target = GDB_TGT_GPU;
+      mnemonics = GDBDisasmGPUMnemonics;
+   }
+   else if (strcmp(which, "dsp") == 0)
+   {
+      target = GDB_TGT_DSP;
+      mnemonics = GDBDisasmDSPMnemonics;
+   }
+   else
+      return snprintf(out, (size_t)outMax, "unknown target '%s' (want gpu or dsp)\n", which);
+
+   if (count > 64)
+      count = 64;
+
+   for (i = 0; i < count && n < outMax - 2; i++)
+   {
+      uint32_t a = addr + i * 2;
+      uint16_t w  = GDBRiscReadWord(target, a);
+      uint16_t w2 = ((w >> 10) == 38) ? GDBRiscReadWord(target, a + 2) : 0;
+      uint16_t w3 = ((w >> 10) == 38) ? GDBRiscReadWord(target, a + 4) : 0;
+
+      n += GDBDisasmOne(mnemonics, a, w, w2, w3, out + n, outMax - n - 1);
+      if (n < outMax - 1)
+         out[n++] = '\n';
+   }
+
+   return n;
+}
+
+static int GDBMonitorRegs(const char *args, char *out, int outMax)
+{
+   char which[8];
+
+   if (sscanf(args, "%7s", which) < 1)
+      which[0] = '\0';
+
+   if (strcmp(which, "gpu") == 0)
+   {
+      int i, n = 0;
+
+      n += snprintf(out + n, (size_t)(outMax - n), "GPU PC=$%06X FLAGS=$%08X CTRL=$%08X\n",
+                    GPUGetPC(), GPUGetFlags(), GPUGetControl());
+      for (i = 0; i < 32; i++)
+         n += snprintf(out + n, (size_t)(outMax - n), "r%-2d=$%08X%s", i,
+                       GPUGetReg(i), (i % 4 == 3) ? "\n" : "  ");
+      return n;
+   }
+
+   if (strcmp(which, "dsp") == 0)
+   {
+      int i, n = 0;
+
+      n += snprintf(out + n, (size_t)(outMax - n), "DSP PC=$%06X FLAGS=$%08X CTRL=$%08X\n",
+                    DSPGetPC(), DSPGetFlags(), DSPGetControl());
+      for (i = 0; i < 32; i++)
+         n += snprintf(out + n, (size_t)(outMax - n), "r%-2d=$%08X%s", i,
+                       DSPGetReg(i), (i % 4 == 3) ? "\n" : "  ");
+      return n;
+   }
+
+   return snprintf(out, (size_t)outMax,
+      "68K PC=$%06X SR=$%04X\n", m68k_get_reg(NULL, M68K_REG_PC),
+      m68k_get_reg(NULL, M68K_REG_SR));
+}
+
+static int GDBMonitorHalt(const char *args, char *out, int outMax)
+{
+   char which[8];
+   int target;
+
+   if (sscanf(args, "%7s", which) < 1)
+      return snprintf(out, (size_t)outMax, "usage: monitor halt <68k|gpu|dsp>\n");
+
+   if (strcmp(which, "68k") == 0)
+      target = GDB_TGT_68K;
+   else if (strcmp(which, "gpu") == 0)
+      target = GDB_TGT_GPU;
+   else if (strcmp(which, "dsp") == 0)
+      target = GDB_TGT_DSP;
+   else
+      return snprintf(out, (size_t)outMax, "unknown target '%s'\n", which);
+
+   /* Arms unconditionally for the very next instruction on that
+    * processor -- takes effect next time it actually runs, same one-shot
+    * primitive `s`/vCont;s and the gdb_wait boot halt use. */
+   gdbBp[target].oneShot       = 1;
+   gdbBp[target].oneShotReason = GDB_STOP_USER;
+   GDBRecomputeArmed(target);
+
+   return snprintf(out, (size_t)outMax,
+      "%s will halt on its next instruction\n", which);
+}
+
+static int GDBMonitorTrace(const char *args, char *out, int outMax)
+{
+   int n = 0;
+   unsigned i;
+   unsigned start;
+
+   (void)args;
+
+   /* The #542 traceback ring: 0x400 entries, pcQPtr is the NEXT slot to
+    * write, so the oldest live entry is right there and the newest is
+    * one behind it. Dump oldest-to-newest, capped so a 4096-byte reply
+    * buffer never overflows (each line is at most ~9 chars). */
+   start = pcQPtr;
+   for (i = 0; i < 0x400 && n < outMax - 16; i++)
+   {
+      unsigned idx = (start + i) & 0x3FF;
+
+      n += snprintf(out + n, (size_t)(outMax - n), "$%06X\n", pcQueue[idx]);
+   }
+
+   return n;
+}
+
+static int GDBMonitorWatch(const char *args, char *out, int outMax)
+{
+   char kindStr[8];
+   unsigned int addr;
+   int type = GDB_BP_WATCH_RW;
+   int scanned;
+   int rc;
+
+   kindStr[0] = '\0';
+   scanned = sscanf(args, "%x %7s", &addr, kindStr);
+
+   if (scanned >= 1)
+   {
+      if (strcmp(kindStr, "w") == 0)
+         type = GDB_BP_WATCH_WR;
+      else if (strcmp(kindStr, "r") == 0)
+         type = GDB_BP_WATCH_RD;
+
+      rc = GDBInsertWatch(addr, type);
+      if (rc == -2)
+         return snprintf(out, (size_t)outMax,
+            "watch slot already in use by a different address\n");
+
+      return snprintf(out, (size_t)outMax, "watchpoint armed at $%06X\n", addr);
+   }
+
+   gdbWatchArmed    = 0;
+   gdbWatchKindMask = 0;
+   bpmActive        = false;
+
+   return snprintf(out, (size_t)outMax, "watchpoint cleared\n");
+}
+
+static int GDBMonitorCmd(void *user, const char *cmd, char *out, int outMax)
+{
+   (void)user;
+
+   if (strncmp(cmd, "disasm", 6) == 0)
+      return GDBMonitorDisasm(cmd + 6, out, outMax);
+   if (strncmp(cmd, "regs", 4) == 0)
+      return GDBMonitorRegs(cmd + 4, out, outMax);
+   if (strncmp(cmd, "halt", 4) == 0)
+      return GDBMonitorHalt(cmd + 4, out, outMax);
+   if (strncmp(cmd, "trace", 5) == 0)
+      return GDBMonitorTrace(cmd + 5, out, outMax);
+   if (strncmp(cmd, "watch", 5) == 0)
+      return GDBMonitorWatch(cmd + 5, out, outMax);
+
+   return snprintf(out, (size_t)outMax,
+      "unknown monitor command '%s'\n"
+      "commands: disasm <gpu|dsp> <addr> [count], regs [gpu|dsp],\n"
+      "          halt <68k|gpu|dsp>, trace, watch [<addr> [r|w]]\n", cmd);
+}
+
+/* ------------------------------------------------------------------ */
+/* Target ops tables                                                    */
+/* ------------------------------------------------------------------ */
+
 const struct GDBTargetOps *GDBJaguarOps(void)
 {
    static struct GDBTargetOps ops;
 
-   ops.readRegisters = GDBReadRegs68K;
-   ops.readMemory    = GDBReadMem68K;
+   ops.readRegisters  = GDBReadRegs68K;
+   ops.writeRegisters = GDBWriteRegs68K;
+   ops.readMemory     = GDBReadMem68K;
+   ops.writeMemory    = GDBWriteMem68K;
+   ops.insertBreak    = GDB68KInsertBreak;
+   ops.removeBreak    = GDB68KRemoveBreak;
+   ops.targetXML      = NULL;   /* thread 1: GDB's native m68k description */
+   ops.monitorCmd     = GDBMonitorCmd;
    return &ops;
+}
+
+const struct GDBTargetOps *GDBGpuOps(void)
+{
+   static struct GDBTargetOps ops;
+
+   ops.readRegisters  = GDBReadRegsGPU;
+   ops.writeRegisters = GDBWriteRegsGPU;
+   /* Memory is the same unified 24-bit bus for every processor -- see
+    * the comment above GDBWriteMem68K. */
+   ops.readMemory     = GDBReadMem68K;
+   ops.writeMemory    = GDBWriteMem68K;
+   ops.insertBreak    = GDBGpuInsertBreak;
+   ops.removeBreak    = GDBGpuRemoveBreak;
+   ops.targetXML      = GDBGpuTargetXML;
+   ops.monitorCmd     = NULL;   /* only thread 1's ops.monitorCmd is called */
+   return &ops;
+}
+
+const struct GDBTargetOps *GDBDspOps(void)
+{
+   static struct GDBTargetOps ops;
+
+   ops.readRegisters  = GDBReadRegsDSP;
+   ops.writeRegisters = GDBWriteRegsDSP;
+   ops.readMemory     = GDBReadMem68K;
+   ops.writeMemory    = GDBWriteMem68K;
+   ops.insertBreak    = GDBDspInsertBreak;
+   ops.removeBreak    = GDBDspRemoveBreak;
+   ops.targetXML      = GDBDspTargetXML;
+   ops.monitorCmd     = NULL;
+   return &ops;
+}
+
+/* ------------------------------------------------------------------ */
+/* Session, socket pump and the blocking halt loop                      */
+/* ------------------------------------------------------------------ */
+
+static struct GDBSession gdbSession;
+static char gdbRxBuf[GDB_PACKET_MAX];
+static int  gdbRxLen = 0;
+static int  gdbHaltedTarget = -1;
+static int  gdbHaltTimeoutSeconds = 0;
+static int  gdbClientWasPresent = 0;
+static int  gdbClientAttachEventPending = 0;
+
+static void GDBSleepMs(int ms)
+{
+#if defined(_WIN32)
+   Sleep((DWORD)ms);
+#else
+   usleep((unsigned int)(ms * 1000));
+#endif
+}
+
+/*
+ * One non-blocking pass: accept, drain whatever the socket has into
+ * gdbRxBuf, dispatch every complete "$...#cs" packet currently buffered.
+ * Handles the low-level +/- ack byte (docs/gdb-stub-design.md Testing
+ * item 5's "off-by-one": the packet that flips into no-ack mode is
+ * itself still acked; nothing received after is). Returns 1 if the
+ * client disconnected during this pass (everything already disarmed by
+ * the time it returns), 0 otherwise.
+ */
+static int GDBPumpOnce(int *resumeRequested, int *resumeIsStep)
+{
+   int wasClientPresent;
+
+   GDBSockPoll();
+
+   wasClientPresent = gdbClientWasPresent;
+   gdbClientWasPresent = GDBSockHasClient();
+   if (!wasClientPresent && gdbClientWasPresent)
+   {
+      LOG_INF("[GDB] client attached\n");
+      gdbClientAttachEventPending = 1;
+   }
+
+   for (;;)
+   {
+      int room = (int)sizeof(gdbRxBuf) - gdbRxLen;
+      int n;
+
+      if (room <= 0)
+      {
+         gdbRxLen = 0;
+         break;
+      }
+
+      n = GDBSockRecv(gdbRxBuf + gdbRxLen, room);
+      if (n < 0)
+      {
+         gdbRxLen = 0;
+         gdbClientWasPresent = 0;
+         GDBTargetResetState();
+         return 1;
+      }
+      if (n == 0)
+         break;
+
+      gdbRxLen += n;
+   }
+
+   for (;;)
+   {
+      static char payload[GDB_PACKET_MAX];
+      static char reply[GDB_PACKET_MAX];
+      static char encoded[GDB_PACKET_MAX + 8];
+      int i;
+      int dollarAt = -1;
+      int hashAt   = -1;
+      int payLen, consumed, remaining;
+
+      for (i = 0; i < gdbRxLen; i++)
+      {
+         if (gdbRxBuf[i] == '$')
+         {
+            dollarAt = i;
+            break;
+         }
+      }
+
+      if (dollarAt < 0)
+      {
+         /* Nothing but stray +/- ack bytes (or garbage) buffered. */
+         gdbRxLen = 0;
+         break;
+      }
+
+      for (i = dollarAt + 1; i < gdbRxLen; i++)
+      {
+         if (gdbRxBuf[i] == '#')
+         {
+            hashAt = i;
+            break;
+         }
+      }
+
+      if (hashAt < 0 || (hashAt + 2) >= gdbRxLen)
+      {
+         if (dollarAt > 0)
+         {
+            remaining = gdbRxLen - dollarAt;
+            memmove(gdbRxBuf, gdbRxBuf + dollarAt, (size_t)remaining);
+            gdbRxLen = remaining;
+         }
+         break;
+      }
+
+      payLen = GDBDecodePacket(gdbRxBuf + dollarAt, hashAt + 3 - dollarAt,
+                               payload, (int)sizeof(payload));
+
+      if (payLen >= 0)
+      {
+         int wasAckMode = !gdbSession.noAckMode;
+         int replyLen, encLen;
+         int myResume = 0, myStep = 0;
+
+         if (wasAckMode)
+            GDBSockSend("+", 1);
+
+         replyLen = GDBHandlePacket(&gdbSession, payload, payLen,
+                                    reply, (int)sizeof(reply),
+                                    &myResume, &myStep);
+
+         if (replyLen > 0)
+         {
+            encLen = GDBEncodePacket(reply, replyLen, encoded,
+                                     (int)sizeof(encoded));
+            if (encLen > 0)
+               GDBSockSend(encoded, encLen);
+         }
+
+         if (myResume)
+         {
+            *resumeRequested = 1;
+            *resumeIsStep     = myStep;
+         }
+      }
+      else if (payLen == -2 && !gdbSession.noAckMode)
+      {
+         /* Checksum mismatch: ask the client to retransmit. */
+         GDBSockSend("-", 1);
+      }
+
+      consumed  = hashAt + 3;
+      remaining = gdbRxLen - consumed;
+      memmove(gdbRxBuf, gdbRxBuf + consumed, (size_t)remaining);
+      gdbRxLen = remaining;
+   }
+
+   return 0;
+}
+
+void GDBTargetServicePoll(void)
+{
+   int resumeRequested = 0, resumeIsStep = 0;
+
+   /* Not halted: a stray c/s/vCont (a client racing an unsolicited
+    * continue, or simple client bugs) has nothing to resume. Discard it
+    * rather than let it leak into a future real halt. */
+   GDBPumpOnce(&resumeRequested, &resumeIsStep);
+}
+
+int GDBSockHasClientAttachEvent(void)
+{
+   if (!gdbClientAttachEventPending)
+      return 0;
+   gdbClientAttachEventPending = 0;
+   return 1;
+}
+
+void GDBTargetSetHaltTimeout(int seconds)
+{
+   gdbHaltTimeoutSeconds = seconds;
+}
+
+void GDBTargetArmWaitAtBoot(void)
+{
+   gdbBp[GDB_TGT_68K].oneShot       = 1;
+   gdbBp[GDB_TGT_68K].oneShotReason = GDB_STOP_USER;
+   GDBRecomputeArmed(GDB_TGT_68K);
+}
+
+void GDBHalt(int target, int reason, unsigned int pc)
+{
+   time_t startTime;
+   char stopMsg[32];
+   char encoded[48];
+   int encLen;
+   int effectiveReason;
+
+   if (target < 0 || target >= GDB_NUM_TARGETS)
+      return;
+
+   effectiveReason = (reason == GDB_STOP_BREAKPOINT) ? gdbLastReason[target] : reason;
+   gdbHaltedTarget = target;
+   startTime = time(NULL);
+
+   LOG_INF("[GDB] halt: target=%d reason=%d pc=$%06X\n", target, effectiveReason, pc);
+
+   sprintf(stopMsg, "T05thread:%x;", target + 1);
+   encLen = GDBEncodePacket(stopMsg, (int)strlen(stopMsg), encoded, (int)sizeof(encoded));
+   if (encLen > 0)
+      GDBSockSend(encoded, encLen);
+
+   for (;;)
+   {
+      int resumeRequested = 0, resumeIsStep = 0;
+
+      if (GDBPumpOnce(&resumeRequested, &resumeIsStep))
+         break;   /* client disconnected -- GDBTargetResetState() already ran */
+
+      if (resumeRequested)
+      {
+         if (resumeIsStep)
+         {
+            gdbBp[target].oneShot       = 1;
+            gdbBp[target].oneShotReason = GDB_STOP_STEP;
+            GDBRecomputeArmed(target);
+         }
+         break;
+      }
+
+      if (gdbHaltTimeoutSeconds > 0 &&
+          (int)difftime(time(NULL), startTime) >= gdbHaltTimeoutSeconds)
+      {
+         LOG_WRN("[GDB] halt-timeout (%ds) with no continue -- auto-resuming "
+                 "(breakpoints stay armed; expect this to repeat if the same "
+                 "PC is hit again)\n", gdbHaltTimeoutSeconds);
+         break;
+      }
+
+      GDBSleepMs(2);
+   }
+
+   gdbHaltedTarget = -1;
+}
+
+void GDBTargetResetState(void)
+{
+   int t;
+
+   for (t = 0; t < GDB_NUM_TARGETS; t++)
+   {
+      int i;
+
+      gdbBp[t].count    = 0;
+      gdbBp[t].oneShot  = 0;
+      for (i = 0; i < GDB_MAX_BP; i++)
+         gdbBp[t].used[i] = 0;
+      for (i = 0; i < GDB_BP_CACHE_SIZE; i++)
+         gdbBp[t].cache[i] = GDB_BP_EMPTY;
+      GDBRecomputeArmed(t);
+   }
+
+   gdbWatchArmed    = 0;
+   gdbWatchKindMask = 0;
+   bpmActive        = false;
+
+   gdbHaltedTarget         = -1;
+   gdbRxLen                = 0;
+   gdbClientWasPresent     = 0;
+   gdbClientAttachEventPending = 0;
+   gdbSession.threadG = 1;
+   gdbSession.threadC = 1;
+}
+
+void GDBTargetOpen(void)
+{
+   GDBSessionInit(&gdbSession, GDBJaguarOps(), NULL);
+   GDBSessionSetTargetOps(&gdbSession, GDB_TGT_GPU, GDBGpuOps(), NULL);
+   GDBSessionSetTargetOps(&gdbSession, GDB_TGT_DSP, GDBDspOps(), NULL);
+   GDBTargetResetState();
+}
+
+void GDBTargetClose(void)
+{
+   GDBTargetResetState();
+   gdbHaltTimeoutSeconds = 0;
 }

--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -33,6 +33,7 @@
 #include "bus_arbiter.h"
 #include "../core/vjtrace.h"
 #include "perf_iface.h"
+#include "gdbstub.h"
 
 // Seems alignment in loads & stores was off...
 #define DSP_CORRECT_ALIGNMENT
@@ -951,23 +952,62 @@ uint32_t DSPGetFlags(void)
 	return dsp_flags;
 }
 
-/* vjtrace_snapshot() (src/core/vjtrace.c) is itself compiled only under
- * VJ_TRACE; DSPGetReg is new-for-vjtrace surface (unlike GPU's
- * pre-existing #406 GPUGetReg, left unguarded elsewhere), so it
- * compiles out entirely in shipped/non-test builds rather than relying
- * solely on exports.list to hide it. */
-#ifdef VJ_TRACE
-/* Diagnostic-only accessor (vjtrace #408 snapshot export): expose a DSP
- * register by index from the CURRENT bank, mirroring GPUGetReg in
- * src/tom/gpu.c. Not part of the shipped ABI (production link uses
- * exports.list, which does not have the _DSP* wildcard). */
+/* Write side of DSPGetFlags, added for the GDB stub (issue #652). A raw
+ * poke of dsp_flags -- see GPUSetFlags in src/tom/gpu.c for why this
+ * bypasses the D_FLAGS MMIO write path (interrupt-mask side effects a
+ * debugger write should not trigger as a side effect of merely wanting
+ * to see a different N/C/Z combination). */
+void DSPSetFlags(uint32_t v)
+{
+	dsp_flags = v;
+}
+
+/* DSPGetPC/DSPSetPC, added for the GDB stub (issue #652): dsp_pc had no
+ * accessor at all before this (GPU's equivalent, GPUGetPC, predates
+ * vjtrace -- issue #406). Raw poke on the write side, like GPUSetPC. */
+uint32_t DSPGetPC(void)
+{
+	return dsp_pc;
+}
+
+void DSPSetPC(uint32_t pc)
+{
+	dsp_pc = pc;
+}
+
+/* Diagnostic-only accessor, added for `monitor regs dsp` (the GDB stub,
+ * issue #652): the raw D_CTRL value, read-only -- see GPUGetControl in
+ * src/tom/gpu.c for why the write side is not exposed. */
+uint32_t DSPGetControl(void)
+{
+	return dsp_control;
+}
+
+/* Originally vjtrace-only (#408) and gated behind VJ_TRACE, like GPU's
+ * GPUGetReg was NOT (issue #406, pre-existing). The GDB stub (issue
+ * #652) needs DSPGetReg in every build (shipped-by-default, off by
+ * default -- see docs/gdb-stub-design.md), so it is unconditional now,
+ * matching GPUGetReg. This does not change the shipped dylib's exported
+ * symbol list -- production links still use exports.list, which never
+ * listed either accessor. */
 uint32_t DSPGetReg(int n)
 {
 	if (n < 0 || n > 31)
 		return 0;
 	return dsp_reg[n];
 }
-#endif /* VJ_TRACE */
+
+/* Write side of DSPGetReg, added for the GDB stub (issue #652). Pokes
+ * the ACTIVE bank directly, mirroring GPUSetReg's reasoning in
+ * src/tom/gpu.c: the $F1A000-range MMIO register window addresses both
+ * banks unconditionally by register number, which is NOT what "the
+ * current register file" means once REGPAGE has flipped. */
+void DSPSetReg(int n, uint32_t v)
+{
+	if (n < 0 || n > 31)
+		return;
+	dsp_reg[n] = v;
+}
 
 void DSPInit(void)
 {
@@ -1860,6 +1900,19 @@ void DSPExec(int32_t cycles)
 	if (vjtrace_armed || vjtrace_nwatch)
 		idleSkipActive = 0;
 #endif
+#ifndef VJ_GDB_STUB_DISABLE_HOOKS
+	/* GDB stub (issue #652): DSPIdleLoopProbe() extrapolates the PC
+	 * forward over many idle-loop iterations without visiting each one,
+	 * exactly the class of per-instruction side effect the #569 idle-skip
+	 * gate list above already disables for (blit memo, busArbiter,
+	 * vjtrace watch). A DSP breakpoint or pending step would be stepped
+	 * clean over. This is a RUNTIME check, same reasoning as the VJ_TRACE
+	 * block above: gdbArmedDSP defaults to 0 and costs one load + branch
+	 * when nothing is armed. VJ_GDB_STUB_DISABLE_HOOKS exists only for
+	 * the Phase 2 A/B perf measurement. */
+	if (gdbArmedDSP)
+		idleSkipActive = 0;
+#endif
 	/* Probe + reject memo are re-derived from scratch every call, so
 	 * nothing here reaches a savestate and nothing survives a slice. */
 	idleProbeStage = 0;
@@ -1920,6 +1973,18 @@ void DSPExec(int32_t cycles)
 		}
 
 		pcThis = dsp_pc;
+
+#ifndef VJ_GDB_STUB_DISABLE_HOOKS
+		/* GDB stub (issue #652): one load of a hot global, one
+		 * never-taken branch when no DSP breakpoint/step is armed -- see
+		 * docs/gdb-stub-design.md "Breakpoint detection". GDBHalt()
+		 * blocks in place (does not unwind this loop) until the client
+		 * continues, steps, or disconnects. VJ_GDB_STUB_DISABLE_HOOKS
+		 * exists only for the Phase 2 A/B perf measurement -- see the
+		 * comment in src/core/jaguar.c's M68KInstructionHook(). */
+		if (gdbArmedDSP && GDBCheckPC(GDB_TGT_DSP, pcThis))
+			GDBHalt(GDB_TGT_DSP, GDB_STOP_BREAKPOINT, pcThis);
+#endif
 
 		if (dsp_pc >= DSP_WORK_RAM_BASE && dsp_pc < DSP_WORK_RAM_BASE + 0x2000)
 		{

--- a/src/jerry/dsp.h
+++ b/src/jerry/dsp.h
@@ -37,6 +37,15 @@ void DSPReleaseTimeslice(void);
 bool DSPIsRunning(void);
 uint8_t *DSPGetRAM(void);
 uint32_t DSPGetFlags(void);
+void DSPSetFlags(uint32_t v);
+/* GDB stub accessors (issue #652): the active register bank and PC,
+ * read and write. See src/jerry/dsp.c for why the writes are raw pokes
+ * rather than routed through the MMIO write path. */
+uint32_t DSPGetPC(void);
+void DSPSetPC(uint32_t pc);
+uint32_t DSPGetControl(void);
+uint32_t DSPGetReg(int n);
+void DSPSetReg(int n, uint32_t v);
 
 void DSPExecP(int32_t cycles);
 void DSPExecP2(int32_t cycles);

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -38,6 +38,7 @@
 #include "../core/vjtrace.h"
 #include "../core/crash_detect.h"
 #include "perf_iface.h"
+#include "gdbstub.h"
 
 
 // Seems alignment in loads & stores was off...
@@ -690,10 +691,24 @@ uint32_t GPUGetPC(void)
 	return gpu_pc;
 }
 
+/* Diagnostic-only accessor, added for `monitor regs gpu` (the GDB stub,
+ * issue #652): the raw G_CTRL value (GPUGO, SINGLE_STEP, IMASK and the
+ * REGPAGE bit), read-only -- writing this is not exposed, since it is
+ * exactly the register real hardware uses to start/stop the RISC core
+ * and a debugger accidentally toggling GPUGO would be far more
+ * surprising than useful. */
+uint32_t GPUGetControl(void)
+{
+	return gpu_control;
+}
+
 /* Diagnostic-only accessor (issue #406 investigation): expose the active
  * register bank so test harnesses can inspect GPU register state without
  * a full savestate. Not part of the shipped ABI (production link uses
- * exports.list, which does not have the _GPU* wildcard). */
+ * exports.list, which does not have the _GPU* wildcard). Also used
+ * unconditionally by the GDB stub (src/debug/gdbtarget.c, issue #652)
+ * to serve GDB thread 2's register file -- see GPUSetReg below for the
+ * write side. */
 uint32_t GPUGetReg(int n)
 {
 	if (n < 0 || n > 31)
@@ -701,19 +716,27 @@ uint32_t GPUGetReg(int n)
 	return gpu_reg[n];
 }
 
-/* vjtrace_snapshot() (src/core/vjtrace.c) is itself compiled only under
- * VJ_TRACE, so its two supporting accessors below are guarded the same
- * way -- unlike GPUGetReg above (pre-existing, #406, left as-is), these
- * are new-for-vjtrace surface and the project convention is that all
- * new vjtrace-only code compiles out entirely in shipped/non-test
- * builds rather than relying solely on exports.list to hide it. */
-#ifdef VJ_TRACE
-/* Diagnostic-only accessor (vjtrace #408 snapshot export): expose GPU
- * local work RAM (the REGSGPU/GPURAM sections of vjtrace_snapshot()).
- * Same not-in-shipped-ABI caveat as GPUGetReg above. */
-uint8_t * GPUGetRAM(void)
+/* Write side of GPUGetReg, added for the GDB stub (issue #652): "G"
+ * (write all registers) pokes the ACTIVE bank directly, exactly
+ * mirroring what GPUGetReg reads -- not the $F02000-$F020FF MMIO window,
+ * which addresses both banks unconditionally by register number and
+ * would silently write the wrong one whenever REGPAGE has bank_1
+ * active. A raw poke, like m68k_set_reg(): no side effects, same as any
+ * other debugger register write. */
+void GPUSetReg(int n, uint32_t v)
 {
-	return gpu_ram_8;
+	if (n < 0 || n > 31)
+		return;
+	gpu_reg[n] = v;
+}
+
+/* GPUGetPC's write counterpart, added for the GDB stub (issue #652). A
+ * raw poke of gpu_pc, not a simulated G_CTRL PC-latch write -- GDB
+ * setting PC must not also toggle GPUGO or any other control-register
+ * side effect. */
+void GPUSetPC(uint32_t pc)
+{
+	gpu_pc = pc;
 }
 
 /* Diagnostic-only accessor: raw GPU_FLAGS/control register value. Like
@@ -721,10 +744,35 @@ uint8_t * GPUGetRAM(void)
  * separately in gpu_flag_n/c/z for cheap RMW) are merged into gpu_flags
  * only on the $F02100 register-read path (see the case 0x00 block
  * above), so this can read one flag update stale mid-instruction --
- * snapshot-quality only, not for cycle-exact NCZ probes. */
+ * snapshot-quality only, not for cycle-exact NCZ probes.
+ *
+ * Originally vjtrace-only (#408) and gated behind VJ_TRACE; the GDB stub
+ * (issue #652) needs it in every build (shipped-by-default, off by
+ * default -- see docs/gdb-stub-design.md), so it is unconditional now.
+ * This does not change the shipped dylib's exported symbol list --
+ * production links still use exports.list, which never listed this. */
 uint32_t GPUGetFlags(void)
 {
 	return gpu_flags;
+}
+
+/* Write side of GPUGetFlags, added for the GDB stub (issue #652). A raw
+ * poke of gpu_flags -- see the GPUSetPC comment above for why this
+ * bypasses the G_FLAGS MMIO write path (interrupt-mask side effects a
+ * debugger write should not trigger as a side effect of merely wanting
+ * to see a different N/C/Z combination). */
+void GPUSetFlags(uint32_t v)
+{
+	gpu_flags = v;
+}
+
+#ifdef VJ_TRACE
+/* Diagnostic-only accessor (vjtrace #408 snapshot export): expose GPU
+ * local work RAM (the REGSGPU/GPURAM sections of vjtrace_snapshot()).
+ * Same not-in-shipped-ABI caveat as GPUGetReg above. */
+uint8_t * GPUGetRAM(void)
+{
+	return gpu_ram_8;
 }
 #endif /* VJ_TRACE */
 
@@ -1463,6 +1511,18 @@ void GPUExec(int32_t cycles)
 #ifdef VJ_TRACE
       VJT_PCHIST_GPU(gpu_pc);
 #endif
+#ifndef VJ_GDB_STUB_DISABLE_HOOKS
+      /* GDB stub (issue #652): one load of a hot global, one never-taken
+       * branch when no GPU breakpoint/step is armed -- see
+       * docs/gdb-stub-design.md "Breakpoint detection". GDBHalt() blocks
+       * in place (does not unwind this loop) until the client continues,
+       * steps, or disconnects. VJ_GDB_STUB_DISABLE_HOOKS exists only for
+       * the Phase 2 A/B perf measurement -- see the comment in
+       * src/core/jaguar.c's M68KInstructionHook(). */
+      if (gdbArmedGPU && GDBCheckPC(GDB_TGT_GPU, gpu_pc))
+         GDBHalt(GDB_TGT_GPU, GDB_STOP_BREAKPOINT, gpu_pc);
+#endif
+
       if (gpu_pc >= GPU_WORK_RAM_BASE && gpu_pc < GPU_WORK_RAM_BASE + 0x1000)
       {
          uint32_t off = gpu_pc - GPU_WORK_RAM_BASE;

--- a/src/tom/gpu.h
+++ b/src/tom/gpu.h
@@ -45,6 +45,15 @@ void GPUWriteWord(uint32_t offset, uint16_t data, uint32_t who);
 void GPUWriteLong(uint32_t offset, uint32_t data, uint32_t who);
 
 uint32_t GPUGetPC(void);
+/* GDB stub accessors (issue #652): the active register bank, PC and
+ * flags register, read and write. See src/tom/gpu.c for why the writes
+ * are raw pokes rather than routed through the MMIO write path. */
+uint32_t GPUGetReg(int n);
+void GPUSetReg(int n, uint32_t v);
+void GPUSetPC(uint32_t pc);
+uint32_t GPUGetFlags(void);
+void GPUSetFlags(uint32_t v);
+uint32_t GPUGetControl(void);
 void GPUReleaseTimeslice(void);
 void GPUCPUINTCallback(void);
 void GPUResetStats(void);

--- a/test/tools/gdb_attach_probe.py
+++ b/test/tools/gdb_attach_probe.py
@@ -1,5 +1,22 @@
 #!/usr/bin/env python3
-"""Minimal RSP client: attach to the core's GDB stub and validate Phase 1."""
+"""
+Minimal RSP client: attach to the core's GDB stub and validate the wire
+protocol a real `m68k-elf-gdb` actually depends on.
+
+Phase 1's version of this script passed without ever looking at the
+low-level '+'/'-' acknowledgement byte, which is exactly the gap
+docs/gdb-stub-design.md's Testing section calls out: a real gdb stalls on
+its very first qSupported without it. This version reads and verifies
+that byte explicitly, before every reply, until QStartNoAckMode is
+negotiated -- and then verifies acks STOP arriving afterward, including
+the off-by-one case (the OK reply to QStartNoAckMode itself is still
+acked; nothing sent after it is).
+
+Assumes something else has already launched a core with
+virtualjaguar_gdb_stub=enabled on the given port (see
+test/tools/gdb_determinism_probe.c for a way to do that headlessly, or
+attach to a real running RetroArch/session).
+"""
 import socket, sys
 
 def cksum(payload: bytes) -> int:
@@ -9,46 +26,83 @@ def pack(payload: str) -> bytes:
     b = payload.encode()
     return b"$" + b + b"#" + ("%02x" % cksum(b)).encode()
 
-def recv_packet(sock) -> str:
+def recv_reply(sock, expect_ack: bool) -> str:
+    """Reads exactly one ack byte (if expect_ack) followed by one
+    "$...#cs" packet. Raises if the ack is missing/wrong when expected,
+    or if the packet checksum doesn't validate."""
     buf = b""
+
+    if expect_ack:
+        while len(buf) < 1:
+            chunk = sock.recv(1)
+            if not chunk:
+                raise RuntimeError("stub closed the connection waiting for ack")
+            buf += chunk
+        ack, buf = buf[0:1], buf[1:]
+        if ack != b"+":
+            raise RuntimeError(f"expected '+' ack byte, got {ack!r}")
+
     while b"#" not in buf or len(buf.split(b"#")[-1]) < 2:
         chunk = sock.recv(4096)
         if not chunk:
             raise RuntimeError("stub closed the connection")
         buf += chunk
+
+    if buf and buf[0:1] != b"$":
+        raise RuntimeError(f"expected packet to start with '$', got {buf[:16]!r}")
+
     body = buf[buf.index(b"$") + 1 : buf.rindex(b"#")]
     want = int(buf[buf.rindex(b"#") + 1 : buf.rindex(b"#") + 3], 16)
     if cksum(body) != want:
         raise RuntimeError("checksum mismatch from stub")
     return body.decode()
 
+def send_and_check(sock, payload: str, expect_ack: bool) -> str:
+    sock.sendall(pack(payload))
+    return recv_reply(sock, expect_ack)
+
 def main(port: int) -> int:
     s = socket.create_connection(("127.0.0.1", port), timeout=5)
     s.sendall(b"+")
 
-    s.sendall(pack("qSupported:multiprocess+"))
-    sup = recv_packet(s)
+    # --- ack mode: every reply must be preceded by a lone '+' byte. ---
+    sup = send_and_check(s, "qSupported:multiprocess+", expect_ack=True)
     assert "PacketSize=" in sup, f"qSupported lacked PacketSize: {sup!r}"
 
-    s.sendall(pack("?"))
-    assert recv_packet(s) == "S05"
+    assert send_and_check(s, "?", expect_ack=True) == "S05"
 
-    s.sendall(pack("g"))
-    regs = recv_packet(s)
+    regs = send_and_check(s, "g", expect_ack=True)
     assert len(regs) == 144, f"g returned {len(regs)} chars, want 144"
     int(regs, 16)                      # must be pure hex
 
-    s.sendall(pack("m0,10"))
-    mem = recv_packet(s)
+    mem = send_and_check(s, "m0,10", expect_ack=True)
     assert len(mem) == 32, f"m0,10 returned {len(mem)} chars, want 32"
     int(mem, 16)
 
     # A wild address must be refused, not mirrored.
-    s.sendall(pack("mffffffff,4"))
-    assert recv_packet(s) == "E01"
+    assert send_and_check(s, "mffffffff,4", expect_ack=True) == "E01"
+
+    # --- the no-ack transition, including its off-by-one: the OK for
+    # QStartNoAckMode is STILL acked (it was sent while ack mode was
+    # still active); nothing received after it is. ---
+    assert send_and_check(s, "QStartNoAckMode", expect_ack=True) == "OK"
+
+    # From here on, no ack byte should precede any reply.
+    assert send_and_check(s, "?", expect_ack=False) == "S05"
+    regs2 = send_and_check(s, "g", expect_ack=False)
+    assert regs2 == regs, "registers changed between reads with nothing executing"
+
+    # Z0/z0 (software breakpoint) round-trip -- protocol-level only here;
+    # test/tools/gdb_determinism_probe.c and the C unit tests
+    # (test/tools/test_gdbstub_proto.c) cover an actual breakpoint firing
+    # and the armed-flag gate's cost, respectively.
+    assert send_and_check(s, "Z0,1000,2", expect_ack=False) == "OK"
+    assert send_and_check(s, "z0,1000,2", expect_ack=False) == "OK"
 
     s.close()
-    print("PASS: attach, qSupported, halt reason, registers, memory, bounds refusal")
+    print("PASS: attach, ack byte (every reply), no-ack transition "
+          "(including the QStartNoAckMode-reply-is-still-acked case), "
+          "halt reason, registers, memory, bounds refusal, breakpoint insert/remove")
     return 0
 
 if __name__ == "__main__":

--- a/test/tools/gdb_breakpoint_probe.py
+++ b/test/tools/gdb_breakpoint_probe.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+gdb_breakpoint_probe.py -- end-to-end proof that a Z0 breakpoint actually
+halts execution at the armed address (issue #652, Phase 2).
+
+test/tools/test_gdbstub_proto.c proves the Z0/z0 PROTOCOL (insert/remove
+call the target ops, replies are correct) with a fake target. It cannot
+prove a real breakpoint actually STOPS the emulated 68000 at the right
+PC, because that requires the machine to actually be running. This
+script does that, deterministically, without depending on any
+particular ROM's boot behaviour:
+
+  1. Launch the core headlessly (test/tools/gdb_determinism_probe as a
+     free-running host process -- it already knows how to open the GDB
+     port from a core option and just run frames).
+  2. Attach, negotiate QStartNoAckMode.
+  3. Write two bytes forming a single 68K instruction -- BRA.S * (opcode
+     0x60FE, "branch to self", i.e. a tight infinite loop) -- into RAM
+     at a scratch address, via the GDB 'M' (write memory) packet.
+  4. Redirect the 68K's PC to that address via 'G' (write registers).
+  5. Arm a Z0 breakpoint at that exact address.
+  6. Continue.
+  7. Because nothing has "used up" the PC value we just poked (a
+     register write is an out-of-band state change, not a hook call),
+     the very next M68KInstructionHook() invocation is for that address
+     and matches the just-armed breakpoint immediately -- the stop reply
+     must name thread 1 (68K) and 'g' must show PC still at that exact
+     address.
+
+This is deterministic and ROM-independent: steps 3-4 make the "what PC
+will the breakpoint hit at" question something WE decide, not something
+that depends on knowing a specific ROM's code layout.
+"""
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LOOP_ADDR = 0x1000
+PORT = 22349
+
+CORE_NAMES = {
+    "darwin": "virtualjaguar_libretro.dylib",
+    "linux": "virtualjaguar_libretro.so",
+    "win32": "virtualjaguar_libretro.dll",
+}
+
+
+def cksum(payload: bytes) -> int:
+    return sum(payload) & 0xFF
+
+
+def pack(payload: str) -> bytes:
+    b = payload.encode()
+    return b"$" + b + b"#" + ("%02x" % cksum(b)).encode()
+
+
+def recv_packet(sock, timeout=10.0) -> str:
+    sock.settimeout(timeout)
+    buf = b""
+    while b"#" not in buf or len(buf.split(b"#")[-1]) < 2:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise RuntimeError("stub closed the connection")
+        buf += chunk
+    body = buf[buf.index(b"$") + 1 : buf.rindex(b"#")]
+    want = int(buf[buf.rindex(b"#") + 1 : buf.rindex(b"#") + 3], 16)
+    if cksum(body) != want:
+        raise RuntimeError(f"checksum mismatch: {buf!r}")
+    return body.decode()
+
+
+def cmd(sock, payload: str, timeout=10.0) -> str:
+    sock.sendall(pack(payload))
+    return recv_packet(sock, timeout)
+
+
+def main() -> int:
+    core = REPO_ROOT / CORE_NAMES.get(sys.platform, "virtualjaguar_libretro.so")
+    rom = REPO_ROOT / "test" / "roms" / "yarc.j64"
+    tool = REPO_ROOT / "test" / "tools" / "gdb_determinism_probe"
+
+    if not core.exists():
+        sys.exit(f"Core not found at {core}. Run `make` first.")
+    if not tool.exists():
+        sys.exit(f"{tool} not built -- see its file header for the build command.")
+
+    # virtualjaguar_gdb_wait halts before the 68000's very first
+    # instruction. This isn't just convenient -- it's load-bearing for
+    # this test's determinism: an already-running ROM's own boot code
+    # (stack usage, RAM clears, blitter/OP destinations) can and does
+    # overwrite an arbitrarily-chosen scratch address within a single
+    # frame, racing our injected instruction before the CPU ever fetches
+    # it (observed directly while developing this script: a plain
+    # `M`-write to 0x1000 without gdb_wait read back as the ROM's own
+    # data moments later). Halting before anything has executed means
+    # nothing else can be writing to RAM yet.
+    proc = subprocess.Popen(
+        [str(tool), str(core), str(rom), "--frames", "100000",
+         "--option", "virtualjaguar_gdb_stub=enabled",
+         "--option", "virtualjaguar_gdb_wait=enabled",
+         "--option", f"virtualjaguar_gdb_port={PORT}"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+    try:
+        s = None
+        for _ in range(50):
+            try:
+                s = socket.create_connection(("127.0.0.1", PORT), timeout=1)
+                break
+            except OSError:
+                time.sleep(0.1)
+        if s is None:
+            sys.exit("could not connect to the core's GDB stub")
+
+        s.sendall(b"+")
+        sup = cmd(s, "qSupported:multiprocess+")
+        assert "PacketSize=" in sup
+
+        assert cmd(s, "QStartNoAckMode") == "OK"
+
+        # We should already be halted (gdb_wait fired on the very first
+        # M68KInstructionHook() call, before our connection even
+        # existed -- its own unsolicited stop reply went to no one).
+        # Confirm via '?' rather than assuming.
+        assert cmd(s, "?") == "S05"
+
+        # 0x60FE = BRA.S -2 (branch to self): a single-instruction,
+        # two-byte infinite loop. Written to scratch RAM while nothing
+        # is running to contend for it.
+        assert cmd(s, f"M{LOOP_ADDR:x},2:60fe") == "OK"
+        assert cmd(s, f"m{LOOP_ADDR:x},2") == "60fe", "write didn't stick before anything ran"
+
+        # Read the current register file, then rewrite only the PC field
+        # (the last 8 of the 144 hex chars: D0-D7, A0-A7, SR, PC) so we
+        # don't disturb SR (interrupt mask / supervisor bit).
+        regs = cmd(s, "g")
+        assert len(regs) == 144, f"g returned {len(regs)} chars, want 144"
+        new_regs = regs[:-8] + f"{LOOP_ADDR:08x}"
+        assert cmd(s, f"G{new_regs}") == "OK"
+
+        assert cmd(s, f"Z0,{LOOP_ADDR:x},2") == "OK"
+
+        # 'c' gets no immediate reply -- the eventual stop reply arrives
+        # out of band, whenever the halted processor actually reports in.
+        # This resumes from the gdb_wait halt; the CPU's very next fetch
+        # is our injected instruction at LOOP_ADDR, which immediately
+        # re-visits LOOP_ADDR (it's a branch to itself) and matches the
+        # Z0 we just armed there -- a REAL breakpoint hit, not the
+        # one-shot that produced the original gdb_wait halt.
+        s.sendall(pack("c"))
+        stop = recv_packet(s, timeout=15.0)
+        assert stop.startswith("T05"), f"expected a T05 stop reply, got {stop!r}"
+        assert "thread:1" in stop, f"expected thread 1 (68K) to report, got {stop!r}"
+
+        pc_regs = cmd(s, "g")
+        halted_pc = pc_regs[-8:]
+        assert halted_pc.lower() == f"{LOOP_ADDR:08x}", (
+            f"halted at PC={halted_pc}, want {LOOP_ADDR:08x} -- the breakpoint "
+            f"fired at the wrong address (or didn't fire and this is a stale "
+            f"reply)")
+
+        assert cmd(s, f"z0,{LOOP_ADDR:x},2") == "OK"
+        s.close()
+
+        print("PASS: injected a real 68K instruction, redirected PC to it, "
+              f"armed Z0 at ${LOOP_ADDR:04x}, continued, and the stub halted "
+              f"there and reported it -- confirmed via a fresh register read "
+              f"(PC=${halted_pc}) after the stop reply named thread 1.")
+        return 0
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/tools/gdb_determinism_probe.c
+++ b/test/tools/gdb_determinism_probe.c
@@ -1,0 +1,265 @@
+/*
+ * gdb_determinism_probe.c -- Phase 2 determinism gate (issue #652).
+ *
+ * docs/gdb-stub-design.md: "With the stub enabled but no breakpoint
+ * armed, emulation is bit-identical to the stub being disabled. This is
+ * a test, not a claim." Prints one savestate digest at --frames; compare
+ * the output across three runs of this tool:
+ *
+ *   ./gdb_determinism_probe core rom --frames 300 \
+ *       --option virtualjaguar_gdb_stub=disabled
+ *   ./gdb_determinism_probe core rom --frames 300 \
+ *       --option virtualjaguar_gdb_stub=enabled --option virtualjaguar_gdb_port=22346
+ *   ./gdb_determinism_probe core rom --frames 300 \
+ *       --option virtualjaguar_gdb_stub=enabled --option virtualjaguar_gdb_port=22347 \
+ *       --attach-port 22347
+ *
+ * The third run's --attach-port spawns a background thread that opens a
+ * raw RSP client connection, negotiates QStartNoAckMode exactly like a
+ * real `gdb` attach, and holds the socket open (arming zero breakpoints)
+ * for the rest of the run -- this is the "enabled, attached, zero
+ * breakpoints" configuration the design doc's determinism gate names.
+ * It has to be a background thread, not something done synchronously
+ * inside the frame callback: the stub's non-blocking per-frame poll
+ * (GDBTargetServicePoll(), called from the TOP of retro_run()) only
+ * advances once per retro_run() call, so a client that blocks on recv()
+ * from the SAME thread that drives the harness's retro_run() loop would
+ * deadlock -- nothing would ever call retro_run() again to produce the
+ * reply it is waiting for. Two threads sidesteps that entirely: the main
+ * thread keeps calling retro_run() every frame regardless of what the
+ * attach thread is doing.
+ *
+ * No libretro.py/RETRO_ENVIRONMENT_GET_PERF_INTERFACE dependency, unlike
+ * a Python-driven attach -- this tool uses the same dlopen-based harness
+ * every other test/tools digest probe does.
+ *
+ * Build:
+ *   cc -O2 -Wall -std=c99 -I. -I./test/harness -I./libretro-common/include \
+ *      -o test/tools/gdb_determinism_probe test/tools/gdb_determinism_probe.c \
+ *      test/harness/harness.c -ldl -lm -lpthread
+ */
+
+#include "harness.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+typedef size_t (*serialize_size_fn)(void);
+typedef bool (*serialize_fn)(void *, size_t);
+
+typedef struct {
+    harness_config *cfg;
+    serialize_size_fn ssize;
+    serialize_fn      ser;
+    unsigned          digest_frame;
+    int               did_digest;
+    int               failures;
+} gd_state;
+
+typedef struct {
+    int  port;
+    int  attached;   /* set by the thread once the handshake succeeds */
+    int  failed;
+} gd_attach_ctx;
+
+static unsigned char gd_cksum(const char *p, size_t len)
+{
+    unsigned sum = 0;
+    size_t i;
+    for (i = 0; i < len; i++)
+        sum += (unsigned char)p[i];
+    return (unsigned char)sum;
+}
+
+/* Runs on its own thread: connect, send an unframed ack (as a real
+ * client would after receiving OUR previous replies -- harmless here
+ * since we've sent nothing yet), then qSupported and QStartNoAckMode,
+ * blocking on recv() after each -- safe here because the MAIN thread is
+ * concurrently driving retro_run() every frame, which is what lets the
+ * stub's non-blocking per-frame poll actually produce those replies.
+ * Retries the connect for a few seconds in case this thread wins the
+ * race against the harness's own retro_load_game() (which is what opens
+ * the listener). Then holds the socket open, arming nothing, until the
+ * process exits. */
+static void *gd_attach_thread(void *arg)
+{
+    gd_attach_ctx *ctx = (gd_attach_ctx *)arg;
+    struct sockaddr_in addr;
+    int fd = -1;
+    char buf[512];
+    char pkt[64];
+    int n, i, tries;
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port   = htons((unsigned short)ctx->port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    for (tries = 0; tries < 100; tries++) {
+        fd = socket(AF_INET, SOCK_STREAM, 0);
+        if (fd >= 0 && connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0)
+            break;
+        if (fd >= 0)
+            close(fd);
+        fd = -1;
+        usleep(20000);
+    }
+
+    if (fd < 0) {
+        ctx->failed = 1;
+        return NULL;
+    }
+
+    send(fd, "+", 1, 0);
+
+    for (i = 0; i < 2; i++) {
+        const char *payload = (i == 0) ? "qSupported:multiprocess+" : "QStartNoAckMode";
+        size_t plen = strlen(payload);
+
+        snprintf(pkt, sizeof(pkt), "$%s#%02x", payload, gd_cksum(payload, plen));
+        send(fd, pkt, strlen(pkt), 0);
+
+        n = (int)recv(fd, buf, sizeof(buf) - 1, 0);
+        if (n <= 0) {
+            ctx->failed = 1;
+            close(fd);
+            return NULL;
+        }
+    }
+
+    ctx->attached = 1;
+
+    /* Hold the connection open for the rest of the run -- arming
+     * nothing -- by blocking on a recv() that the harness process's
+     * exit (closing every fd) is what ultimately ends. A real client
+     * would sit here too, between commands. */
+    recv(fd, buf, sizeof(buf), 0);
+    close(fd);
+    return NULL;
+}
+
+static bool gd_frame(void *ud, unsigned frame)
+{
+    gd_state *st = (gd_state *)ud;
+    size_t sz;
+    uint8_t *buf;
+    uint64_t h;
+    size_t i;
+
+    if (frame != st->digest_frame)
+        return true;
+
+    sz = st->ssize();
+    if (sz == 0) {
+        fprintf(stderr, "frame %u: retro_serialize_size() == 0\n", frame);
+        st->failures++;
+        return true;
+    }
+    buf = (uint8_t *)malloc(sz);
+    if (!buf || !st->ser(buf, sz)) {
+        fprintf(stderr, "frame %u: retro_serialize failed\n", frame);
+        st->failures++;
+        free(buf);
+        return true;
+    }
+    h = 1469598103934665603ULL;
+    for (i = 0; i < sz; i++) {
+        h ^= (uint64_t)buf[i];
+        h *= 1099511628211ULL;
+    }
+    printf("STATE_DIGEST frame=%u size=%zu fnv=%016llx\n",
+           frame, sz, (unsigned long long)h);
+    fflush(stdout);
+    st->did_digest = 1;
+    free(buf);
+    return true;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    gd_state st;
+    gd_attach_ctx actx;
+    pthread_t attach_tid;
+    int have_attach_thread = 0;
+    int i;
+
+    memset(&st, 0, sizeof(st));
+    memset(&actx, 0, sizeof(actx));
+    actx.port = -1;
+    cfg.frames = 300;
+
+    /* --attach-port is this tool's own flag, not the shared harness's --
+     * strip it before handing argv to the harness so it does not choke
+     * on an unrecognized option. */
+    {
+        char **filtered = (char **)malloc(sizeof(char *) * (size_t)argc);
+        int fc = 0;
+
+        filtered[fc++] = argv[0];
+        for (i = 1; i < argc; i++) {
+            if (strcmp(argv[i], "--attach-port") == 0 && i + 1 < argc) {
+                actx.port = atoi(argv[++i]);
+            } else {
+                filtered[fc++] = argv[i];
+            }
+        }
+
+        if (!harness_init_from_args(&cfg, fc, filtered)) {
+            free(filtered);
+            return 1;
+        }
+        free(filtered);
+    }
+
+    if (!cfg.rom_path) {
+        fprintf(stderr, "gdb_determinism_probe: no ROM given\n");
+        return 1;
+    }
+
+    st.cfg = &cfg;
+    st.digest_frame = cfg.frames;
+    cfg.frame_callback      = gd_frame;
+    cfg.frame_callback_data = &st;
+
+    if (!harness_load_rom(&cfg))
+        return 1;
+
+    st.ssize = (serialize_size_fn)harness_dlsym(&cfg, "retro_serialize_size");
+    st.ser   = (serialize_fn)harness_dlsym(&cfg, "retro_serialize");
+    if (!st.ssize || !st.ser)
+        return 1;
+
+    if (actx.port > 0) {
+        if (pthread_create(&attach_tid, NULL, gd_attach_thread, &actx) == 0)
+            have_attach_thread = 1;
+        else
+            fprintf(stderr, "gdb_determinism_probe: pthread_create failed\n");
+    }
+
+    harness_run(&cfg);
+    harness_shutdown(&cfg);
+
+    if (!st.did_digest || st.failures) {
+        fprintf(stderr, "gdb_determinism_probe: digest=%d failures=%d\n",
+                st.did_digest, st.failures);
+        return 1;
+    }
+    if (have_attach_thread) {
+        if (!actx.attached) {
+            fprintf(stderr, "gdb_determinism_probe: attach thread never completed "
+                    "its handshake within the run (failed=%d)\n", actx.failed);
+            return 1;
+        }
+        fprintf(stderr, "gdb_determinism_probe: attached to 127.0.0.1:%d "
+                "(zero breakpoints) for the rest of the run\n", actx.port);
+    }
+    return 0;
+}

--- a/test/tools/gpu_disasm_dump.c
+++ b/test/tools/gpu_disasm_dump.c
@@ -9,33 +9,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../harness/harness.h"
-
-static const char *mn[64] = {
-"add","addc","addq","addqt","sub","subc","subq","subqt",
-"neg","and","or","xor","not","btst","bset","bclr",
-"mult","imult","imultn","resmac","imacn","div","abs","sh",
-"shlq","shrq","sha","sharq","ror","rorq","cmp","cmpq",
-"sat8","sat16","move","moveq","moveta","movefa","movei","loadb",
-"loadw","load","loadp","load(r14+n)","load(r15+n)","storeb","storew","store",
-"storep","store(r14+n)","store(r15+n)","move pc","jump","jr","mmult","mtoi",
-"normi","nop","load(r14+rn)","load(r15+rn)","store(r14+rn)","store(r15+rn)","sat24","pack"
-};
-/* Real jr/jump condition-code decode (mirrors build_branch_condition_table
- * in src/tom/gpu.c): the 5-bit field is NOT simply "cc[n&7]" -- bit 4
- * selects the N flag instead of C for the carry-style tests in bits 2-3,
- * so values >=16 alias onto the low-3-bit table if you mask with &7
- * (issue #406 investigation: this masking bug mislabeled a real
- * "branch if negative" as "always taken"). Decode the raw bits instead. */
-static void print_cc(unsigned j)
-{
-    int need_and = 0;
-    if (j == 0) { printf("T"); return; }
-    if (j & 1) { printf("NZ"); need_and = 1; }
-    if (j & 2) { printf("%sZ", need_and ? " " : ""); need_and = 1; }
-    if (j & 4) { printf("%s%s", need_and ? " " : "", (j & 0x10) ? "NN" : "NC"); need_and = 1; }
-    if (j & 8) { printf("%s%s", need_and ? " " : "", (j & 0x10) ? "N" : "C"); need_and = 1; }
-    if (!need_and) printf("cc%u", j);
-}
+/* The mnemonic table and decode logic live in exactly one place -- see
+ * docs/gdb-stub-design.md (issue #652): "do not write a second
+ * disassembler." src/debug/gdbtarget.c's `monitor disasm` uses the same
+ * header for the live, in-process case; this tool is the offline,
+ * dlsym-based one. */
+#include "../../src/debug/gdbdisasm.h"
 
 int main(int argc, char **argv)
 {
@@ -77,35 +56,17 @@ int main(int argc, char **argv)
     for (i = 0; i < words; i++)
     {
         uint32_t addr = at + i * 2;
-        uint16_t w;
-        unsigned op, r1, r2;
+        uint16_t w, w2, w3;
+        char line[128];
+        int n;
+
         w  = rdw(addr, 0);
-        op = w >> 10; r1 = (w >> 5) & 0x1F; r2 = w & 0x1F;
-        printf("$%06X: %04X  %-14s", addr, w, mn[op]);
-        if (op == 53)               /* jr */
-        {
-            printf(" ");
-            print_cc(r2);
-            printf(", %+d -> $%06X", (int)((r1 & 0x10) ? (int)r1 - 32 : (int)r1),
-                   addr + 2 + ((int)((r1 & 0x10) ? (int)r1 - 32 : (int)r1)) * 2);
-        }
-        else if (op == 52)          /* jump */
-        {
-            printf(" ");
-            print_cc(r2);
-            printf(", (r%u)", r1);
-        }
-        else if (op == 38)          /* movei */
-        {
-            uint32_t lo = rdw(addr + 2, 0);
-            uint32_t hi = rdw(addr + 4, 0);
-            printf(" #$%08X, r%u", (hi << 16) | lo, r2);
-        }
-        else if (op == 2 || op == 6 || op == 31 || op == 35 || op == 24 || op == 25)
-            printf(" #%u, r%u", r1 ? r1 : 32, r2);
-        else
-            printf(" r%u, r%u", r1, r2);
-        printf("\n");
+        w2 = ((w >> 10) == 38) ? rdw(addr + 2, 0) : 0;   /* movei low word */
+        w3 = ((w >> 10) == 38) ? rdw(addr + 4, 0) : 0;   /* movei high word */
+        n = GDBDisasmOne(GDBDisasmGPUMnemonics, addr, w, w2, w3,
+                         line, (int)sizeof(line) - 1);
+        line[n] = '\0';
+        printf("%s\n", line);
     }
     harness_shutdown(&cfg);
     return 0;

--- a/test/tools/test_gdbstub_proto.c
+++ b/test/tools/test_gdbstub_proto.c
@@ -139,11 +139,23 @@ static void setup_session(void) {
     GDBSessionInit(&g_sess, &ops, NULL);
 }
 
+/* Phase 2 added two out-parameters to GDBHandlePacket (resumeRequested/
+ * resumeIsStep, for c/s/vCont -- see gdbstub.h). Every pre-existing test
+ * below only cares about the reply, so this thin wrapper keeps them
+ * readable; the new tests that DO care about resume signalling call
+ * GDBHandlePacket directly. */
+static int TF_Handle(struct GDBSession *s, const char *pay, int payLen,
+                      char *reply, int replyMax) {
+    int resumeRequested = 0, resumeIsStep = 0;
+    return GDBHandlePacket(s, pay, payLen, reply, replyMax,
+                           &resumeRequested, &resumeIsStep);
+}
+
 TEST(qsupported_advertises_packet_size) {
     char reply[256];
     int n;
     setup_session();
-    n = GDBHandlePacket(&g_sess, "qSupported:multiprocess+", 24, reply, sizeof(reply));
+    n = TF_Handle(&g_sess, "qSupported:multiprocess+", 24, reply, sizeof(reply));
     ASSERT(n > 0);
     reply[n] = '\0';
     ASSERT(strstr(reply, "PacketSize=") != NULL);
@@ -152,14 +164,14 @@ TEST(qsupported_advertises_packet_size) {
 TEST(unknown_command_returns_empty_reply) {
     char reply[256];
     setup_session();
-    ASSERT_EQ(GDBHandlePacket(&g_sess, "zzUnknown", 9, reply, sizeof(reply)), 0);
+    ASSERT_EQ(TF_Handle(&g_sess, "zzUnknown", 9, reply, sizeof(reply)), 0);
 }
 
 TEST(halt_reason_reports_sigtrap) {
     char reply[256];
     int n;
     setup_session();
-    n = GDBHandlePacket(&g_sess, "?", 1, reply, sizeof(reply));
+    n = TF_Handle(&g_sess, "?", 1, reply, sizeof(reply));
     ASSERT(n > 0);
     reply[n] = '\0';
     ASSERT_STR(reply, "S05");
@@ -208,7 +220,7 @@ TEST(parse_hex_u32_rejects_non_hex) {
 TEST(read_memory_returns_hex) {
     char reply[256]; int n;
     setup_mem_session();
-    n = GDBHandlePacket(&g_sess, "m0,2", 4, reply, sizeof(reply));
+    n = TF_Handle(&g_sess, "m0,2", 4, reply, sizeof(reply));
     ASSERT_EQ(n, 4);
     reply[n] = '\0';
     ASSERT_STR(reply, "dead");
@@ -218,7 +230,7 @@ TEST(read_memory_past_end_is_refused) {
     char reply[256]; int n;
     setup_mem_session();
     /* 0xFF + 4 bytes overruns the 256-byte fake guest */
-    n = GDBHandlePacket(&g_sess, "mff,4", 5, reply, sizeof(reply));
+    n = TF_Handle(&g_sess, "mff,4", 5, reply, sizeof(reply));
     ASSERT(n > 0);
     reply[n] = '\0';
     ASSERT_STR(reply, "E01");
@@ -227,7 +239,7 @@ TEST(read_memory_past_end_is_refused) {
 TEST(read_memory_wild_address_is_refused) {
     char reply[256]; int n;
     setup_mem_session();
-    n = GDBHandlePacket(&g_sess, "mffffffff,4", 11, reply, sizeof(reply));
+    n = TF_Handle(&g_sess, "mffffffff,4", 11, reply, sizeof(reply));
     ASSERT(n > 0);
     reply[n] = '\0';
     ASSERT_STR(reply, "E01");
@@ -237,7 +249,7 @@ TEST(read_memory_absurd_length_is_refused) {
     char reply[64]; int n;
     setup_mem_session();
     /* len would overflow the caller's reply buffer even if in range */
-    n = GDBHandlePacket(&g_sess, "m0,1000", 7, reply, sizeof(reply));
+    n = TF_Handle(&g_sess, "m0,1000", 7, reply, sizeof(reply));
     ASSERT(n > 0);
     reply[n] = '\0';
     ASSERT_STR(reply, "E01");
@@ -246,7 +258,7 @@ TEST(read_memory_absurd_length_is_refused) {
 TEST(read_memory_without_target_op_is_unsupported) {
     char reply[256];
     setup_session();   /* ops.readMemory == NULL */
-    ASSERT_EQ(GDBHandlePacket(&g_sess, "m0,2", 4, reply, sizeof(reply)), 0);
+    ASSERT_EQ(TF_Handle(&g_sess, "m0,2", 4, reply, sizeof(reply)), 0);
 }
 
 /* ------------------------------------------------------------------ */
@@ -274,7 +286,7 @@ TEST(read_registers_returns_144_hex_chars) {
     memset(&ops, 0, sizeof(ops));
     ops.readRegisters = fake_read_regs;
     GDBSessionInit(&g_sess, &ops, NULL);
-    n = GDBHandlePacket(&g_sess, "g", 1, reply, sizeof(reply));
+    n = TF_Handle(&g_sess, "g", 1, reply, sizeof(reply));
     ASSERT_EQ(n, 144);
     ASSERT_EQ(memcmp(reply, "00000001", 8), 0);          /* d0 first */
     ASSERT_EQ(memcmp(reply + 136, "00802000", 8), 0);    /* pc last  */
@@ -283,10 +295,280 @@ TEST(read_registers_returns_144_hex_chars) {
 TEST(read_registers_without_target_op_is_unsupported) {
     char reply[512];
     setup_session();
-    ASSERT_EQ(GDBHandlePacket(&g_sess, "g", 1, reply, sizeof(reply)), 0);
+    ASSERT_EQ(TF_Handle(&g_sess, "g", 1, reply, sizeof(reply)), 0);
+}
+
+/* ------------------------------------------------------------------ */
+/* Phase 2: register/memory writes, Z/z, c/s/vCont, qRcmd, threads     */
+/* ------------------------------------------------------------------ */
+
+static char last_written_hex[512];
+static int last_written_hex_len;
+
+static int fake_write_regs(void *user, const char *hex, int hexLen) {
+    (void)user;
+    if (hexLen < 144) return -1;
+    memcpy(last_written_hex, hex, (size_t)hexLen);
+    last_written_hex_len = hexLen;
+    return 0;
+}
+
+TEST(write_registers_calls_ops_and_replies_ok) {
+    char reply[64]; int n;
+    static struct GDBTargetOps ops;
+    char pay[1 + 144];
+    memset(&ops, 0, sizeof(ops));
+    ops.writeRegisters = fake_write_regs;
+    GDBSessionInit(&g_sess, &ops, NULL);
+    pay[0] = 'G';
+    memset(pay + 1, '0', 144);
+    last_written_hex_len = 0;
+    n = TF_Handle(&g_sess, pay, (int)sizeof(pay), reply, sizeof(reply));
+    ASSERT_EQ(n, 2);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "OK");
+    ASSERT_EQ(last_written_hex_len, 144);
+}
+
+TEST(write_registers_without_target_op_is_unsupported) {
+    char reply[64];
+    char pay[1 + 144];
+    setup_session();
+    pay[0] = 'G';
+    memset(pay + 1, '0', 144);
+    ASSERT_EQ(TF_Handle(&g_sess, pay, (int)sizeof(pay), reply, sizeof(reply)), 0);
+}
+
+static unsigned char fake_write_mem_target[256];
+
+static int fake_write_mem(void *user, unsigned int addr, int len,
+                          const char *hex, int hexLen) {
+    static const char hx[] = "0123456789abcdef";
+    int i;
+    (void)user;
+    if (addr > sizeof(fake_write_mem_target) || len < 0) return -1;
+    if ((addr + (unsigned int)len) > sizeof(fake_write_mem_target)) return -1;
+    if (hexLen != len * 2) return -1;
+    for (i = 0; i < len; i++) {
+        const char *hi = strchr(hx, hex[i*2]);
+        const char *lo = strchr(hx, hex[i*2+1]);
+        if (!hi || !lo) return -1;
+        fake_write_mem_target[addr+i] = (unsigned char)(((hi - hx) << 4) | (lo - hx));
+    }
+    return 0;
+}
+
+static void setup_write_mem_session(void) {
+    static struct GDBTargetOps ops;
+    memset(&ops, 0, sizeof(ops));
+    ops.writeMemory = fake_write_mem;
+    GDBSessionInit(&g_sess, &ops, NULL);
+    memset(fake_write_mem_target, 0, sizeof(fake_write_mem_target));
+}
+
+TEST(write_memory_writes_and_replies_ok) {
+    char reply[64]; int n;
+    setup_write_mem_session();
+    n = TF_Handle(&g_sess, "M0,2:dead", 9, reply, sizeof(reply));
+    ASSERT_EQ(n, 2);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "OK");
+    ASSERT_EQ(fake_write_mem_target[0], 0xDE);
+    ASSERT_EQ(fake_write_mem_target[1], 0xAD);
+}
+
+TEST(write_memory_length_mismatch_is_refused) {
+    char reply[64]; int n;
+    setup_write_mem_session();
+    /* len=2 promised, only 1 byte (2 hex chars) supplied */
+    n = TF_Handle(&g_sess, "M0,2:de", 7, reply, sizeof(reply));
+    ASSERT(n > 0);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "E01");
+}
+
+static int fake_insert_break_calls;
+static int fake_insert_break_result = 0;
+
+static int fake_insert_break(void *user, int type, unsigned int addr, unsigned int kind) {
+    (void)user; (void)type; (void)addr; (void)kind;
+    fake_insert_break_calls++;
+    return fake_insert_break_result;
+}
+
+static int fake_remove_break_calls;
+
+static int fake_remove_break(void *user, int type, unsigned int addr, unsigned int kind) {
+    (void)user; (void)type; (void)addr; (void)kind;
+    fake_remove_break_calls++;
+    return 0;
+}
+
+static void setup_break_session(void) {
+    static struct GDBTargetOps ops;
+    memset(&ops, 0, sizeof(ops));
+    ops.insertBreak = fake_insert_break;
+    ops.removeBreak = fake_remove_break;
+    GDBSessionInit(&g_sess, &ops, NULL);
+    fake_insert_break_calls = 0;
+    fake_remove_break_calls = 0;
+    fake_insert_break_result = 0;
+}
+
+TEST(insert_breakpoint_replies_ok) {
+    char reply[64]; int n;
+    setup_break_session();
+    n = TF_Handle(&g_sess, "Z0,1000,2", 9, reply, sizeof(reply));
+    ASSERT_EQ(n, 2);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "OK");
+    ASSERT_EQ(fake_insert_break_calls, 1);
+}
+
+TEST(insert_breakpoint_out_of_resources_is_e01) {
+    char reply[64]; int n;
+    setup_break_session();
+    fake_insert_break_result = -2;
+    n = TF_Handle(&g_sess, "Z1,2000,2", 9, reply, sizeof(reply));
+    ASSERT(n > 0);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "E01");
+}
+
+TEST(remove_breakpoint_replies_ok) {
+    char reply[64]; int n;
+    setup_break_session();
+    n = TF_Handle(&g_sess, "z0,1000,2", 9, reply, sizeof(reply));
+    ASSERT_EQ(n, 2);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "OK");
+    ASSERT_EQ(fake_remove_break_calls, 1);
+}
+
+TEST(watchpoint_type_reaches_ops_too) {
+    char reply[64]; int n;
+    setup_break_session();
+    n = TF_Handle(&g_sess, "Z2,3000,4", 9, reply, sizeof(reply));
+    ASSERT_EQ(n, 2);
+    ASSERT_EQ(fake_insert_break_calls, 1);
+}
+
+TEST(breakpoint_without_target_op_is_unsupported) {
+    char reply[64];
+    setup_session();
+    ASSERT_EQ(TF_Handle(&g_sess, "Z0,1000,2", 9, reply, sizeof(reply)), 0);
+}
+
+TEST(continue_sets_resume_and_suppresses_reply) {
+    char reply[64];
+    int resumeRequested = 0, resumeIsStep = 1;
+    int n;
+    setup_session();
+    n = GDBHandlePacket(&g_sess, "c", 1, reply, sizeof(reply),
+                        &resumeRequested, &resumeIsStep);
+    ASSERT_EQ(n, 0);
+    ASSERT_EQ(resumeRequested, 1);
+    ASSERT_EQ(resumeIsStep, 0);
+}
+
+TEST(step_sets_resume_and_is_step) {
+    char reply[64];
+    int resumeRequested = 0, resumeIsStep = 0;
+    int n;
+    setup_session();
+    n = GDBHandlePacket(&g_sess, "s", 1, reply, sizeof(reply),
+                        &resumeRequested, &resumeIsStep);
+    ASSERT_EQ(n, 0);
+    ASSERT_EQ(resumeRequested, 1);
+    ASSERT_EQ(resumeIsStep, 1);
+}
+
+TEST(vcont_query_lists_continue_and_step) {
+    char reply[64]; int n;
+    setup_session();
+    n = TF_Handle(&g_sess, "vCont?", 6, reply, sizeof(reply));
+    ASSERT(n > 0);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "vCont;c;s");
+}
+
+TEST(vcont_step_action_sets_resume_step) {
+    char reply[64];
+    int resumeRequested = 0, resumeIsStep = 0;
+    int n;
+    setup_session();
+    n = GDBHandlePacket(&g_sess, "vCont;s:1", 9, reply, sizeof(reply),
+                        &resumeRequested, &resumeIsStep);
+    ASSERT_EQ(n, 0);
+    ASSERT_EQ(resumeRequested, 1);
+    ASSERT_EQ(resumeIsStep, 1);
+}
+
+TEST(vcont_continue_action_sets_resume_not_step) {
+    char reply[64];
+    int resumeRequested = 0, resumeIsStep = 1;
+    int n;
+    setup_session();
+    n = GDBHandlePacket(&g_sess, "vCont;c", 7, reply, sizeof(reply),
+                        &resumeRequested, &resumeIsStep);
+    ASSERT_EQ(n, 0);
+    ASSERT_EQ(resumeRequested, 1);
+    ASSERT_EQ(resumeIsStep, 0);
+}
+
+static int fake_monitor_cmd(void *user, const char *cmd, char *out, int outMax) {
+    (void)user;
+    return snprintf(out, (size_t)outMax, "you said: %s", cmd);
+}
+
+TEST(qrcmd_decodes_hex_and_encodes_reply) {
+    /* "hi" hex-encoded is "6869" */
+    char reply[128]; int n;
+    static struct GDBTargetOps ops;
+    memset(&ops, 0, sizeof(ops));
+    ops.monitorCmd = fake_monitor_cmd;
+    GDBSessionInit(&g_sess, &ops, NULL);
+    n = TF_Handle(&g_sess, "qRcmd,6869", 10, reply, sizeof(reply));
+    ASSERT(n > 0);
+    reply[n] = '\0';
+    /* Reply is hex-encoded text "you said: hi" -- spot-check it decodes
+     * to something containing "hi" without writing a second hex decoder
+     * in the test: just check the known hex prefix for "you said: h". */
+    ASSERT(strncmp(reply, "796f7520736169643a2068", 22) == 0);
+}
+
+TEST(qrcmd_without_monitor_op_is_unsupported) {
+    char reply[128];
+    setup_session();
+    ASSERT_EQ(TF_Handle(&g_sess, "qRcmd,6869", 10, reply, sizeof(reply)), 0);
+}
+
+TEST(thread_roster_is_fixed_at_three) {
+    char reply[64]; int n;
+    setup_session();
+    n = TF_Handle(&g_sess, "qfThreadInfo", 12, reply, sizeof(reply));
+    ASSERT(n > 0);
+    reply[n] = '\0';
+    ASSERT_STR(reply, "m1,2,3");
+    n = TF_Handle(&g_sess, "qsThreadInfo", 12, reply, sizeof(reply));
+    reply[n] = '\0';
+    ASSERT_STR(reply, "l");
+}
+
+TEST(hg_selects_thread_and_qc_reports_it) {
+    char reply[64]; int n;
+    setup_session();
+    n = TF_Handle(&g_sess, "Hg2", 3, reply, sizeof(reply));
+    reply[n] = '\0';
+    ASSERT_STR(reply, "OK");
+    n = TF_Handle(&g_sess, "qC", 2, reply, sizeof(reply));
+    reply[n] = '\0';
+    ASSERT_STR(reply, "QC2");
 }
 
 int main(void) {
+    int total_fail = 0;
+
     SUITE("gdbstub framing");
     RUN(checksum_is_modulo_256_sum);
     RUN(checksum_wraps_at_256);
@@ -315,5 +597,28 @@ int main(void) {
     RUN(read_memory_without_target_op_is_unsupported);
     RUN(read_registers_returns_144_hex_chars);
     RUN(read_registers_without_target_op_is_unsupported);
-    return REPORT();
+    total_fail += REPORT();
+
+    SUITE("gdbstub phase 2: writes, breakpoints, resume, monitor, threads");
+    RUN(write_registers_calls_ops_and_replies_ok);
+    RUN(write_registers_without_target_op_is_unsupported);
+    RUN(write_memory_writes_and_replies_ok);
+    RUN(write_memory_length_mismatch_is_refused);
+    RUN(insert_breakpoint_replies_ok);
+    RUN(insert_breakpoint_out_of_resources_is_e01);
+    RUN(remove_breakpoint_replies_ok);
+    RUN(watchpoint_type_reaches_ops_too);
+    RUN(breakpoint_without_target_op_is_unsupported);
+    RUN(continue_sets_resume_and_suppresses_reply);
+    RUN(step_sets_resume_and_is_step);
+    RUN(vcont_query_lists_continue_and_step);
+    RUN(vcont_step_action_sets_resume_step);
+    RUN(vcont_continue_action_sets_resume_not_step);
+    RUN(qrcmd_decodes_hex_and_encodes_reply);
+    RUN(qrcmd_without_monitor_op_is_unsupported);
+    RUN(thread_roster_is_fixed_at_three);
+    RUN(hg_selects_thread_and_qc_reports_it);
+    total_fail += REPORT();
+
+    return total_fail;
 }


### PR DESCRIPTION
Refs #652

## Perf number, up front

**Not measured this pass.** The design doc's go/no-go gate requires an idle machine
(A/B/B/A interleaved, `hooks present` vs `VJ_GDB_STUB_DISABLE_HOOKS`), and this host
stayed under sustained, unrelated load for the entire session -- `uptime` load
averages ranged 9-26 across more than half a dozen checks spaced ~15-20 minutes apart
near the end of the session, with unrelated processes (another Cursor renderer at
500%+ CPU, Xcode's sourcekit-lsp, other git/build processes) visibly running the
whole time. Per this repo's own documented history (a sequential "-O3 +12.5%" flipped
to "-11.7%" when interleaved on a loaded box), a number taken under these conditions
would be worse than no number.

`VJ_GDB_STUB_DISABLE_HOOKS` is wired at all three hook sites (`M68KInstructionHook()`
in `src/core/jaguar.c`, the `GPUExec()` loop in `src/tom/gpu.c`, the `DSPExec()` loop
in `src/jerry/dsp.c`, plus the DSP idle-skip gate) so the A/B this design requires can
be run on an idle machine before merge -- build once normally, once with
`-DVJ_GDB_STUB_DISABLE_HOOKS`, and compare an interleaved A/B/B/A. I'd ask a
maintainer (or a follow-up session on an idle box) to run this before merging, since
it's the actual go/no-go for the whole ship-by-default premise. Everything else in
this PR is independently reviewable regardless of that number.

## What landed

### Phase 2 -- breakpoints and the armed-flag gate
- The `+`/`-` RSP acknowledgement byte, honoring `QStartNoAckMode` (Phase 1 shipped
  without this -- no real `gdb` could attach; `qSupported` would stall forever).
- Per-target armed counters (`gdbArmed68K`/`GPU`/`DSP`) plus a 256-entry direct-mapped
  PC cache, exactly as designed: one load and one never-taken branch when nothing is
  armed. Never patches emulated memory.
- `Z0`/`Z1` breakpoints, `Z2`/`Z3`/`Z4` watchpoints, `c`/`s`/`vCont`, register and
  memory writes (`G`/`M`).
- The blocking halt loop: `GDBHalt()` freezes `retro_run()` in place (does not unwind
  the call stack) until continue/step/disconnect. Client disconnect while halted
  disarms everything and resumes immediately.
- `virtualjaguar_gdb_wait` (halt before the 68K's first instruction) and
  `virtualjaguar_gdb_halt_timeout` (auto-continue + loud log after N seconds idle,
  off by default) core options.

### Phase 3 -- GPU and DSP threads
- GPU/DSP as GDB threads 2/3, `org.atari.jaguar.risc` custom target description
  (R0-R31 = 0-31, PC = 32, FLAGS = 33 -- fixed forever, per the design doc's warning
  that clients cache this) served over `qXfer:features:read`.
- Thread enumeration/selection (`qfThreadInfo`/`qsThreadInfo`/`Hg`/`Hc`/`qC`), stop
  replies naming the halted thread.
- `monitor` commands via `qRcmd`: `disasm <gpu|dsp> <addr> [count]`, `regs [gpu|dsp]`,
  `halt <68k|gpu|dsp>`, `trace` (dumps the #542 68K PC traceback ring), `watch`.
- The RISC disassembler is genuinely shared, not "not duplicated in spirit":
  `src/debug/gdbdisasm.h` is a new header-only module used by both `gdbtarget.c`
  (live) and the refactored `test/tools/gpu_disasm_dump.c` (offline) -- there is
  exactly one implementation, and the offline tool's old inline copy is gone.

### Phase 4 -- documentation
`docs/gdb-stub-guide.md`: attach walkthrough, the frontend-freeze halt model (with
its mitigations), `monitor disasm` for the RISC-disassembly gap, and an explicit
"symbol-level, not source-level" section (rln emits mc68k COFF, not DWARF; no
`m68k-elf-gdb` ships in this repo's toolchain -- bring your own).

## What I found that the design doc got right, and one thing I initially got wrong

- **"Watchpoints ride the existing exported memory-access breakpoint vars, already
  checked at six sites" turned out to be literally true**, but not for the reason it
  first looked true. I initially thought `ALPINE_FUNCTIONS` (which gates those six
  sites in `src/core/jaguar.c`) was undefined anywhere in the build and nearly
  reported this as a design-doc inaccuracy -- but that macro is `#define`d
  unconditionally in `jaguar.c` itself (not passed by any Makefile target), so the
  six sites really were compiled into every build. What *was* dead: `bpmActive`
  defaulted false and nothing ever set it, and its only consumer
  (`M68KDebugHalt()`/`SPCFLAG_DEBUGGER`) would have wedged the 68K forever, since
  nothing ever called the matching `M68KDebugResume()`. This module is now the first
  and only thing that ever arms `bpmActive`/`bpmAddress1`, via the new
  `GDBMemWatchHit()`.
- **Stepping does not use the 68K's `SPCFLAG_DEBUGGER` path**, contrary to what the
  design doc specified. All three processors share one one-shot primitive on the
  same per-target breakpoint structure `GDBCheckPC()` already needed for GPU/DSP
  stepping. `SPCFLAG_DEBUGGER` makes `m68k_execute()` return early to its *caller*
  rather than block in place, which would need extra scheduler plumbing to notice
  "a step just completed" and re-enter `GDBHalt()` -- not worth the risk of a subtle
  bug under time pressure when a uniform, already-necessary mechanism was available.
  Documented as a deliberate deviation in the design doc.
- Single watchpoint slot (matching `bpmAddress1`'s literal singular shape) was
  implemented as designed; a second `Z2`/`Z3`/`Z4` while one is armed elsewhere is
  refused (E01), documented as a known limitation.

Full details of both in `docs/gdb-stub-design.md`'s new "Phase 2/3 implementation
notes" section.

## Verification (real output)

```
$ DEVELOPER_DIR=/Library/Developer/CommandLineTools make -j4
... clean build, 0 errors, 1 pre-existing unrelated warning (deps/libchdr miniz)

$ bash scripts/c89-lint.sh <every touched src/ file + libretro.c>
C89 lint passed

$ DEVELOPER_DIR=/Library/Developer/CommandLineTools make TEST_EXPORTS=1 test
... 0 FAIL lines across the whole suite; 75 "OK"/"passed, 0 failed" suite summaries,
including test/tools/test_gdbstub_proto's two suites (45/45 individual tests: 27
Phase-1 protocol tests + 18 new Phase-2 tests covering register/memory writes,
Z/z insert/remove, c/s/vCont resume signalling, qRcmd, and thread selection)
exit code: 0
```

Determinism gate (`test/tools/gdb_determinism_probe.c`, new -- drives the core via
the existing C harness so a live socket client can stay attached across the run,
which the batch-only `hires_state_digest` pattern can't do on its own):

```
$ ./test/tools/gdb_determinism_probe ./virtualjaguar_libretro.dylib test/roms/yarc.j64 \
    --frames 300 --option virtualjaguar_gdb_stub=disabled
STATE_DIGEST frame=300 size=2621440 fnv=8b13b9f3a6513082

$ ./test/tools/gdb_determinism_probe ... --option virtualjaguar_gdb_stub=enabled --option virtualjaguar_gdb_port=22346
STATE_DIGEST frame=300 size=2621440 fnv=8b13b9f3a6513082

$ ./test/tools/gdb_determinism_probe ... --option virtualjaguar_gdb_stub=enabled --option virtualjaguar_gdb_port=22347 --attach-port 22347
STATE_DIGEST frame=300 size=2621440 fnv=8b13b9f3a6513082
gdb_determinism_probe: attached to 127.0.0.1:22347 (zero breakpoints) for the rest of the run
```

All three digests byte-identical: disabled / enabled-unattached / enabled-attached-
with-a-real-negotiated-client-and-zero-breakpoints.

Live protocol verification (`test/tools/gdb_attach_probe.py`, extended -- this is the
exact gap the design doc calls out: Phase 1's probe never checked the ack byte a real
`gdb` needs):

```
$ python3 test/tools/gdb_attach_probe.py <port>
PASS: attach, ack byte (every reply), no-ack transition (including the
QStartNoAckMode-reply-is-still-acked case), halt reason, registers, memory,
bounds refusal, breakpoint insert/remove
```

A real breakpoint actually halting real execution (`test/tools/gdb_breakpoint_probe.py`,
new): halts at boot (`virtualjaguar_gdb_wait`), injects a single 68K instruction
(`BRA.S *`, a branch-to-self loop) into scratch RAM, redirects PC to it, arms `Z0`
there, continues, and confirms the stop reply names thread 1 with PC still at the
exact armed address:

```
$ python3 test/tools/gdb_breakpoint_probe.py
PASS: injected a real 68K instruction, redirected PC to it, armed Z0 at $1000,
continued, and the stub halted there and reported it -- confirmed via a fresh
register read (PC=$00001000) after the stop reply named thread 1.
```

(This script's gdb_wait halt-before-injecting step is load-bearing, not just tidy: an
earlier version picked an arbitrary "probably unused" RAM address without halting
first, and the ROM's own boot code overwrote the injected instruction before the CPU
fetched it, within a single frame -- confirmed by reading the address back and
finding the ROM's own data there instead. Noted in the design doc so it isn't
re-learned the hard way.)

## Not done / explicitly scoped out

- **The Phase 2 perf gate is unmeasured** -- see the top of this description.
- Multi-architecture GDB sessions (native m68k thread + two custom-description
  threads in one inferior) are implemented to spec and covered by this repo's own
  scripted client, but never verified against a real `gdb` binary -- none ships in
  this repo's toolchain (Open Question 1, answered in Phase 1). Documented as an
  explicit caveat in the user guide.
- Single memory-watchpoint slot (by design, matching the pre-existing mechanism this
  rides on).