### PR TITLE
docs(gdb-stub): record the Phase 2 perf-gate measurement

### DIFF
--- a/docs/gdb-stub-design.md
+++ b/docs/gdb-stub-design.md
@@ -305,6 +305,19 @@ Five layers, in increasing cost:
    "-O3 +12.5%" once flipped to -11.7% when interleaved. **If the cost is not
    within noise, the shipped-by-default decision must be revisited rather than
    the number explained away.**
+
+   **Measured** (2026-08-27, idle host, load average 9-10 throughout, via
+   `test/tools/opt_ab.sh 'VJ_GDB_STUB_DISABLE_HOOKS=0' 'VJ_GDB_STUB_DISABLE_HOOKS=1' 12`,
+   12 quartets / 24 samples per arm): median delta +1.9% (hooks-disabled
+   nominally faster), Mann-Whitney p=0.50 — **not significant**, i.e. within
+   noise. The armed-flag hypothesis holds; shipped-by-default stands.
+   `opt_ab.sh` cannot take `CFLAGS=...` directly as one of its arms here — a
+   command-line `CFLAGS` assignment blocks every later `+=` in this Makefile
+   too (not only plain re-assignment), which silently drops the `-I`/`-D`
+   flags the build needs and fails it outright. The measurement instead used
+   a dedicated `VJ_GDB_STUB_DISABLE_HOOKS=1` make variable gating a `CFLAGS +=
+   -DVJ_GDB_STUB_DISABLE_HOOKS` line, added to the Makefile only for the
+   benchmark run and reverted immediately after.
 5. **End-to-end against real GDB.** Drive `m68k-elf-gdb` (from the toolchain in
    #581, if it ships gdb — otherwise a scripted RSP client) against a test ROM:
    attach, set a breakpoint at a known symbol, continue, assert the stop reply


### PR DESCRIPTION
## Summary
- PR #685 shipped the GDB stub's armed-counter hot-path gate but explicitly deferred its own go/no-go measurement (host was under sustained unrelated load for the whole session).
- Ran it now on an idle box: `test/tools/opt_ab.sh 'VJ_GDB_STUB_DISABLE_HOOKS=0' 'VJ_GDB_STUB_DISABLE_HOOKS=1' 12` -- 12 interleaved A/B/B/A quartets (24 samples/arm) of hooks-present vs `-DVJ_GDB_STUB_DISABLE_HOOKS`.
- Result: median delta +1.9%, Mann-Whitney p=0.4962 -- **not significant, within noise**. The armed-flag hypothesis holds; the shipped-by-default decision stands.
- Also documents a pitfall hit while setting this up: `opt_ab.sh`'s own arm-argument convention (`'CFLAGS=...'`) can't be used directly here -- a command-line `CFLAGS` assignment blocks every later `+=` in this Makefile too (not just plain re-assignment), silently dropping every `-I`/`-D` the build needs and failing arm A outright. Routed through a dedicated `VJ_GDB_STUB_DISABLE_HOOKS` make variable instead so a future re-run doesn't rediscover the same broken build.

No code changes -- design doc only.

## Test plan
- [x] Verified both arms actually build and differ (`jaguar.o` differs between `VJ_GDB_STUB_DISABLE_HOOKS=0`/`=1`) before trusting the run.
- [x] `opt_ab.sh` refused to run while load average exceeded core count, per its own guard; re-ran once the host settled to load 9-10 and stayed there through all 12 quartets.
- [x] Worktree left clean afterward -- default (hooks-present) dylib rebuilt, temporary Makefile knob reverted.

Refs #652

<!-- link-issue: #652 -->