### PR TITLE
perf(core): tier-2 micro-optimizations (keyboard poll gate, netlink clock skip)

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -294,6 +294,33 @@ static void gdb_stub_show_banner(const char *text)
 static bool libretro_supports_bitmasks = false;
 static bool save_data_needs_unpack = false;
 
+/* Keyboard-presence latch (#569/P8).  update_input()'s default (non-remap)
+ * path polls 24 keyboard fallback keys per frame; on keyboard-less devices
+ * (every phone/TV box) all 24 input_state_cb round trips return 0 forever.
+ * The frontend's own keyboard event callback is the cheapest presence
+ * signal we have: register it, and only start the per-frame polls after
+ * the first key event ever arrives (any key, either edge -- evidence a
+ * physical keyboard exists trumps decoding which key it was).  Latch-only,
+ * never cleared mid-session, so once a keyboard is seen behavior is
+ * bit-identical to the unconditional polling this replaces.  A frontend
+ * that declines SET_KEYBOARD_CALLBACK gets the old unconditional polls --
+ * the gate must fail open or a declining frontend would lose keyboard
+ * input entirely.  The numpad_to_kb path stays gated on its own option
+ * (explicitly configuring it is already a "keyboard present" statement),
+ * and the voice-chat PTT poll is gated on VoiceChatEnabled(). */
+static bool kb_callback_registered = false;
+static bool kb_event_seen = false;
+
+static void keyboard_event_cb(bool down, unsigned keycode,
+                              uint32_t character, uint16_t key_modifiers)
+{
+   (void)down;
+   (void)keycode;
+   (void)character;
+   (void)key_modifiers;
+   kb_event_seen = true;
+}
+
 /* Auto-frameskip (#684) -- the standard libretro pattern (gpsp/snes9x):
  * when the frontend's audio buffer is draining, skip VIDEO PRESENTATION
  * for a frame so a slow host catches up before the buffer underruns.
@@ -3393,6 +3420,10 @@ static void update_input(void)
    unsigned i;
    int16_t ret[2];
    unsigned player;
+   /* Keyboard fallback polls run only once a keyboard has proven itself
+    * (kb_event_seen) -- or unconditionally, exactly as before, when the
+    * frontend declined the keyboard callback and no proof is possible. */
+   bool kb_poll = !kb_callback_registered || kb_event_seen;
    if (!input_poll_cb)
       return;
 
@@ -3559,29 +3590,32 @@ static void update_input(void)
          if (ret[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R2))
             joypad0Buttons[BUTTON_4] = 0xff;
       }
-      if (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_0))
+      /* Keyboard fallbacks below are latch-gated (kb_poll): 24 frontend
+       * round trips per frame otherwise, all returning 0 on any device
+       * without a keyboard (#569/P8). */
+      if (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_0))
          joypad0Buttons[BUTTON_0] = 0xff;
-      if (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_1))
+      if (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_1))
          joypad0Buttons[BUTTON_1] = 0xff;
-      if (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_2))
+      if (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_2))
          joypad0Buttons[BUTTON_2] = 0xff;
-      if (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_3))
+      if (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_3))
          joypad0Buttons[BUTTON_3] = 0xff;
-      if (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_4))
+      if (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_4))
          joypad0Buttons[BUTTON_4] = 0xff;
-      if (ret[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L3) || (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_5)? 1 : 0))
+      if (ret[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L3) || (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_5)? 1 : 0))
          joypad0Buttons[BUTTON_5] = 0xff;
-      if (ret[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R3) || (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_6)? 1 : 0))
+      if (ret[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R3) || (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_6)? 1 : 0))
          joypad0Buttons[BUTTON_6] = 0xff;
-      if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_7)? 1 : 0))
+      if ((kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_7)? 1 : 0))
          joypad0Buttons[BUTTON_7] = 0xff;
-      if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_8)? 1 : 0))
+      if ((kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_8)? 1 : 0))
          joypad0Buttons[BUTTON_8] = 0xff;
-      if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_9)? 1 : 0))
+      if ((kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_9)? 1 : 0))
          joypad0Buttons[BUTTON_9] = 0xff;
-      if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_MINUS)? 1 : 0))
+      if ((kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_MINUS)? 1 : 0))
          joypad0Buttons[BUTTON_s] = 0xff;
-      if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_EQUALS)? 1 : 0))
+      if ((kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_EQUALS)? 1 : 0))
          joypad0Buttons[BUTTON_d] = 0xff;
 
       if (ret[1] & (1 << RETRO_DEVICE_ID_JOYPAD_UP))
@@ -3631,29 +3665,29 @@ static void update_input(void)
          if (ret[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R2))
             joypad1Buttons[BUTTON_4] = 0xff;
       }
-      if (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_p))
+      if (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_p))
          joypad1Buttons[BUTTON_0] = 0xff;
-      if (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_q))
+      if (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_q))
          joypad1Buttons[BUTTON_1] = 0xff;
-      if (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_w))
+      if (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_w))
          joypad1Buttons[BUTTON_2] = 0xff;
-      if (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_e))
+      if (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_e))
          joypad1Buttons[BUTTON_3] = 0xff;
-      if (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_r))
+      if (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_r))
          joypad1Buttons[BUTTON_4] = 0xff;
-      if (ret[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L3) || (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_t)? 1 : 0))
+      if (ret[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L3) || (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_t)? 1 : 0))
          joypad1Buttons[BUTTON_5] = 0xff;
-      if (ret[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R3) || (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_y)? 1 : 0))
+      if (ret[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R3) || (kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_y)? 1 : 0))
          joypad1Buttons[BUTTON_6] = 0xff;
-      if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_u)? 1 : 0))
+      if ((kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_u)? 1 : 0))
          joypad1Buttons[BUTTON_7] = 0xff;
-      if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_i)? 1 : 0))
+      if ((kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_i)? 1 : 0))
          joypad1Buttons[BUTTON_8] = 0xff;
-      if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_o)? 1 : 0))
+      if ((kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_o)? 1 : 0))
          joypad1Buttons[BUTTON_9] = 0xff;
-      if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_LEFTBRACKET)? 1 : 0))
+      if ((kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_LEFTBRACKET)? 1 : 0))
          joypad1Buttons[BUTTON_s] = 0xff;
-      if ((input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_RIGHTBRACKET)? 1 : 0))
+      if ((kb_poll && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_RIGHTBRACKET)? 1 : 0))
          joypad1Buttons[BUTTON_d] = 0xff;
    }
 
@@ -5930,6 +5964,16 @@ void retro_init(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_INPUT_BITMASKS, NULL))
       libretro_supports_bitmasks = true;
 
+   /* Keyboard-presence latch (see keyboard_event_cb above).  Registered
+    * here, once, rather than per-load: keyboard presence is a host
+    * property, not a content property. */
+   {
+      struct retro_keyboard_callback kb_cb;
+      kb_cb.callback = keyboard_event_cb;
+      kb_callback_registered =
+         environ_cb(RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK, &kb_cb);
+   }
+
    /* Controller types the frontend may assign per port (#428/#429/#436).
     * Port 1 offers pad or rotary: the ST/Amiga mouse adapter is a
     * vendor-documented PORT 2 device, every title known to read one reads
@@ -6015,6 +6059,8 @@ void retro_init(void)
 void retro_deinit(void)
 {
    libretro_supports_bitmasks = false;
+   kb_callback_registered = false;
+   kb_event_seen = false;
 
    /* Dump totals to the frontend log before going inert.  RetroArch shows
     * the same numbers in its UI, but a log line is what can actually be

--- a/src/jerry/jlink.c
+++ b/src/jerry/jlink.c
@@ -581,9 +581,16 @@ static void JLinkDiscRawDispatch(const uint8_t *buf, size_t len,
    agreeing the session is still eligible and still the SAME connection
    that earned it (jlinkNegWasConnected forces a fresh handshake, not a
    trusted carry-over, across any disconnected->connected transition). */
-static void JLinkNegTick(uint32_t nowMs)
+static void JLinkNegTick(void)
 {
    int connected = JLinkConnected();
+   /* Deliberately uninitialised: assigned right before the retry-throttle
+    * check below, the first point that needs a timestamp.  That point is
+    * only reached during an ACTIVE client-side negotiation (eligible,
+    * connected, not yet confirmed/given-up), so the common every-frame
+    * pass through this function -- netlink disabled entirely included --
+    * costs no clock_gettime (#569/P8). */
+   uint32_t nowMs;
 
    /* Test-only mechanism escape hatch, same spirit as jlink.c's own
       VJ_NETLINK_HOST/VJ_NETLINK_PORT-style overrides: real negotiation
@@ -651,6 +658,7 @@ static void JLinkNegTick(uint32_t nowMs)
    if (jlinkMode != JLINK_MODE_TCP_CLIENT)
       return;
 
+   nowMs = JLinkNowMs();
    if (jlinkNegAttempts > 0
        && (uint32_t)(nowMs - jlinkNegLastSendMs) < JLINK_NEG_RETRY_MS)
       return;
@@ -689,13 +697,20 @@ static void JLinkNegTick(uint32_t nowMs)
 void JLinkFrameTick(void)
 {
    long long budget;
-   uint32_t nowMs = JLinkNowMs();
+   /* The clock query lives inside the discovery gate (and inside
+      JLinkNegTick's own active-negotiation tail) rather than up front:
+      with netlink off this function still runs every video frame, and a
+      per-frame clock_gettime for a timestamp nobody reads was measurable
+      noise on slow hosts (#569/P8).  Discovery and negotiation now take
+      independent JLinkNowMs() samples a few microseconds apart in ticks
+      where both run; both consumers work on 1 s / 10 s cadences, so the
+      skew is immaterial. */
    if (JLinkDiscActive())
-      jlinkDiscChanged |= JLinkDiscPoll(nowMs);
+      jlinkDiscChanged |= JLinkDiscPoll(JLinkNowMs());
    /* #552 wire-speedup negotiation.  Runs unconditionally, ahead of the
       jlinkWaitEnabled early-return below -- negotiation must not depend
       on the unrelated reply-wait option. */
-   JLinkNegTick(nowMs);
+   JLinkNegTick();
    if (jlinkDevice == JLINK_DEVICE_VOICEMODEM)
       VMFrameTick();
    if (!jlinkWaitEnabled)


### PR DESCRIPTION
Closes #703

Finishes the tier-2 micro-optimization list from `docs/perf-audit-2026-08.md`. Of the five audited items, three turned out to already be on `develop` (verified against current code, details below); this PR lands the remaining two P8 items. Both are byte-identical to develop on framebuffer + audio + savestate.

## Changes

- **`libretro.c` — gate the 24 per-frame keyboard fallback polls on a keyboard-presence latch.** `update_input()`'s default path polled 24 `input_state_cb(RETRO_DEVICE_KEYBOARD, ...)` fallback keys every frame; on keyboard-less devices (every phone/TV box) they all return 0 forever. The core now registers `RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK` purely as a presence signal and starts polling after the first key event ever arrives (latch-only — once a keyboard is seen, behavior is bit-identical to unconditional polling). The gate fails open: a frontend that declines the callback keeps today's unconditional polls, so no frontend can lose keyboard input. The `numpad_to_kb` path stays gated on its own option and the voice-chat PTT poll on `VoiceChatEnabled()`, both unchanged.
- **`src/jerry/jlink.c` — skip the per-frame `clock_gettime` when nothing reads it.** `JLinkFrameTick()` sampled `JLinkNowMs()` every video frame even with netlink fully disabled. The sample now lives at its two consumption points: inside the `JLinkDiscActive()` gate, and in `JLinkNegTick`'s active-negotiation client tail (only reached while an eligible, connected, unconfirmed TCP-client negotiation is in flight). In ticks where both run they take independent samples a few microseconds apart; both consumers work on 1 s / 10 s cadences, so the skew is immaterial. Complements fef12fc, which gated the separate peer-picker query in `libretro.c`.

## Audited items verified as already done (no change here)

- **P5 (DSP `sh`/`sha` 32-iteration loops):** the live `dsp_opcode_sh`/`dsp_opcode_sha` were converted to single native shifts with the `>=32` guard in 36c6720, matching the GPU versions. The four `while (shift)` loops still greppable in `dsp.c` are in `DSP_sh`/`DSP_sha` of the dead pipelined interpreter (`DSPExecP/P2/Comp` are declared but never defined; `DSPOpcode[]` is only invoked from `DSP_jr`/`DSP_jump`, themselves reachable only through that same table) — zero runtime cost, and the audit reserves that removal for a separate cleanup PR because it touches savestate layout.
- **P7 (68K hook-chain fast-reject):** landed in d8df30b. `M68KInstructionHook` gates all three cross-TU calls on `hle_active || jaguarMemTrackInserted || (bootConfig.strategy && bootConfig.strategy->instruction_hook)`, reading the live state directly each instruction, so there is no rebuild-at-mutation-site hazard by construction. The traceback ring store is untouched.
- **P8 (`tom.c` BG line-buffer clear):** widened to 720 16-bit stores in 84618f0; the code comment already cites #569/P8 and notes clang/gcc -O3 emit dup+stp.

## Verification

- `make -j8` clean; `bash scripts/c89-lint.sh` clean on both touched files (also enforced by the pre-commit hook).
- `make TEST_EXPORTS=1 test`: exit 0, **0 failed** across the suite, including `test_audio_clipping`, `test_audio_presence` (Iron Soldier 1 in envelope), the inputdev/joystick tests, and the run-ahead determinism gate.
- **Byte-identical A/B vs develop** (`test/tools/dsp_idle_ab`, default options both arms, 1800 frames, per-frame FNV over visible framebuffer + every audio sample + savestate every 300 frames): Iron Soldier (World) v1.04 and yarc.j64 both `cmp`-identical; comparator sanity-checked against a cross-title diff.
- `./test/regression_test.sh`: **10 passed, 0 failed** (screenshot baselines, determinism, frameskip invariance, savestate round-trip, rewind).
- Under the headless harness the keyboard gate is inert by construction either way: if the harness declines `SET_KEYBOARD_CALLBACK` the old unconditional polls run; if it accepts, the skipped polls were returning 0.
- cachegrind `ir_ab.sh` delta: **not run** — no valgrind on this macOS arm64 host; the win is 24 frontend round trips + one `clock_gettime` per frame, both outside the emulation core, so Ir would barely see it anyway.