### PR TITLE
perf(gpu): port idle-loop fast-forward to GPU interpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ tools/jagcd/*.exe
 test/tools/blit_memo_verify
 test/tools/dsp_idle_ab
 test/tools/dsp_idle_probe_falsify
+test/tools/gpu_idle_ab
+test/tools/gpu_idle_probe_falsify
 test/tools/i2s_lag_probe
 test/tools/test_memory_map
 test/tools/test_op_gpu_object

--- a/Makefile
+++ b/Makefile
@@ -1306,6 +1306,7 @@ clean:
 		test/test_titledb test/test_titlehook test/tools/test_hook_gate \
 		test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace test/test_voicechat test/test_voice_netpacket test/tools/test_voicechat_inertness test/tools/voicechat_pair test/tools/i2s_lag_probe \
 		test/tools/dsp_idle_probe_falsify test/tools/dsp_idle_ab \
+		test/tools/gpu_idle_probe_falsify test/tools/gpu_idle_ab \
 		test/tools/joymatrix_identity test/tools/teamtap_ports \
 		test/tools/teamtap_rom_probe test/tools/mouse_decode_test \
 		test/tools/rotary_decode_test test/tools/analog_decode_test \
@@ -1370,7 +1371,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_framebuffer_integrity test/test_state_compat \
 		test/test_frontend_pacing test/test_jgd \
 		test/tools/test_runahead_determinism test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace \
-		test/tools/dsp_idle_probe_falsify \
+		test/tools/dsp_idle_probe_falsify test/tools/gpu_idle_probe_falsify \
 		test/test_butch_cd test/test_bios_config test/test_boot_config \
 		test/test_cart_format test/test_cart_needs_bios test/test_cart_bios_loader \
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_chd test/test_chd_unit test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda test/test_cd_synth_subq \
@@ -1686,6 +1687,13 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# genuinely idle loop, so a silently-disabled feature cannot pass.
 	@# Hand-assembles both shapes into DSP RAM; needs no ROM but yarc.
 	./test/tools/dsp_idle_probe_falsify ./$(TARGET) test/roms/yarc.j64 --quiet
+	@# GPU port of the same admission rule (issue #569).  The GPU's
+	@# executed-path identity is opcost == idleBodyCount (its inlined
+	@# delay slots are NOT counted, unlike the DSP's +1), so this pins
+	@# both directions: a genuine loop must still fire (a +1 off-by-one
+	@# would silently disable the feature) and the compound-period
+	@# store-hiding exploit must still be rejected.
+	./test/tools/gpu_idle_probe_falsify ./$(TARGET) test/roms/yarc.j64 --quiet
 	@# Texture dump mode (issue #369): identity-contract freeze vs the
 	@# committed golden list, determinism, fast/accurate engine
 	@# independence, machine inertness (fb hashes + savestate digests
@@ -2558,6 +2566,22 @@ test/tools/dsp_idle_ab: test/tools/dsp_idle_ab.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/dsp_idle_ab.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
+
+# GPU analogs of the two tools above (issue #569, GPU port).
+test/tools/gpu_idle_probe_falsify: test/tools/gpu_idle_probe_falsify.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/gpu_idle_probe_falsify.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
+
+# Not built by `test`: an A/B measurement harness, not an assertion.
+test/tools/gpu_idle_ab: test/tools/gpu_idle_ab.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/gpu_idle_ab.c \
 		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl -lrt) -lm
 

--- a/libretro.c
+++ b/libretro.c
@@ -2276,11 +2276,11 @@ static bool titledb_negative_warn_seen(const char *key)
 
 /* Compounding-settings warning (issue #595).
  *
- * The DSP idle-loop fast-forward (virtualjaguar_risc_idle_skip) is the
+ * The RISC idle-loop fast-forward (virtualjaguar_risc_idle_skip) is the
  * largest speed lever the core has (66-87% less DSP interpretation on the
- * titles measured, #569), and DSPExec() gates it off entirely whenever
- * certain other options are active -- see the gate comment at the top of
- * DSPExec() in src/jerry/dsp.c.  So a user who raises the RISC overclock on
+ * titles measured, #569, plus the GPU port), and DSPExec()/GPUExec() gate
+ * it off entirely whenever certain other options are active -- see the
+ * gate comment at the top of DSPExec() in src/jerry/dsp.c.  So a user who raises the RISC overclock on
  * a borderline-slow title pays the overclock's own cost AND silently
  * forfeits the bigger win: it reads as "overclocking made it much slower"
  * with nothing anywhere to explain why.  Name the suppressor in the log.
@@ -2345,7 +2345,7 @@ static void perf_warn_idle_skip_suppressed(void)
       return;
 
    LOG_WRN("[perf] virtualjaguar_risc_idle_skip is enabled but suppressed by: "
-           "%s -- the DSP idle-loop fast-forward is doing nothing, so this "
+           "%s -- the GPU/DSP idle-loop fast-forward is doing nothing, so this "
            "combination can run slower than idle-skip alone. Your settings "
            "are honored, not overridden.\n", who);
    perf_conflict_warned = 1;
@@ -2840,7 +2840,7 @@ static void check_variables(void)
          GPUPipeTimingReset();
    }
 
-   /* DSP idle-loop fast-forward (issue #569).  Bit-exact by
+   /* GPU/DSP idle-loop fast-forward (issue #569 + GPU port).  Bit-exact by
     * construction -- see the safety theorem in src/jerry/dsp.c -- and
     * the corpus A/B (Iron Soldier, AvP, Doom, Wolfenstein 3D, Tempest
     * 2000, jagniccc, yarc, plus the CD titles Primal Rage and Battle
@@ -2850,7 +2850,7 @@ static void check_variables(void)
     * through is a silent audio/video divergence nobody can attribute,
     * against a speed win a user can opt into with one toggle -- an
     * asymmetry a nine-title corpus does not settle for a ~200-title
-    * library.  DSPExec re-checks the interacting options (dram timing,
+    * library.  DSPExec/GPUExec re-check the interacting options (dram timing,
     * pipeline timing, clock scale, blit memo) itself, so the order the
     * option loop reads them in does not matter. */
    var.key = "virtualjaguar_risc_idle_skip";

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -238,9 +238,9 @@ struct retro_core_option_v2_definition option_defs_us[] = {
     * idle-skip, which is undiscoverable from a different category. */
    {
       "virtualjaguar_risc_idle_skip",
-      "DSP Idle-Loop Fast-Forward",
+      "RISC Idle-Loop Fast-Forward (GPU + DSP)",
       NULL,
-      "Fast-forward the DSP through provably redundant iterations of a wait loop -- the largest single speed-up the core offers (66-87% less DSP interpretation on the titles measured). Bit-exact by construction: registers, flags, cycles and instruction count land exactly where interpreting would have left them, so save states, run-ahead and netplay are unaffected. Off by default while the compatibility corpus grows -- if a title looks or sounds wrong with it on, turn it off and please report it. IMPORTANT: a non-stock RISC Clock Scale, DRAM Timing, GPU Pipeline Timing or Blit Memoization switches this off entirely, so turning one of those on costs you this speed-up on top of its own cost. The M68K clock scale and Blitter Bus Timing do not affect it.",
+      "Fast-forward the GPU and DSP through provably redundant iterations of a wait loop -- the largest single speed-up the core offers (66-87% less DSP interpretation and 60%+ less GPU interpretation on the titles measured). Bit-exact by construction: registers, flags, cycles and instruction count land exactly where interpreting would have left them, so save states, run-ahead and netplay are unaffected. Off by default while the compatibility corpus grows -- if a title looks or sounds wrong with it on, turn it off and please report it. IMPORTANT: a non-stock RISC Clock Scale, DRAM Timing, GPU Pipeline Timing or Blit Memoization switches this off entirely, so turning one of those on costs you this speed-up on top of its own cost. The M68K clock scale and Blitter Bus Timing do not affect it.",
       NULL,
       "speed",
       {

--- a/src/tom/gpu.c
+++ b/src/tom/gpu.c
@@ -35,6 +35,7 @@
 #include "tom.h"
 #include "event.h"
 #include "settings.h"
+#include "blit_memo.h"
 #include "../core/vjtrace.h"
 #include "../core/crash_detect.h"
 #include "perf_iface.h"
@@ -1452,6 +1453,672 @@ void GPUSyncToM68K(void)
    VJP_LEAVE(VJP_GPU_SYNC);
 }
 
+/* ==================================================================
+ * Cycle-exact idle-loop fast-forward   (issue #569, GPU port)
+ * ==================================================================
+ *
+ * Port of the DSP idle-loop fast-forward (src/jerry/dsp.c -- read the
+ * theorem/proof block there first; this comment only records what is
+ * DIFFERENT on the GPU).  Motivation and loop shapes:
+ * docs/perf-audit/mc3d-stall-attribution.md -- Missile Command 3D
+ * parks the GPU in a 3-instruction semaphore poll at $F03134 for 66.8%
+ * of all interpreted GPU instructions, jagniccc's $F03042 mailbox poll
+ * and yarc's $F03192 self-jr are ~100% of their GPU samples.  Same
+ * contract as the DSP: NOT an approximation -- registers, flags, PC,
+ * cycles charged and gpu_exec_opcode_count all end up exactly where
+ * the interpreter would have left them.
+ *
+ * ---- SAFETY THEOREM, GPU DELTAS (verified against this tree) --------
+ *
+ * (1) Nothing else in the machine executes inside one GPUExec() call.
+ *     Same scheduler argument as the DSP: JaguarExecuteNew() runs the
+ *     68K, then GPUExec, then DSPExec; events (OP halfline, timers,
+ *     I2S) are dispatched by HandleNextEvent AFTER the exec calls
+ *     return.  GPUSyncToM68K() is a different, EARLIER GPUExec call
+ *     with its own budget (it runs from 68K writes into GPU local RAM,
+ *     i.e. during the 68K's slice, never nested inside GPUExec).
+ *     MC3D's poll on main-RAM $9704 exits via a 68K write that can
+ *     therefore only land BETWEEN GPUExec calls: within one call the
+ *     polled word is constant, the loop is a fixed point for the rest
+ *     of the call's budget, and skipping to one-iteration-before-
+ *     budget-end is exact.  The probe state is reset at every GPUExec
+ *     entry, so a probe never spans two calls.
+ *
+ * (2) No GPU interrupt can be dispatched mid-call for an admitted
+ *     body.  STRONGER than the DSP case: GPUExec's only dispatch is
+ *     the GPUHandleIRQs() call at slice ENTRY, before the exec loop --
+ *     there is no in-loop IMASKCleared re-check because the GPU has no
+ *     D_FLAGS retire-delay analog; a G_FLAGS write that clears IMASK
+ *     dispatches synchronously INSIDE GPUWriteLong (case 0x00), which
+ *     only a store can reach, and the whitelist admits no store.
+ *     GPUSetIRQLine's other callers (tom.c timers, op.c, cdrom.c) all
+ *     run from event callbacks, i.e. between slices per (1).  So the
+ *     probe needs no IMASKCleared/retire-delay reset check at all.
+ *
+ * (3) The register banks cannot move.  gpu_reg / gpu_alternate_reg are
+ *     repointed only by GPUUpdateRegisterBanks(), reachable from a
+ *     G_FLAGS write (a store -- excluded) or from GPUHandleIRQs
+ *     (excluded by (2)).  The probe still records and re-checks the
+ *     bank pointer, same belt-and-braces as the DSP.
+ *
+ * (4) GPU-side reads of the admitted EA classes are pure.  GPU local
+ *     RAM ($F03000-$F03FFF, 4K -- not the DSP's 8K) is served straight
+ *     out of gpu_ram_8 by GPUReadLong with no side effect.  Main DRAM
+ *     below 2 MB takes JaguarReadLong's `addr < 0x800000` fast path
+ *     (src/core/jaguar.c), whose only side effects are VJT_WATCH_RD
+ *     (a hard gate below) and BlitMemoNoteRead (gated on
+ *     blitMemoRecording, a hard gate below); busArbiter is charged
+ *     there only for `who == OP`.  Register space ($F02000-$F020FF,
+ *     the MMIO view of the banks) and G_CTRL space are NOT admitted:
+ *     bank values change per iteration and the control decode has
+ *     side effects.
+ *
+ * ---- ADMISSION / PROOF DELTAS ---------------------------------------
+ *
+ * Identical to the DSP (three head snapshots S0/S1/S2 driven by
+ * ordinary interpreted iterations, elementwise-equal deltas across
+ * both banks, identical flags at all three heads, measured -- never
+ * recomputed -- cycle and opcode costs, nonzero-delta registers
+ * touched only by addqt/subqt onto themselves, EA checks deferred to
+ * S2) except for:
+ *
+ *   - THE EXECUTED-PATH IDENTITY IS opcost == idleBodyCount, NOT
+ *     idleBodyCount + 1.  gpu_exec_opcode_count is a liveness counter
+ *     incremented ONLY in GPUExec's main loop (see its declaration):
+ *     the delay slot inlined by gpu_opcode_jump/jr does NOT increment
+ *     it, unlike dsp_opcode_jump/jr.  One straight-line traversal of
+ *     the decoded body therefore charges (idleBodyCount - 1) body
+ *     instructions plus the loop-closing jr = idleBodyCount, with the
+ *     delay slot uncounted.  The soundness argument survives: any
+ *     OTHER route from one head arrival to the next executes the whole
+ *     body and the (not-taken) jr, then at least one further main-loop
+ *     -counted instruction to get back -- inlined delay slots are the
+ *     only uncounted instructions and they cannot BE the route (the
+ *     branch owning them is itself counted) -- so any compound period
+ *     costs strictly more than idleBodyCount and exact equality admits
+ *     the straight-line traversal and nothing else.  This is pinned by
+ *     test/tools/gpu_idle_probe_falsify.
+ *
+ *   - Load EA rules follow the GPU's own opcode semantics
+ *     (gpu_opcode_load* above), which differ from the DSP's in the
+ *     masking: loadb/loadw take the pure containing-long local read
+ *     only when the RAW address is inside local RAM (outside, they
+ *     divert to JaguarReadByte/Word, unaudited -- rejected); load
+ *     masks ~3 unconditionally; the indexed and ri forms do NOT mask
+ *     the base -- they test the RAW effective address for the local
+ *     range and mask only in that branch, so the admission check here
+ *     classifies the raw EA exactly as the opcode will.
+ *
+ *   - Delay-slot IRQ hazard (gpu_ds_irq_dispatched): an admitted body
+ *     contains no store, so its delay slot cannot dispatch an
+ *     interrupt and the probe can never be reached with gpu_pc
+ *     pointing at a vector from its own loop's delay slot.
+ *
+ * Extrapolation, exit and savestate behavior are the DSP's: n =
+ * (cycles / cost) - 1 iterations are applied as reg += n*delta,
+ * cycles -= n*cost, gpu_exec_opcode_count += n*opcost (crash_detect's
+ * gpu wedge predicate reads that counter), flags/PC already correct by
+ * construction; the write that ends the wait lands between slices, the
+ * next probe fails, interpretation resumes; no probe state survives a
+ * slice, so savestates are untouched.
+ */
+
+/* Longest body accepted, in 16-bit words (jr offset range [-8,-1]).
+ * Belt-and-braces only: the caller's `pcThis - gpu_pc <= 14` filter
+ * already caps [head, jr) at 7 words, so this bound never binds. */
+#define GPU_IDLE_MAX_BODY	8
+/* Body instruction slots: <= 7 before the jr, plus the delay slot. */
+#define GPU_IDLE_MAX_INSN	10
+/* Per-slice reject memo: without it a loop that fails the fixed-point
+ * test would be re-probed every three iterations for the whole slice. */
+#define GPU_IDLE_MEMO		16
+
+/* Effective addresses we will admit for a load: GPU local SRAM (the 4K
+ * range GPUReadLong itself serves out of gpu_ram_8) or main DRAM below
+ * the 2 MB aperture, where JaguarReadLong is a plain GET32 of
+ * jaguarMainRAM.  Register space $F02000-$F020FF stays excluded. */
+#define GPU_IDLE_EA_OK(ea) \
+	(((ea) >= GPU_WORK_RAM_BASE && (ea) <= GPU_WORK_RAM_BASE + 0xFFF) \
+	 || ((ea) < 0x200000))
+
+#define GPU_IDLE_FETCH(a) \
+	((uint16_t)(((uint16_t)gpu_ram_8[(a) - GPU_WORK_RAM_BASE] << 8) \
+	            | (uint16_t)gpu_ram_8[(a) - GPU_WORK_RAM_BASE + 1]))
+
+/* Option gate (libretro `virtualjaguar_risc_idle_skip`) lives in vjs. */
+/* Diagnostics: counted only on the cold probe path, never per opcode. */
+uint32_t gpu_idle_skip_fires   = 0;		/* successful extrapolations */
+uint32_t gpu_idle_skip_rejects = 0;		/* candidate loops turned down */
+uint32_t gpu_idle_skip_iters   = 0;		/* iterations actually skipped */
+uint32_t gpu_idle_skip_opcodes = 0;		/* opcodes NOT interpreted -- the
+										 * honest, host-independent measure:
+										 * gpu_exec_opcode_count is advanced
+										 * over a skip on purpose, so it does
+										 * NOT show the saving. */
+
+static int       idleProbeStage;		/* 0 = none, 1 = have S0, 2 = have S1 */
+static uint32_t  idleProbeHead;
+static uint32_t  idleProbeJr;
+static uint32_t *idleProbeBank;			/* gpu_reg at S0 -- see theorem (3) */
+static int32_t   idleProbeCyc0, idleProbeCyc1;
+static uint32_t  idleProbeOpc0, idleProbeOpc1;
+static uint32_t  idleProbeS0[64], idleProbeS1[64];
+static uint8_t   idleProbeFz0, idleProbeFn0, idleProbeFc0;
+static uint8_t   idleProbeFz1, idleProbeFn1, idleProbeFc1;
+
+static uint8_t   idleBodyIdx[GPU_IDLE_MAX_INSN];
+static uint8_t   idleBodyP1[GPU_IDLE_MAX_INSN];
+static uint8_t   idleBodyP2[GPU_IDLE_MAX_INSN];
+static uint32_t  idleBodyImm[GPU_IDLE_MAX_INSN];
+static int       idleBodyCount;
+
+static uint32_t  idleMemoHead[GPU_IDLE_MEMO];
+static uint32_t  idleMemoJr[GPU_IDLE_MEMO];
+static int       idleMemoCount;
+static int       idleMemoNext;
+
+/* Opcode whitelist -- the DSP's list transposed to the GPU dispatch
+ * table.  Indices 0-31 and 34-44/57-59 name the same operations on
+ * both processors; the divergent slots are 32/33 (GPU sat8/sat16 vs
+ * DSP subqmod/sat16s -- 33 is a pure RN->RN saturate on both and stays
+ * admitted, 32 differs and stays out), 42 (GPU loadp reads AND writes
+ * gpu_hidata, which the snapshot does not model -- rejected, where the
+ * DSP's 42 was sat32s rejected for reading the accumulator), 48 (GPU
+ * storep -- a store, out like every store) and 62/63 (GPU sat24/pack
+ * -- pure, but left out to keep the whitelist to opcodes wait loops
+ * actually use, same policy as the DSP's mirror/move_pc).  Both
+ * branches (52/53) are deliberately absent: excluding every
+ * PC-modifying opcode but the loop-closing jr itself is load-bearing
+ * for the executed-path check. */
+static int gpu_idle_op_admitted(uint32_t idx)
+{
+	switch (idx)
+	{
+	case  0: case  1: case  2: case  3:		/* add addc addq addqt */
+	case  4: case  5: case  6: case  7:		/* sub subc subq subqt */
+	case  8: case  9: case 10: case 11:		/* neg and or xor */
+	case 12: case 13: case 14: case 15:		/* not btst bset bclr */
+	case 22:								/* abs */
+	case 24: case 25: case 27:				/* shlq shrq sharq */
+	case 28: case 29:						/* ror rorq */
+	case 30: case 31:						/* cmp cmpq */
+	case 33:								/* sat16 */
+	case 34: case 35: case 36: case 37:		/* move moveq moveta movefa */
+	case 38:								/* movei */
+	case 39: case 40: case 41:				/* loadb loadw load */
+	case 43: case 44:						/* load_r14/15_indexed */
+	case 57:								/* nop */
+	case 58: case 59:						/* load_r14/15_ri */
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+/* Register operands of an admitted opcode, as indices into the 64-entry
+ * snapshot (0..31 = gpu_reg_bank_0, 32..63 = gpu_reg_bank_1).  `cur` is
+ * the base of the bank gpu_reg points at, `alt` the other one.  *dst is
+ * -1 when the instruction writes no register. */
+static int gpu_idle_operands(uint32_t idx, uint32_t p1, uint32_t p2,
+                             int cur, int alt, int *src, int *nsrc, int *dst)
+{
+	*nsrc = 0;
+	*dst  = -1;
+
+	switch (idx)
+	{
+	case  0: case  1: case  4: case  5:		/* add addc sub subc */
+	case  9: case 10: case 11:				/* and or xor */
+	case 28:								/* ror  (RM = count) */
+		src[(*nsrc)++] = cur + (int)p1;
+		src[(*nsrc)++] = cur + (int)p2;
+		*dst = cur + (int)p2;
+		return 1;
+	case 30:								/* cmp -- flags only */
+		src[(*nsrc)++] = cur + (int)p1;
+		src[(*nsrc)++] = cur + (int)p2;
+		return 1;
+	case  2: case  3: case  6: case  7:		/* addq addqt subq subqt */
+	case  8: case 12: case 14: case 15:		/* neg not bset bclr */
+	case 22: case 24: case 25: case 27:		/* abs shlq shrq sharq */
+	case 29: case 33:						/* rorq sat16 */
+		src[(*nsrc)++] = cur + (int)p2;
+		*dst = cur + (int)p2;
+		return 1;
+	case 13: case 31:						/* btst cmpq -- flags only */
+		src[(*nsrc)++] = cur + (int)p2;
+		return 1;
+	case 34:								/* move   RN = RM */
+	case 39: case 40: case 41:				/* loadb loadw load: RM = base */
+		src[(*nsrc)++] = cur + (int)p1;
+		*dst = cur + (int)p2;
+		return 1;
+	case 35: case 38:						/* moveq / movei -- immediate */
+		*dst = cur + (int)p2;
+		return 1;
+	case 36:								/* moveta  ALT_RN = RM */
+		src[(*nsrc)++] = cur + (int)p1;
+		*dst = alt + (int)p2;
+		return 1;
+	case 37:								/* movefa  RN = ALT_RM */
+		src[(*nsrc)++] = alt + (int)p1;
+		*dst = cur + (int)p2;
+		return 1;
+	case 43:								/* load_r14_indexed */
+		src[(*nsrc)++] = cur + 14;
+		*dst = cur + (int)p2;
+		return 1;
+	case 44:								/* load_r15_indexed */
+		src[(*nsrc)++] = cur + 15;
+		*dst = cur + (int)p2;
+		return 1;
+	case 58:								/* load_r14_ri */
+		src[(*nsrc)++] = cur + 14;
+		src[(*nsrc)++] = cur + (int)p1;
+		*dst = cur + (int)p2;
+		return 1;
+	case 59:								/* load_r15_ri */
+		src[(*nsrc)++] = cur + 15;
+		src[(*nsrc)++] = cur + (int)p1;
+		*dst = cur + (int)p2;
+		return 1;
+	case 57:								/* nop */
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+static int gpu_idle_memo_hit(uint32_t head, uint32_t jr)
+{
+	int i;
+
+	for (i = 0; i < idleMemoCount; i++)
+		if (idleMemoHead[i] == head && idleMemoJr[i] == jr)
+			return 1;
+	return 0;
+}
+
+static void gpu_idle_memo_reject(uint32_t head, uint32_t jr)
+{
+	if (gpu_idle_memo_hit(head, jr))
+		return;
+	idleMemoHead[idleMemoNext] = head;
+	idleMemoJr[idleMemoNext]   = jr;
+	idleMemoNext = (idleMemoNext + 1) % GPU_IDLE_MEMO;
+	if (idleMemoCount < GPU_IDLE_MEMO)
+		idleMemoCount++;
+	gpu_idle_skip_rejects++;
+}
+
+/* Register-independent decode of target..jr plus the delay slot. */
+static int gpu_idle_decode(uint32_t head, uint32_t jrAddr)
+{
+	uint32_t pc = head;
+	uint16_t op;
+	uint32_t idx;
+	int n = 0;
+
+	idleBodyCount = 0;
+
+	while (pc < jrAddr)
+	{
+		if (n >= GPU_IDLE_MAX_BODY)
+			return 0;
+		op  = GPU_IDLE_FETCH(pc);
+		idx = (uint32_t)(op >> 10);
+		if (!gpu_idle_op_admitted(idx))
+			return 0;
+		idleBodyIdx[n] = (uint8_t)idx;
+		idleBodyP1[n]  = (uint8_t)((op >> 5) & 0x1F);
+		idleBodyP2[n]  = (uint8_t)(op & 0x1F);
+		idleBodyImm[n] = 0;
+		if (idx == 38)						/* movei: opcode + LSW + MSW */
+		{
+			if (pc + 6 > jrAddr)			/* immediate would overrun the jr */
+				return 0;
+			idleBodyImm[n] = (uint32_t)GPU_IDLE_FETCH(pc + 2)
+			               | ((uint32_t)GPU_IDLE_FETCH(pc + 4) << 16);
+			pc += 6;
+		}
+		else
+			pc += 2;
+		n++;
+	}
+
+	if (pc != jrAddr)						/* decode fell out of step */
+		return 0;
+
+	/* The inlined delay slot at jr+2 runs on every iteration too.  A
+	 * movei there would fetch its immediate from past the branch, so
+	 * reject it rather than model it. */
+	op  = GPU_IDLE_FETCH(jrAddr + 2);
+	idx = (uint32_t)(op >> 10);
+	if (idx == 38 || !gpu_idle_op_admitted(idx))
+		return 0;
+	idleBodyIdx[n] = (uint8_t)idx;
+	idleBodyP1[n]  = (uint8_t)((op >> 5) & 0x1F);
+	idleBodyP2[n]  = (uint8_t)(op & 0x1F);
+	idleBodyImm[n] = 0;
+	n++;
+
+	idleBodyCount = n;
+	return 1;
+}
+
+/* Register-dependent half of the admission rule, run at S2 where the
+ * head state is provably steady.  Walks the body tracking each
+ * register's known value so a load base written earlier in the same
+ * body (`movei #addr,r2 ; load (r2),r1`) resolves to the address the
+ * load will really use, not to whatever the head snapshot held. */
+static int gpu_idle_check_body(const uint32_t *delta, int cur, int alt)
+{
+	uint32_t kval[64];
+	uint8_t  kok[64];
+	int src[3];
+	int nsrc, dst, s, j, i;
+	uint32_t idx, p1, p2, ea;
+
+	for (i = 0; i < 32; i++)
+	{
+		kval[i]      = gpu_reg_bank_0[i];
+		kval[32 + i] = gpu_reg_bank_1[i];
+		kok[i]       = 1;
+		kok[32 + i]  = 1;
+	}
+
+	for (j = 0; j < idleBodyCount; j++)
+	{
+		idx = idleBodyIdx[j];
+		p1  = idleBodyP1[j];
+		p2  = idleBodyP2[j];
+
+		if (!gpu_idle_operands(idx, p1, p2, cur, alt, src, &nsrc, &dst))
+			return 0;
+
+		/* A register whose per-iteration delta is nonzero is a pure
+		 * counter: it may only be read, and only be written, by an
+		 * addqt/subqt targeting itself.  Those two are the only
+		 * admitted opcodes that touch no flag, so this forbids a
+		 * growing value from reaching a compare, a load address, a
+		 * shift count or anything else. */
+		for (s = 0; s < nsrc; s++)
+			if (delta[src[s]] != 0
+			    && !((idx == 3 || idx == 7) && src[s] == dst))
+				return 0;
+		if (dst >= 0 && delta[dst] != 0 && !(idx == 3 || idx == 7))
+			return 0;
+
+		/* Loads: the effective address must be provably plain RAM.
+		 * The EA classification mirrors each gpu_opcode_* body above
+		 * exactly -- see the admission-delta comment in the header
+		 * block for why the masking differs from the DSP's. */
+		switch (idx)
+		{
+		case 39:							/* loadb */
+		case 40:							/* loadw */
+			/* Pure containing-long local read only when the RAW
+			 * address is inside GPU local RAM; anywhere else these
+			 * divert to JaguarReadByte / JaguarReadWord, whose full
+			 * TOM/JERRY decode is not audited here. */
+			if (!kok[cur + (int)p1])
+				return 0;
+			ea = kval[cur + (int)p1];
+			if (!(ea >= GPU_WORK_RAM_BASE && ea <= GPU_WORK_RAM_BASE + 0xFFF))
+				return 0;
+			break;
+		case 41:							/* load -- masks ~3 always */
+			if (!kok[cur + (int)p1])
+				return 0;
+			ea = kval[cur + (int)p1] & 0xFFFFFFFC;
+			if (!GPU_IDLE_EA_OK(ea))
+				return 0;
+			break;
+		case 43:							/* load_r14_indexed -- raw base */
+			if (!kok[cur + 14])
+				return 0;
+			ea = kval[cur + 14] + (gpu_convert_zero[p1] << 2);
+			if (!GPU_IDLE_EA_OK(ea))
+				return 0;
+			break;
+		case 44:							/* load_r15_indexed */
+			if (!kok[cur + 15])
+				return 0;
+			ea = kval[cur + 15] + (gpu_convert_zero[p1] << 2);
+			if (!GPU_IDLE_EA_OK(ea))
+				return 0;
+			break;
+		case 58:							/* load_r14_ri -- raw sum */
+			if (!kok[cur + 14] || !kok[cur + (int)p1])
+				return 0;
+			ea = kval[cur + 14] + kval[cur + (int)p1];
+			if (!GPU_IDLE_EA_OK(ea))
+				return 0;
+			break;
+		case 59:							/* load_r15_ri */
+			if (!kok[cur + 15] || !kok[cur + (int)p1])
+				return 0;
+			ea = kval[cur + 15] + kval[cur + (int)p1];
+			if (!GPU_IDLE_EA_OK(ea))
+				return 0;
+			break;
+		default:
+			break;
+		}
+
+		/* Propagate what we can still prove about the destination. */
+		if (dst >= 0)
+		{
+			switch (idx)
+			{
+			case 38:						/* movei -- 32-bit immediate */
+				kval[dst] = idleBodyImm[j];
+				kok[dst]  = 1;
+				break;
+			case 35:						/* moveq -- RN = IMM_1 */
+				kval[dst] = p1;
+				kok[dst]  = 1;
+				break;
+			case 34: case 36: case 37:		/* move / moveta / movefa */
+				kval[dst] = kval[src[0]];
+				kok[dst]  = kok[src[0]];
+				break;
+			default:
+				kok[dst] = 0;
+				break;
+			}
+		}
+	}
+
+	return 1;
+}
+
+static void gpu_idle_snapshot(uint32_t *s)
+{
+	memcpy(s,      gpu_reg_bank_0, 32 * sizeof(uint32_t));
+	memcpy(s + 32, gpu_reg_bank_1, 32 * sizeof(uint32_t));
+}
+
+/* Give up on an in-flight probe.  When the loop that displaced it is a
+ * different one, memo the abandoned loop: otherwise two interleaved
+ * loops could restart each other forever without either reaching S2. */
+static void gpu_idle_probe_abandon(uint32_t head, uint32_t jr)
+{
+	if (idleProbeStage != 0
+	    && (idleProbeHead != head || idleProbeJr != jr))
+		gpu_idle_memo_reject(idleProbeHead, idleProbeJr);
+	idleProbeStage = 0;
+}
+
+/* Called from GPUExec immediately after a taken backward/self `jr`, with
+ * gpu_pc already at the loop head and the delay slot already executed.
+ * Returns the (possibly advanced) cycle budget. */
+static int32_t GPUIdleLoopProbe(int32_t cycles, uint32_t head, uint32_t jrAddr)
+{
+	uint32_t delta[64];
+	int32_t  cost, n;
+	uint32_t opcost;
+	int      cur, alt, i;
+
+	/* Whole body -- including the delay slot and its trailing byte --
+	 * must sit in GPU local SRAM, so every fetch is a pure gpu_ram_8
+	 * read (GPUExec's own fast path for this range). */
+	if (head < GPU_WORK_RAM_BASE
+	    || jrAddr + 3 > GPU_WORK_RAM_BASE + 0xFFF)
+	{
+		gpu_idle_probe_abandon(head, jrAddr);
+		return cycles;
+	}
+
+	/* No IMASKCleared / retire-delay reset here, deliberately: the GPU
+	 * dispatches an IMASK-clearing G_FLAGS write synchronously inside
+	 * the store itself, and no store is admitted -- see theorem (2). */
+
+	/* A different loop showed up mid-probe.  Only then -- calling this
+	 * unconditionally would reset the probe of the loop we are actually
+	 * in the middle of measuring, and nothing would ever reach S2. */
+	if (idleProbeStage != 0
+	    && (idleProbeHead != head || idleProbeJr != jrAddr))
+		gpu_idle_probe_abandon(head, jrAddr);
+
+	if (gpu_idle_memo_hit(head, jrAddr))
+		return cycles;
+
+	if (idleProbeStage == 0)
+	{
+		if (!gpu_idle_decode(head, jrAddr))
+		{
+			gpu_idle_memo_reject(head, jrAddr);
+			return cycles;
+		}
+		gpu_idle_snapshot(idleProbeS0);
+		idleProbeFz0   = gpu_flag_z;
+		idleProbeFn0   = gpu_flag_n;
+		idleProbeFc0   = gpu_flag_c;
+		idleProbeCyc0  = cycles;
+		idleProbeOpc0  = gpu_exec_opcode_count;
+		idleProbeHead  = head;
+		idleProbeJr    = jrAddr;
+		idleProbeBank  = gpu_reg;
+		idleProbeStage = 1;
+		return cycles;
+	}
+
+	if (idleProbeStage == 1)
+	{
+		gpu_idle_snapshot(idleProbeS1);
+		idleProbeFz1   = gpu_flag_z;
+		idleProbeFn1   = gpu_flag_n;
+		idleProbeFc1   = gpu_flag_c;
+		idleProbeCyc1  = cycles;
+		idleProbeOpc1  = gpu_exec_opcode_count;
+		idleProbeStage = 2;
+		return cycles;
+	}
+
+	/* Stage 2: the live machine state is S2. */
+	idleProbeStage = 0;
+
+	/* Flags must have been identical at all THREE loop heads.  Comparing
+	 * only S0 against S2 would admit a two-iteration oscillation whose
+	 * third iteration behaves like neither probe. */
+	if (idleProbeFz1 != idleProbeFz0 || idleProbeFn1 != idleProbeFn0
+	    || idleProbeFc1 != idleProbeFc0
+	    || gpu_flag_z != idleProbeFz0 || gpu_flag_n != idleProbeFn0
+	    || gpu_flag_c != idleProbeFc0)
+	{
+		gpu_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+
+	/* Theorem (3): the bank pointers must not have moved. */
+	if (gpu_reg != idleProbeBank)
+	{
+		gpu_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+
+	/* Cost and opcode count measured, never recomputed: the inlined
+	 * delay slot is not charged by GPUExec's own `cycles -=`. */
+	cost = idleProbeCyc0 - idleProbeCyc1;
+	if (cost <= 0 || (idleProbeCyc1 - cycles) != cost)
+	{
+		gpu_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+	opcost = idleProbeOpc1 - idleProbeOpc0;
+	if (opcost == 0 || (gpu_exec_opcode_count - idleProbeOpc1) != opcost)
+	{
+		gpu_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+
+	/* EXECUTED-PATH CHECK -- see the header block for the full argument
+	 * and for why the GPU identity is idleBodyCount, NOT the DSP's
+	 * idleBodyCount + 1: gpu_exec_opcode_count is incremented only in
+	 * GPUExec's main loop, never for the delay slot gpu_opcode_jr/jump
+	 * inline.  One straight-line traversal charges the (idleBodyCount-1)
+	 * decoded body instructions plus the loop-closing jr; any other
+	 * route from head back to head must additionally execute at least
+	 * one more counted instruction, so exact equality admits the
+	 * straight-line traversal and nothing else.  Without this, a
+	 * compound period hiding an undecoded store behind a not-taken jr
+	 * would pass every other check -- pinned by
+	 * test/tools/gpu_idle_probe_falsify. */
+	if (opcost != (uint32_t)idleBodyCount)
+	{
+		gpu_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+
+	/* Per-iteration register delta must be constant across both probes. */
+	for (i = 0; i < 32; i++)
+	{
+		delta[i]      = idleProbeS1[i] - idleProbeS0[i];
+		delta[32 + i] = idleProbeS1[32 + i] - idleProbeS0[32 + i];
+		if (gpu_reg_bank_0[i] - idleProbeS1[i] != delta[i])
+		{
+			gpu_idle_memo_reject(head, jrAddr);
+			return cycles;
+		}
+		if (gpu_reg_bank_1[i] - idleProbeS1[32 + i] != delta[32 + i])
+		{
+			gpu_idle_memo_reject(head, jrAddr);
+			return cycles;
+		}
+	}
+
+	cur = (gpu_reg == gpu_reg_bank_0) ? 0 : 32;
+	alt = 32 - cur;
+
+	if (!gpu_idle_check_body(delta, cur, alt))
+	{
+		gpu_idle_memo_reject(head, jrAddr);
+		return cycles;
+	}
+
+	/* Always leave one full iteration to execute normally. */
+	n = (cycles / cost) - 1;
+	if (n <= 0)
+		return cycles;
+
+	for (i = 0; i < 32; i++)
+	{
+		if (delta[i])
+			gpu_reg_bank_0[i] += (uint32_t)n * delta[i];
+		if (delta[32 + i])
+			gpu_reg_bank_1[i] += (uint32_t)n * delta[32 + i];
+	}
+	cycles -= n * cost;
+	gpu_exec_opcode_count += (uint32_t)n * opcost;
+
+	gpu_idle_skip_fires++;
+	gpu_idle_skip_iters   += (uint32_t)n;
+	gpu_idle_skip_opcodes += (uint32_t)n * opcost;
+
+	return cycles;
+}
+
 // Main GPU execution core
 
 void GPUExec(int32_t cycles)
@@ -1471,6 +2138,7 @@ void GPUExec(int32_t cycles)
     * the same reason. */
    int      pipeTiming;
    uint32_t riscScale;
+   int      idleSkipActive;
 
    if (!GPU_RUNNING)
       return;
@@ -1503,10 +2171,41 @@ void GPUExec(int32_t cycles)
    pipeTiming = vjs.gpuPipelineTiming ? 1 : 0;
    riscScale  = riscClockScalePct;
 
+   /* Idle-loop fast-forward gates (issue #569, GPU port).  Same
+    * suppression list as DSPExec's -- every entry adds per-instruction
+    * state the affine extrapolation does not model, so any of them
+    * turns the whole thing off; see the rationale on each item there.
+    * The vjtrace/gdb checks are RUNTIME checks for the same reason as
+    * the DSP's: the test ABI is built with -DVJ_TRACE, and a compile-
+    * time gate would make every headless harness silently measure a
+    * disabled feature. */
+   idleSkipActive = vjs.riscIdleSkip
+                 && !blitMemoMode && !blitMemoRecording
+                 && riscClockScalePct == 100
+                 && !busArbiter.enabled
+                 && !vjs.gpuPipelineTiming
+                 && !(gpu_control & 0x18);
+#ifdef VJ_TRACE
+   if (vjtrace_armed || vjtrace_nwatch)
+      idleSkipActive = 0;
+#endif
+#ifndef VJ_GDB_STUB_DISABLE_HOOKS
+   /* GDB stub (issue #652): a GPU breakpoint or pending step inside the
+    * loop would be stepped clean over -- same reasoning as DSPExec. */
+   if (gdbArmedGPU)
+      idleSkipActive = 0;
+#endif
+   /* Probe + reject memo are re-derived from scratch every call, so
+    * nothing here reaches a savestate and nothing survives a slice. */
+   idleProbeStage = 0;
+   idleMemoCount  = 0;
+   idleMemoNext   = 0;
+
    while (cycles > 0 && GPU_RUNNING)
    {
       uint16_t opcode;
       uint32_t index;
+      uint32_t pcThis;
       gpuExecSliceRemaining = cycles;
 #ifdef VJ_TRACE
       VJT_PCHIST_GPU(gpu_pc);
@@ -1522,6 +2221,8 @@ void GPUExec(int32_t cycles)
       if (gdbArmedGPU && GDBCheckPC(GDB_TGT_GPU, gpu_pc))
          GDBHalt(GDB_TGT_GPU, GDB_STOP_BREAKPOINT, gpu_pc);
 #endif
+
+      pcThis = gpu_pc;
 
       if (gpu_pc >= GPU_WORK_RAM_BASE && gpu_pc < GPU_WORK_RAM_BASE + 0x1000)
       {
@@ -1586,6 +2287,15 @@ void GPUExec(int32_t cycles)
       else
          cycles -= gpu_opcode_cycles[index] + (int32_t)gpu_bus_stall
                  + (int32_t)gpu_pipe_core_stall;
+
+      /* Idle-loop fast-forward (issue #569, GPU port).  A taken `jr`
+       * that landed on or behind its own address, at most 8 words back,
+       * is the only candidate; the unsigned difference rejects a
+       * not-taken jr (pc = pcThis + 2) and every forward branch in one
+       * compare. */
+      if (idleSkipActive && index == 53
+          && (uint32_t)(pcThis - gpu_pc) <= 14)
+         cycles = GPUIdleLoopProbe(cycles, gpu_pc, pcThis);
 
       /* Single-step barrier (G_CTRL SINGLE_STEP, bit 3): a running RISC core
        * that has just set SINGLE_STEP has entered single-step mode and stops

--- a/src/tom/gpu.h
+++ b/src/tom/gpu.h
@@ -82,6 +82,14 @@ extern uint32_t gpu_reg_bank_0[], gpu_reg_bank_1[];
 extern uint32_t gpu_irq0_count;
 extern uint32_t gpu_irq3_count;
 
+/* Idle-loop fast-forward diagnostics (issue #569, GPU port).  Counted
+ * only on the cold probe path; read by test/tools, never by the
+ * emulator itself. */
+extern uint32_t gpu_idle_skip_fires;
+extern uint32_t gpu_idle_skip_rejects;
+extern uint32_t gpu_idle_skip_iters;
+extern uint32_t gpu_idle_skip_opcodes;
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/tools/gpu_idle_ab.c
+++ b/test/tools/gpu_idle_ab.c
@@ -1,0 +1,215 @@
+/*
+ * gpu_idle_ab.c -- A/B determinism harness for the GPU idle-loop
+ * fast-forward (issue #569, GPU port).  Built via
+ * `make test/tools/gpu_idle_ab`; not itself wired into `make test`
+ * (gpu_idle_probe_falsify is the committed, always-run regression
+ * guard -- this tool is for manual sweeps across titles/frame counts
+ * when re-validating the feature).  Byte-for-byte the same harness as
+ * test/tools/dsp_idle_ab.c with the GPU counters dlsym'd instead.
+ *
+ * Emits one CSV row per frame:
+ *     frame,vhash,ahash,asamples,statehash
+ * where vhash is FNV-1a over the visible XRGB8888 framebuffer, ahash is
+ * FNV-1a over every int16 audio sample the core emitted for that frame,
+ * and statehash is FNV-1a over retro_serialize()'s blob (only on frames
+ * that are a multiple of --state-every, else 0).
+ *
+ * Two arms are byte-identical iff the two CSVs are byte-identical.
+ *
+ * A trailer (to stderr) reports the deterministic counters:
+ *   gpu_exec_opcode_count total + per frame, and the idle-skip
+ *   fire/reject/iteration counts.
+ *
+ * Build:  make test/tools/gpu_idle_ab TEST_EXPORTS=1
+ *
+ * Run (one arm of an option sweep):
+ *   VJ_EXPECT_BUILD=$(./scripts/build-id.sh) ./test/tools/gpu_idle_ab \
+ *      ./virtualjaguar_libretro.dylib "<rom>" --frames 3300 --warmup 300 \
+ *      --state-every 100 --csv arm.csv --system-dir test/roms/private \
+ *      --option virtualjaguar_risc_idle_skip=enabled
+ *
+ * Then `cmp` the two arms' CSVs: byte-identical means the option changed
+ * nothing observable.  Always confirm the comparator can actually SEE a
+ * change (perturb one arm deliberately) before trusting a clean result --
+ * "we compared and found nothing" is also what a broken comparator says.
+ *
+ * Needs the wide test ABI (make TEST_EXPORTS=1) for the dlsym'd counters.
+ */
+
+#include "../harness/harness.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FNV_OFF 1469598103934665603ULL
+#define FNV_PRM 1099511628211ULL
+
+static FILE    *g_csv;
+static uint64_t g_vhash = FNV_OFF;
+static uint64_t g_ahash;
+static uint64_t g_asamples;
+static unsigned g_warmup;
+static unsigned g_state_every;
+
+static uint32_t *p_gpu_opcodes;
+static uint32_t *p_fires;
+static uint32_t *p_rejects;
+static uint32_t *p_iters;
+static uint32_t *p_skipops;
+
+static size_t   (*p_serialize_size)(void);
+static int      (*p_serialize)(void *, size_t);
+static void     *g_state_buf;
+static size_t    g_state_size;
+
+static uint64_t  g_op_base;
+static uint32_t  g_fires_base, g_rej_base, g_iters_base, g_skip_base;
+
+static uint64_t fnv(uint64_t h, const void *p, size_t n)
+{
+    const uint8_t *b = (const uint8_t *)p;
+    size_t i;
+    for (i = 0; i < n; i++) {
+        h ^= (uint64_t)b[i];
+        h *= FNV_PRM;
+    }
+    return h;
+}
+
+static void ab_video(void *ud, const void *data, unsigned w, unsigned h,
+                     size_t pitch)
+{
+    uint64_t hv = FNV_OFF;
+    unsigned y;
+    (void)ud;
+    if (!data)
+        return;                     /* duped frame: keep previous hash */
+    for (y = 0; y < h; y++)
+        hv = fnv(hv, (const uint8_t *)data + (size_t)y * pitch,
+                 (size_t)w * 4);
+    hv = fnv(hv, &w, sizeof(w));
+    hv = fnv(hv, &h, sizeof(h));
+    g_vhash = hv;
+}
+
+static size_t ab_audio(const int16_t *data, size_t frames)
+{
+    if (data && frames) {
+        g_ahash = fnv(g_ahash, data, frames * 2 * sizeof(int16_t));
+        g_asamples += (uint64_t)frames;
+    }
+    return frames;
+}
+
+static bool ab_frame(void *ud, unsigned frame)
+{
+    uint64_t sh = 0;
+    (void)ud;
+    if (frame >= g_warmup) {
+        if (g_state_every && ((frame - g_warmup) % g_state_every) == 0
+            && p_serialize && g_state_buf) {
+            memset(g_state_buf, 0, g_state_size);
+            if (p_serialize(g_state_buf, g_state_size))
+                sh = fnv(FNV_OFF, g_state_buf, g_state_size);
+        }
+        fprintf(g_csv, "%u,%016llx,%016llx,%llu,%016llx\n", frame,
+                (unsigned long long)g_vhash, (unsigned long long)g_ahash,
+                (unsigned long long)g_asamples, (unsigned long long)sh);
+    }
+    if (frame == g_warmup) {
+        /* Baseline EVERY counter at the same point -- mixing a windowed
+         * opcode delta with a since-boot skip total makes the derived
+         * "interpreted" figure nonsense (it can even go negative). */
+        if (p_gpu_opcodes) g_op_base    = *p_gpu_opcodes;
+        if (p_fires)       g_fires_base = *p_fires;
+        if (p_rejects)     g_rej_base   = *p_rejects;
+        if (p_iters)       g_iters_base = *p_iters;
+        if (p_skipops)     g_skip_base  = *p_skipops;
+    }
+    g_ahash    = FNV_OFF;
+    g_asamples = 0;
+    return true;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    const char *csv = "ab.csv";
+    void (*set_batch)(size_t (*)(const int16_t *, size_t));
+    int i;
+    unsigned counted;
+
+    g_warmup      = 0;
+    g_state_every = 0;
+    g_ahash       = FNV_OFF;
+
+    for (i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--csv") && i + 1 < argc)
+            csv = argv[++i];
+        else if (!strcmp(argv[i], "--warmup") && i + 1 < argc)
+            g_warmup = (unsigned)strtoul(argv[++i], NULL, 10);
+        else if (!strcmp(argv[i], "--state-every") && i + 1 < argc)
+            g_state_every = (unsigned)strtoul(argv[++i], NULL, 10);
+    }
+
+    cfg.frames             = 3300;
+    cfg.quiet              = 1;
+    cfg.video_callback     = ab_video;
+    cfg.frame_callback     = ab_frame;
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+    if (!harness_load_rom(&cfg))
+        return 1;
+
+    g_csv = fopen(csv, "w");
+    if (!g_csv) {
+        fprintf(stderr, "cannot open %s\n", csv);
+        return 1;
+    }
+
+    /* Take over the audio batch callback so we see raw samples. */
+    set_batch = (void (*)(size_t (*)(const int16_t *, size_t)))
+                harness_dlsym(&cfg, "retro_set_audio_sample_batch");
+    if (set_batch)
+        set_batch(ab_audio);
+    else
+        fprintf(stderr, "WARN: no retro_set_audio_sample_batch\n");
+
+    p_gpu_opcodes = (uint32_t *)harness_dlsym(&cfg, "gpu_exec_opcode_count");
+    p_fires       = (uint32_t *)harness_dlsym(&cfg, "gpu_idle_skip_fires");
+    p_rejects     = (uint32_t *)harness_dlsym(&cfg, "gpu_idle_skip_rejects");
+    p_iters       = (uint32_t *)harness_dlsym(&cfg, "gpu_idle_skip_iters");
+    p_skipops     = (uint32_t *)harness_dlsym(&cfg, "gpu_idle_skip_opcodes");
+
+    p_serialize_size = (size_t (*)(void))harness_dlsym(&cfg, "retro_serialize_size");
+    p_serialize      = (int (*)(void *, size_t))harness_dlsym(&cfg, "retro_serialize");
+    if (g_state_every && p_serialize_size) {
+        g_state_size = p_serialize_size();
+        g_state_buf  = calloc(1, g_state_size);
+    }
+
+    harness_run(&cfg);
+
+    counted = (cfg.frames > g_warmup) ? (cfg.frames - g_warmup) : 1;
+    fprintf(stderr,
+            "TRAILER frames=%u warmup=%u gpu_opcodes_total=%llu "
+            "gpu_opcodes_per_frame=%.1f fires=%u rejects=%u iters_skipped=%u "
+            "opcodes_skipped=%u interpreted_per_frame=%.1f\n",
+            cfg.frames, g_warmup,
+            p_gpu_opcodes ? (unsigned long long)(*p_gpu_opcodes - g_op_base) : 0ULL,
+            p_gpu_opcodes ? (double)(*p_gpu_opcodes - g_op_base) / (double)counted : 0.0,
+            p_fires ? (*p_fires - g_fires_base) : 0,
+            p_rejects ? (*p_rejects - g_rej_base) : 0,
+            p_iters ? (*p_iters - g_iters_base) : 0,
+            p_skipops ? (*p_skipops - g_skip_base) : 0,
+            p_gpu_opcodes
+              ? ((double)(*p_gpu_opcodes - g_op_base)
+                 - (double)(p_skipops ? (*p_skipops - g_skip_base) : 0))
+                / (double)counted
+              : 0.0);
+
+    fclose(g_csv);
+    harness_shutdown(&cfg);
+    return 0;
+}

--- a/test/tools/gpu_idle_probe_falsify.c
+++ b/test/tools/gpu_idle_probe_falsify.c
@@ -1,0 +1,232 @@
+/*
+ * test/tools/gpu_idle_probe_falsify.c — falsification test for the GPU
+ * idle-loop fast-forward's admission rule (issue #569, GPU port).
+ * Mirror of test/tools/dsp_idle_probe_falsify.c; read that header for
+ * the full argument.  The GPU-specific twist this test pins down:
+ *
+ * gpu_exec_opcode_count is incremented ONLY in GPUExec's main loop --
+ * the delay slot inlined by gpu_opcode_jr/jump is NOT counted (unlike
+ * the DSP's, which is).  The executed-path identity is therefore
+ * opcost == idleBodyCount on the GPU, not idleBodyCount + 1, and an
+ * off-by-one in either direction has a distinct failure mode:
+ *   - requiring idleBodyCount + 1 would make the probe reject every
+ *     genuine loop, silently disabling the feature (program A guards);
+ *   - a laxer check would admit the compound-period exploit hiding an
+ *     undecoded store behind a not-taken jr (program B guards).
+ *
+ *   A. a genuinely idle loop  ->  the probe MUST fire.
+ *      addqt #1,r0 ; jr always,-2 ; (ds) nop
+ *
+ *   B. the compound-period exploit  ->  the probe MUST NOT fire.
+ *      head:  subq #1,r1
+ *      jr:    jr NE,head
+ *             nop                  <- delay slot, decoded
+ *             store r3,(r4)        <- NEVER DECODED
+ *             movei #2,r1          <- NEVER DECODED
+ *             jump always,(r5)     <- NEVER DECODED, r5 = head
+ *             nop
+ *      Every arrival sees r1 == 1, all 64 register deltas are zero,
+ *      the flags match, cost and opcode cost are uniform, the decoded
+ *      portion is whitelisted.  Only the executed-path check (opcost
+ *      == idleBodyCount: here 7 counted opcodes vs the 2 a
+ *      straight-line body charges) rejects it.
+ *
+ * Unlike the DSP test, gpu_control is static, so the GPU is started
+ * through the G_CTRL MMIO write path (GPUWriteLong), and yarc's GPU
+ * program actively uses interrupts -- GPUSetFlags(0) masks INT_ENA0-4
+ * first so GPUExec's slice-entry GPUHandleIRQs cannot hijack the PC
+ * into a vector mid-test.
+ *
+ * Build: cc -O2 -Wall -std=c99 $(INCFLAGS) -o test/tools/gpu_idle_probe_falsify \
+ *          test/tools/gpu_idle_probe_falsify.c test/harness/harness.c -ldl -lm
+ * Needs the wide test ABI (make TEST_EXPORTS=1).  Uses test/roms/yarc.j64,
+ * which is in-tree, so this never skips.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../harness/harness.h"
+
+/* RISC opcode indices (src/tom/gpu.c gpu_dispatch[]) */
+#define OP_ADDQT   3
+#define OP_SUBQ    6
+#define OP_STORE  47
+#define OP_JUMP   52
+#define OP_JR     53
+#define OP_NOP    57
+#define OP_MOVEI  38
+
+/* Branch condition codes: 0 = always, 1 = NE (fails when Z is set). */
+#define CC_ALWAYS  0
+#define CC_NE      1
+
+#define GPU_RAM_BASE 0x00F03000u
+#define G_CTRL       0x00F02114u
+
+/* High in the 4K local RAM, clear of the ISR vectors ($F03010-$F0305F)
+ * and of yarc's own spin code around $F03192. */
+#define PROG_A_OFF   0x0E00          /* $F03E00 */
+#define PROG_B_OFF   0x0E80          /* $F03E80 */
+#define SCRATCH_OFF  0x0F80          /* $F03F80 -- the exploit's store target */
+
+static uint8_t  *gpu_ram;
+static uint32_t *p_bank0;
+static uint32_t *p_bank1;
+static uint32_t *p_fires;
+static uint32_t *p_rejects;
+static uint32_t *p_opcount;
+static void    (*p_gpuexec)(int32_t);
+static void    (*p_setpc)(uint32_t);
+static void    (*p_setflags)(uint32_t);
+static void    (*p_writelong)(uint32_t, uint32_t, uint32_t);
+
+static uint16_t enc(uint32_t idx, uint32_t p1, uint32_t p2)
+{
+    return (uint16_t)((idx << 10) | ((p1 & 0x1F) << 5) | (p2 & 0x1F));
+}
+
+static void put16(uint32_t off, uint16_t w)
+{
+    gpu_ram[off]     = (uint8_t)(w >> 8);
+    gpu_ram[off + 1] = (uint8_t)(w & 0xFF);
+}
+
+/* Write the same value into both banks: which one is current depends on
+ * G_FLAGS REGPAGE/IMASK, which is not exported.  Writing both makes the
+ * setup correct either way. */
+static void setreg(unsigned n, uint32_t v)
+{
+    p_bank0[n] = v;
+    p_bank1[n] = v;
+}
+
+static void build_prog_a(void)
+{
+    /* addqt #1,r0 ; jr always,-2 ; (ds) nop
+     * jr offset -2 -> target = (jr+2) + (-2*2) = jr - 2 = head. */
+    put16(PROG_A_OFF + 0, enc(OP_ADDQT, 1, 0));
+    put16(PROG_A_OFF + 2, enc(OP_JR, 0x1E /* -2 */, CC_ALWAYS));
+    put16(PROG_A_OFF + 4, enc(OP_NOP, 0, 0));
+}
+
+static void build_prog_b(void)
+{
+    put16(PROG_B_OFF +  0, enc(OP_SUBQ, 1, 1));               /* subq #1,r1     */
+    put16(PROG_B_OFF +  2, enc(OP_JR, 0x1E /* -2 */, CC_NE)); /* jr ne,head     */
+    put16(PROG_B_OFF +  4, enc(OP_NOP, 0, 0));                /* (delay slot)   */
+    put16(PROG_B_OFF +  6, enc(OP_STORE, 4, 3));              /* store r3,(r4)  */
+    put16(PROG_B_OFF +  8, enc(OP_MOVEI, 0, 1));              /* movei #2,r1    */
+    put16(PROG_B_OFF + 10, 0x0002);                           /*   LSW          */
+    put16(PROG_B_OFF + 12, 0x0000);                           /*   MSW          */
+    put16(PROG_B_OFF + 14, enc(OP_JUMP, 5, CC_ALWAYS));       /* jump (r5)      */
+    put16(PROG_B_OFF + 16, enc(OP_NOP, 0, 0));                /* (delay slot)   */
+
+    setreg(1, 2);                                  /* loop counter             */
+    setreg(3, 0xDEADBEEFu);                        /* value the store writes   */
+    setreg(4, GPU_RAM_BASE + SCRATCH_OFF);         /* store destination        */
+    setreg(5, GPU_RAM_BASE + PROG_B_OFF);          /* jump target = head       */
+}
+
+/* Run one hand-assembled program from `off` for `cycles`, returning how
+ * many times the fast-forward fired. */
+static uint32_t run_prog(uint32_t off, int32_t cycles,
+                         uint32_t *rejects_out, uint32_t *opcodes_out)
+{
+    uint32_t f0 = *p_fires, r0 = *p_rejects, o0 = *p_opcount;
+
+    /* Mask every GPU interrupt enable (raw poke -- no MMIO decode side
+     * effects) so the slice-entry GPUHandleIRQs cannot vector away. */
+    p_setflags(0);
+    p_setpc(GPU_RAM_BASE + off);
+    p_writelong(G_CTRL, 0x01, 0);                  /* GPUGO */
+    p_gpuexec(cycles);
+
+    if (rejects_out)
+        *rejects_out = *p_rejects - r0;
+    if (opcodes_out)
+        *opcodes_out = *p_opcount - o0;
+    return *p_fires - f0;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    harness_result res[3];
+    unsigned nres = 0;
+    uint32_t fires_a, fires_b, rej_a, rej_b, ops_a, ops_b;
+    static char detail_a[192], detail_b[192], detail_c[192];
+    int ok_a, ok_b;
+
+    cfg.frames = 2;
+    cfg.quiet  = 1;
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+    /* The feature is off by default; this test is about the admission
+     * rule, so turn it on explicitly. */
+    harness_set_option(&cfg, "virtualjaguar_risc_idle_skip", "enabled");
+    if (!harness_load_rom(&cfg))
+        return 1;
+    harness_run(&cfg);                             /* let options apply */
+
+    gpu_ram     = (uint8_t *)((uint8_t *(*)(void))harness_dlsym(&cfg, "GPUGetRAM"))();
+    p_bank0     = (uint32_t *)harness_dlsym(&cfg, "gpu_reg_bank_0");
+    p_bank1     = (uint32_t *)harness_dlsym(&cfg, "gpu_reg_bank_1");
+    p_fires     = (uint32_t *)harness_dlsym(&cfg, "gpu_idle_skip_fires");
+    p_rejects   = (uint32_t *)harness_dlsym(&cfg, "gpu_idle_skip_rejects");
+    p_opcount   = (uint32_t *)harness_dlsym(&cfg, "gpu_exec_opcode_count");
+    p_gpuexec   = (void (*)(int32_t))harness_dlsym(&cfg, "GPUExec");
+    p_setpc     = (void (*)(uint32_t))harness_dlsym(&cfg, "GPUSetPC");
+    p_setflags  = (void (*)(uint32_t))harness_dlsym(&cfg, "GPUSetFlags");
+    p_writelong = (void (*)(uint32_t, uint32_t, uint32_t))
+                  harness_dlsym(&cfg, "GPUWriteLong");
+
+    if (!gpu_ram || !p_bank0 || !p_bank1 || !p_fires || !p_rejects
+        || !p_opcount || !p_gpuexec || !p_setpc || !p_setflags
+        || !p_writelong) {
+        fprintf(stderr, "gpu_idle_probe_falsify: missing test ABI symbols "
+                        "(build with TEST_EXPORTS=1)\n");
+        return 1;
+    }
+
+    build_prog_a();
+    build_prog_b();
+
+    fires_a = run_prog(PROG_A_OFF, 20000, &rej_a, &ops_a);
+    fires_b = run_prog(PROG_B_OFF, 20000, &rej_b, &ops_b);
+
+    ok_a = (fires_a > 0);
+    ok_b = (fires_b == 0);
+
+    snprintf(detail_a, sizeof detail_a,
+             "genuinely idle loop (addqt/jr/nop) fired %u time(s), "
+             "%u reject(s), %u opcodes charged", fires_a, rej_a, ops_a);
+    res[nres].status = ok_a ? "PASS" : "FAIL";
+    res[nres].name   = "gpu_idle_loop_still_fires";
+    res[nres].detail = detail_a;
+    nres++;
+
+    snprintf(detail_b, sizeof detail_b,
+             "compound period hiding an undecoded store fired %u time(s) "
+             "(must be 0), %u reject(s), %u opcodes charged",
+             fires_b, rej_b, ops_b);
+    res[nres].status = ok_b ? "PASS" : "FAIL";
+    res[nres].name   = "gpu_undecoded_store_path_rejected";
+    res[nres].detail = detail_b;
+    nres++;
+
+    snprintf(detail_c, sizeof detail_c,
+             "exploit arrival-to-arrival costs 7 counted opcodes vs the "
+             "idleBodyCount = 2 a straight-line body charges (GPU delay "
+             "slots are uncounted, unlike the DSP's)");
+    res[nres].status = "INFO";
+    res[nres].name   = "gpu_executed_path_invariant";
+    res[nres].detail = detail_c;
+    nres++;
+
+    harness_report(&cfg, res, nres);
+    harness_shutdown(&cfg);
+    return (ok_a && ok_b) ? 0 : 1;
+}


### PR DESCRIPTION
Closes #698

## Summary

Ports the DSP idle-loop fast-forward (#569) to the GPU interpreter, per the merged audit [`docs/perf-audit/mc3d-stall-attribution.md`](https://github.com/libretro/virtualjaguar-libretro/blob/develop/docs/perf-audit/mc3d-stall-attribution.md) candidate #1. Same three-snapshot fixed-point probe, same admission rules (plain-RAM/local-RAM loads + ALU + the loop-closing `jr`; register space excluded), wired to the SAME core option `virtualjaguar_risc_idle_skip` (no new option, still default-off), with the same suppression list: blit memo, non-stock RISC clock scale, `dram_timing`, `gpu_pipeline_timing`, armed vjtrace or gdb.

GPU-specific deltas (documented in the `gpu.c` header block, each one verified against this tree):

- **Executed-path identity is `opcost == idleBodyCount`, not the DSP's `idleBodyCount + 1`**: `gpu_exec_opcode_count` is incremented only in `GPUExec`'s main loop -- the delay slot inlined by `gpu_opcode_jr/jump` is NOT counted, unlike `dsp_opcode_jr/jump`. The compound-period soundness argument survives (inlined delay slots cannot BE the return route; the owning branch is itself counted).
- **No `IMASKCleared`/retire-delay probe reset**: the GPU dispatches an IMASK-clearing `G_FLAGS` write synchronously inside the store itself, and no store is admitted; `GPUExec` has no in-loop IRQ dispatch at all (slice-entry `GPUHandleIRQs` only).
- **Load EA classification follows the GPU opcodes' own masking**: `loadb/loadw` take the pure containing-long local read only for a RAW address inside the 4K local RAM; `load` masks `~3` unconditionally; the indexed/ri forms test the raw EA (no base masking).
- **Slice safety for MC3D's semaphore**: the poll exits via a 68K write to main RAM that can only land between `GPUExec` calls (`GPUSyncToM68K` is a separate, earlier call, never nested); probe state resets at every `GPUExec` entry, so the fixed point is only ever assumed within one call's budget.

## Measured (test/tools/gpu_idle_ab, 1500 frames / 300 warmup, macOS arm64)

| title | interpreted GPU ops/frame off -> on | reduction | fires/frame | admitted shape |
| --- | --- | ---: | ---: | --- |
| Missile Command 3D | 442,703 -> 73,925 | **-83.3%** | ~1,425 | `$F03134` main-RAM `$9704` semaphore poll (`load/cmp/jr N`) + further overlay wait loops |
| yarc.j64 | 442,798 -> 13,785 | **-96.9%** | ~1,627 | `$F03192` `jr Z,-1` self-spin (delay-slot `cmpq`) |
| jagniccc.j64 | 442,712 -> 190,162 | **-57.0%** | ~1,003 | `$F03042/44` GPU-local mailbox poll (`cmpq/jr NZ` + delay-slot `load (r15)`) |

Every framebuffer, audio and periodic savestate hash is **byte-identical** with the option off vs on for all three titles (CSV arms `cmp` clean; comparator sensitivity cross-checked). `gpu_opcodes_total` is bit-equal across arms, as the contract requires.

jagniccc's smaller win is structural, not a miss: its 68K feeds the GPU mailbox through `GPUSyncToM68K`, which fragments the GPU budget into many short `GPUExec` calls, and each call re-pays the 3-iteration probe plus the trailing interpreted iteration. MC3D's ~2.5 rejects/frame are the `$F03924` blitter-feed head (not a spin -- exits after one iteration, audit §1) and store-containing loops, as designed.

## New tests

- `test/tools/gpu_idle_probe_falsify` (wired into `make test`): pins BOTH directions of the GPU's off-by-one hazard -- a genuine loop must still fire (a `+1` identity would silently disable the feature) and the compound period hiding an undecoded store behind a not-taken `jr` must stay rejected.
- `test/tools/gpu_idle_ab`: the `dsp_idle_ab` analog (manual A/B sweep harness, not wired into `make test`, same as the DSP one).

## Test plan

- [x] `make -j8` clean build (production ABI)
- [x] `make TEST_EXPORTS=1 test` -- 0 failed (includes both idle falsify guards, `test_audio_clipping`, `test_audio_presence`)
- [x] `bash scripts/c89-lint.sh src/tom/gpu.c` / `libretro.c` -- pass
- [x] A/B hash sweep (video+audio+savestate) byte-identical on yarc, jagniccc, Missile Command 3D, 1200 measured frames each
- [x] `./test/regression_test.sh` -- all PASS (baselines, determinism, frameskip invariance, savestate round-trip, rewind)