### PR TITLE
perf(simd): SSE2 ports of OP phrase stores and TOM scanline converters

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -787,16 +787,18 @@ jobs:
           # file that no longer exists and fails the whole job with
           # "no input files" / "expected exactly one compiler job".
           #
-          # blitter_simd_<arch>.{c,h} are all excluded. Only one arch is
-          # ever built, so the other two .c files aren't in
-          # compile_commands.json; and the .h files are include-only
-          # fragments that refuse to be compiled standalone (they
-          # #error unless blitter_simd.h pulled them in), so linting one
-          # directly is guaranteed to fail. They are covered instead by
+          # Every *_simd_<arch>.{c,h} fragment (blitter_simd_*, op_simd_*,
+          # tom_scan_simd_*, and any future src/jerry ones) is excluded.
+          # Only one arch is ever built, so the other arch .c files
+          # aren't in compile_commands.json; and the .h files are
+          # include-only fragments that cannot be linted standalone
+          # (blitter's #error unless blitter_simd.h pulled them in; the
+          # op/tom ones compile to nothing without their host .c's
+          # capability macros and includes). They are covered instead by
           # c89-lint's per-arch pass, which compiles them the way the
           # build does.
           FILES=$(git diff --name-only --diff-filter=d "$BASE"...HEAD -- '*.c' '*.h' \
-            | grep -Ev '^(src/m68000/|src/bios/jag.*\.c$|libretro-common/|src/core/version\.h$|src/tom/blitter_simd_(neon|sse2|scalar)\.(c|h)$)' \
+            | grep -Ev '^(src/m68000/|src/bios/jag.*\.c$|libretro-common/|src/core/version\.h$|src/(tom|jerry)/[a-z0-9_]+_simd_(neon|sse2|scalar)\.(c|h)$)' \
             | grep -E '^(src/|libretro\.c$)' || true)
           if [ -z "$FILES" ]; then
             echo "No relevant C files changed; skipping clang-tidy."

--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -35,7 +35,9 @@ skip_file() {
         # checked, with the right define and target, by check_simd_arch below.
         src/tom/blitter_simd_neon.c|src/tom/blitter_simd_sse2.c) return 0 ;;
         src/tom/op_simd_neon.h) return 0 ;;
+        src/tom/op_simd_sse2.h) return 0 ;;
         src/tom/tom_scan_simd_neon.h) return 0 ;;
+        src/tom/tom_scan_simd_sse2.h) return 0 ;;
         src/jerry/voicechat_simd_neon.h) return 0 ;;
         # Depends on rcheevos headers fetched at runtime by the e2e shell wrapper.
         test/tools/test_rcheevos_e2e.c) return 0 ;;
@@ -69,7 +71,7 @@ CHECK_SIMD=0
 for f in $FILES; do
     [ -f "$f" ] || continue
     case "$f" in *.c) ;; *) continue ;; esac
-    case "$f" in src/tom/blitter.c|src/tom/blitter_simd_*.c) CHECK_SIMD=1 ;; esac
+    case "$f" in src/tom/blitter.c|src/tom/blitter_simd_*.c|src/tom/op.c|src/tom/tom.c) CHECK_SIMD=1 ;; esac
     if skip_file "$f"; then continue; fi
 
     if ! $CC $CFLAGS $INCLUDES $DEFINES "$f" 2>&1; then
@@ -90,6 +92,12 @@ done
 # Re-check blitter.c (and the arch's own .c) once per arch, cross-
 # targeting when the host can't do it natively.  A host that can't
 # cross-target says so out loud rather than passing silently.
+#
+# op.c and tom.c ride the same pass: they include the guard-selected
+# op_simd_<arch>.h / tom_scan_simd_<arch>.h fragments, which the default
+# loop only ever sees with the host's own capability macros.  Compiling
+# them per-arch is the only host-side syntax check the non-native
+# fragment header gets.
 check_simd_arch() {
     arch="$1"      # sse2 | neon
     define="$2"    # BLITTER_SIMD_SSE2 | BLITTER_SIMD_NEON
@@ -113,7 +121,8 @@ check_simd_arch() {
     rm -f "$probe_c"
 
     arch_failed=0
-    for f in src/tom/blitter.c "src/tom/blitter_simd_$arch.c"; do
+    for f in src/tom/blitter.c "src/tom/blitter_simd_$arch.c" \
+             src/tom/op.c src/tom/tom.c; do
         [ -f "$f" ] || continue
         if ! $cc $CFLAGS $target $INCLUDES $DEFINES "-D$define" "$f" 2>&1; then
             echo "C89 lint: $arch pass failed on $f"

--- a/src/tom/op.c
+++ b/src/tom/op.c
@@ -26,6 +26,7 @@
 #include "tom.h"
 #include "../core/vjtrace.h"
 #include "op_simd_neon.h"
+#include "op_simd_sse2.h"
 
 #define BLEND_Y(dst, src)	op_blend_y[(((uint16_t)dst<<8)) | ((uint16_t)(src))]
 #define BLEND_CR(dst, src)	op_blend_cr[(((uint16_t)dst)<<8) | ((uint16_t)(src))]
@@ -1179,6 +1180,19 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
             i = 0;
             continue;
          }
+#elif defined(BLITTER_SIMD_HAVE_SSE2)
+         /* Same guard as the NEON branch above; only the store differs. */
+         if (!flagRMW && lbufDelta == 2
+               && !shadowFBActive && !shadowHiresActive
+               && OP_LBUF_IN_BOUNDS(currentLineBuffer, 8)
+               && i == 0 && firstPix == 0)
+         {
+            op_store_phrase_16bpp_sse2(currentLineBuffer, pixels, flagTRANS);
+            currentLineBuffer += 8;
+            firstPix = 0;
+            i = 0;
+            continue;
+         }
 #endif
 
          while (i++ < 4)
@@ -1260,6 +1274,18 @@ void OPProcessFixedBitmap(uint64_t p0, uint64_t p1, bool render)
                && i == 0 && firstPix == 0)
          {
             op_store_phrase_24bpp_neon(currentLineBuffer, pixels, flagTRANS);
+            currentLineBuffer += 8;
+            firstPix = 0;
+            i = 0;
+            continue;
+         }
+#elif defined(BLITTER_SIMD_HAVE_SSE2)
+         /* Same guard as the NEON branch above; only the store differs. */
+         if (!flagRMW && lbufDelta == 4
+               && OP_LBUF_IN_BOUNDS(currentLineBuffer, 8)
+               && i == 0 && firstPix == 0)
+         {
+            op_store_phrase_24bpp_sse2(currentLineBuffer, pixels, flagTRANS);
             currentLineBuffer += 8;
             firstPix = 0;
             i = 0;

--- a/src/tom/op_simd_sse2.h
+++ b/src/tom/op_simd_sse2.h
@@ -1,0 +1,132 @@
+#ifndef OP_SIMD_SSE2_H
+#define OP_SIMD_SSE2_H
+
+/*
+ * Object Processor 16bpp / 24bpp phrase store — x86 SSE2 implementation
+ *
+ * Included by op.c. Capability comes from blitter_simd_arch.h
+ * (BLITTER_SIMD_HAVE_SSE2): baseline on x86-64, __SSE2__-gated on i386,
+ * /arch:SSE2-gated on 32-bit MSVC — same policy as the blitter kernels,
+ * so a plain i386 build stays scalar instead of taking intrinsics its
+ * target cannot execute.
+ *
+ * SSE2 only (emmintrin.h). Do not add SSSE3/SSE4 ops here (pshufb,
+ * blendv, ptest) — the libretro buildbot x86 baseline is SSE2.
+ *
+ * Port of op_simd_neon.h; the semantics comments there are the
+ * authority. The 8-byte phrase lives in the low half of an __m128i
+ * (movq load/store); the high half is ignored.
+ */
+
+#include "blitter_simd_arch.h"
+
+#if defined(BLITTER_SIMD_HAVE_SSE2)
+
+#include <stdint.h>
+#include <boolean.h>
+#include <emmintrin.h>
+
+#if defined(_MSC_VER)
+#  define OP_SIMD_INLINE __forceinline
+#elif defined(__GNUC__) || defined(__clang__)
+#  define OP_SIMD_INLINE inline __attribute__((always_inline))
+#else
+#  define OP_SIMD_INLINE INLINE
+#endif
+
+/*
+ * Store one 16bpp phrase (4 pixels / 8 bytes) into LBUF.
+ *
+ * Byte order matches OPProcessFixedBitmap's scalar walk: bitsHi then
+ * bitsLo per pixel through a uint8_t* with lbufDelta == +2, which is
+ * pixels[63:56], [55:48], …, [7:0]. The explicit byte extract is host-
+ * endian independent, exactly as in the NEON port.
+ *
+ * flagTRANS: skip a u16 lane when both bytes are zero (same test as
+ * (bitsLo | bitsHi) == 0) — _mm_cmpeq_epi16 against zero is lane-order
+ * agnostic, so the swapped byte order inside the lane doesn't matter.
+ * Keep the existing LBUF bytes via and/andnot/or select (the SSE2
+ * spelling of vbsl). Opaque: straight 8-byte store. Caller has already
+ * gated RMW, REFLECT, shadow-FB hooks, and LBUF bounds.
+ */
+static OP_SIMD_INLINE void op_store_phrase_16bpp_sse2(
+      uint8_t *lbuf, uint64_t pixels, bool flagTRANS)
+{
+   uint8_t bytes[8];
+   __m128i src;
+   __m128i cur;
+   __m128i mask;
+   __m128i zero;
+
+   bytes[0] = (uint8_t)(pixels >> 56);
+   bytes[1] = (uint8_t)(pixels >> 48);
+   bytes[2] = (uint8_t)(pixels >> 40);
+   bytes[3] = (uint8_t)(pixels >> 32);
+   bytes[4] = (uint8_t)(pixels >> 24);
+   bytes[5] = (uint8_t)(pixels >> 16);
+   bytes[6] = (uint8_t)(pixels >> 8);
+   bytes[7] = (uint8_t)(pixels);
+
+   src = _mm_loadl_epi64((const __m128i *)bytes);
+   if (!flagTRANS)
+   {
+      _mm_storel_epi64((__m128i *)lbuf, src);
+      return;
+   }
+
+   zero = _mm_setzero_si128();
+   mask = _mm_cmpeq_epi16(src, zero);
+   cur = _mm_loadl_epi64((const __m128i *)lbuf);
+   src = _mm_or_si128(_mm_and_si128(mask, cur),
+                      _mm_andnot_si128(mask, src));
+   _mm_storel_epi64((__m128i *)lbuf, src);
+}
+
+/*
+ * Store one 24bpp phrase (2 pixels / 8 bytes) into LBUF.
+ *
+ * Byte order matches OPProcessFixedBitmap's scalar walk: bits3..bits0
+ * per pixel through a uint8_t* with lbufDelta == +4. The 24bpp loop
+ * never applies RMW or shadow-FB hooks (RMW is 16bpp CRY-only); the
+ * caller still gates REFLECT, partial firstPix/i, and LBUF bounds.
+ *
+ * flagTRANS: skip a u32 lane when all four bytes are zero (same test
+ * as (bits3 | bits2 | bits1 | bits0) == 0). Opaque: straight 8-byte
+ * store.
+ */
+static OP_SIMD_INLINE void op_store_phrase_24bpp_sse2(
+      uint8_t *lbuf, uint64_t pixels, bool flagTRANS)
+{
+   uint8_t bytes[8];
+   __m128i src;
+   __m128i cur;
+   __m128i mask;
+   __m128i zero;
+
+   bytes[0] = (uint8_t)(pixels >> 56);
+   bytes[1] = (uint8_t)(pixels >> 48);
+   bytes[2] = (uint8_t)(pixels >> 40);
+   bytes[3] = (uint8_t)(pixels >> 32);
+   bytes[4] = (uint8_t)(pixels >> 24);
+   bytes[5] = (uint8_t)(pixels >> 16);
+   bytes[6] = (uint8_t)(pixels >> 8);
+   bytes[7] = (uint8_t)(pixels);
+
+   src = _mm_loadl_epi64((const __m128i *)bytes);
+   if (!flagTRANS)
+   {
+      _mm_storel_epi64((__m128i *)lbuf, src);
+      return;
+   }
+
+   zero = _mm_setzero_si128();
+   mask = _mm_cmpeq_epi32(src, zero);
+   cur = _mm_loadl_epi64((const __m128i *)lbuf);
+   src = _mm_or_si128(_mm_and_si128(mask, cur),
+                      _mm_andnot_si128(mask, src));
+   _mm_storel_epi64((__m128i *)lbuf, src);
+}
+
+#endif /* BLITTER_SIMD_HAVE_SSE2 */
+
+#endif /* OP_SIMD_SSE2_H */

--- a/src/tom/tom.c
+++ b/src/tom/tom.c
@@ -255,6 +255,7 @@
 
 #include "tom.h"
 #include "tom_scan_simd_neon.h"
+#include "tom_scan_simd_sse2.h"
 
 #include <string.h>								// For memset()
 #include "blitter.h"
@@ -1198,6 +1199,8 @@ static void tom_render_scanline_hires(uint32_t * backbuffer)
    uint32_t px;
 #if defined(BLITTER_SIMD_HAVE_NEON)
    unsigned neon_done;
+#elif defined(BLITTER_SIMD_HAVE_SSE2)
+   unsigned sse2_done;
 #endif
 
    if (fn == tom_render_16bpp_cry_scanline)
@@ -1223,6 +1226,15 @@ static void tom_render_scanline_hires(uint32_t * backbuffer)
          tomHiresScratch[i] = backbuffer[i * n];
    }
    else
+#elif defined(BLITTER_SIMD_HAVE_SSE2)
+   /* Same n==2 gate as the NEON branch above. */
+   if (n == 2u)
+   {
+      sse2_done = tom_scan_sse2_hires_gather_n2(backbuffer, tomHiresScratch, w);
+      for (i = sse2_done; i < w; i++)
+         tomHiresScratch[i] = backbuffer[i * n];
+   }
+   else
 #endif
    {
       for (i = 0; i < w; i++)
@@ -1238,6 +1250,15 @@ static void tom_render_scanline_hires(uint32_t * backbuffer)
          neon_done = tom_scan_neon_hires_expand_n2(tomHiresScratch, dst, w);
          dst += neon_done * 2u;
          i = neon_done;
+      }
+      else
+         i = 0;
+#elif defined(BLITTER_SIMD_HAVE_SSE2)
+      if (n == 2u)
+      {
+         sse2_done = tom_scan_sse2_hires_expand_n2(tomHiresScratch, dst, w);
+         dst += sse2_done * 2u;
+         i = sse2_done;
       }
       else
          i = 0;
@@ -1294,6 +1315,15 @@ void tom_render_24bpp_scanline(uint32_t * VJ_RESTRICT backbuffer)
       backbuffer += n;
       width = (uint16_t)(width - n);
    }
+#elif defined(BLITTER_SIMD_HAVE_SSE2)
+   if (pwidth_scale == 1)
+   {
+      unsigned n;
+      n = tom_scan_sse2_24bpp(current_line_buffer, backbuffer, width);
+      current_line_buffer += n * 4;
+      backbuffer += n;
+      width = (uint16_t)(width - n);
+   }
 #endif
    while (width >= pwidth_scale)
    {
@@ -1327,6 +1357,15 @@ void tom_render_16bpp_direct_scanline(uint32_t * VJ_RESTRICT backbuffer)
    {
       unsigned n;
       n = tom_scan_neon_16bpp_direct(current_line_buffer, backbuffer, width);
+      current_line_buffer += n * 2;
+      backbuffer += n;
+      width = (uint16_t)(width - n);
+   }
+#elif defined(BLITTER_SIMD_HAVE_SSE2)
+   if (pwidth_scale == 1)
+   {
+      unsigned n;
+      n = tom_scan_sse2_16bpp_direct(current_line_buffer, backbuffer, width);
       current_line_buffer += n * 2;
       backbuffer += n;
       width = (uint16_t)(width - n);
@@ -1417,6 +1456,15 @@ void tom_render_16bpp_rgb_scanline(uint32_t * VJ_RESTRICT backbuffer)
    {
       unsigned n;
       n = tom_scan_neon_16bpp_rgb(current_line_buffer, backbuffer, width);
+      current_line_buffer += n * 2;
+      backbuffer += n;
+      width = (uint16_t)(width - n);
+   }
+#elif defined(BLITTER_SIMD_HAVE_SSE2)
+   if (pwidth_scale == 1)
+   {
+      unsigned n;
+      n = tom_scan_sse2_16bpp_rgb(current_line_buffer, backbuffer, width);
       current_line_buffer += n * 2;
       backbuffer += n;
       width = (uint16_t)(width - n);

--- a/src/tom/tom_scan_simd_sse2.h
+++ b/src/tom/tom_scan_simd_sse2.h
@@ -1,0 +1,205 @@
+/*
+ * TOM scanline converters — x86 SSE2 implementation.
+ *
+ * Guarded by BLITTER_SIMD_HAVE_SSE2 from blitter_simd_arch.h (capability,
+ * not a new BUILD_AXES flag).  Port of tom_scan_simd_neon.h; the
+ * semantics comments there are the authority.  Kernels use only SSE2
+ * (emmintrin.h) — no SSSE3 pshufb, no SSE4 — because the libretro
+ * buildbot x86 baseline is SSE2.  Included from tom.c; keep this file
+ * C89 (vars at top of each block).
+ *
+ * SSE2 implies x86, which is always little-endian, so the u32-lane
+ * tricks below (24bpp field extraction from a raw dword load) can
+ * assume byte 0 of memory is bits 7:0 of the lane.
+ */
+
+#ifndef TOM_SCAN_SIMD_SSE2_H
+#define TOM_SCAN_SIMD_SSE2_H
+
+#include "blitter_simd_arch.h"
+
+#if defined(BLITTER_SIMD_HAVE_SSE2)
+
+#include <emmintrin.h>
+#include <stdint.h>
+
+#ifndef VJ_RESTRICT
+#if defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER)
+#  define VJ_RESTRICT __restrict
+#else
+#  define VJ_RESTRICT
+#endif
+#endif
+
+#ifndef INLINE
+#define INLINE
+#endif
+
+/* Byte-swap each u16 lane: the vrev16q_u8 of SSE2. */
+#define TOM_SCAN_SSE2_BSWAP16(v) \
+   _mm_or_si128(_mm_slli_epi16((v), 8), _mm_srli_epi16((v), 8))
+
+/* 8 BE u16 pixels -> XRGB8888 via (color >> 1), matching
+ * tom_render_16bpp_direct_scanline.  Returns pixels written (multiple of 8). */
+static INLINE unsigned tom_scan_sse2_16bpp_direct(
+   const uint8_t * VJ_RESTRICT src,
+   uint32_t * VJ_RESTRICT dst,
+   unsigned n)
+{
+   unsigned i;
+   unsigned done;
+   __m128i raw;
+   __m128i pix;
+   __m128i zero;
+
+   done = n & ~7u;
+   zero = _mm_setzero_si128();
+   for (i = 0; i < done; i += 8)
+   {
+      raw = _mm_loadu_si128((const __m128i *)(src + (i * 2)));
+      pix = _mm_srli_epi16(TOM_SCAN_SSE2_BSWAP16(raw), 1);
+      _mm_storeu_si128((__m128i *)(dst + i), _mm_unpacklo_epi16(pix, zero));
+      _mm_storeu_si128((__m128i *)(dst + i + 4), _mm_unpackhi_epi16(pix, zero));
+   }
+   return done;
+}
+
+/* 4 Jaguar 24bpp pixels (G,R,pad,B) per step -> XRGB8888
+ * 0xFF000000 | (r << 16) | (g << 8) | b.  Returns pixels written (multiple of 4).
+ *
+ * No vld4 deinterleave here: on little-endian x86 a raw dword load puts
+ * G in bits 7:0, R in 15:8, pad in 23:16, B in 31:24, so per lane
+ *    out = 0xFF000000 | ((x & 0xFFFF) << 8) | (x >> 24)
+ * moves G to 15:8, R to 23:16 and B to 7:0 in three ops. */
+static INLINE unsigned tom_scan_sse2_24bpp(
+   const uint8_t * VJ_RESTRICT src,
+   uint32_t * VJ_RESTRICT dst,
+   unsigned n)
+{
+   unsigned i;
+   unsigned done;
+   __m128i x;
+   __m128i out;
+   __m128i alpha;
+   __m128i mask_gr;
+
+   done = n & ~3u;
+   alpha = _mm_set1_epi32((int)0xFF000000u);
+   mask_gr = _mm_set1_epi32(0x0000FFFF);
+   for (i = 0; i < done; i += 4)
+   {
+      x = _mm_loadu_si128((const __m128i *)(src + (i * 4)));
+      out = _mm_or_si128(alpha,
+            _mm_or_si128(_mm_slli_epi32(_mm_and_si128(x, mask_gr), 8),
+                         _mm_srli_epi32(x, 24)));
+      _mm_storeu_si128((__m128i *)(dst + i), out);
+   }
+   return done;
+}
+
+/* 8 Jaguar RGB16 pixels (RBG 556: RRRRR BBBBB GGGGGG) -> XRGB8888, bit-
+ * identical to RGB16ToRGB32[] filled by TOMFillLookupTables:
+ *   0xFF000000 | ((c & 0xF800) << 8) | ((c & 0x003F) << 10) | ((c & 0x07C0) >> 3)
+ * Returns pixels written (multiple of 8). */
+static INLINE unsigned tom_scan_sse2_16bpp_rgb(
+   const uint8_t * VJ_RESTRICT src,
+   uint32_t * VJ_RESTRICT dst,
+   unsigned n)
+{
+   unsigned i;
+   unsigned done;
+   __m128i raw;
+   __m128i c;
+   __m128i c32;
+   __m128i r;
+   __m128i g;
+   __m128i b;
+   __m128i out;
+   __m128i zero;
+   __m128i alpha;
+   __m128i mask_r;
+   __m128i mask_g;
+   __m128i mask_b;
+
+   done = n & ~7u;
+   zero = _mm_setzero_si128();
+   alpha = _mm_set1_epi32((int)0xFF000000u);
+   mask_r = _mm_set1_epi32(0xF800);
+   mask_g = _mm_set1_epi32(0x003F);
+   mask_b = _mm_set1_epi32(0x07C0);
+   for (i = 0; i < done; i += 8)
+   {
+      raw = _mm_loadu_si128((const __m128i *)(src + (i * 2)));
+      c = TOM_SCAN_SSE2_BSWAP16(raw);
+
+      c32 = _mm_unpacklo_epi16(c, zero);
+      r = _mm_slli_epi32(_mm_and_si128(c32, mask_r), 8);
+      g = _mm_slli_epi32(_mm_and_si128(c32, mask_g), 10);
+      b = _mm_srli_epi32(_mm_and_si128(c32, mask_b), 3);
+      out = _mm_or_si128(alpha, _mm_or_si128(r, _mm_or_si128(g, b)));
+      _mm_storeu_si128((__m128i *)(dst + i), out);
+
+      c32 = _mm_unpackhi_epi16(c, zero);
+      r = _mm_slli_epi32(_mm_and_si128(c32, mask_r), 8);
+      g = _mm_slli_epi32(_mm_and_si128(c32, mask_g), 10);
+      b = _mm_srli_epi32(_mm_and_si128(c32, mask_b), 3);
+      out = _mm_or_si128(alpha, _mm_or_si128(r, _mm_or_si128(g, b)));
+      _mm_storeu_si128((__m128i *)(dst + i + 4), out);
+   }
+   return done;
+}
+
+/* Strided gather of every 2nd uint32: dst[i] = src[i * 2].
+ * Matches tom_render_scanline_hires's seed of tomHiresScratch from the
+ * existing Nx row.  _mm_shuffle_ps(a, b, 2,0,2,0) is the vld2q lane-0
+ * gather (bit moves only — no FP arithmetic, so no denormal hazard).
+ * Returns source pixels written (multiple of 4). */
+static INLINE unsigned tom_scan_sse2_hires_gather_n2(
+   const uint32_t * VJ_RESTRICT src,
+   uint32_t * VJ_RESTRICT dst,
+   unsigned n)
+{
+   unsigned i;
+   unsigned done;
+   __m128i a;
+   __m128i b;
+   __m128i even;
+
+   done = n & ~3u;
+   for (i = 0; i < done; i += 4)
+   {
+      a = _mm_loadu_si128((const __m128i *)(src + (i * 2)));
+      b = _mm_loadu_si128((const __m128i *)(src + (i * 2) + 4));
+      even = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(a), _mm_castsi128_ps(b),
+            _MM_SHUFFLE(2, 0, 2, 0)));
+      _mm_storeu_si128((__m128i *)(dst + i), even);
+   }
+   return done;
+}
+
+/* 2x box-replicate: dst[2*i] = dst[2*i+1] = src[i].
+ * unpacklo/unpackhi_epi32(a, a) is the vzipq pair.  Returns source
+ * pixels expanded (multiple of 4). */
+static INLINE unsigned tom_scan_sse2_hires_expand_n2(
+   const uint32_t * VJ_RESTRICT src,
+   uint32_t * VJ_RESTRICT dst,
+   unsigned n)
+{
+   unsigned i;
+   unsigned done;
+   __m128i a;
+
+   done = n & ~3u;
+   for (i = 0; i < done; i += 4)
+   {
+      a = _mm_loadu_si128((const __m128i *)(src + i));
+      _mm_storeu_si128((__m128i *)(dst + (i * 2)), _mm_unpacklo_epi32(a, a));
+      _mm_storeu_si128((__m128i *)(dst + (i * 2) + 4), _mm_unpackhi_epi32(a, a));
+   }
+   return done;
+}
+
+#endif /* BLITTER_SIMD_HAVE_SSE2 */
+
+#endif /* TOM_SCAN_SIMD_SSE2_H */


### PR DESCRIPTION
Closes #686

## What was ported

x86 SSE2 (`emmintrin.h` only) equivalents of the NEON fast paths from #670 / #672 / #682, so Intel Linux/Windows/macOS and Android x86/x86_64 builds get the same wins:

- **`src/tom/op_simd_sse2.h`** — `op_store_phrase_16bpp_sse2()` and `op_store_phrase_24bpp_sse2()`: 8-byte phrase stores via `movq` load/store, TRANS lane masking via `_mm_cmpeq_epi16/epi32` against zero + the `and/andnot/or` select (the SSE2 spelling of `vbsl`). Dispatched from `OPProcessFixedBitmap` in `op.c` as an `#elif defined(BLITTER_SIMD_HAVE_SSE2)` branch with the guard conditions copied verbatim from the NEON branch (no RMW, `lbufDelta` +2/+4, no shadow-FB hooks on 16bpp, full phrase only, LBUF bounds).
- **`src/tom/tom_scan_simd_sse2.h`** — `tom_scan_sse2_16bpp_direct()`, `tom_scan_sse2_24bpp()`, `tom_scan_sse2_16bpp_rgb()`, plus the 2x hi-res `gather_n2` (`_mm_shuffle_ps` even-lane gather) and `expand_n2` (`_mm_unpacklo/hi_epi32`) kernels. Dispatched from `tom.c` with the same `pwidth_scale == 1` / `n == 2` gates as NEON. The 24bpp converter needs no `vld4`-style deinterleave: x86 is always little-endian, so a raw dword load + `((x & 0xFFFF) << 8) | (x >> 24)` + alpha reassembles XRGB8888 in three vector ops — no converter had to be skipped, and nothing needs SSSE3/SSE4.

Capability comes from the existing `BLITTER_SIMD_HAVE_SSE2` in `blitter_simd_arch.h`; exactly one (or neither) fast path compiles per target.

## Deliberately skipped

- **Voicechat mix**: #666 merged while this was in flight; the SSE2 port of `voicechat_simd_neon.h` is a separate follow-up (the broadened tidy regex below already covers `src/jerry/` fragments).
- **CRC32**: x86 `_mm_crc32_*` is CRC-32C (Castagnoli polynomial) and **cannot** compute the ISO-HDLC CRC32 this core uses (#676's ARM port uses ARMv8's ISO-HDLC `crc32*` instructions, which have no x86 counterpart). Please don't "finish" this later with the SSE4.2 intrinsics — the polynomial is wrong.
- `src/m68000/` and the blitter untouched (blitter already has its SSE2 arm).

## CI / lint changes

- **clang-tidy job**: the changed-files exclusion regex only carved out `src/tom/blitter_simd_(neon|sse2|scalar).{c,h}`; the newer include-only SIMD fragment headers would fail the job whenever a PR touches them. Broadened to `src/(tom|jerry)/[a-z0-9_]+_simd_(neon|sse2|scalar)\.(c|h)$` (covers `op_simd_*`, `tom_scan_simd_*`, `voicechat_simd_*`, and future fragments); comment updated. Verified the new regex keeps `op.c`, `tom.c`, and the lintable dispatcher `blitter_simd.h` in scope.
- **`scripts/c89-lint.sh`**: new headers added to the default-pass skip list (same pattern as the NEON ones), and the per-arch `check_simd_arch` pass now also compiles `src/tom/op.c` and `src/tom/tom.c` per arch — that pass (`--target=x86_64… -msse2` / `--target=aarch64…`) is the only host-side syntax coverage the non-native fragment header gets, and is how the SSE2 headers were syntax-probed on this arm64 Mac.

## Build-system verification (no flag changes needed)

- **x86_64 (unix / MSYS2 MINGW64 / osx cross)**: SSE2 is the ABI baseline; `BLITTER_SIMD_HAVE_SSE2` is unconditional there. No changes.
- **32-bit i686 (Linux i686 CI row, MSYS2 MINGW32)**: `Makefile.common` already appends `-msse2` whenever it selects the SSE2 blitter (its "required on i686 / gcc -m32" rule) — both 32-bit CI rows select it, so `__SSE2__` is defined and the new paths ride along with **zero** flag changes. A generic i386 build that neither selects the SSE2 blitter nor passes `-msse2` correctly stays scalar via the capability macro — that is the designed behavior (`blitter_simd_arch.h` tests capability, not architecture), so no `-msse2` was forced onto any target that didn't already have it.
- **Android x86/x86_64**: NDK baselines include SSE2; the existing CI assertion (`blitter_simd_sse2.o` per ABI) is unchanged.
- **MSVC x64 / 2015+ x86**: `/arch:SSE2`-or-baseline, `_M_IX86_FP == 2` gate already handled by the capability macro; `windows_msvc2010_*` stays scalar as before.
- `test/tools/simd_matrix_check.sh` asserts Makefile-level *blitter selection* via variable expansion; the new headers are compile-time capability-guarded, not Makefile-selected, so no rows extend naturally and it is untouched.

## Test evidence (arm64 macOS host, Rosetta 2 available)

1. **Native arm64 build** (`make -j8` clean tree): 0 errors — NEON side unchanged, SSE2 headers compile to nothing.
2. **arm64 `make TEST_EXPORTS=1 test`**: full suite exits 0, **0 failed** (2 environmental skips: no `/tmp/fountain_vj.j64`, no CHSE-capable chdman — both pre-existing).
3. **x86_64 cross build** (`make platform=osx CC="cc -arch x86_64" … BLITTER_SIMD=sse2`, mirroring the "macOS x86_64 (Clang, cross)" CI row): links clean; `pcmpeqw/pcmpeqd` present in the dylib text section.
4. **Rosetta regression**: `test/regression_test.sh` on the x86_64 SSE2 core with an x86_64 miniretro — **10 passed, 0 failed**, yarc "0 pixels differ" vs committed baselines, determinism / frameskip-invariance / savestate / rewind all PASS.
5. **Rosetta A/B vs develop-built x86_64 core** (`frame_hash_ab`, full-framebuffer FNV per frame): 600 frames × {yarc.j64, jagniccc.j64} × {default, `virtualjaguar_internal_resolution=2x`} — all four CSV pairs **byte-identical** (601 rows each). The 2x runs render 640×480, so the hi-res gather/expand kernels executed on both sides.
6. **`bash scripts/c89-lint.sh src/tom/op.c src/tom/tom.c`**: pass, including the new sse2/neon per-arch passes.

24bpp mode isn't reachable from the two public ROMs; that path is identical-by-construction to the NEON port (same guards, same lane test) and is covered by the Linux x86_64 acid/regression CI on this PR.

No perf numbers claimed from this host: Rosetta translates SSE2 to NEON, so timings here say nothing about real Intel hardware.