### PR TITLE
docs(debug): corroborate the m68k-elf-gdb/DWARF findings from source

### DIFF
--- a/docs/gdb-stub-design.md
+++ b/docs/gdb-stub-design.md
@@ -377,6 +377,20 @@ Five layers, in increasing cost:
    distributed for classic Mac/Amiga/Atari ST development, works against a
    plain `m68k` architecture with no custom target description) rather than
    implying this repo provides one.
+
+   **Further verified 2026-08-27:** no bottled `m68k-elf-gdb` exists on
+   Homebrew either (`brew search`: `aarch64-elf-gdb`, `arm-none-eabi-gdb`,
+   `i386-elf-gdb`, `riscv64-elf-gdb`, `x86_64-elf-gdb` are all real bottles;
+   `m68k-elf-gdb` is not among them) — a developer has to build GDB from
+   source with `--target=m68k-elf` themselves; upstream GDB does support the
+   architecture, there is just no pre-built binary to point users at.
+   Homebrew *does* bottle a genuinely separate, actively-maintained C
+   toolchain for this target — `m68k-elf-gcc` (16.2.0) and
+   `m68k-elf-binutils` (2.47) — but that is GCC+GNU `ld`, unrelated to this
+   repo's `rmac`/`rln` assembler pipeline (#581); using it would mean
+   writing C and building a new path from its ELF+DWARF output to something
+   loadable on the emulated Jaguar, not something this repo's build wires up
+   today.
 2. **What DWARF, if any, does `rln` emit?** **Answered 2026-08-26, Phase 1
    implementation: none.** Verified by building the toolchain and actually
    linking a test object: `rln -e` output identifies as `mc68k COFF object
@@ -397,6 +411,23 @@ Five layers, in increasing cost:
    debugging" claim in this document has been corrected accordingly; do not
    reintroduce it without new evidence that some other tool in the chain
    (not `rln`) emits real DWARF.
+
+   **Further verified 2026-08-27, by reading `rmac`/`rln` source directly**
+   (mwenge/rmac@50e66ea, rln@a617009, both pinned in `PIN`) rather than only
+   testing one linked output: exhaustive grep for `dwarf` and `.debug_`
+   (case-insensitive) across both tools' entire source trees returns zero
+   matches, under any flag. `rln`'s object-file magic-number detection only
+   recognises BSD a.out (`0107`), DRI/Alcyon (`601A`), and `ar` archives —
+   there is no ELF magic (`0x7F454C46`) check anywhere in it. `rmac` *can*
+   emit an ELF object with a real `.symtab`/`.strtab` (`object.c`'s
+   `ELFSectionNames` / `AddELFSymEntry`), but that path is orphaned: `rln`
+   structurally cannot read it, so it is never exercised by the actual
+   working `rmac`→`rln` pipeline. And `-g`'s real mechanism, per `rln.c`'s
+   `OSTAdd()`, is a filter that keeps or drops symbols whose type carries a
+   `0xF0000000` "debug" tag in `rln`'s own proprietary Atari-era symbol
+   table — which is what explains the byte-identical link above: whatever
+   symbol category that tag marks was never present to filter in the tested
+   case, so the flag had nothing to do either way.
 3. **Register numbering for the RISC target descriptions.** **Answered
    2026-08-27, Phase 3 implementation: R0-R31 = index 0-31, PC = 32,
    FLAGS = 33 (34 registers total), identical for the GPU and DSP


### PR DESCRIPTION
## Summary

`docs/gdb-stub-design.md`'s two open questions ("does the #581 toolchain
ship `m68k-elf-gdb`?" and "what DWARF, if any, does `rln` emit?") were
already answered 2026-08-26 by black-box testing — building the
toolchain, linking a test object, and running `file`/`objdump`/SHA-256
against the output. This adds independent corroboration from reading
the pinned `rmac`/`rln` source directly, which explains the *mechanism*
behind those results rather than only the observed behavior:

- `rln`'s object-file magic-number detection (`rln.c`) only recognizes
  BSD a.out, DRI/Alcyon, and `ar` archives — no ELF magic check exists
  anywhere in it. `rmac` *can* emit ELF objects with a real `.symtab`,
  but that path is orphaned: `rln` structurally cannot read ELF input,
  so it's never exercised by the actual working pipeline.
- `rln`'s `-g` flag is a filter in `OSTAdd()` on symbols carrying a
  `0xF0000000` "debug" type tag in `rln`'s own proprietary symbol
  table — not DWARF, not line numbers. This is *why* the prior test
  found `-g` produced a byte-identical link: whatever symbol category
  that tag marks wasn't present to filter either way, not that the
  flag is a no-op by design.
- Exhaustive grep for `dwarf`/`.debug_` (case-insensitive) across both
  tools' entire source trees: zero matches, under any flag — a
  broader form of evidence than testing one linked output.
- Homebrew has no bottled `m68k-elf-gdb` (checked against the five
  sibling `*-elf-gdb` formulas that do exist), so "bring your own
  `m68k-elf-gdb`" means building GDB from source. Homebrew does bottle
  a real, separate `m68k-elf-gcc`/`binutils` toolchain (GCC 16.2.0 /
  Binutils 2.47) capable of genuine ELF+DWARF, but it's a distinct C
  pipeline from #581's `rmac`/`rln` assembler toolchain, and nothing
  wires it to a loadable Jaguar image today.

No conclusions changed — this reinforces the existing "symbol-level,
never source-level" answer with source-level evidence of its own.

## Test plan

- [x] Docs-only change — no code affected, no build/test impact.
- [x] Findings independently verified by cloning the exact pinned
      sources (`mwenge/rmac@50e66ea`, `rln@a617009` per `PIN`) and
      reading the object-format/symbol-handling code directly.

Refs #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)