### PR TITLE
fix(debug): stop asserting frozen registers in gdb_attach_probe.py

### DIFF
--- a/test/tools/gdb_attach_probe.py
+++ b/test/tools/gdb_attach_probe.py
@@ -16,6 +16,18 @@ Assumes something else has already launched a core with
 virtualjaguar_gdb_stub=enabled on the given port (see
 test/tools/gdb_determinism_probe.c for a way to do that headlessly, or
 attach to a real running RetroArch/session).
+
+Deliberately does NOT assume that target is halted: attaching a GDB
+client does not stop emulation by itself (see
+GDBSockHasClientAttachEvent() in src/debug/gdbtarget.c -- it only flags
+a UI banner), so a target launched without virtualjaguar_gdb_wait, or a
+real game already past its boot halt, keeps running the whole time this
+script is connected. This script has to hold for both of those and for
+a genuinely halted target (virtualjaguar_gdb_wait, or an already-hit
+breakpoint), so it never asserts that two register reads taken moments
+apart are identical -- only that each is a well-formed reply. An
+earlier version of this script asserted exact equality and failed
+nondeterministically depending on how far the 68000 got between reads.
 """
 import socket, sys
 
@@ -89,8 +101,13 @@ def main(port: int) -> int:
 
     # From here on, no ack byte should precede any reply.
     assert send_and_check(s, "?", expect_ack=False) == "S05"
+    # NOT compared against `regs` for equality -- see the module docstring
+    # for why "nothing executing between two reads" isn't a safe premise
+    # here. What the protocol does guarantee, halted or not, is a reply
+    # this shape after the no-ack transition.
     regs2 = send_and_check(s, "g", expect_ack=False)
-    assert regs2 == regs, "registers changed between reads with nothing executing"
+    assert len(regs2) == 144, f"g (no-ack) returned {len(regs2)} chars, want 144"
+    int(regs2, 16)                     # must be pure hex
 
     # Z0/z0 (software breakpoint) round-trip -- protocol-level only here;
     # test/tools/gdb_determinism_probe.c and the C unit tests


### PR DESCRIPTION
## Summary

`test/tools/gdb_attach_probe.py` asserted that two `g` (read registers)
replies taken moments apart are byte-identical, on the premise that
"nothing is executing" while the script is attached. That premise is
false in general: attaching a GDB client does not halt emulation by
itself — `GDBSockHasClientAttachEvent()` (`src/debug/gdbtarget.c`) only
flags a UI banner — so unless the target was launched with
`virtualjaguar_gdb_wait=enabled` (or a breakpoint had already fired),
the 68000 keeps running the whole time the script is connected, and its
registers legitimately differ between any two reads.

Measured directly: 3 fresh cores launched without `gdb_wait` showed the
PC advancing across exactly this pair of reads every time (e.g.
`$008020b8` -> `$00802112`), and 4/4 connected runs of the unmodified
script failed on this exact assertion. Adding
`virtualjaguar_gdb_wait=enabled` made it pass reliably — confirming the
assertion was never validating protocol correctness, only getting
lucky whenever nothing had scheduled the 68000 forward yet.

The script is also documented to attach to a real, already-running
RetroArch session, where retroactively halting at boot isn't an
option — so requiring `gdb_wait` isn't a fix, it would just narrow the
script's stated use case. What the protocol does guarantee regardless
of run state is that `g` keeps returning a well-formed 144-hex-char
reply after the no-ack transition; that's what's checked now, matching
the shape check already used for the first read.

- Replaced the equality assertion with the same well-formedness check
  (length 144, pure hex) already used for the first `g` read.
- Documented the "why" in both the module docstring and inline, since
  the constraint (attach ≠ halt) isn't obvious from the code alone.

## Test plan

- [x] Reproduced the flake fresh: 4/4 connected runs of the unmodified
      script failed on `regs2 == regs` (a 5th hit an unrelated
      connection-timing miss, not this bug).
- [x] Fixed script: 6/6 fresh runs pass without `gdb_wait` (previously
      failing).
- [x] Fixed script: still passes against a `gdb_wait`-halted core (no
      regression in the case the original assertion happened to work
      for).
- [x] `make TEST_EXPORTS=1 test`: exit 0, all clean.
- [x] Not a C change — `scripts/c89-lint.sh` not applicable.

Found while fixing the unrelated `GDBPumpOnce` empty-reply bug (merged
`develop@e42a58a`, #697); kept separate per that work's own note not to
bundle GDB-stub fixes together. A further pre-existing, unrelated flake
was spotted in passing in the sibling script
`test/tools/gdb_breakpoint_probe.py` (a packet-coalescing race, ~1/3 of
runs) — not touched here, filed as its own follow-up.

Refs #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)