### PR TITLE
feat(libretro): enhancement profile option (auto/quality/performance)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1945,6 +1945,10 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@rm -f $(EEPROM_GEN_TOOL) $(EEPROM_FIXTURE)
 	@# Per-title enhancement defaults DB E2E (#368): apply / disable /
 	@# user-override contract, driven through the real dlopen'd core.
+	@# Cases 9-12 extend it to the enhancement profile (P9): performance
+	@# suppresses the DB defaults, an explicit user option beats the
+	@# profile, quality applies them, and the 'auto' runtime demotion
+	@# drops them mid-session on sustained synthetic underrun reports.
 	@# Cases 7/8 extend this to the negative/known-bad entry class (#464):
 	@# refuse-the-default / honour-and-warn-the-user, via a
 	@# programmatically-installed row (TitleDBSetNegativeForTest) so the
@@ -1973,6 +1977,14 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 			./test/tools/test_pertitle_db ./$(TARGET) "$$avp" --case 7 --quiet || rc=1; \
 			./test/tools/test_pertitle_db ./$(TARGET) "$$avp" --case 8 --quiet \
 				--option virtualjaguar_true_color=enabled || rc=1; \
+			./test/tools/test_pertitle_db ./$(TARGET) "$$avp" --case 9 --quiet \
+				--option virtualjaguar_enhancement_profile=performance || rc=1; \
+			./test/tools/test_pertitle_db ./$(TARGET) "$$avp" --case 10 --quiet \
+				--option virtualjaguar_enhancement_profile=performance \
+				--option virtualjaguar_internal_resolution=2x || rc=1; \
+			./test/tools/test_pertitle_db ./$(TARGET) "$$avp" --case 11 --quiet \
+				--option virtualjaguar_enhancement_profile=quality || rc=1; \
+			./test/tools/test_pertitle_db ./$(TARGET) "$$avp" --case 12 --quiet || rc=1; \
 			exit $$rc; \
 		else \
 			bash scripts/test-skip.sh record "Per-title defaults (AvP apply/disable/override)" \

--- a/libretro.c
+++ b/libretro.c
@@ -317,6 +317,17 @@ static bool     retro_audio_buff_underrun;
 static unsigned frameskip_audio_latency;
 static bool     update_audio_latency;
 
+/* Enhancement profile (P9, docs/perf-audit-2026-08.md): the 'auto' profile
+ * watches the same frontend audio-buffer signal frameskip consumes, so its
+ * registration rides init_frameskip() below.  What init_frameskip() last saw
+ * enhancement_watch_wanted() return, so check_variables() can re-run it when
+ * the answer changes without thrashing the frontend's audio driver on every
+ * unrelated option flip.  Full state + helpers live next to the titledb
+ * plumbing further down; this is host-side presentation state and must never
+ * enter retro_serialize, same rule as the frameskip block above. */
+static int enhancement_watch_registered;
+static int enhancement_watch_wanted(void);
+
 /* CD content state. The Tier 1 weak symbols for external_cd_bios[] and
  * cd_bios_loaded_externally are overridden by the strong definitions below. */
 static bool jaguar_cd_mode = false;
@@ -357,21 +368,34 @@ static void retro_audio_buff_status_cb(bool active, unsigned occupancy,
  * driver on that call, which is only safe between frames. */
 static void init_frameskip(void)
 {
-   if (frameskip_type > 0)
+   /* The enhancement-profile 'auto' watch (P9) shares this registration:
+    * it needs the buffer-status reports even while frameskip is disabled.
+    * It never asks for extra audio latency -- that request stays keyed to
+    * frameskip alone, because the frontend re-inits its audio driver on
+    * the deferred SET_MINIMUM_AUDIO_LATENCY call in retro_run(). */
+   int want_watch = enhancement_watch_wanted();
+
+   enhancement_watch_registered = want_watch;
+   if (frameskip_type > 0 || want_watch)
    {
       struct retro_audio_buffer_status_callback buf_status_cb;
       buf_status_cb.callback = retro_audio_buff_status_cb;
       if (!environ_cb(RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK,
             &buf_status_cb))
       {
-         LOG_WRN("[frameskip] frontend does not support the audio buffer "
-                 "status callback -- automatic frameskip disabled\n");
+         if (frameskip_type > 0)
+            LOG_WRN("[frameskip] frontend does not support the audio buffer "
+                    "status callback -- automatic frameskip disabled\n");
+         else
+            LOG_INF("[perf] frontend does not support the audio buffer "
+                    "status callback -- enhancement profile 'auto' keeps "
+                    "the per-title enhancement defaults\n");
          retro_audio_buff_active    = false;
          retro_audio_buff_occupancy = 0;
          retro_audio_buff_underrun  = false;
          frameskip_audio_latency    = 0;
       }
-      else
+      else if (frameskip_type > 0)
       {
          /* 6 frames of headroom at the current video standard. */
          float frame_time_msec = 1000.0f
@@ -379,6 +403,8 @@ static void init_frameskip(void)
          frameskip_audio_latency = (unsigned)((6.0f * frame_time_msec) + 0.5f);
          frameskip_audio_latency = (frameskip_audio_latency + 0x1F) & ~0x1F;
       }
+      else
+         frameskip_audio_latency = 0;
    }
    else
    {
@@ -2351,6 +2377,144 @@ static void perf_warn_idle_skip_suppressed(void)
    perf_conflict_warned = 1;
 }
 
+/* Enhancement profile (P9, docs/perf-audit-2026-08.md).
+ *
+ * The titledb enables expensive visual enhancements (internal resolution
+ * 2x, true color) by default for titles verified to benefit -- but the
+ * hi-res render + shadow path they turn on is ~30% of AvP's frame on the
+ * host, which is the difference between playable and not on slow devices.
+ * The profile decides whether those DB DEFAULTS may apply at all:
+ *
+ *   quality      apply them (the pre-profile behaviour, unchanged);
+ *   performance  never apply them;
+ *   auto         apply them on capable hosts; behave like 'performance'
+ *                when (a) the build targets 32-bit ARM -- there is no
+ *                per-platform define reaching C for the rpi / classic_armv7
+ *                makefile targets, so the compiler's own __arm__ /
+ *                __aarch64__ macros are the platform signal -- or (b) the
+ *                frontend's audio-buffer status reports underrun danger
+ *                for ENH_DEMOTE_UNDERRUN_FRAMES consecutive frames inside
+ *                the first ENH_WATCH_WINDOW_FRAMES of a session (the same
+ *                signal auto-frameskip consumes, #684).
+ *
+ * ONLY titledb-sourced defaults are affected.  get_variable_pertitle()
+ * substitutes a DB value only when the user left the option at its
+ * registered default, so an explicit user choice is out of this code's
+ * reach by construction -- the DB's one hard rule ("user-set values
+ * always win") holds for the profile too.
+ *
+ * The runtime demotion (b) is evaluated ONLY during the first
+ * ENH_WATCH_WINDOW_FRAMES of a loaded session, because dropping the
+ * internal resolution is a live geometry switch: confined to the first
+ * seconds it lands during boot logos/menus rather than mid-game, and a
+ * transient stall later in the session (shader compile, background task)
+ * can never yank the resolution out from under the player.  All of this
+ * is host-side presentation state -- never serialized. */
+#if defined(__arm__) && !defined(__aarch64__)
+#define ENHANCEMENT_PLATFORM_SLOW 1
+#else
+#define ENHANCEMENT_PLATFORM_SLOW 0
+#endif
+
+/* ~10 s NTSC watch window; demote after ~3 s of sustained underrun danger. */
+#define ENH_WATCH_WINDOW_FRAMES    600
+#define ENH_DEMOTE_UNDERRUN_FRAMES 180
+
+static int enhancement_profile_opt;      /* 0 auto / 1 quality / 2 performance */
+static int enhancement_auto_demoted;     /* runtime latch: 'auto' measured an
+                                          * overrun this load and demoted */
+static int enhancement_suppress_logged;  /* one [perf] line per load */
+static int titledb_enhancement_applied;  /* a DB enhancement default was
+                                          * substituted this load (arms the
+                                          * 'auto' watch: nothing applied ->
+                                          * nothing to demote) */
+static int hires_from_titledb;           /* this session's 2x came from the DB,
+                                          * not from the user (see the load-time
+                                          * latch in retro_load_game) */
+static unsigned enhancement_watch_frames;   /* frames since load, saturating
+                                             * at ENH_WATCH_WINDOW_FRAMES */
+static unsigned enhancement_underrun_run;   /* consecutive underrun frames */
+
+/* Per-load reset, same three call sites as titledb_reset_negative_warnings()
+ * (retro_load_game / retro_unload_game / retro_deinit -- iOS cannot dlclose
+ * a core, so statics must be reset by hand).  enhancement_profile_opt itself
+ * is re-read from the option, not reset here. */
+static void enhancement_profile_reset(void)
+{
+   enhancement_auto_demoted    = 0;
+   enhancement_suppress_logged = 0;
+   titledb_enhancement_applied = 0;
+   hires_from_titledb          = 0;
+   enhancement_watch_frames    = 0;
+   enhancement_underrun_run    = 0;
+}
+
+/* Raw read (never through get_variable_pertitle()), same reasoning as the
+ * pertitle gate: a DB row must not be able to pick its own profile.  Called
+ * at the top of check_variables() and once in retro_load_game() before the
+ * hires latch, which runs before check_variables(). */
+static void enhancement_profile_read(void)
+{
+   struct retro_variable var;
+   var.key   = "virtualjaguar_enhancement_profile";
+   var.value = NULL;
+   enhancement_profile_opt = 0;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "quality") == 0)
+         enhancement_profile_opt = 1;
+      else if (strcmp(var.value, "performance") == 0)
+         enhancement_profile_opt = 2;
+   }
+}
+
+/* The keys the profile governs: the expensive visual enhancements the perf
+ * audit measured.  Deliberately a curated list, not "every DB pair" -- a
+ * future compatibility row (e.g. a controller type) is not an enhancement
+ * and must keep applying whatever the profile says, and a future speedup
+ * row (blit_memo) would be exactly backwards to suppress on slow hosts. */
+static int enhancement_profile_governs(const char *key)
+{
+   return strcmp(key, "virtualjaguar_internal_resolution") == 0
+       || strcmp(key, "virtualjaguar_true_color") == 0;
+}
+
+/* Does the profile currently resolve to "suppress the DB enhancement
+ * defaults"?  On yes, *reason names why for the log line. */
+static int enhancement_profile_suppressing(const char **reason)
+{
+   if (enhancement_profile_opt == 1)
+      return 0;
+   if (enhancement_profile_opt == 2)
+   {
+      *reason = "performance profile selected";
+      return 1;
+   }
+#if ENHANCEMENT_PLATFORM_SLOW
+   *reason = "32-bit ARM host";
+   return 1;
+#else
+   if (enhancement_auto_demoted)
+   {
+      *reason = "measured frame-budget overrun";
+      return 1;
+   }
+   return 0;
+#endif
+}
+
+/* Should the 'auto' runtime watch be running?  Also consulted by
+ * init_frameskip() to decide whether the audio-buffer status callback
+ * must stay registered while frameskip itself is disabled. */
+static int enhancement_watch_wanted(void)
+{
+   return !ENHANCEMENT_PLATFORM_SLOW
+       && enhancement_profile_opt == 0
+       && !enhancement_auto_demoted
+       && titledb_enhancement_applied
+       && enhancement_watch_frames < ENH_WATCH_WINDOW_FRAMES;
+}
+
 /* GET_VARIABLE with per-title defaults (issue #368) and known-bad refusal
  * (issue #464).
  *
@@ -2381,6 +2545,35 @@ static bool get_variable_pertitle(struct retro_variable *var)
    def = core_option_default(var->key);
    ovr = TitleDBOverride(var->key);
 
+   /* Enhancement profile (P9): when the profile resolves to 'performance',
+    * a DB enhancement default is dropped HERE, before the substitution --
+    * exactly as if the title had no row for this key.  Explicit user
+    * choices never reach this branch (the substitution below only fires
+    * with the option at its registered default), so they are untouched. */
+   if (ovr && enhancement_profile_governs(var->key))
+   {
+      const char *why = NULL;
+      if (enhancement_profile_suppressing(&why))
+      {
+         if (!enhancement_suppress_logged)
+         {
+            const char *title = TitleDBTitleName();
+            if (enhancement_profile_opt == 2)
+               LOG_INF("[perf] enhancement profile 'performance': not "
+                       "applying %s's per-title enhancement defaults (%s). "
+                       "Options you set yourself are honored as always.\n",
+                       title ? title : "this title", why);
+            else
+               LOG_WRN("[perf] enhancement profile 'auto': not applying "
+                       "%s's per-title enhancement defaults (%s). Options "
+                       "you set yourself are honored as always.\n",
+                       title ? title : "this title", why);
+            enhancement_suppress_logged = 1;
+         }
+         ovr = NULL;
+      }
+   }
+
    if (ovr && (!ok || (def && !strcmp(var->value, def))))
    {
       if (TitleDBUnsafeValue(var->key, ovr, def))
@@ -2395,6 +2588,10 @@ static bool get_variable_pertitle(struct retro_variable *var)
       LOG_INF("[titledb] %s: %s=%s (option at default)\n",
               TitleDBTitleName(), var->key, ovr);
       var->value = ovr;
+      /* Arms the enhancement-profile 'auto' watch: a session where no DB
+       * enhancement default applied has nothing to demote. */
+      if (enhancement_profile_governs(var->key))
+         titledb_enhancement_applied = 1;
       return true;
    }
 
@@ -2592,6 +2789,10 @@ static void check_variables(void)
    else
       pertitle_enabled = true;
 
+   /* Enhancement profile (P9): raw read, before any get_variable_pertitle()
+    * call below consults it. */
+   enhancement_profile_read();
+
    var.key = "virtualjaguar_usefastblitter";
    var.value = NULL;
 
@@ -2713,7 +2914,11 @@ static void check_variables(void)
 
       if (frameskip_type != fs_prev_type
           || frameskip_threshold != fs_prev_threshold
-          || !frameskip_init_done)
+          || !frameskip_init_done
+          /* Enhancement profile (P9): the 'auto' watch rides this
+           * registration, so re-run when its answer changed (e.g. the
+           * profile option flipped mid-session). */
+          || enhancement_watch_wanted() != enhancement_watch_registered)
       {
          frameskip_init_done = 1;
          init_frameskip();
@@ -3298,6 +3503,54 @@ static void check_variables(void)
                                        + 0.5));
 
    update_option_visibility();
+}
+
+/* Enhancement profile (P9) runtime demotion: the 'auto' watch measured a
+ * sustained frame-budget overrun early in the session, so drop the
+ * titledb-sourced enhancement defaults NOW, once, at a frame boundary
+ * (called from retro_run() between the frameskip verdict and the pre-render
+ * geometry latch -- no halfline is mid-render there).
+ *
+ * True color re-resolves live through the check_variables() below, exactly
+ * like a user toggling the option.  Internal resolution is normally
+ * restart-only because SET_GEOMETRY cannot GROW past the advertised
+ * maximum (see the load-time latch in retro_load_game), but a demotion
+ * only ever SHRINKS 2x -> 1x, which stays inside the session's advertised
+ * maximum: ShadowHiresSetN(1) tears the hi-res arena down (the same
+ * teardown the load-time allocation-failure fallback uses), the memo cache
+ * is flushed because its recorded post-states are sized N*N, and zeroing
+ * videoWidth/videoHeight forces the existing pre-render geometry block in
+ * retro_run() to re-latch pitch + SET_GEOMETRY from TOM's current stock
+ * size before the next frame renders.  Presentation-only throughout:
+ * emulation state, savestates, run-ahead and netplay are unaffected.
+ *
+ * Only a DB-sourced 2x is dropped (hires_from_titledb): a user's explicit
+ * 2x is out of reach, per the profile's contract. */
+static void enhancement_auto_demote(void)
+{
+   enhancement_auto_demoted = 1;
+   LOG_WRN("[perf] enhancement profile 'auto': the audio buffer reported "
+           "underrun danger for %u consecutive frames -- dropping the "
+           "per-title enhancement defaults for this session (measured "
+           "frame-budget overrun). Set the Enhancement Profile option to "
+           "'quality' to keep them regardless.\n",
+           (unsigned)ENH_DEMOTE_UNDERRUN_FRAMES);
+   if (hires_from_titledb && shadowHiresN > 1)
+   {
+      LOG_WRN("[perf] internal resolution: per-title default %dx -> 1x\n",
+              shadowHiresN);
+      BlitMemoFlush();
+      ShadowHiresSetN(1);
+      /* Force the pre-render geometry block in retro_run() to re-latch
+       * game_width/game_height, the screen pitch and SET_GEOMETRY from
+       * TOM's current stock size. */
+      videoWidth  = 0;
+      videoHeight = 0;
+   }
+   /* Re-resolve every option with the suppression now active: true color
+    * (and any future live-applied enhancement default) falls back to the
+    * user's own value on this same code path a menu toggle would take. */
+   check_variables();
 }
 
 /* Team Tap sockets 1-3 (#513).
@@ -5238,6 +5491,12 @@ bool retro_load_game(const struct retro_game_info *info)
          pertitle_enabled = true;
    }
 
+   /* Enhancement profile (P9): per-load state reset, then a raw read for
+    * the same reason the gate above is raw -- the hires latch below runs
+    * before check_variables() and already consults the profile. */
+   enhancement_profile_reset();
+   enhancement_profile_read();
+
    /* Enhancement-hook gate (issue #370), latched HERE and nowhere else.
     * Read raw for the same reason the gate above is: otherwise a DB row
     * could carry {"virtualjaguar_enhancement_hooks","enabled"} in its own
@@ -5361,11 +5620,20 @@ bool retro_load_game(const struct retro_game_info *info)
    {
       struct retro_variable hires_var;
       int hires_n = 1;
+      int hires_raw_2x = 0;
+      /* Raw read first, so a DB-substituted 2x is distinguishable from a
+       * user-set one: the enhancement-profile 'auto' runtime demotion may
+       * only ever drop the DB's 2x, never the user's (P9). */
       hires_var.key = "virtualjaguar_internal_resolution";
+      hires_var.value = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &hires_var)
+          && hires_var.value && strcmp(hires_var.value, "2x") == 0)
+         hires_raw_2x = 1;
       hires_var.value = NULL;
       if (get_variable_pertitle(&hires_var)
           && hires_var.value && strcmp(hires_var.value, "2x") == 0)
          hires_n = 2;
+      hires_from_titledb = (hires_n == 2 && !hires_raw_2x);
       ShadowHiresSetN(hires_n);
       hires_restart_notice_logged = 0;
    }
@@ -5772,6 +6040,10 @@ void retro_unload_game(void)
     * warning latch: same reasoning, same reset. */
    TitleDBSetPairsForTest(NULL, 0);
    perf_conflict_reset();
+   /* Enhancement profile (P9): the runtime-demotion latch and its watch
+    * are title-scoped like everything above -- the next load re-evaluates
+    * from scratch. */
+   enhancement_profile_reset();
    /* Widescreen (#530) is title-scoped like everything above and was
     * missed when it landed (#605).  iOS never dlcloses the core, so
     * leaving these set lets a 16:9 title hand its aspect ratio to the
@@ -6197,6 +6469,10 @@ void retro_deinit(void)
     * warning latch: same per-load re-arm as above. */
    TitleDBSetPairsForTest(NULL, 0);
    perf_conflict_reset();
+   /* Enhancement profile (P9): same per-load re-arm as above; the option
+    * itself is re-read on the next load. */
+   enhancement_profile_reset();
+   enhancement_profile_opt = 0;
    /* Widescreen (#530/#605): same per-load re-arm as above. */
    widescreen_reset();
 
@@ -6384,6 +6660,33 @@ void retro_run(void)
    }
    else
       frameskip_counter = 0;
+
+   /* Enhancement profile 'auto' runtime watch (P9): evaluated ONLY during
+    * the first ENH_WATCH_WINDOW_FRAMES of a loaded session (see the state
+    * block's comment for why -- the demotion is a live geometry switch and
+    * must land during boot/menus, never mid-game).  Demote once when the
+    * frontend reports underrun danger for ENH_DEMOTE_UNDERRUN_FRAMES
+    * consecutive frames; retro_audio_buff_active is only true while a
+    * registered buffer-status callback is being fed, so frontends without
+    * the callback can never demote.  Sits between the frameskip verdict
+    * above (fresh buffer report) and the geometry block below, which
+    * applies the demotion's forced geometry re-latch this same frame,
+    * before rendering. */
+   if (enhancement_watch_frames < ENH_WATCH_WINDOW_FRAMES)
+   {
+      enhancement_watch_frames++;
+      if (enhancement_watch_wanted())
+      {
+         if (retro_audio_buff_active && retro_audio_buff_underrun)
+         {
+            enhancement_underrun_run++;
+            if (enhancement_underrun_run >= ENH_DEMOTE_UNDERRUN_FRAMES)
+               enhancement_auto_demote();
+         }
+         else
+            enhancement_underrun_run = 0;
+      }
+   }
 
    /* Deferred from init_frameskip(): tell the frontend how much audio
     * buffering frameskip needs to see the drain coming (0 = restore its

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -299,6 +299,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "3"
    },
    {
+      "virtualjaguar_enhancement_profile",
+      "Enhancement Profile (Per-Title Defaults)",
+      NULL,
+      "Decide whether the per-title enhancement database may switch on expensive visual enhancements (Internal Resolution 2x, True Color) by default for recognized games. 'Quality' always applies them. 'Performance' never does. 'Auto' applies them on capable hardware, but suppresses them on 32-bit ARM devices and drops them early in a session if the audio buffer reports the machine cannot keep up (the same signal Frameskip uses). Only database-supplied DEFAULTS are affected: any option you set yourself always wins, whatever the profile says.",
+      NULL,
+      "speed",
+      {
+         { "auto",        "Auto" },
+         { "quality",     "Quality" },
+         { "performance", "Performance" },
+         { NULL, NULL },
+      },
+      "auto"
+   },
+   {
       "virtualjaguar_m68k_clock_scale",
       "M68K Clock Scale (Overclock)",
       NULL,

--- a/test/harness/harness.c
+++ b/test/harness/harness.c
@@ -451,6 +451,17 @@ static bool cb_environment(unsigned cmd, void *data)
     case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
         *(const char **)data = "/tmp";
         return true;
+    case RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK:
+        /* Opt-in like --av-skip-video below: tools that predate this hook
+         * keep getting `false`, so the core treats the frontend as not
+         * supporting buffer-status reports (auto frameskip and the
+         * enhancement-profile watch then stand down, exactly as before). */
+        if (!active_cfg || !active_cfg->accept_audio_buf_cb)
+            return false;
+        active_cfg->audio_buf_cb = data
+            ? ((const struct retro_audio_buffer_status_callback *)data)->callback
+            : NULL;
+        return true;
     case RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE:
         /* Only answer when a tool explicitly opted in (--av-skip-video);
          * otherwise fall through to `default: return false`, which is

--- a/test/harness/harness.h
+++ b/test/harness/harness.h
@@ -267,6 +267,19 @@ typedef struct {
      * predates this option -- see cb_environment() in harness.c. */
     int           av_skip_video;
 
+    /* RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK capture (opt-in
+     * like av_skip_video/mic_tone): when accept_audio_buf_cb is non-zero
+     * the environment callback accepts the registration and stores the
+     * core's callback here, so a test can feed synthetic occupancy /
+     * underrun-likely reports the way a real frontend would (once per
+     * frame, before retro_run).  Default 0 refuses the call, matching
+     * every harness tool that predates this option.  The signature is
+     * retro_audio_buffer_status_callback_t from libretro.h, spelled out
+     * because this header does not include it. */
+    int           accept_audio_buf_cb;
+    void        (*audio_buf_cb)(bool active, unsigned occupancy,
+                                bool underrun_likely);
+
     /* Runtime state (set by harness) */
     void  *core_handle;
     unsigned current_frame;
@@ -316,6 +329,8 @@ typedef struct {
     .last_fb_hash = 0, \
     .mic_tone = 0, \
     .av_skip_video = 0, \
+    .accept_audio_buf_cb = 0, \
+    .audio_buf_cb = NULL, \
     .core_handle = NULL, \
     .current_frame = 0, \
     .audio = {0}, \

--- a/test/tools/test_pertitle_db.c
+++ b/test/tools/test_pertitle_db.c
@@ -55,6 +55,28 @@
  *      explicit user choice; a [titledb] warning is still logged so a bug
  *      report against this title starts from the right hypothesis.
  *
+ * Enhancement profile cases (P9, docs/perf-audit-2026-08.md):
+ *
+ *   9  AvP, virtualjaguar_enhancement_profile=performance -- the DB's
+ *      enhancement defaults are NOT applied: shadowHiresN == 1, a [perf]
+ *      "not applying" line is logged, and no "(option at default)"
+ *      substitution line appears.
+ *  10  AvP, profile=performance PLUS virtualjaguar_internal_resolution=2x
+ *      set EXPLICITLY -- the user's own choice beats the profile:
+ *      shadowHiresN == 2 (the profile governs DB defaults only).
+ *  11  AvP, virtualjaguar_enhancement_profile=quality -- the DB defaults
+ *      apply exactly as before the profile existed: shadowHiresN == 2
+ *      with the substitution line logged.  (Case 1, which passes no
+ *      profile option, doubles as the 'auto'-on-a-capable-host arm: the
+ *      registered default is auto and this host is not 32-bit ARM.)
+ *  12  AvP, default options (profile=auto), with the harness accepting
+ *      the core's RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK
+ *      registration -- the runtime demotion: the DB's 2x applies at load,
+ *      then the test feeds "underrun likely" reports the way a struggling
+ *      frontend would; after the demotion threshold the core must drop to
+ *      shadowHiresN == 1 mid-session, log the [perf] demotion warning
+ *      naming the measured overrun, and keep running.
+ *
  * The [titledb] substitution/miss lines are logged at RETRO_LOG_INFO via
  * LOG_INF(), which the harness's cb_log filters out below RETRO_LOG_WARN
  * unless VJ_HARNESS_LOG_INFO=1 is set (see harness.c) -- this test sets it
@@ -207,9 +229,9 @@ int main(int argc, char **argv)
         if (strcmp(argv[i], "--case") == 0 && i + 1 < argc)
             case_num = atoi(argv[i + 1]);
     }
-    if (case_num < 1 || case_num > 8) {
+    if (case_num < 1 || case_num > 12) {
         fprintf(stderr,
-                "usage: test_pertitle_db [core] <rom> --case N[1-8] "
+                "usage: test_pertitle_db [core] <rom> --case N[1-12] "
                 "[--option KEY=VALUE ...]\n");
         return 1;
     }
@@ -270,6 +292,13 @@ int main(int argc, char **argv)
         set_negative(negative_true_color, 1);
     }
 
+    /* Case 12 (P9): accept the core's audio-buffer status callback
+     * registration so the test can feed synthetic underrun reports, and
+     * keep the stderr capture open across the feeding loop below -- the
+     * [perf] demotion warning is logged mid-run, not at load. */
+    if (case_num == 12)
+        cfg.accept_audio_buf_cb = 1;
+
     log_capture_begin();
     if (!harness_load_rom(&cfg)) {
         log_capture_end();
@@ -277,13 +306,15 @@ int main(int argc, char **argv)
                 cfg.rom_path);
         return 1;
     }
-    log_capture_end();
+    if (case_num != 12)
+        log_capture_end();
 
     harness_run(&cfg);
 
     hires_n_ptr       = (int *)harness_dlsym(&cfg, "shadowHiresN");
     shadow_active_ptr = (int *)harness_dlsym(&cfg, "shadowFBActive");
     if (!hires_n_ptr || !shadow_active_ptr) {
+        log_capture_end();   /* still open for case 12 */
         fprintf(stderr,
                 "test_pertitle_db: missing shadowHiresN/shadowFBActive "
                 "exports -- rebuild with `make TEST_EXPORTS=1`\n");
@@ -419,6 +450,90 @@ int main(int argc, char **argv)
             warn_logged ? "[titledb] known-bad warning logged"
                         : "no [titledb] known-bad warning found");
         pass = tc_honored && warn_logged;
+        break;
+    }
+    case 9: {
+        /* performance profile: the DB's enhancement defaults must not
+         * apply -- exactly as if the title had no row. */
+        int hires_ok   = (*hires_n_ptr == 1);
+        int perf_log   = log_contains("not applying");
+        int no_sub_log = !log_contains("(option at default)");
+        results[nres++] = mkres(hires_ok, "case9_performance_suppresses_db",
+            hires_ok ? "shadowHiresN == 1 (DB default suppressed)"
+                     : "shadowHiresN != 1 (DB default applied despite "
+                       "performance profile!)");
+        results[nres++] = mkres(perf_log, "case9_perf_log_present",
+            perf_log ? "[perf] suppression line logged"
+                     : "no [perf] suppression line found");
+        results[nres++] = mkres(no_sub_log, "case9_no_substitution_log",
+            no_sub_log ? "no [titledb] substitution line (correctly none)"
+                       : "unexpected [titledb] substitution line under "
+                         "performance profile");
+        pass = hires_ok && perf_log && no_sub_log;
+        break;
+    }
+    case 10: {
+        /* performance profile + EXPLICIT internal_resolution=2x: the
+         * user's own choice is out of the profile's reach. */
+        int hires_ok = (*hires_n_ptr == 2);
+        results[nres++] = mkres(hires_ok, "case10_explicit_beats_profile",
+            hires_ok ? "shadowHiresN == 2 (explicit user choice honored)"
+                     : "shadowHiresN != 2 (profile overrode an explicit "
+                       "user choice!)");
+        pass = hires_ok;
+        break;
+    }
+    case 11: {
+        /* quality profile: pre-profile behaviour, DB defaults apply. */
+        int hires_ok  = (*hires_n_ptr == 2);
+        int logged_ok = log_contains("(option at default)");
+        results[nres++] = mkres(hires_ok, "case11_quality_applies_db",
+            hires_ok ? "shadowHiresN == 2 (DB applied under quality)"
+                     : "shadowHiresN != 2");
+        results[nres++] = mkres(logged_ok, "case11_titledb_log_present",
+            logged_ok ? "[titledb] substitution logged (option at default)"
+                      : "no [titledb] substitution log line found");
+        pass = hires_ok && logged_ok;
+        break;
+    }
+    case 12: {
+        /* Runtime demotion (profile=auto): the DB's 2x applied at load;
+         * now feed "underrun likely" once per frame the way a struggling
+         * frontend would, past the core's consecutive-frame threshold
+         * (180), and the core must drop to 1x mid-session and say why.
+         * The loop keeps stepping past the demotion (the core unregisters
+         * the callback once the watch is spent -- the harness then holds
+         * NULL) to prove the session keeps running at 1x. */
+        int hires_before = *hires_n_ptr;
+        int cb_ok        = (cfg.audio_buf_cb != NULL);
+        int hires_after;
+        int demote_logged;
+        int j;
+
+        for (j = 0; j < 250 && !cfg.stop_requested; j++) {
+            if (cfg.audio_buf_cb)
+                cfg.audio_buf_cb(true, 0, true);
+            harness_step(&cfg);
+        }
+        log_capture_end();
+
+        hires_after   = *hires_n_ptr;
+        demote_logged = log_contains("enhancement profile 'auto'")
+                     && log_contains("measured frame-budget overrun");
+        results[nres++] = mkres(hires_before == 2, "case12_db_applied_at_load",
+            hires_before == 2 ? "shadowHiresN == 2 before the underrun feed"
+                              : "shadowHiresN != 2 at load (nothing to demote)");
+        results[nres++] = mkres(cb_ok, "case12_buffer_cb_registered",
+            cb_ok ? "core registered the audio-buffer status callback"
+                  : "core never registered the audio-buffer status callback");
+        results[nres++] = mkres(hires_after == 1, "case12_runtime_demotion",
+            hires_after == 1 ? "shadowHiresN == 1 after sustained underrun"
+                             : "shadowHiresN != 1 (no runtime demotion)");
+        results[nres++] = mkres(demote_logged, "case12_demotion_logged",
+            demote_logged ? "[perf] demotion warning logged (measured overrun)"
+                          : "no [perf] demotion warning found");
+        pass = (hires_before == 2) && cb_ok && (hires_after == 1)
+            && demote_logged;
         break;
     }
     default:


### PR DESCRIPTION
Closes #705

## Summary

Implements perf-audit item **P9**: a new speed-category core option `virtualjaguar_enhancement_profile` that decides whether the titledb may switch on its expensive visual-enhancement **defaults** (`internal_resolution=2x`, `true_color`) for recognized titles — the hi-res render + shadow path is ~30% of AvP's frame on the host, which pushes slow devices under 60fps.

- **`quality`** — pre-profile behaviour, DB defaults apply (byte-identical, see A/B below).
- **`performance`** — DB enhancement defaults are never applied.
- **`auto`** (default) — `quality` on capable hosts; `performance` when either heuristic below fires.

Only titledb-sourced defaults are governed. The suppression sits in `get_variable_pertitle()` **before** the at-default substitution — the only place DB defaults ever apply — so an explicit user-set option is out of the profile's reach by construction (the DB's "user-set values always win" rule holds). The governed keys are a curated list (`internal_resolution`, `true_color`): a future compatibility row (controller type) or speedup row (`blit_memo`) must keep applying whatever the profile says.

## The auto heuristic, exactly

**(a) Compile-time platform:** `#if defined(__arm__) && !defined(__aarch64__)` — 32-bit ARM builds (all `rpi0..rpi5` 32-bit-userland targets, `classic_armv7_a7`, generic `armv*`, Android armeabi-v7a). No platform makefile define reaches the C code for these targets (the only per-platform `-D` is `BLITTER_SIMD_*`, which doesn't discriminate — arm64 gets NEON too), so the compiler's own architecture macros are the existing signal; no new build flag invented.

**(b) Runtime measured overrun:** reuses the #684 auto-frameskip plumbing — `RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK` registration now also stays live while the `auto` watch is armed (frameskip's audio-latency request stays keyed to frameskip alone). If the frontend reports `underrun_likely` for **180 consecutive frames** (~3 s NTSC) within the **first 600 frames** (~10 s) of a loaded session, the core demotes once and latches for the session.

**Mid-game-disruption decision (documented per the design constraint):** the internal-resolution option is normally restart-only because `SET_GEOMETRY` cannot *grow* past the advertised maximum — but a demotion only ever **shrinks** 2x→1x, which stays inside the session's advertised maximum. So the demotion is applied **once, at a frame boundary** in `retro_run()` (between the frameskip verdict and the pre-render geometry latch): `ShadowHiresSetN(1)` (the same teardown the load-time allocation-failure fallback uses), `BlitMemoFlush()` (memo post-states are sized N×N), and a forced re-latch of pitch + `SET_GEOMETRY` through the existing pre-render geometry block. True color re-resolves live through `check_variables()`, the same path a menu toggle takes. The watch is additionally confined to the first ~10 s so the one-time switch lands during boot logos/menus, never mid-game, and a transient stall later in a session can't yank the resolution from under the player. Only a DB-sourced 2x is dropped (`hires_from_titledb`, latched at load by comparing the raw frontend value against the substituted one). All new state is host-side presentation state — never serialized; savestates/run-ahead/netplay unaffected.

**Logging** follows the `[perf]` house style, naming the reason: `LOG_WRN` for both auto demotions ("32-bit ARM host" / "measured frame-budget overrun"), `LOG_INF` when the user explicitly selected `performance`. One line per load, reset in the same three places as the other titledb latches.

## Tests

`test_pertitle_db` cases 9–12 (wired into `make test` next to cases 1–8; case 1, which passes no profile option, doubles as the auto-on-capable-host arm):

- **9** `performance` on AvP → `shadowHiresN == 1`, `[perf]` suppression logged, no substitution line.
- **10** `performance` + explicit `internal_resolution=2x` → `shadowHiresN == 2` (explicit user option beats the profile).
- **11** `quality` → `shadowHiresN == 2` with the substitution line (rows apply).
- **12** runtime demotion: default options, harness now captures `SET_AUDIO_BUFFER_STATUS_CALLBACK` (new opt-in `accept_audio_buf_cb`, refused by default so every existing tool is unaffected); test feeds synthetic `underrun_likely` reports → 2x at load, 1x after the threshold, `[perf]` warning naming the measured overrun, session keeps running.

`make TEST_EXPORTS=1 test`: **0 failed** (2 standard optional skips: Fountain live ROM, chdman). `bash scripts/c89-lint.sh` clean on all touched files. `./test/regression_test.sh`: **10/10 PASS** (screenshots, determinism, frameskip invariance, savestate round-trip, rewind).

## A/B evidence (Missile Command 3D, CRC 0xDA9C4162, 1800 frames, frame_hash_ab)

| arm | result |
| --- | --- |
| develop baseline run 1 vs run 2 | identical (determinism established) |
| develop vs this PR `profile=quality` | **byte-identical** per-frame framebuffer hashes |
| develop vs this PR default (`auto`, capable host) | **byte-identical** |
| this PR `profile=performance` | diverges as intended: renders **326×240 (1x)** vs 652×480 (2x) |

Performance arm log line:

```
[perf] enhancement profile 'performance': not applying Missile Command 3D's per-title enhancement defaults (performance profile selected). Options you set yourself are honored as always.
```