### PR TITLE
fix(debug): answer unsupported RSP packets, and clear noAckMode on disconnect

### DIFF
--- a/src/debug/gdbtarget.c
+++ b/src/debug/gdbtarget.c
@@ -986,12 +986,23 @@ static int GDBPumpOnce(int *resumeRequested, int *resumeIsStep)
                                     reply, (int)sizeof(reply),
                                     &myResume, &myStep);
 
+         /* RSP: an EMPTY packet ("$#00") is how a stub says "I do not
+          * implement this".  Silence is not the same thing -- the client
+          * waits for a reply that never comes, which is what hung LLDB's
+          * attach.  GDBHandlePacket() returning 0 means exactly that,
+          * EXCEPT for c/s/vCont, which also return 0 but set myResume:
+          * there the next packet the client should see is the stop reply
+          * once the machine halts, not an empty one now. */
          if (replyLen > 0)
          {
             encLen = GDBEncodePacket(reply, replyLen, encoded,
                                      (int)sizeof(encoded));
             if (encLen > 0)
                GDBSockSend(encoded, encLen);
+         }
+         else if (replyLen == 0 && !myResume)
+         {
+            GDBSockSend("$#00", 4);
          }
 
          if (myResume)
@@ -1120,6 +1131,11 @@ void GDBTargetResetState(void)
    gdbWatchArmed    = 0;
    gdbWatchKindMask = 0;
    bpmActive        = false;
+
+   /* A fresh client always starts in ack mode: QStartNoAckMode is
+    * negotiated per connection.  Leaving this set meant the NEXT client
+    * connected expecting acks and got none, and stalled. */
+   gdbSession.noAckMode    = 0;
 
    gdbHaltedTarget         = -1;
    gdbRxLen                = 0;


### PR DESCRIPTION
Fixes both defects in #696. Two small changes in `src/debug/gdbtarget.c`; no engine changes.

## 1. Unsupported packets got silence

RSP defines an empty packet (`$#00`) as "not implemented". `GDBHandlePacket()` returns 0 to mean exactly that — its own comment says so — but the caller only sent a reply when `replyLen > 0`, so the empty reply was dropped. A real LLDB attach hangs on this, and a real GDB very likely does too, since it probes a list of optional packets during negotiation.

**The part worth reviewing carefully:** `c`/`s`/`vCont` *also* return 0, but set `myResume`. There the client should next see the **stop reply**, not an empty packet now. So the condition is `replyLen == 0 && !myResume` — a naive "send `$#00` on any empty reply" would fire a spurious packet after every continue.

## 2. `noAckMode` leaked across connections

It is negotiated **per connection**, but `GDBTargetResetState()` cleared breakpoints, watchpoints, halt state and the rx buffer while leaving `noAckMode` set. The second client of a run connected expecting acks, got none, and stalled.

## Verification

- **Live, end to end**: sent a deliberately unsupported packet to a running core. Now returns `+$#00`; before this change it timed out. That is the actual bug, reproduced and then shown fixed.
- `make TEST_EXPORTS=1 test`: exit 0, **zero FAIL lines**, all 45 gdbstub tests pass (27 framing + 18 phase 2).
- `make -j8`: clean. `c89-lint.sh`: clean.

## Why the existing tests did not catch these

Neither bug is in the engine. The unit tests drive `GDBHandlePacket()` against a fake transport and correctly assert it returns 0; both defects are in the transport-facing caller that interprets that return value. `gdb_attach_probe.py` never probes an unsupported packet and only ever opens one connection.

#696 suggests the coverage worth adding: a probe that sends an unsupported packet and asserts `$#00`, and one that connects twice.

Found while building the tooling in #693, deliberately not bundled there.

Refs #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)