### PR TITLE
perf: RISC spin-PC + frame-cost attribution tooling and MC3D stall audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,9 +177,12 @@ __pycache__/
 /test/tools/counter_rate_scan
 /test/tools/gpu_bench_read
 /test/tools/gpu_disasm_dump
+/test/tools/frame_cost_probe
 /test/tools/gpu_pipe_probe
 /test/tools/irq_rate_probe
 /test/tools/m68k_pc_histogram
+/test/tools/risc_backtrace_histogram
+/test/tools/risc_pc_histogram
 /test/tools/menu_step_probe
 /test/tools/present_rate_probe
 test/tools/blitter_static_leak

--- a/docs/perf-audit/mc3d-stall-attribution.md
+++ b/docs/perf-audit/mc3d-stall-attribution.md
@@ -1,0 +1,172 @@
+# Missile Command 3D — RISC stall attribution (2026-08-27)
+
+Where MC3D's interpreter budget actually goes, and what the >16 ms spike frames do
+differently (answer: nothing — see §3).  Follows up the host profile that showed GPU
+interpreter ~33% / DSP interpreter ~28% of samples with `jr` the top single opcode in both.
+Shorthand, LLM-oriented; companion to [`../perf-audit-2026-08.md`](../perf-audit-2026-08.md).
+
+**Tools introduced with this audit** (both need `make TEST_EXPORTS=1`; build lines in each
+file's header):
+
+- `test/tools/risc_backtrace_histogram.c` — drains the vjtrace GPU/DSP PC-history rings
+  (`vjtrace_backtrace()`, last 1024 PCs/processor) after every frame and histograms them, so
+  the profile covers **in-frame** execution, not just the parked frame-end PC that the
+  existing `risc_pc_histogram` samples.  Disassembles the loop body around each top PC from a
+  **first-sighting snapshot** (MC3D overlays GPU kernels, so code read at exit can be a
+  different program — the tool flags that), and records frame-end parked-PC **register
+  snapshots**, which is what resolved the polled addresses below.
+- `test/tools/frame_cost_probe.c` — per-frame CSV of wall ms + work counts
+  (GPU/DSP interpreted-opcode deltas, DSP idle-skip savings, IRQ/OP/blitter event counters
+  from `vjtrace_counters`), plus a `--top N` most-expensive-frames-vs-median report.
+
+Setup: worktree at `libretro/develop` (baf682d), macOS arm64 (M-series),
+`make TEST_EXPORTS=1`, MC3D attract mode (no input — fixed-frame scripted input is invalid
+for timing, per the vj-debug trap list), 900-frame warmup, 6000 measured frames.
+Caveat that applies to every number here: **arming vjtrace force-disables the DSP idle-loop
+fast-forward** (`DSPExec` gate, issue #569) and adds per-instruction ring-write overhead, so
+the armed runs measure the fully-interpreted stream.  That matches the shipping default
+(`virtualjaguar_risc_idle_skip` ships disabled) but not a config where the user enabled it.
+Counts are load-insensitive; the ms columns are same-run-relative only.
+
+## 1. GPU: 66.8% of interpreted instructions are ONE 3-instruction semaphore poll
+
+Backtrace-ring histogram, 6,144,000 sampled instructions (1024/frame × 6000 frames):
+
+| rank | PC | share | what |
+| --- | --- | ---: | --- |
+| 1-3 | `$F03134/36/38` | **66.75%** | scene-ready semaphore poll (below) |
+| 4-20 | `$F03924-48` | ~8.2% (0.48% each, flat) | blitter-feeding kernel — straight-line real work |
+
+The dominant loop (all three PCs are the same loop):
+
+```
+$F03134: A402  load   (r0),r2      ; r0 = $00009704  (main RAM, from parked-reg snapshot)
+$F03136: 7822  cmp    r1,r2        ; r1 = 3
+$F03138: D7B8  jr     N,-3 -> $F03134
+$F0313A: 8C04  moveq  #0,r4        ; delay slot
+```
+
+It polls **main-RAM word `$9704` until it reaches 3**.  A vjtrace watch
+(`--watch 0x9704:4:rw`) names both sides: the **68K writes 1→2→3 from PC `$9A18`** (~1.4
+writes/frame) and the GPU itself clears it at `$F03144` after the wait exits.  So this is a
+GPU-waits-for-68K scene semaphore: the 68K prepares the next scene stage while the GPU burns
+its entire remaining slice budget interpreting a 3-instruction wait.  `gpu_exec_opcode_count`
+is ~442,700/frame, dead flat — deterministic slice budgets mean the GPU consumes its full
+26.6 MHz budget every frame whether it works or waits.
+
+The flat 0.48%-per-PC block at `$F03924-48` is a per-strip blit submission kernel (parked
+r14=`$F02200` A1_BASE, r15=`$F02224` A1_PIXEL, r16=`$F02238` B_CMD, r18=`$F0223C` B_COUNT).
+Its `load (r16) ; btst #0 ; jr Z,-3` head looks like a blitter-busy wait but is NOT a spin in
+this core: blits execute synchronously on the B_CMD write, so the poll exits after one
+iteration.  Equal hit counts across all ~17 PCs confirm straight-line execution — this ~8% is
+real work, not elidable.
+
+MC3D swaps GPU overlays (the RAM at `$F03134` holds an MMULT transform kernel at other
+times), which is why the first-sighting code snapshot in the tool matters.
+
+## 2. DSP: 57.4% is the Atari sound driver's I2S tick poll
+
+| rank | PC | share | what |
+| --- | --- | ---: | --- |
+| 1-3 | `$F1B128/2A/2C` | **57.4%** | I2S frame-counter poll (below) |
+| 4-9 | `$F1B0E8-F4` | ~4.6% | command/jump-table dispatch — real work |
+| 10+ | `$F1B2B8...` | ~0.29% each, flat | mixer straight-line code — real work |
+
+```
+$F1B128: 7B82  cmp     r28,r2       ; r28 = local tick counter
+$F1B12A: 96A2  movefa  r21,r2       ; r2 = ALTERNATE-bank r21 (written by the I2S ISR)
+$F1B12C: D7A2  jr      Z,-3 -> $F1B128
+$F1B12E: 0C20  addqt   r1,r0        ; delay slot: monotonic accumulator
+```
+
+Same driver family as Iron Soldier / AvP (`perf-audit-2026-08.md` measured 74-99.7% there):
+wait until the ISR-advanced alternate-bank counter differs from the local copy.
+`dsp_exec_opcode_count` ~473,700/frame — the DSP too consumes its whole budget every frame.
+
+**The shipped DSP idle-loop fast-forward already catches this loop.**  With
+`virtualjaguar_risc_idle_skip=enabled` (`test/tools/dsp_idle_ab`, 300 measured frames):
+interpreted DSP opcodes drop 474,867 → 182,637/frame (**−61.5%**), fires=995/frame,
+opcodes_skipped=87.7M/300 frames.  It ships **disabled by default** while the compatibility
+corpus grows, and is also suppressed by blit-memo / non-stock clock scale / dram_timing /
+gpu_pipeline_timing / armed vjtrace.  There is **no GPU equivalent** yet (P1 "port to GPU" is
+unimplemented).
+
+## 3. Spike frames: the expensive frames do the SAME emulated work
+
+`frame_cost_probe`, 6000 frames.  Clean (unarmed) baseline from `risc_pc_histogram` on the
+same host/session: p50 8.7 ms, p99 47.8 ms, p999 114.6 ms, max 199 ms, 15.45% over the 16.67 ms
+budget (this host was noisier than the earlier 3.0/30.6 ms capture; the bimodal shape
+reproduces regardless).
+
+Per-frame work counts vs frame time, 6000 frames:
+
+| column | correlation with ms |
+| --- | ---: |
+| gpu_ops | 0.004 |
+| dsp_ops | 0.041 |
+| blit_cmd | 0.281 |
+| op_obj / op_list / irq_assert | constant (1007 / 256 / 1 per frame) |
+
+The worst frame (124.6 ms) executed 442,707 GPU ops, 440,502 DSP ops, 326 blits, 1007 OP
+objects — indistinguishable from the 12 ms median frame (442,703 / 456,065 / 324 / 1007).  A
+60 ms frame ran **zero** blits; the 6,589-blit frame took 32.6 ms.  Slow frames cluster in
+adjacent runs (297 of 579 over-budget frames are adjacent to another; e.g. 3321-3323,
+6206-6207) — the signature of transient host interference, not workload.
+
+**Conclusion: the spikes are host-side (scheduler/QoS/thermal), not emulated-work bursts.**
+The emulated workload is nearly constant per frame *because* both RISC interpreters always
+burn their full slice budgets — mostly spinning.  The actionable lever is therefore not
+"find the expensive frame" but "lower the constant baseline" so host-noise spikes stay under
+budget: on the A12 the same interference lands on a much higher baseline and drops frames.
+(yarc cross-check reproduces this: frames 62-70 hit 12-14 ms vs a 5.95 ms median with
+byte-flat counts.)
+
+## 4. Cross-checks (300 frames each)
+
+- **yarc.j64** — GPU: **100%** of sampled instructions at `$F03192` `jr Z,-1` self-spin
+  (delay slot `cmpq #0,r22` re-arms Z; exits via interrupt).  DSP: 0 instructions.  Confirms
+  the #533 "yarc is an amplifier" caveat with the loop now named.
+- **jagniccc.j64** — GPU: **100%** split across `$F03042/44`:
+  `load (r15),r0 (ds) ; cmpq #0,r0 ; jr NZ,-2` with parked r15=`$F03FF0` — polls a 68K
+  mailbox in GPU **local** RAM (matches `perf-audit-2026-08.md`'s finding, now with the
+  address resolved from registers).  DSP: healthy spread (top PC 7.6%, mixer/dispatch code) —
+  niccc's DSP does real work; its wait share is small.  Frame times tight (p99 6.5 ms armed).
+
+## 5. Ranked optimization candidates
+
+1. **GPU port of the idle-loop fast-forward** (P1 phase 3, issue #569 framework) — MC3D's
+   `$F03134` poll is 66.8% of GPU interpretation (≈22% of total frame at the profiled 33%
+   GPU share); jagniccc's mailbox poll is ~100% of its GPU samples; yarc's self-`jr` is 100%.
+   All three shapes are admissible under the existing DSP admission rules (plain-RAM/local-RAM
+   loads + ALU + the loop-closing `jr`; register-space loads stay excluded).
+   *Determinism risk: must stay byte-identical* — same contract the DSP skip already meets
+   (cycles, registers, flags, `gpu_exec_opcode_count` advanced exactly; gate off under
+   dram_timing / pipeline timing / clock scale / armed vjtrace; A/B with
+   `test/tools/dsp_idle_ab`-style framebuffer+audio hash sweep and `ir_ab.sh`).
+2. **Ship `virtualjaguar_risc_idle_skip` wider** (per-title titledb rows or default-on after
+   corpus validation) — zero new code; measured −61.5% DSP interpretation on MC3D, and the
+   DSP is ~28% of frame → ≈16% of total frame recovered on the default config that currently
+   leaves it off.  *Determinism risk: bit-exact by construction; the open question is corpus
+   coverage, which is a validation task, not a design one.*
+3. **Semaphore wait-elision beyond affine loops** (future, only if 1 underdelivers): MC3D's
+   GPU poll exits via a 68K write that can only land between RISC slices, so a slice whose
+   fixed-point probe proves "polled RAM word unchanged ⇒ loop is a fixed point" could skip to
+   slice end in O(1) even where the affine-delta test fails.  *Determinism risk: same
+   byte-identical contract; needs the same probe framework.*
+4. **Host scheduling headroom on Apple TV / A12** (frontend-side, not core): the spikes are
+   host interference amplified by a high constant baseline.  After 1+2 cut the baseline
+   ~35-40%, re-measure on-device with the perf-counter route (`docs/profiling.md`) before
+   inventing further core work.  *No determinism risk.*
+5. **Not candidates**: the `$F03924` blitter-feed kernel (~8% GPU) and the DSP dispatch/mixer
+   code (~5%) are straight-line real work; the B_CMD `btst` poll exits after one iteration
+   because blits are synchronous in this core.
+
+## Follow-ups (tooling gaps found while measuring)
+
+- vjtrace has no per-frame **blitter pixel volume** counter (only BLIT_CMD count), so a
+  same-command-count/large-area blit storm would be invisible to `frame_cost_probe`; the
+  BENCH_PROFILE `blitter_inner` counter covers it but needs a separate build.  Noted rather
+  than added — out of scope for a tools-only PR.
+- `vjtrace_backtrace`'s ring records interpreter-loop PCs only (inlined `jr`/`jump` delay
+  slots and idle-skipped iterations don't push), so histogram shares slightly undercount
+  delay-slot instructions.  Documented in the tool header; harmless for spin attribution.

--- a/test/tools/frame_cost_probe.c
+++ b/test/tools/frame_cost_probe.c
@@ -1,0 +1,245 @@
+/* test/tools/frame_cost_probe.c -- what did the expensive frames DO?
+ *
+ * Times every retro_run() with the monotonic clock and pairs each frame
+ * with per-frame work counts: GPU/DSP interpreted-instruction deltas
+ * (gpu_exec_opcode_count / dsp_exec_opcode_count), the DSP idle-skip
+ * savings (dsp_idle_skip_opcodes: opcodes NOT interpreted), and the
+ * vjtrace event-type counters (IRQ asserts/dispatches, GPU_GO, OP list
+ * starts/objects/branches, blitter commands -- vjtrace_counters, the
+ * same totals trace_probe's --field-csv drains).  Purpose: attribute
+ * frame-time spikes (a 110 ms frame on a title whose p50 is 3 ms) to
+ * WHAT that frame did more of -- blitter storm, GPU scene rebuild, OP
+ * list explosion, IRQ pileup.
+ *
+ * Output: a CSV (one row per measured frame) to --csv FILE or stdout,
+ * plus a --top N report (stderr) ranking the N most expensive frames
+ * with their counts next to the median frame's.
+ *
+ * Timing caveat (docs/agent/testing.md "Measurement hazards"): wall
+ * clock needs a quiet host; use the count columns for cross-run
+ * comparison and the ms column only for same-run spike attribution.
+ * Fixed-frame scripted input is invalid for timing runs -- drive
+ * attract mode or a --load-state instead.
+ *
+ * Needs a TEST_EXPORTS=1 core (opcode counters + vjtrace are only
+ * exported there); exits loudly otherwise.
+ *
+ * Build:
+ *   make TEST_EXPORTS=1
+ *   cc -O2 -Wall -std=c99 -I. -I./libretro-common/include \
+ *      -o test/tools/frame_cost_probe \
+ *      test/tools/frame_cost_probe.c test/harness/harness.c -ldl -lm
+ *
+ * Run:
+ *   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
+ *   test/tools/frame_cost_probe ./virtualjaguar_libretro.dylib rom.jag \
+ *      --frames 2000 --warmup 900 --csv /tmp/cost.csv --top 12
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../harness/harness.h"
+#include "src/core/vjtrace.h"    /* event enum + vjtrace_counters_t (outside
+                                  * the VJ_TRACE guard by design) */
+
+/* One numeric field per column so the median/top report can iterate. */
+typedef enum { F_GPU, F_DSP, F_SKIP, F_IRQA, F_IRQD, F_GGO, F_OPL, F_OPO,
+               F_OPB, F_BLT, F__N } field_id;
+
+typedef struct
+{
+    double   ms;
+    uint64_t v[F__N];
+} frame_row;
+
+static const char *csv_header =
+    "frame,ms,gpu_ops,dsp_ops,dsp_skip_ops,irq_assert,irq_dispatch,"
+    "gpu_go,op_list,op_obj,op_branch,blit_cmd";
+
+static int cmp_double(const void *a, const void *b)
+{
+    double da = *(const double *)a, db = *(const double *)b;
+    return (da > db) - (da < db);
+}
+
+static int cmp_u64(const void *a, const void *b)
+{
+    uint64_t da = *(const uint64_t *)a, db = *(const uint64_t *)b;
+    return (da > db) - (da < db);
+}
+
+static void print_row(FILE *out, const char *label, double ms,
+                      const uint64_t *v)
+{
+    int f;
+    fprintf(out, "%8s %9.2f", label, ms);
+    for (f = 0; f < F__N; f++)
+        fprintf(out, " %9llu", (unsigned long long)v[f]);
+    fprintf(out, "\n");
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    void (*arm)(void);
+    vjtrace_counters_t *ctr;
+    uint32_t *gpu_cnt, *dsp_cnt, *skip_cnt;
+    frame_row *rows;
+    FILE *csv = stdout;
+    const char *csv_path = NULL;
+    unsigned warmup = 0, top_n = 10, i;
+    int a;
+
+    cfg.frames = 2000;
+    for (a = 1; a < argc; a++)
+    {
+        if (!strcmp(argv[a], "--warmup") && a + 1 < argc)
+            warmup = (unsigned)strtoul(argv[++a], NULL, 10);
+        else if (!strcmp(argv[a], "--csv") && a + 1 < argc)
+            csv_path = argv[++a];
+        else if (!strcmp(argv[a], "--top") && a + 1 < argc)
+            top_n = (unsigned)strtoul(argv[++a], NULL, 10);
+    }
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+    if (!harness_load_rom(&cfg))
+        return 1;
+
+    arm      = (void (*)(void))harness_dlsym(&cfg, "vjtrace_arm");
+    ctr      = (vjtrace_counters_t *)harness_dlsym(&cfg, "vjtrace_counters");
+    gpu_cnt  = (uint32_t *)harness_dlsym(&cfg, "gpu_exec_opcode_count");
+    dsp_cnt  = (uint32_t *)harness_dlsym(&cfg, "dsp_exec_opcode_count");
+    skip_cnt = (uint32_t *)harness_dlsym(&cfg, "dsp_idle_skip_opcodes");
+    if (!arm || !ctr || !gpu_cnt || !dsp_cnt)
+    {
+        fprintf(stderr, "frame_cost_probe: required symbols not exported -- "
+                        "build the core with TEST_EXPORTS=1\n");
+        return 2;
+    }
+    arm();   /* vjtrace counters only advance while armed */
+
+    if (csv_path)
+    {
+        csv = fopen(csv_path, "w");
+        if (!csv)
+        {
+            fprintf(stderr, "cannot open %s for writing\n", csv_path);
+            return 1;
+        }
+    }
+
+    rows = (frame_row *)calloc(cfg.frames, sizeof(frame_row));
+    if (!rows)
+    {
+        fprintf(stderr, "calloc failed for %u rows\n", cfg.frames);
+        return 1;
+    }
+
+    for (i = 0; i < warmup; i++)
+        harness_step(&cfg);
+
+    fprintf(csv, "%s\n", csv_header);
+    {
+        uint32_t g0 = *gpu_cnt, d0 = *dsp_cnt;
+        uint32_t s0 = skip_cnt ? *skip_cnt : 0;
+        vjtrace_counters_t c0 = *ctr;
+        for (i = 0; i < cfg.frames; i++)
+        {
+            frame_row *r = &rows[i];
+            uint64_t t0 = harness_time_now(), t1;
+            int f;
+            harness_step(&cfg);
+            t1 = harness_time_now();
+            r->ms        = harness_time_elapsed_sec(t0, t1) * 1000.0;
+            r->v[F_GPU]  = *gpu_cnt - g0;               g0 = *gpu_cnt;
+            r->v[F_DSP]  = *dsp_cnt - d0;               d0 = *dsp_cnt;
+            r->v[F_SKIP] = skip_cnt ? (uint32_t)(*skip_cnt - s0) : 0;
+            if (skip_cnt) s0 = *skip_cnt;
+            r->v[F_IRQA] = ctr->ev[VJT_EV_IRQ_ASSERT]    - c0.ev[VJT_EV_IRQ_ASSERT];
+            r->v[F_IRQD] = ctr->ev[VJT_EV_IRQ_DISPATCH]  - c0.ev[VJT_EV_IRQ_DISPATCH];
+            r->v[F_GGO]  = ctr->ev[VJT_EV_GPU_GO]        - c0.ev[VJT_EV_GPU_GO];
+            r->v[F_OPL]  = ctr->ev[VJT_EV_OP_LIST_START] - c0.ev[VJT_EV_OP_LIST_START];
+            r->v[F_OPO]  = ctr->ev[VJT_EV_OP_OBJECT]     - c0.ev[VJT_EV_OP_OBJECT];
+            r->v[F_OPB]  = ctr->ev[VJT_EV_OP_BRANCH]     - c0.ev[VJT_EV_OP_BRANCH];
+            r->v[F_BLT]  = ctr->ev[VJT_EV_BLIT_CMD]      - c0.ev[VJT_EV_BLIT_CMD];
+            c0 = *ctr;
+            fprintf(csv, "%u,%.3f", warmup + i + 1, r->ms);
+            for (f = 0; f < F__N; f++)
+                fprintf(csv, ",%llu", (unsigned long long)r->v[f]);
+            fprintf(csv, "\n");
+        }
+    }
+    if (csv != stdout)
+        fclose(csv);
+
+    /* ---- summary + --top N report (stderr so the CSV can be stdout) ---- */
+    {
+        unsigned n = cfg.frames;
+        double *ms_sorted = (double *)malloc(n * sizeof(double));
+        unsigned *order   = (unsigned *)malloc(n * sizeof(unsigned));
+        uint64_t *scratch = (uint64_t *)malloc(n * sizeof(uint64_t));
+        if (n && ms_sorted && order && scratch)
+        {
+            uint64_t med_v[F__N];
+            double p50, p99, max_ms;
+            unsigned over = 0, j, k;
+            int f;
+            for (i = 0; i < n; i++)
+                ms_sorted[i] = rows[i].ms;
+            qsort(ms_sorted, n, sizeof(double), cmp_double);
+            p50    = ms_sorted[n / 2];
+            p99    = ms_sorted[(unsigned)((double)n * 0.99)];
+            max_ms = ms_sorted[n - 1];
+            for (i = 0; i < n; i++)
+                if (rows[i].ms > 1000.0 / 60.0)
+                    over++;
+            fprintf(stderr, "frame_cost_probe: %u frames (warmup %u)  "
+                            "p50=%.2fms p99=%.2fms max=%.2fms  "
+                            "over-budget=%u (%.2f%%)\n",
+                    n, warmup, p50, p99, max_ms, over, 100.0 * over / n);
+
+            for (f = 0; f < F__N; f++)
+            {
+                for (i = 0; i < n; i++)
+                    scratch[i] = rows[i].v[f];
+                qsort(scratch, n, sizeof(uint64_t), cmp_u64);
+                med_v[f] = scratch[n / 2];
+            }
+
+            /* Partial selection sort: top_n most expensive frames. */
+            for (i = 0; i < n; i++)
+                order[i] = i;
+            if (top_n > n)
+                top_n = n;
+            for (j = 0; j < top_n; j++)
+            {
+                unsigned best = j;
+                for (k = j + 1; k < n; k++)
+                    if (rows[order[k]].ms > rows[order[best]].ms)
+                        best = k;
+                { unsigned t = order[j]; order[j] = order[best]; order[best] = t; }
+            }
+
+            fprintf(stderr, "\n--- top %u most expensive frames vs median ---\n",
+                    top_n);
+            fprintf(stderr, "%8s %9s %9s %9s %9s %9s %9s %9s %9s %9s %9s %9s\n",
+                    "frame", "ms", "gpu_ops", "dsp_ops", "skip_ops", "irq_a",
+                    "irq_d", "gpu_go", "op_list", "op_obj", "op_br", "blit");
+            print_row(stderr, "median", p50, med_v);
+            for (j = 0; j < top_n; j++)
+            {
+                char label[16];
+                snprintf(label, sizeof(label), "%u", warmup + order[j] + 1);
+                print_row(stderr, label, rows[order[j]].ms, rows[order[j]].v);
+            }
+        }
+        free(ms_sorted);
+        free(order);
+        free(scratch);
+    }
+
+    free(rows);
+    harness_shutdown(&cfg);
+    return 0;
+}

--- a/test/tools/risc_backtrace_histogram.c
+++ b/test/tools/risc_backtrace_histogram.c
@@ -1,0 +1,437 @@
+/* test/tools/risc_backtrace_histogram.c -- WHERE do the GPU and DSP
+ * interpreters actually spend their instructions?
+ *
+ * Companion to test/tools/risc_pc_histogram.c, which samples ONE PC per
+ * frame (the parked frame-end PC) and therefore measures "where is the
+ * processor when retro_run returns".  This tool instead drains the
+ * vjtrace GPU/DSP PC-history rings (vjtrace_backtrace(), up to 1024 PCs
+ * per processor per frame -- see src/core/vjtrace.h) after every frame,
+ * so the histogram covers in-frame execution, not just the final slice.
+ * A `jr`-dominated interpreter profile resolves here into the exact
+ * spin-loop PCs, each with its loop body disassembled so you can read
+ * what the loop is polling.
+ *
+ * Overlay safety: 3D engines (e.g. Missile Command 3D) swap GPU kernels
+ * in and out of local RAM, so code read at exit can be a DIFFERENT
+ * program than the one that was hot.  The disassembly context is
+ * therefore snapshotted from RISC RAM the first time a PC enters the
+ * histogram, and the dump marks a PC whose resident code has since
+ * changed.  (If two overlays run hot code at the SAME address, their
+ * hits merge into one bucket -- an aliasing this tool reports but
+ * cannot split.)
+ *
+ * Polled-address identification: after every frame the tool also
+ * records where each processor is PARKED (gpu_pc / dsp_pc) together
+ * with a first-seen snapshot of the 32 current-bank registers, so a
+ * spin loop like `load (r0),r2 ; cmp r1,r2 ; jr N,-3` can be resolved
+ * to the concrete address in r0.  Registers are read between slices,
+ * so the snapshot is architecturally consistent with the parked PC.
+ *
+ * Sampling model / caveats:
+ *   - The ring keeps the LAST 1024 PCs, so each frame contributes a
+ *     1024-instruction window biased toward end-of-frame slices.  With
+ *     ~400-450k RISC instructions per busy frame that is a ~0.2%
+ *     sample; spin loops (thousands of iterations per slice) dominate
+ *     any window, which is exactly the signal wanted.
+ *   - To avoid re-counting stale history when a processor is halted or
+ *     slow, only min(opcode_count_delta, ring_fill) NEWEST entries are
+ *     consumed per sample (gpu_exec_opcode_count / dsp_exec_opcode_count
+ *     deltas).  Delay-slot instructions advance the opcode counters
+ *     without pushing ring entries, so the delta can exceed the pushed
+ *     count -- the min() makes that safe (never stale data; at worst
+ *     the whole ring is consumed).
+ *   - Arming vjtrace force-disables the DSP idle-loop fast-forward
+ *     (vjs.riscIdleSkip gate in DSPExec), so this tool always measures
+ *     the FULLY INTERPRETED instruction stream -- which matches the
+ *     shipping default (the option ships disabled), but NOT a config
+ *     where the user enabled it.
+ *
+ * Needs a TEST_EXPORTS=1 core (vjtrace_arm/vjtrace_backtrace are only
+ * exported there); exits loudly otherwise.
+ *
+ * Build:
+ *   make TEST_EXPORTS=1
+ *   cc -O2 -Wall -std=c99 -I./libretro-common/include \
+ *      -o test/tools/risc_backtrace_histogram \
+ *      test/tools/risc_backtrace_histogram.c test/harness/harness.c -ldl -lm
+ *
+ * Run:
+ *   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) \
+ *   test/tools/risc_backtrace_histogram ./virtualjaguar_libretro.dylib \
+ *      rom.jag --frames 2000 --warmup 900 [--every N] [--top N] [--no-disasm]
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../harness/harness.h"
+
+/* who values for vjtrace_backtrace(), mirroring the enum in
+ * src/core/vjag_memory.h: { UNKNOWN, JAGUAR, DSP, GPU, ... }. */
+#define WHO_DSP 2
+#define WHO_GPU 3
+
+#define BT_CAP    1024          /* VJT_PCHIST_CAP */
+#define NBUCKET   32768u        /* per-processor open-addressing table */
+#define CTX_BEFORE 8            /* disasm context: instrs before hot PC */
+#define CTX_AFTER  5            /* ... and after (covers jr + delay slot) */
+#define CTX_WORDS (CTX_BEFORE + 1 + CTX_AFTER)
+#define NPARK     32            /* distinct parked PCs tracked per proc */
+
+typedef void (*backtrace_fn)(int who, uint32_t *out, int maxn, int *count);
+typedef uint16_t (*read_word_fn)(uint32_t addr, uint32_t who);
+typedef uint32_t (*get_reg_fn)(int reg);
+
+static backtrace_fn  g_backtrace;
+static read_word_fn  g_rd;
+static uint32_t     *g_gpu_cnt, *g_dsp_cnt;
+static uint32_t     *g_gpu_pc,  *g_dsp_pc;
+static get_reg_fn    g_gpu_reg, g_dsp_reg;
+
+typedef struct
+{
+    uint32_t pc[NBUCKET];
+    uint64_t n[NBUCKET];
+    uint16_t code[NBUCKET][CTX_WORDS];  /* first-sighting snapshot */
+    uint64_t total;
+    uint32_t last_cnt;          /* opcode counter at previous sample */
+} pc_hist;
+
+/* Frame-end parked-PC table: count per distinct parked PC, plus the
+ * current-bank register file captured the first time it was seen. */
+typedef struct
+{
+    uint32_t pc[NPARK];
+    uint64_t n[NPARK];
+    uint32_t regs[NPARK][32];
+    unsigned used;
+    uint64_t overflow;          /* parks at PCs beyond the NPARK table */
+} park_tab;
+
+static pc_hist  hist_gpu, hist_dsp;
+static park_tab park_gpu, park_dsp;
+
+static unsigned opt_warmup = 0;
+static unsigned opt_every  = 1;
+static unsigned opt_top    = 20;
+static int      opt_disasm = 1;
+
+static uint32_t ctx_base(uint32_t pc)
+{
+    return (pc >= 2u * CTX_BEFORE) ? pc - 2u * CTX_BEFORE : 0;
+}
+
+static void bump(pc_hist *h, uint32_t pc)
+{
+    uint32_t start = (pc * 2654435761u) % NBUCKET, i;
+    for (i = 0; i < NBUCKET; i++)
+    {
+        uint32_t k = (start + i) % NBUCKET;
+        if (h->n[k] && h->pc[k] != pc)
+            continue;
+        if (!h->n[k] && g_rd)
+        {
+            /* New bucket: snapshot the surrounding code NOW, while the
+             * overlay that is executing this PC is resident. */
+            uint32_t base = ctx_base(pc), w;
+            for (w = 0; w < CTX_WORDS; w++)
+                h->code[k][w] = g_rd(base + w * 2, 0);
+        }
+        h->pc[k] = pc;
+        h->n[k]++;
+        h->total++;
+        return;
+    }
+}
+
+static void park_note(park_tab *t, uint32_t pc, get_reg_fn getreg)
+{
+    unsigned i;
+    for (i = 0; i < t->used; i++)
+    {
+        if (t->pc[i] == pc)
+        {
+            t->n[i]++;
+            return;
+        }
+    }
+    if (t->used < NPARK)
+    {
+        int r;
+        t->pc[t->used] = pc;
+        t->n[t->used]  = 1;
+        if (getreg)
+            for (r = 0; r < 32; r++)
+                t->regs[t->used][r] = getreg(r);
+        t->used++;
+    }
+    else
+        t->overflow++;
+}
+
+/* Drain one processor's backtrace into its histogram, consuming only
+ * the entries new since the previous sample (see header comment). */
+static void sample_proc(pc_hist *h, int who, uint32_t *cnt_sym)
+{
+    uint32_t buf[BT_CAP];
+    int got = 0, take, i;
+    uint32_t delta;
+
+    g_backtrace(who, buf, BT_CAP, &got);
+    if (got <= 0)
+        return;
+    if (cnt_sym)
+    {
+        uint32_t cur = *cnt_sym;
+        delta = cur - h->last_cnt;      /* wraparound-safe */
+        h->last_cnt = cur;
+    }
+    else
+        delta = (uint32_t)got;
+    take = (delta < (uint32_t)got) ? (int)delta : got;
+    /* buf[] is oldest-first; the newest `take` entries are at the end. */
+    for (i = got - take; i < got; i++)
+        bump(h, buf[i]);
+}
+
+static bool on_frame(void *ud, unsigned frame)
+{
+    (void)ud;
+    if (frame <= opt_warmup)
+    {
+        /* Keep the "new since last sample" cursors current through the
+         * warmup so the first counted sample isn't credited with the
+         * whole warmup's opcode delta. */
+        if (g_gpu_cnt) hist_gpu.last_cnt = *g_gpu_cnt;
+        if (g_dsp_cnt) hist_dsp.last_cnt = *g_dsp_cnt;
+        return true;
+    }
+    if ((frame - opt_warmup) % opt_every)
+        return true;
+    sample_proc(&hist_gpu, WHO_GPU, g_gpu_cnt);
+    sample_proc(&hist_dsp, WHO_DSP, g_dsp_cnt);
+    if (g_gpu_pc)
+        park_note(&park_gpu, *g_gpu_pc, g_gpu_reg);
+    if (g_dsp_pc)
+        park_note(&park_dsp, *g_dsp_pc, g_dsp_reg);
+    return true;
+}
+
+/* ---- RISC disassembler (pattern from test/tools/gpu_disasm_dump.c) ---- */
+
+static const char *mn_gpu[64] = {
+"add","addc","addq","addqt","sub","subc","subq","subqt",
+"neg","and","or","xor","not","btst","bset","bclr",
+"mult","imult","imultn","resmac","imacn","div","abs","sh",
+"shlq","shrq","sha","sharq","ror","rorq","cmp","cmpq",
+"sat8","sat16","move","moveq","moveta","movefa","movei","loadb",
+"loadw","load","loadp","load(r14+n)","load(r15+n)","storeb","storew","store",
+"storep","store(r14+n)","store(r15+n)","move pc","jump","jr","mmult","mtoi",
+"normi","nop","load(r14+rn)","load(r15+rn)","store(r14+rn)","store(r15+rn)","sat24","pack"
+};
+/* DSP slots that differ from the GPU (src/jerry/dsp.c dispatch table):
+ * 32 subqmod, 33 sat16s, 42 sat32s, 48 mirror, 62 illegal, 63 addqmod. */
+static const char *mn_dsp[64] = {
+"add","addc","addq","addqt","sub","subc","subq","subqt",
+"neg","and","or","xor","not","btst","bset","bclr",
+"mult","imult","imultn","resmac","imacn","div","abs","sh",
+"shlq","shrq","sha","sharq","ror","rorq","cmp","cmpq",
+"subqmod","sat16s","move","moveq","moveta","movefa","movei","loadb",
+"loadw","load","sat32s","load(r14+n)","load(r15+n)","storeb","storew","store",
+"mirror","store(r14+n)","store(r15+n)","move pc","jump","jr","mmult","mtoi",
+"normi","nop","load(r14+rn)","load(r15+rn)","store(r14+rn)","store(r15+rn)","illegal","addqmod"
+};
+
+/* Real jr/jump condition-code decode (mirrors build_branch_condition_table
+ * in src/tom/gpu.c): bit 4 selects N instead of C for the tests in bits
+ * 2-3 -- do NOT mask with &7 (the issue #406 mislabeling bug). */
+static void print_cc(unsigned j)
+{
+    int need_and = 0;
+    if (j == 0) { printf("T"); return; }
+    if (j & 1) { printf("NZ"); need_and = 1; }
+    if (j & 2) { printf("%sZ", need_and ? " " : ""); need_and = 1; }
+    if (j & 4) { printf("%s%s", need_and ? " " : "", (j & 0x10) ? "NN" : "NC"); need_and = 1; }
+    if (j & 8) { printf("%s%s", need_and ? " " : "", (j & 0x10) ? "N" : "C"); need_and = 1; }
+    if (!need_and) printf("cc%u", j);
+}
+
+/* Disassemble the snapshotted context window around hot_pc.  The words
+ * came from the first-sighting snapshot, so a `movei` immediate that
+ * extends past the window end is simply not decoded (shown raw). */
+static void disasm_window(uint32_t hot_pc, const uint16_t *code,
+                          const char **mn, int overlaid)
+{
+    uint32_t base = ctx_base(hot_pc);
+    int wi;
+    if (overlaid)
+        printf("      (RISC RAM at this address has been overlaid since "
+               "sampling; showing sampled-time code)\n");
+    for (wi = 0; wi < CTX_WORDS; wi++)
+    {
+        uint32_t a = base + (uint32_t)wi * 2;
+        uint16_t w = code[wi];
+        unsigned op = w >> 10, r1 = (w >> 5) & 0x1F, r2 = w & 0x1F;
+        printf("      %c $%06X: %04X  %-14s", (a == hot_pc) ? '*' : ' ',
+               a, w, mn[op]);
+        if (op == 53)               /* jr */
+        {
+            int off = (r1 & 0x10) ? (int)r1 - 32 : (int)r1;
+            printf(" ");
+            print_cc(r2);
+            printf(", %+d -> $%06X", off, (uint32_t)(a + 2 + off * 2));
+        }
+        else if (op == 52)          /* jump */
+        {
+            printf(" ");
+            print_cc(r2);
+            printf(", (r%u)", r1);
+        }
+        else if (op == 38 && wi + 2 < CTX_WORDS)   /* movei */
+            printf(" #$%08X, r%u",
+                   ((uint32_t)code[wi + 2] << 16) | code[wi + 1], r2);
+        else if (op == 35)          /* moveq: literal 0-31 */
+            printf(" #%u, r%u", r1, r2);
+        else if (op == 31)          /* cmpq: signed -16..15 */
+            printf(" #%d, r%u", (int)((r1 ^ 0x10) - 0x10), r2);
+        else if (op == 2 || op == 6 || op == 24 || op == 25)
+            printf(" #%u, r%u", r1 ? r1 : 32, r2);   /* quick: 0 means 32 */
+        else
+            printf(" r%u, r%u", r1, r2);
+        printf("\n");
+    }
+}
+
+static const pc_hist *g_sort_hist;
+static int cmp_desc(const void *a, const void *b)
+{
+    uint32_t ia = *(const uint32_t *)a, ib = *(const uint32_t *)b;
+    uint64_t na = g_sort_hist->n[ia], nb = g_sort_hist->n[ib];
+    return (nb > na) - (nb < na);
+}
+
+static void dump_hist(const char *tag, pc_hist *h, const char **mn,
+                      uint32_t local_base, uint32_t local_size)
+{
+    static uint32_t order[NBUCKET];
+    unsigned i, shown = 0;
+    printf("\n=== %s backtrace-ring PC histogram: %llu sampled instructions ===\n",
+           tag, (unsigned long long)h->total);
+    if (!h->total)
+        return;
+    g_sort_hist = h;
+    for (i = 0; i < NBUCKET; i++)
+        order[i] = i;
+    qsort(order, NBUCKET, sizeof(order[0]), cmp_desc);
+    for (i = 0; i < NBUCKET && shown < opt_top; i++)
+    {
+        uint32_t k = order[i];
+        if (!h->n[k])
+            break;
+        printf("  #%-2u $%06X  %10llu  %5.2f%%%s\n", shown + 1, h->pc[k],
+               (unsigned long long)h->n[k], 100.0 * (double)h->n[k] / (double)h->total,
+               (h->pc[k] >= local_base && h->pc[k] < local_base + local_size)
+                   ? "" : "  (outside local RAM)");
+        if (opt_disasm && g_rd && shown < 8)
+        {
+            int overlaid = 0;
+            uint32_t hot_wi = (h->pc[k] - ctx_base(h->pc[k])) / 2;
+            if (g_rd(h->pc[k], 0) != h->code[k][hot_wi])
+                overlaid = 1;
+            disasm_window(h->pc[k], h->code[k], mn, overlaid);
+        }
+        shown++;
+    }
+}
+
+static void dump_park(const char *tag, const park_tab *t, uint64_t frames)
+{
+    unsigned i, j;
+    if (!frames)
+        return;
+    printf("\n--- %s frame-end parked PCs (%llu sampled frames%s) ---\n",
+           tag, (unsigned long long)frames,
+           t->overflow ? ", table overflowed" : "");
+    for (i = 0; i < t->used; i++)
+    {
+        /* Only worth printing when the processor parks there repeatedly. */
+        if (t->n[i] * 50 < frames)
+            continue;
+        printf("  parked $%06X  %llu frames (%.1f%%), first-seen regs:\n",
+               t->pc[i], (unsigned long long)t->n[i],
+               100.0 * (double)t->n[i] / (double)frames);
+        for (j = 0; j < 32; j++)
+            printf("    r%-2u=$%08X%s", j, t->regs[i][j],
+                   (j % 4 == 3) ? "\n" : "");
+    }
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    void (*arm)(void);
+    uint64_t sampled_frames;
+    int a;
+    cfg.frames = 2000;
+    for (a = 1; a < argc; a++)
+    {
+        if (!strcmp(argv[a], "--warmup") && a + 1 < argc)
+            opt_warmup = (unsigned)strtoul(argv[++a], NULL, 10);
+        else if (!strcmp(argv[a], "--every") && a + 1 < argc)
+        {
+            opt_every = (unsigned)strtoul(argv[++a], NULL, 10);
+            if (!opt_every) opt_every = 1;
+        }
+        else if (!strcmp(argv[a], "--top") && a + 1 < argc)
+        {
+            opt_top = (unsigned)strtoul(argv[++a], NULL, 10);
+            if (!opt_top) opt_top = 20;
+        }
+        else if (!strcmp(argv[a], "--no-disasm"))
+            opt_disasm = 0;
+    }
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+    cfg.frame_callback = on_frame;
+    if (!harness_load_rom(&cfg))
+        return 1;
+
+    arm         = (void (*)(void))harness_dlsym(&cfg, "vjtrace_arm");
+    g_backtrace = (backtrace_fn)harness_dlsym(&cfg, "vjtrace_backtrace");
+    g_rd        = (read_word_fn)harness_dlsym(&cfg, "JaguarReadWord");
+    g_gpu_cnt   = (uint32_t *)harness_dlsym(&cfg, "gpu_exec_opcode_count");
+    g_dsp_cnt   = (uint32_t *)harness_dlsym(&cfg, "dsp_exec_opcode_count");
+    g_gpu_pc    = (uint32_t *)harness_dlsym(&cfg, "gpu_pc");
+    g_dsp_pc    = (uint32_t *)harness_dlsym(&cfg, "dsp_pc");
+    g_gpu_reg   = (get_reg_fn)harness_dlsym(&cfg, "GPUGetReg");
+    g_dsp_reg   = (get_reg_fn)harness_dlsym(&cfg, "DSPGetReg");
+    if (!arm || !g_backtrace)
+    {
+        fprintf(stderr, "vjtrace_arm/vjtrace_backtrace not exported -- "
+                        "build the core with TEST_EXPORTS=1\n");
+        return 2;
+    }
+    /* The GPU/DSP PC-history hooks are disarmed by default (see the
+     * PERFORMANCE NOTE in src/core/vjtrace.h); nothing fills the rings
+     * until this call. */
+    arm();
+
+    harness_run(&cfg);
+
+    sampled_frames = (cfg.frames > opt_warmup)
+                     ? (cfg.frames - opt_warmup + opt_every - 1) / opt_every
+                     : 0;
+    printf("risc_backtrace_histogram: %u frames run, warmup %u, sampled every %u\n",
+           cfg.frames, opt_warmup, opt_every);
+    if (g_gpu_cnt)
+        printf("gpu_exec_opcode_count total=%u\n", *g_gpu_cnt);
+    if (g_dsp_cnt)
+        printf("dsp_exec_opcode_count total=%u\n", *g_dsp_cnt);
+    dump_hist("GPU", &hist_gpu, mn_gpu, 0xF03000, 0x1000);
+    dump_park("GPU", &park_gpu, sampled_frames);
+    dump_hist("DSP", &hist_dsp, mn_dsp, 0xF1B000, 0x2000);
+    dump_park("DSP", &park_dsp, sampled_frames);
+
+    harness_shutdown(&cfg);
+    return 0;
+}


### PR DESCRIPTION
Closes #688

## Summary

Two new headless tools plus a findings doc attributing the `jr`-dominated RISC interpreter profile and the bimodal frame times seen on Missile Command 3D. **No emulator-core changes** — `src/` is untouched.

### `test/tools/risc_backtrace_histogram.c`
- Drains the vjtrace GPU/DSP PC-history rings (`vjtrace_backtrace`, last 1024 PCs per processor, fill-tracked) after every frame and histograms the PCs — covers in-frame execution, unlike the parked frame-end PC the existing `risc_pc_histogram` samples.
- Disassembles a window around each top PC from a **first-sighting code snapshot** (MC3D overlays GPU kernels into local RAM, so code read at run end can belong to a different program; divergence is flagged).
- Captures a full register snapshot the first time a processor is parked at a given frame-end PC, which is what lets the report name the exact polled address (e.g. the main-RAM semaphore word) instead of just the loop shape.
- Named `risc_backtrace_histogram` because `risc_pc_histogram` already exists with different (frame-end-only) sampling semantics; both binaries are now gitignored.

### `test/tools/frame_cost_probe.c`
- Per-frame CSV: frame index, wall-clock ms for that `retro_run`, GPU/DSP interpreted-opcode deltas (`gpu_exec_opcode_count`/`dsp_exec_opcode_count`), DSP idle-skip savings, and vjtrace IRQ / OP-object / blitter event counters.
- `--top N` prints the N most expensive frames with their counts side-by-side against the median frame.

### `docs/perf-audit/mc3d-stall-attribution.md`
Findings from MC3D (attract, 900-frame warmup, 6000 measured frames) with yarc/jagniccc cross-checks. Headlines:
- **GPU: 66.8% of all interpreted GPU instructions are one 4-instruction poll of main-RAM word `$9704`** (68K-owned scene semaphore; 68K writer at pc `$9A18`) — top wait-elision candidate.
- **DSP: 57.4% sits in the Atari sound driver's I2S tick poll**; the existing (default-off) DSP idle-skip already removes it (measured **-61.5%** interpreted DSP opcodes, byte-identical video digest).
- **Spike frames do the same emulated work as median frames** — every work column is flat across the top-50 slowest frames and slow frames cluster in adjacent bursts; the spikes are host-side (scheduler/QoS), so the actionable lever is lowering the constant spin baseline that the A12 can't absorb.
- Ranked candidates with determinism-risk labels close the doc; a GPU-side idle-skip port is #1.

## Test plan
- [x] Built with `TEST_EXPORTS=1` on macOS arm64; both tools verified against the build-identity guard (`VJ_EXPECT_BUILD`).
- [x] Ran on MC3D (6000 frames), yarc (300), jagniccc (300); outputs reproduced in the doc.
- [x] Both tools fail loudly on a non-TEST_EXPORTS core instead of reporting empty histograms.
- [x] `make test` suite unaffected (tools are on-demand builds, not wired into the suite).
- [x] C89 lint pre-commit hook passed (test/tools is C99-exempt; no `src/` changes).

<!-- link-issue: #688 -->