### PR TITLE
feat(libretro): auto frameskip driven by audio buffer status

### DIFF
--- a/docs/settings-and-performance-guide.md
+++ b/docs/settings-and-performance-guide.md
@@ -341,6 +341,18 @@ What *is* known and actionable:
   expensive thing running.
 - **Then turn on idle-skip.** It removes work rather than doing it faster, which
   is exactly the shape of win a weak CPU needs.
+- **If audio still crackles, enable Frameskip** (`frameskip`, default
+  **disabled**). When the frontend reports its audio buffer draining, the core
+  skips *presenting* a frame — the scanline conversion and framebuffer copy —
+  while the emulated machine still runs that frame in full. `auto` skips only
+  when the frontend says an under-run is imminent; `auto_threshold_15/30/45`
+  skip earlier, whenever buffer occupancy falls below that percentage (45 =
+  most aggressive). **Frameskip Maximum** (`frameskip_max`, 1–4, default 3)
+  caps consecutive skips so the picture never freezes. Presentation-only:
+  save states, run-ahead and netplay are unaffected, and with it disabled the
+  output is bit-identical to previous releases. Needs a frontend new enough to
+  support audio buffer status reporting (RetroArch 1.9.1+); on older frontends
+  every value behaves as disabled.
 - **Fast blitter last**, because it costs correctness.
 - **Do not overclock on a device that is already struggling.** It asks for more
   work, not less — and it takes idle-skip away.
@@ -348,8 +360,10 @@ What *is* known and actionable:
 ### 4.6 Pacing, fast-forward and VRR
 
 **The core has no internal frame limiter.** It never sleeps, never blocks inside
-`retro_run()`, and does not register a frame-time or audio callback. Speed and
-pacing are entirely your frontend's responsibility.
+`retro_run()`, and does not register a frame-time callback. Speed and pacing
+are entirely your frontend's responsibility. (The one audio callback it can
+register — the buffer-status report driving `frameskip`, §4.5 — only sheds
+presentation work; it never slows or blocks the run loop.)
 
 Practical consequences:
 
@@ -491,7 +505,7 @@ timing models, idle-skip, CD read speed — takes effect immediately.
 | **Game runs too fast** (menus fly past, input feels doubled) | The emulated GPU finishes renders 2–4× faster than silicon, so loops paced on render or blit completion outrun hardware. This is a known accuracy gap, not your configuration. | Turn on `gpu_pipeline_timing` and/or `blitter_timing`. Both cost performance and are still being calibrated. Also confirm you have not left a clock scale above 1x. |
 | **Game runs slow** | See §4.2. | Per-title defaults off → 1x / true color off → idle-skip on → fast blitter. |
 | **Fast-forward does nothing** | Frontend setting, or no headroom left. | Check RetroArch's Fast-Forward Ratio and audio sync. If the title already runs near 16.7 ms/frame, there is nothing to gain. Also check the window is focused — a backgrounded window gets OS-throttled. |
-| **Audio crackles or drops out** | Usually frontend audio buffering. | Raise your frontend's audio latency first. If it started after you enabled `risc_idle_skip`, turn it back off and please report it — that is exactly the feedback the opt-in period exists for. |
+| **Audio crackles or drops out** | Usually frontend audio buffering, or the device cannot render every frame in time. | Raise your frontend's audio latency first. On hardware that is genuinely too slow, set `frameskip` = auto (§4.5) — it drops presentation, not emulation, when the buffer drains. If it started after you enabled `risc_idle_skip`, turn it back off and please report it — that is exactly the feedback the opt-in period exists for. |
 | **Audio pitch changed after overclocking** | Should not happen — timers and audio pacing stay at stock speed under both clock scales. | Report it. |
 | **Black screen on a CD game** | Boot path, or a bad rip. | Switch `cd_boot_mode` to Real BIOS and restart. If that fails too, try `cd_bios_type` = Developer. Check the log for `[CD-BOOTSTUB]` — "zero-filled" or "magic mismatch" means the image itself is an incomplete rip, and no setting will fix it. |
 | **CD game hangs after loading got faster** | `cd_read_speed` above 2x. | Set it back to 2x (accurate). |
@@ -531,6 +545,8 @@ timing models, idle-skip, CD read speed — takes effect immediately.
 | `m68k_clock_scale` | 1x | a 68K-bound game stutters (avoid 3x — see #460) |
 | `risc_clock_scale` | 1x | a GPU-bound game stutters — **and never with idle-skip** |
 | `risc_idle_skip` | **off** | you want the single biggest speed-up available |
+| `frameskip` | off | audio crackles on hardware too slow to render every frame |
+| `frameskip_max` | 3 | frameskip is on and you want a different smoothness/audio trade |
 | `dram_timing` / `gpu_pipeline_timing` / `blitter_timing` | off | accuracy investigation only |
 | `bios` (cartridges) | HLE | a cartridge needs the real boot ROM. *Distinct from* `bios_type`, which picks **which** ROM once this is set to Real |
 | `cd_boot_mode` | HLE | a CD game hangs or an FMV freezes (restart) |

--- a/libretro.c
+++ b/libretro.c
@@ -361,6 +361,29 @@ retro_log_printf_t vj_log_cb = NULL;
 static bool libretro_supports_bitmasks = false;
 static bool save_data_needs_unpack = false;
 
+/* Auto-frameskip (#684) -- the standard libretro pattern (gpsp/snes9x):
+ * when the frontend's audio buffer is draining, skip VIDEO PRESENTATION
+ * for a frame so a slow host catches up before the buffer underruns.
+ * Skipping reuses tomSkipVideoPresent, the same presentation-skip path
+ * RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE already drives from retro_run:
+ * emulation runs unabridged, only the host XRGB8888 store is bypassed, so
+ * this cannot desync savestates, run-ahead or netplay (#400).  NOTHING in
+ * this block may ever enter retro_serialize -- it is presentation-only
+ * host state.  Frontends that don't implement the buffer-status callback
+ * leave retro_audio_buff_active false and every mode degrades to
+ * "disabled". */
+static unsigned frameskip_type;             /* 0 off / 1 auto / 2 auto_threshold */
+static unsigned frameskip_threshold;        /* occupancy percent, type 2 only */
+static unsigned frameskip_max          = 3; /* cap on consecutive skips */
+static unsigned frameskip_counter;          /* consecutive skips so far */
+static int      frameskip_this_frame;       /* this retro_run skipped by frameskip */
+static int      frameskip_init_done;
+static bool     retro_audio_buff_active;
+static unsigned retro_audio_buff_occupancy;
+static bool     retro_audio_buff_underrun;
+static unsigned frameskip_audio_latency;
+static bool     update_audio_latency;
+
 /* CD content state. The Tier 1 weak symbols for external_cd_bios[] and
  * cd_bios_loaded_externally are overridden by the strong definitions below. */
 static bool jaguar_cd_mode = false;
@@ -375,6 +398,65 @@ void retro_set_audio_sample(retro_audio_sample_t cb) { (void)cb; }
 void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb) { audio_batch_cb = cb; }
 void retro_set_input_poll(retro_input_poll_t cb) { input_poll_cb = cb; }
 void retro_set_input_state(retro_input_state_t cb) { input_state_cb = cb; }
+
+/* Frontend-driven: RetroArch calls this once per output frame with the
+ * audio buffer's health.  Values are only trusted while active is true
+ * (active false = reporting unavailable, e.g. audio driver off). */
+static void retro_audio_buff_status_cb(bool active, unsigned occupancy,
+      bool underrun_likely)
+{
+   retro_audio_buff_active    = active;
+   retro_audio_buff_occupancy = occupancy;
+   retro_audio_buff_underrun  = underrun_likely;
+}
+
+/* (Un)register the buffer-status callback to match the current option.
+ * Called from check_variables() when the frameskip option changes (which
+ * covers both content load and a mid-session menu change).  On frontends
+ * that don't implement the environment call the registration fails,
+ * retro_audio_buff_active stays false, and every auto mode behaves as
+ * "disabled" -- never crashes, never skips blind.  When frameskip is on
+ * we also ask for ~6 frames of audio latency (rounded up to the frontend
+ * granularity of 32 ms) so the buffer has enough headroom for the
+ * occupancy reports to be meaningful; 0 restores frontend defaults.  The
+ * actual SET_MINIMUM_AUDIO_LATENCY call is deferred to retro_run() via
+ * update_audio_latency, matching gpsp -- the frontend re-inits its audio
+ * driver on that call, which is only safe between frames. */
+static void init_frameskip(void)
+{
+   if (frameskip_type > 0)
+   {
+      struct retro_audio_buffer_status_callback buf_status_cb;
+      buf_status_cb.callback = retro_audio_buff_status_cb;
+      if (!environ_cb(RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK,
+            &buf_status_cb))
+      {
+         LOG_WRN("[frameskip] frontend does not support the audio buffer "
+                 "status callback -- automatic frameskip disabled\n");
+         retro_audio_buff_active    = false;
+         retro_audio_buff_occupancy = 0;
+         retro_audio_buff_underrun  = false;
+         frameskip_audio_latency    = 0;
+      }
+      else
+      {
+         /* 6 frames of headroom at the current video standard. */
+         float frame_time_msec = 1000.0f
+               / (vjs.hardwareTypeNTSC == 1 ? 60.0f : 50.0f);
+         frameskip_audio_latency = (unsigned)((6.0f * frame_time_msec) + 0.5f);
+         frameskip_audio_latency = (frameskip_audio_latency + 0x1F) & ~0x1F;
+      }
+   }
+   else
+   {
+      environ_cb(RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK, NULL);
+      retro_audio_buff_active    = false;
+      retro_audio_buff_occupancy = 0;
+      retro_audio_buff_underrun  = false;
+      frameskip_audio_latency    = 0;
+   }
+   update_audio_latency = true;
+}
 
 
 
@@ -2656,6 +2738,52 @@ static void check_variables(void)
       {
          widescreen_enabled = ws_want;
          widescreen_geometry_pending = true;
+      }
+   }
+
+   /* Auto frameskip (#684): raw read, like widescreen above -- a
+    * device-speed workaround is a viewer choice, never a per-title
+    * substitution.  Presentation-only; see the state block's comment near
+    * the top of this file.  init_frameskip() (which registers or
+    * unregisters the frontend buffer-status callback and re-arms the
+    * minimum-audio-latency request) only runs when the effective setting
+    * actually changed, so an unrelated option flip cannot thrash the
+    * frontend's audio driver. */
+   {
+      unsigned fs_prev_type      = frameskip_type;
+      unsigned fs_prev_threshold = frameskip_threshold;
+
+      var.key = "virtualjaguar_frameskip";
+      var.value = NULL;
+      frameskip_type      = 0;
+      frameskip_threshold = 0;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      {
+         if (strcmp(var.value, "auto") == 0)
+            frameskip_type = 1;
+         else if (strncmp(var.value, "auto_threshold_", 15) == 0)
+         {
+            frameskip_type      = 2;
+            frameskip_threshold = (unsigned)atoi(var.value + 15);
+         }
+      }
+
+      var.key = "virtualjaguar_frameskip_max";
+      var.value = NULL;
+      frameskip_max = 3;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      {
+         int fs_max = atoi(var.value);
+         if (fs_max >= 1 && fs_max <= 4)
+            frameskip_max = (unsigned)fs_max;
+      }
+
+      if (frameskip_type != fs_prev_type
+          || frameskip_threshold != fs_prev_threshold
+          || !frameskip_init_done)
+      {
+         frameskip_init_done = 1;
+         init_frameskip();
       }
    }
 
@@ -6259,6 +6387,54 @@ void retro_run(void)
       tomSkipVideoPresent = (av_enable_flags & RETRO_AV_ENABLE_VIDEO) ? 0 : 1;
    }
 
+   /* Auto frameskip (#684): decide whether THIS frame's presentation is
+    * skipped to let the audio buffer refill.  Rides the same
+    * tomSkipVideoPresent flag the GET_AUDIO_VIDEO_ENABLE block above just
+    * set -- when the frontend already discards this frame's video
+    * (fast-forward, run-ahead hidden frames) there is nothing left to
+    * skip, so the frameskip counter stands down and its cap starts fresh
+    * on the next presented frame.  retro_audio_buff_active is only true
+    * while a registered buffer-status callback is being fed by the
+    * frontend, so unsupported frontends never reach the verdict.
+    * frameskip_counter caps consecutive skips at frameskip_max so the
+    * screen can never freeze even with the buffer pinned at 0%.
+    * frameskip_this_frame is what video_cb consumes below: a
+    * frameskip-skipped frame is presented as a dupe (NULL), which the
+    * GET_AUDIO_VIDEO_ENABLE path must NOT do -- its discarded frames keep
+    * handing videoBuffer to the frontend exactly as before. */
+   frameskip_this_frame = 0;
+   if (frameskip_type > 0 && !tomSkipVideoPresent && retro_audio_buff_active)
+   {
+      int want_skip;
+      if (frameskip_type == 1)
+         want_skip = retro_audio_buff_underrun ? 1 : 0;
+      else
+         want_skip = (retro_audio_buff_occupancy < frameskip_threshold)
+               ? 1 : 0;
+
+      if (!want_skip || frameskip_counter >= frameskip_max)
+         frameskip_counter = 0;
+      else
+      {
+         frameskip_counter++;
+         frameskip_this_frame = 1;
+         tomSkipVideoPresent  = 1;
+      }
+   }
+   else
+      frameskip_counter = 0;
+
+   /* Deferred from init_frameskip(): tell the frontend how much audio
+    * buffering frameskip needs to see the drain coming (0 = restore its
+    * own default).  The frontend re-inits its audio driver on this call,
+    * so it fires once per option change, from retro_run, never per frame. */
+   if (update_audio_latency)
+   {
+      environ_cb(RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY,
+            &frameskip_audio_latency);
+      update_audio_latency = false;
+   }
+
    /* Apply pending geometry change BEFORE rendering this frame.  TOM's
     * scanline renderer reads tomWidth (pixels per row) and screenPitch
     * (line stride) live; if tomWidth grew but screenPitch is stale, later
@@ -6570,7 +6746,16 @@ void retro_run(void)
     * not eeprom_save_buf, so they do not need a flush. */
    mt_flush_save_buf();
 
-   video_cb(videoBuffer, game_width, game_height, game_width << 2);
+   /* A frameskip-skipped frame is handed to the frontend as NULL ("dupe
+    * last frame", the standard libretro frameskip contract -- gpsp does
+    * the same): videoBuffer was not rendered this frame, and NULL also
+    * spares the frontend a redundant texture upload -- part of the very
+    * cost frameskip exists to shed.  The GET_AUDIO_VIDEO_ENABLE skip path
+    * is deliberately NOT routed through this: the frontend told us it is
+    * discarding that video, and it keeps receiving videoBuffer exactly as
+    * it always has. */
+   video_cb(frameskip_this_frame ? NULL : videoBuffer,
+         game_width, game_height, game_width << 2);
 
 #ifdef DEBUG_PRESENTATION
    if (dbg_frame_counter < 5

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -266,6 +266,39 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "virtualjaguar_frameskip",
+      "Frameskip",
+      NULL,
+      "Skip presenting frames to avoid audio buffer under-run (crackling) on hardware too slow to render every frame. 'Auto' skips a frame when the frontend advises an under-run is likely; 'Auto (Threshold)' skips whenever the audio buffer occupancy falls below the chosen percentage (higher = skips earlier and more often). Presentation only: the emulated machine runs every frame in full either way, so save states, run-ahead and netplay are unaffected. Requires frontend support for audio buffer status reporting; without it, all values behave as Disabled.",
+      NULL,
+      "speed",
+      {
+         { "disabled",          "Disabled" },
+         { "auto",              "Auto" },
+         { "auto_threshold_15", "Auto (Threshold 15%)" },
+         { "auto_threshold_30", "Auto (Threshold 30%)" },
+         { "auto_threshold_45", "Auto (Threshold 45%)" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "virtualjaguar_frameskip_max",
+      "Frameskip Maximum",
+      NULL,
+      "Cap on how many frames in a row Frameskip may skip before one is always presented, so the screen keeps moving even while the audio buffer stays low. Has no effect while Frameskip is disabled.",
+      NULL,
+      "speed",
+      {
+         { "1", NULL },
+         { "2", NULL },
+         { "3", NULL },
+         { "4", NULL },
+         { NULL, NULL },
+      },
+      "3"
+   },
+   {
       "virtualjaguar_m68k_clock_scale",
       "M68K Clock Scale (Overclock)",
       NULL,


### PR DESCRIPTION
Closes #684

## What

On slower ARM devices (Apple TV A12, Raspberry Pi), frames that miss the 16.67 ms budget drain the frontend's audio buffer into audible stutter. This adds the standard libretro auto-frameskip (the gpsp/snes9x `retro_audio_buff_active/occupancy/underrun` pattern): `RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK` feeds per-frame buffer health, and when the buffer is draining the core skips **video presentation** for a frame — emulation runs unabridged.

### New core options (Speed category)

| Option | Values | Semantics |
|---|---|---|
| `virtualjaguar_frameskip` | `disabled` (default), `auto`, `auto_threshold_15`, `auto_threshold_30`, `auto_threshold_45` | `auto` skips only when the frontend reports `underrun_likely`; `auto_threshold_N` skips whenever audio buffer occupancy % falls below N |
| `virtualjaguar_frameskip_max` | `1`–`4` (default `3`) | cap on consecutive skipped frames so the screen never freezes |

### How it skips

Rides the existing `tomSkipVideoPresent` presentation-skip path that `RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE` (fast-forward / run-ahead) already drives from `retro_run`: only the host XRGB8888 store in `TOMExecHalfline`, the stale-tail blanking and the framebuffer hash are bypassed; OP/GPU/DSP/blitter/68K execution is untouched — deterministic-safe by construction. A frameskip-skipped frame goes to `video_cb` as `NULL` (frame dupe). When `GET_AUDIO_VIDEO_ENABLE` already discards the frame, frameskip stands down (nothing left to skip) and its consecutive-skip counter resets.

- Callback (un)registration happens in `check_variables()` only when the effective setting changes; on frontends without the environment call, registration fails, a warning is logged once, and every auto mode degrades to `disabled` — never crashes, never skips blind.
- When enabled, the core requests ~6 frames of minimum audio latency (`SET_MINIMUM_AUDIO_LATENCY`, rounded up to 32 ms granularity, fired from `retro_run` once per option change; `0` on disable restores frontend default).
- **Nothing enters `retro_serialize`** — all frameskip state is presentation-only host state (proven below).

### Deviations from the gpsp reference

- Threshold values are folded into the `virtualjaguar_frameskip` value list (`auto_threshold_15/30/45`) instead of gpsp's separate `gpsp_frameskip_threshold` option, and no `fixed_interval` mode is offered (per the issue spec — auto-only keeps default output bit-identical and the option surface small).
- `virtualjaguar_frameskip_max` (1–4) plays the role of gpsp's `gpsp_frameskip_interval` with identical consecutive-skip-cap semantics.
- Skip is presentation-only (`tomSkipVideoPresent`), not an emulation skip — this core's machine step must run every frame for determinism, unlike gpsp's renderer-level skip.

## Docs

`docs/settings-and-performance-guide.md`: new §4.5 bullet, §4.6 pacing note updated (the core now can register one audio callback — it never blocks the run loop), troubleshooting row for audio crackle, quick-reference rows.

## Test evidence

All on macOS host, `DEVELOPER_DIR=/Library/Developer/CommandLineTools`, after rebase onto `develop` @ c7e82d3:

- `bash scripts/c89-lint.sh libretro.c` — pass.
- `make -j8` — clean.
- `make TEST_EXPORTS=1 test` — exit 0, **0 failed** (includes savestate/rewind/determinism/DAC-state checks, and both `test_audio_clipping` + `test_audio_presence`: no clipping signature, presence in expected envelope, IS1 window RMS 3083).
- `MINIRETRO_BIN=... ./test/regression_test.sh ./virtualjaguar_libretro.dylib` — **10 passed, 0 failed**, `yarc` screenshot 0 pixels differ (frameskip disabled by default ⇒ baselines identical), determinism, frameskip-invariance, savestate round-trip and rewind all PASS.
- Functional smoke (throwaway harness injecting a captured buffer-status callback; 240 frames of `yarc.j64`, buffer reported healthy for 120 then starved at 5% occupancy / `underrun_likely` for 120):

| scenario | presented | skipped (NULL to video_cb) | max consecutive |
|---|---|---|---|
| `auto`, max 3 | 150 | 90 (all during starvation) | 3 |
| `auto_threshold_30`, max 3 | 150 | 90 | 3 |
| `auto`, max 1 | 180 | 60 | 1 |
| `auto`, max 4 | 144 | 96 | 4 |
| `disabled` (starved) | 240 | 0 | 0 |
| `auto`, env call unsupported | 240 | 0 | 0 (graceful degradation, `SET_MINIMUM_AUDIO_LATENCY` restored to 0) |

- Savestate safety: `retro_serialize` at frame 240 byte-compared (`cmp`) across a skipping run (90 frames skipped), a healthy `auto` run, and a `disabled` run — **all three states byte-identical**. Harness not committed (needs its own environ_cb answering `SET_AUDIO_BUFFER_STATUS_CALLBACK`, which the shared `test/harness` deliberately declines).