### PR TITLE
perf(voicechat): SSE2 saturating mix for VoiceChatMixInto

### DIFF
--- a/scripts/c89-lint.sh
+++ b/scripts/c89-lint.sh
@@ -39,6 +39,7 @@ skip_file() {
         src/tom/tom_scan_simd_neon.h) return 0 ;;
         src/tom/tom_scan_simd_sse2.h) return 0 ;;
         src/jerry/voicechat_simd_neon.h) return 0 ;;
+        src/jerry/voicechat_simd_sse2.h) return 0 ;;
         # Depends on rcheevos headers fetched at runtime by the e2e shell wrapper.
         test/tools/test_rcheevos_e2e.c) return 0 ;;
         # Diagnostic tools — not part of the libretro core build.
@@ -72,7 +73,7 @@ CHECK_SIMD=0
 for f in $FILES; do
     [ -f "$f" ] || continue
     case "$f" in *.c) ;; *) continue ;; esac
-    case "$f" in src/tom/blitter.c|src/tom/blitter_simd_*.c|src/tom/op.c|src/tom/tom.c) CHECK_SIMD=1 ;; esac
+    case "$f" in src/tom/blitter.c|src/tom/blitter_simd_*.c|src/tom/op.c|src/tom/tom.c|src/jerry/voicechat.c) CHECK_SIMD=1 ;; esac
     if skip_file "$f"; then continue; fi
 
     if ! $CC $CFLAGS $INCLUDES $DEFINES "$f" 2>&1; then
@@ -94,7 +95,7 @@ done
 # targeting when the host can't do it natively.  A host that can't
 # cross-target says so out loud rather than passing silently.
 #
-# op.c and tom.c ride the same pass: they include the guard-selected
+# op.c, tom.c and voicechat.c ride the same pass: they include the guard-selected
 # op_simd_<arch>.h / tom_scan_simd_<arch>.h fragments, which the default
 # loop only ever sees with the host's own capability macros.  Compiling
 # them per-arch is the only host-side syntax check the non-native
@@ -123,7 +124,7 @@ check_simd_arch() {
 
     arch_failed=0
     for f in src/tom/blitter.c "src/tom/blitter_simd_$arch.c" \
-             src/tom/op.c src/tom/tom.c; do
+             src/tom/op.c src/tom/tom.c src/jerry/voicechat.c; do
         [ -f "$f" ] || continue
         if ! $cc $CFLAGS $target $INCLUDES $DEFINES "-D$define" "$f" 2>&1; then
             echo "C89 lint: $arch pass failed on $f"

--- a/src/jerry/voicechat.c
+++ b/src/jerry/voicechat.c
@@ -11,6 +11,8 @@
 
 #if defined(BLITTER_SIMD_HAVE_NEON)
 #include "voicechat_simd_neon.h"
+#elif defined(BLITTER_SIMD_HAVE_SSE2)
+#include "voicechat_simd_sse2.h"
 #endif
 
 #define VC_JITTER_FRAMES   8
@@ -766,6 +768,17 @@ void VoiceChatMixInto(uint16_t *buf, unsigned pairs)
 
 #if defined(BLITTER_SIMD_HAVE_NEON)
       /* vqaddq_s16 matches the scalar clamp iff mixed fits in int16. */
+      if (mixed >= -32768 && mixed <= 32767)
+      {
+         while (n >= 4)
+         {
+            voicechat_mix_sat4(&stereo[i * 2], (int16_t)mixed);
+            i += 4;
+            n -= 4;
+         }
+      }
+#elif defined(BLITTER_SIMD_HAVE_SSE2)
+      /* _mm_adds_epi16 matches the scalar clamp iff mixed fits in int16. */
       if (mixed >= -32768 && mixed <= 32767)
       {
          while (n >= 4)

--- a/src/jerry/voicechat_simd_sse2.h
+++ b/src/jerry/voicechat_simd_sse2.h
@@ -1,0 +1,34 @@
+#ifndef VOICECHAT_SIMD_SSE2_H
+#define VOICECHAT_SIMD_SSE2_H
+
+/*
+ * VoiceChatMixInto SSE2 saturating mix — 4 interleaved stereo pairs.
+ *
+ * Guarded by BLITTER_SIMD_HAVE_SSE2 (src/tom/blitter_simd_arch.h) at the
+ * include site in voicechat.c, exactly like the NEON header.  SSE2 only
+ * (emmintrin.h) — the buildbot x86 baseline.  C89-lint skips this header;
+ * voicechat.c stays C89.
+ *
+ * mixed must already fit in int16.  _mm_adds_epi16 saturates each lane
+ * to [-32768, 32767], matching the scalar (int)add + clamp path when
+ * both addends are int16.  If mixed were truncated from a wider sum,
+ * the results would diverge (e.g. -32768 + 40000 = 7232 scalar vs
+ * sat-add of a truncated mixed).
+ */
+
+#include <stdint.h>
+#include <emmintrin.h>
+
+static void voicechat_mix_sat4(int16_t *stereo, int16_t mixed)
+{
+   __m128i vm;
+   __m128i vbuf;
+   __m128i vout;
+
+   vm = _mm_set1_epi16(mixed);
+   vbuf = _mm_loadu_si128((const __m128i *)stereo);
+   vout = _mm_adds_epi16(vbuf, vm);
+   _mm_storeu_si128((__m128i *)stereo, vout);
+}
+
+#endif /* VOICECHAT_SIMD_SSE2_H */


### PR DESCRIPTION
Closes #694

The voicechat SSE2 port deferred from #687 (now that #666 is merged).

## What

- **`src/jerry/voicechat_simd_sse2.h`** — mirror of `voicechat_simd_neon.h`: `voicechat_mix_sat4()` mixes 4 interleaved stereo pairs per step with `_mm_adds_epi16` (the exact per-lane s16 saturating-add counterpart of `vqaddq_s16`), unaligned `movdqu` load/store. SSE2 only (`emmintrin.h`).
- **`voicechat.c`** — `#elif defined(BLITTER_SIMD_HAVE_SSE2)` after the NEON branch for both the include and the mix loop, with the `mixed`-fits-in-int16 gate copied verbatim (the SIMD saturating add only matches the scalar `(int)add + clamp` when both addends are int16; a wider `mixed` keeps the scalar fallback on both arches). Exactly one (or neither) fast path compiles per target, capability from the existing `BLITTER_SIMD_HAVE_SSE2` in `blitter_simd_arch.h` — no build-flag changes (same analysis as #687: x86_64 baseline, i686 CI rows already get `-msse2` from the blitter selection, plain i386 correctly stays scalar).
- **`scripts/c89-lint.sh`** — new header in the default-pass skip list; `voicechat.c` added to the `CHECK_SIMD` trigger and the per-arch pass (the cross-target `-msse2` / aarch64 compile is the only host-side syntax coverage the non-native fragment header gets). The clang-tidy exclusion regex from #687 already covers `src/jerry/*_simd_{neon,sse2,scalar}.{c,h}`, so no workflow change is needed.

## Byte-identity evidence (arm64 macOS host, Rosetta 2)

Both arms built x86_64 from identical sources; the scalar arm forces the fast path off by predefining the `blitter_simd_arch.h` include guard (`-DBLITTER_SIMD_ARCH_H`), which blanks the capability macros. `objdump` confirms `paddsw` present only in the SSE2 arm.

1. **`test/test_voicechat` (the voicechat unit harness, compiles `voicechat.c` directly; exercises `VoiceChatMixInto` saturation + multi-speaker mix):** both arms pass all **43 checks, 0 FAIL**, stdout **byte-identical** under `arch -x86_64`.
2. **Mix-buffer hash A/B** (throwaway driver, deterministic PRNG buffers, 3 speakers via `VoiceChatJitterPushFrom`, public API only): 7 cases × full output-buffer FNV-1a — **all identical** between arms:
   - mid-scale mix (SIMD path), near-positive-saturation and near-negative-saturation buffers (per-lane clamp exercised both directions),
   - `wide-mixed` (3×15000 speakers ⇒ `mixed` > 32767 pre-clamp — the SIMD branch must decline and the scalar fallback runs; guards divergence like `-32768 + 40000`),
   - tiny buffers (3 and 5 pairs) below/around the 4-pair SIMD width and an odd 401-pair run, so partial upsample groups hit the scalar tail loop.

## Test results

- `bash scripts/c89-lint.sh src/jerry/voicechat.c` — pass, including the new sse2/neon per-arch compiles of `voicechat.c`.
- Native arm64 `make -j8` — clean (NEON side unchanged).
- `make TEST_EXPORTS=1 test` — **exit 0, 0 failed** (2 pre-existing environmental skips: no `/tmp/fountain_vj.j64`, no CHSE-capable chdman). Per the audio-path rule, both gates were checked explicitly: `test_audio_clipping` (Skyhammer / IS2: 0.000% saturated) **and** `test_audio_presence` (Iron Soldier 1: PASS, RMS within envelope). Voicechat coverage in the suite: `test_voicechat` (43 ok), `test_voice_netpacket`, `test_voicechat_inertness`, `voicechat_pair` — all pass.

Rosetta timings say nothing about real Intel hardware, so no perf numbers are claimed; the win is the same shape as #666's.