### PR TITLE
perf(shadowfb): NEON-vectorize hi-res Stage-1 store and line resolve

### DIFF
--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -38,6 +38,7 @@ skip_file() {
         src/tom/op_simd_sse2.h) return 0 ;;
         src/tom/tom_scan_simd_neon.h) return 0 ;;
         src/tom/tom_scan_simd_sse2.h) return 0 ;;
+        src/tom/shadowfb_simd_neon.h) return 0 ;;
         src/jerry/voicechat_simd_neon.h) return 0 ;;
         # Depends on rcheevos headers fetched at runtime by the e2e shell wrapper.
         test/tools/test_rcheevos_e2e.c) return 0 ;;

--- a/src/tom/shadowfb.c
+++ b/src/tom/shadowfb.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "shadowfb.h"
+#include "shadowfb_simd_neon.h"
 #include "blit_memo.h"   /* blit-memo shadow-store logging (issue #411) */
 #include "log.h"
 
@@ -339,7 +340,14 @@ void ShadowHiresStoreCry(uint32_t addr, uint16_t value16, uint16_t frac16)
    /* Stage 1: box replication -- every subpixel carries the stock
     * value (+ the true-color fraction when the write site had one).
     * Stage 2 replaces this loop with real sub-pixel content. */
-   for (k = 0; k < nn; k++)
+#if defined(BLITTER_SIMD_HAVE_NEON)
+   /* nn==4 at N=2, so the whole block is one 16-byte store; the scalar
+    * tail below only runs for a hypothetical non-multiple-of-4 N*N. */
+   k = shadowfb_neon_sub_fill(sub, value16, frac16, nn);
+#else
+   k = 0;
+#endif
+   for (; k < nn; k++)
    {
       sub[k].value16 = value16;
       sub[k].frac16  = frac16;
@@ -569,23 +577,43 @@ int ShadowHiresLineFromRAM(int idx, uint32_t srcAddr, uint16_t value16)
     * line plane keeps its allocation-time zeros (= "no replacement",
     * which is also what the renderer reads while inactive). */
    repl = (shadowHiresReplActive && shadowHiresLineRepl) ? 1 : 0;
-   for (sy = 0; sy < n; sy++)
+#if defined(BLITTER_SIMD_HAVE_NEON)
+   /* n==2 is Stage 1.  The runtime-n double loop below re-tests blk /
+    * rdst per subpixel and never unrolls; the kernels scatter the 2x2
+    * block into the two line rows in two 8-byte stores each. */
+   if (n == 2)
    {
-      uint32_t off = ((uint32_t)sy * SHADOWFB_LINE_PIXELS + (uint32_t)idx)
-                   * (uint32_t)n;
-      dst  = shadowHiresLineSub + off;
-      rdst = repl ? shadowHiresLineRepl + off : NULL;
-      for (sx = 0; sx < n; sx++)
+      uint32_t off0 = (uint32_t)idx * 2u;
+      uint32_t off1 = ((uint32_t)SHADOWFB_LINE_PIXELS + (uint32_t)idx) * 2u;
+      shadowfb_neon_line_sub_n2(shadowHiresLineSub + off0,
+                                shadowHiresLineSub + off1,
+                                blk, value16);
+      if (repl)
+         shadowfb_neon_line_repl_n2(shadowHiresLineRepl + off0,
+                                    shadowHiresLineRepl + off1,
+                                    rblk);
+   }
+   else
+#endif
+   {
+      for (sy = 0; sy < n; sy++)
       {
-         if (blk)
-            dst[sx] = blk[sy * n + sx];
-         else
+         uint32_t off = ((uint32_t)sy * SHADOWFB_LINE_PIXELS + (uint32_t)idx)
+                      * (uint32_t)n;
+         dst  = shadowHiresLineSub + off;
+         rdst = repl ? shadowHiresLineRepl + off : NULL;
+         for (sx = 0; sx < n; sx++)
          {
-            dst[sx].value16 = value16;
-            dst[sx].frac16  = 0;
+            if (blk)
+               dst[sx] = blk[sy * n + sx];
+            else
+            {
+               dst[sx].value16 = value16;
+               dst[sx].frac16  = 0;
+            }
+            if (rdst)
+               rdst[sx] = rblk ? rblk[sy * n + sx] : 0;
          }
-         if (rdst)
-            rdst[sx] = rblk ? rblk[sy * n + sx] : 0;
       }
    }
    shadowHiresLineTag[idx] = (uint32_t)value16 | SHADOWFB_TAG_VALID;

--- a/src/tom/shadowfb_simd_neon.h
+++ b/src/tom/shadowfb_simd_neon.h
@@ -1,0 +1,114 @@
+/*
+ * Hi-res shadow-framebuffer Stage-1 kernels — ARM NEON implementation.
+ *
+ * Guarded by BLITTER_SIMD_HAVE_NEON from blitter_simd_arch.h (capability,
+ * not a new BUILD_AXES flag).  Kernels use only the ARMv7 Advanced-SIMD
+ * subset so rpi2 / rpi3-32-bit stay portable: vget_low_* / vget_high_* +
+ * the struct-returning vzip_u16 rather than any A64-only form (no vzip1 /
+ * vqtbl1q / vaddv).  Included from shadowfb.c; keep this file C89 (vars
+ * at top of each block).
+ *
+ * Every kernel is a pure store rewrite of the scalar loop it replaces:
+ * identical bytes end up at identical addresses, so byte-identity of the
+ * presented frame is structural, not incidental.  The {value16, frac16}
+ * fill pattern is built as uint16 LANES (vzip of two dups) and stored
+ * with vst1*_u16, which writes elements in increasing address order on
+ * any host endianness -- exactly the two uint16_t members of a
+ * shadowfb_sub, with no byte-layout assumption.
+ */
+
+#ifndef SHADOWFB_SIMD_NEON_H
+#define SHADOWFB_SIMD_NEON_H
+
+#include "blitter_simd_arch.h"
+
+#if defined(BLITTER_SIMD_HAVE_NEON)
+
+#include <arm_neon.h>
+#include <stdint.h>
+
+#ifndef VJ_RESTRICT
+#if defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER)
+#  define VJ_RESTRICT __restrict
+#else
+#  define VJ_RESTRICT
+#endif
+#endif
+
+#ifndef INLINE
+#define INLINE
+#endif
+
+/* [value16, frac16, value16, frac16] as uint16 lanes -- two consecutive
+ * shadowfb_sub entries' worth of pattern per 64-bit half. */
+static INLINE uint16x8_t shadowfb_neon_sub_pattern(uint16_t value16,
+                                                   uint16_t frac16)
+{
+   uint16x4x2_t z;
+   z = vzip_u16(vdup_n_u16(value16), vdup_n_u16(frac16));
+   return vcombine_u16(z.val[0], z.val[0]);
+}
+
+/* Fill `nn` shadowfb_sub entries with {value16, frac16} (the Stage-1 box
+ * replication store in ShadowHiresStoreCry).  Returns entries written
+ * (multiple of 4; nn=4 at N=2, so the whole block in one store). */
+static INLINE uint32_t shadowfb_neon_sub_fill(
+   shadowfb_sub * VJ_RESTRICT dst,
+   uint16_t value16,
+   uint16_t frac16,
+   uint32_t nn)
+{
+   uint32_t i;
+   uint32_t done;
+   uint16x8_t q;
+
+   q = shadowfb_neon_sub_pattern(value16, frac16);
+   done = nn & ~3u;
+   for (i = 0; i < done; i += 4)
+      vst1q_u16((uint16_t *)(dst + i), q);
+   return done;
+}
+
+/* ShadowHiresLineFromRAM sub-plane body at N=2: scatter one 2x2 block
+ * (sub-row-major: blk[0..1] -> line sub-row 0, blk[2..3] -> sub-row 1)
+ * into the two line-buffer rows, or box-replicate {value16, 0} on a
+ * resolve miss (blk == NULL).  One 16-byte load + two 8-byte stores
+ * replaces the scalar sy/sx double loop with its per-subpixel blk test. */
+static INLINE void shadowfb_neon_line_sub_n2(
+   shadowfb_sub * VJ_RESTRICT row0,
+   shadowfb_sub * VJ_RESTRICT row1,
+   const shadowfb_sub * VJ_RESTRICT blk,
+   uint16_t value16)
+{
+   uint16x8_t q;
+
+   if (blk)
+      q = vld1q_u16((const uint16_t *)blk);
+   else
+      q = shadowfb_neon_sub_pattern(value16, 0);
+   vst1_u16((uint16_t *)row0, vget_low_u16(q));
+   vst1_u16((uint16_t *)row1, vget_high_u16(q));
+}
+
+/* ShadowHiresLineFromRAM replacement-plane body at N=2: same 2x2
+ * scatter for the pack-art plane (real uint32 entries), zero-filling
+ * when the word carries no replacement block (rblk == NULL) -- exactly
+ * the scalar `rblk ? rblk[sy * n + sx] : 0`. */
+static INLINE void shadowfb_neon_line_repl_n2(
+   uint32_t * VJ_RESTRICT row0,
+   uint32_t * VJ_RESTRICT row1,
+   const uint32_t * VJ_RESTRICT rblk)
+{
+   uint32x4_t q;
+
+   if (rblk)
+      q = vld1q_u32(rblk);
+   else
+      q = vdupq_n_u32(0);
+   vst1_u32(row0, vget_low_u32(q));
+   vst1_u32(row1, vget_high_u32(q));
+}
+
+#endif /* BLITTER_SIMD_HAVE_NEON */
+
+#endif /* SHADOWFB_SIMD_NEON_H */


### PR DESCRIPTION
Closes #691
<!-- link-issue: #691 -->

## Summary

NEON fast paths for the two hot Stage-1 hi-res shadow-framebuffer loops in `src/tom/shadowfb.c` (~8.5% of Apple Silicon profile samples on Missile Command 3D at its titledb-default 2x), byte-identical by construction:

- **New include-only header `src/tom/shadowfb_simd_neon.h`**, guarded by `BLITTER_SIMD_HAVE_NEON` from `blitter_simd_arch.h`, following the `tom_scan_simd_neon.h` structure (INLINE kernels, `VJ_RESTRICT`, scalar tail/fallback in the caller). ARMv7-portable intrinsics only — the `{value16, frac16}` fill pattern is built with the struct-returning `vzip_u16` (no `vzip1`/A64-only forms) as uint16 *lanes*, so the byte layout matches `shadowfb_sub` on any host endianness with no libc dependency.
- **`ShadowHiresStoreCry`**: the N*N box-replication fill becomes one 16-byte store at N=2 (`shadowfb_neon_sub_fill`, multiple-of-4 kernel + scalar tail, so a future N=3 still works).
- **`ShadowHiresLineFromRAM`**: the runtime-n sy/sx double loop (which re-tested `blk`/`rdst`/`rblk` per subpixel) becomes two kernels at N=2 — a 16-byte load + two 8-byte stores scattering the 2x2 block into the two line sub-rows, and the same shape for the pack-art replacement plane (zero-fill on `rblk == NULL`, exactly the scalar semantics). Scalar loops kept verbatim as the non-NEON / N!=2 fallback.
- `shadow_hires_page` (68 samples) is an allocation check, not a loop — nothing to vectorize there. No loop in scope is table-driven (CRY chroma tables are only on the 1x path), so no gather workaround was needed.
- `scripts/c89-lint.sh`: new header added to the skip list alongside the other `_simd_neon.h` entries.

## Verification

- `make -j8` clean; `bash scripts/c89-lint.sh src/tom/shadowfb.c` passes (also enforced by the pre-commit hook).
- ARMv7 syntax probe: `clang -target armv7-none-linux-gnueabihf -mfpu=neon -fsyntax-only -std=gnu89 -Werror=declaration-after-statement` on a TU including the header — clean.
- `make TEST_EXPORTS=1 test` — **0 failed** (2 environment skips: fountain ROM, chdman — corpus/tooling, not code).
- **Byte-identity at 2x** (`frame_hash_ab`, 600 frames, `--option virtualjaguar_internal_resolution=2x`, develop-built reference vs this branch): `test/roms/yarc.j64` and `Missile Command 3D (1995).jag` — **every frame hash identical** on both.
- Coverage proof the identity isn't vacuous: a resolve-counter probe on MC3D@2x shows `shadowHiresActive=1 N=2`, 6.53M resolve hits + 44.4k value misses in 600 frames, so both the `blk` and miss branches of the new kernels ran millions of times.
- `hires_box_check`: **PASS on yarc** (598 frames checked, 0 bad blocks). MC3D presents 652x480 in the headless harness (tall/interlaced mode) with the box gate reporting bad_dims — **identically on unmodified develop**, so that's pre-existing presentation behavior, not a regression from this PR (hash identity above covers MC3D).
- `test/tools/ir_ab.sh --ref libretro/develop HEAD` (cachegrind, MC3D@600 frames, zero-variance): **Ir −0.342%** (65,392,958,093 → 65,169,489,022), I1 misses −5.7%, D1 misses −1.2%, frame-hash CSVs byte-identical inside the instrument too. The −223M instruction delta matches the ~6.5M resolves × ~34 instructions the kernels remove.

## A/B/B/A wall clock (Missile Command 3D, `test_benchmark` 900–1800 frames, warmup 300)

Host was heavily loaded (load avg 16–45) throughout; interleaved A/B/B/A plus reversed B/A/A/B rounds, 16 runs per arm. Pooled p50 medians: **A (develop) 6.76 ms/frame, B (this PR) 6.88 ms/frame**; best-of-run in the quietest sweep: **A 5.114 ms, B 5.117 ms** — statistically flat (per-run spread was ±30–40%, the ordering flipped sign with slot order). The deterministic Ir measurement above is the reliable perf signal on this host: a small real win (−0.34% of total retired instructions on the boot/attract window measured, scaling with 2x blit volume), at zero accuracy risk.