### PR TITLE
fix(build): VJ_GDB_STUB_DISABLE_IDLE_GATE was inert — re-measure the arm (#652)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,8 +255,17 @@ endif
 # Finer control arm: removes ONLY the idle-skip interaction
 # (`if (gdbArmed*) idleSkipActive = 0;`), leaving the per-instruction PC
 # checks in place, so the two halves of the hook cost can be told apart.
-ifeq ($(VJ_GDB_STUB_DISABLE_IDLE_GATE \
-              VJ_GDB_STUB_DISABLE_68K_HOOK VJ_GDB_STUB_DISABLE_DSP_HOOK),1)
+#
+# The backslash-continuation must NOT sit inside the $(...): make would read
+# the whole thing as ONE variable reference named "VJ_GDB_STUB_DISABLE_IDLE_GATE
+# VJ_GDB_STUB_DISABLE_68K_HOOK VJ_GDB_STUB_DISABLE_DSP_HOOK", which does not
+# exist, expands empty, and leaves the macro undefined for every value of
+# every one of those three variables -- an inert control arm that produces a
+# byte-identical binary in both of its A/B arms and therefore a guaranteed
+# null result.  (That is exactly how it shipped, and how the "idle-skip
+# gating costs ~0%" row got recorded; the two names below belong in
+# BUILD_AXES, which is where they have now been put.)
+ifeq ($(VJ_GDB_STUB_DISABLE_IDLE_GATE),1)
 CFLAGS += -DVJ_GDB_STUB_DISABLE_IDLE_GATE
 endif
 
@@ -289,7 +298,8 @@ endif
 BUILD_AXES := TEST_EXPORTS BENCH_PROFILE DEBUG BLITTER_TRACE COVERAGE \
               RELEASE_DEBUG_INFO DEBUG_PRESENTATION STATIC_LINKING platform \
               OPT_LEVEL LTO IOS_MCPU VJ_GDB_STUB_DISABLE_HOOKS \
-              VJ_GDB_STUB_DISABLE_IDLE_GATE
+              VJ_GDB_STUB_DISABLE_IDLE_GATE VJ_GDB_STUB_DISABLE_68K_HOOK \
+              VJ_GDB_STUB_DISABLE_DSP_HOOK
 BUILD_CONFIG := $(strip $(foreach v,$(BUILD_AXES),$(v)=$($(v))))
 BUILD_CONFIG_STAMP := .build-config
 # Superseded .link-mode, which tracked TEST_EXPORTS alone; removed by the

--- a/docs/gdb-stub-design.md
+++ b/docs/gdb-stub-design.md
@@ -356,9 +356,36 @@ Five layers, in increasing cost:
    | Component | Cost | Significance |
    |---|---|---|
    | 68K hook (`M68KInstructionHook`) | ~0% | p=0.8366 |
-   | Idle-skip gating (`idleSkipActive = 0`) | ~0% | p=0.4897 |
+   | Idle-skip gating (`idleSkipActive = 0`) | ~0% | p=0.2238 (re-measured, see below) |
    | GPU per-instruction check | 1.8% | fixed, see below |
    | DSP per-instruction check | ~2.3-2.7% | p=0.0000 |
+
+   **Correction (2026-08-28): the idle-gating row above was originally
+   vacuous, and has been re-measured.** `VJ_GDB_STUB_DISABLE_IDLE_GATE`
+   was inert as shipped -- its `ifeq` carried a backslash-continuation
+   *inside* the `$(...)`, so make read one variable reference named
+   `VJ_GDB_STUB_DISABLE_IDLE_GATE VJ_GDB_STUB_DISABLE_68K_HOOK
+   VJ_GDB_STUB_DISABLE_DSP_HOOK`, which does not exist. It expanded empty,
+   `-DVJ_GDB_STUB_DISABLE_IDLE_GATE` was never defined for any value of any
+   of those three variables, and **both A/B arms compiled to a byte-identical
+   binary** (`de95224107feb3c2` on both, against `81e65904a50a39e3` /
+   `6a6a365e09e8dfbb` / `9f3f63421f1a0275` for the three arms that did work).
+   The original p=0.4897 was therefore one binary measured against itself --
+   the same failure mode this section was written to correct in #709, one
+   level down.
+
+   After fixing the conditional the two arms differ (`8e2a80ecedc0` vs
+   `f28825134333`) and the re-run agrees with the original conclusion on
+   real evidence: 12 quartets, 24 samples/arm, median delta **-1.4%**,
+   z=+1.22, **p=0.2238** -- under the noise floor, no effect. So idle-skip
+   gating really is free, and it is **not** a candidate for the residual
+   below. Host load 6-8 (not idle; the A/B/B/A interleave is what makes the
+   number usable, not a quiet box).
+
+   The three per-processor arms were unaffected -- `opt_ab.sh` runs
+   `make clean` between arms, so the two axes missing from `BUILD_AXES`
+   (`..._68K_HOOK`, `..._DSP_HOOK`, both added there by the same fix) could
+   not have mixed objects into those runs.
 
    **Fix applied: cache the armed flag in a slice-entry local**, exactly as
    #532 does for `pipeTiming`/`riscScale` in the same function. The globals
@@ -379,8 +406,12 @@ Five layers, in increasing cost:
    5. The residual should be re-attributed on a real target (tvOS/A-series,
    RPi) before any further surgery: the per-processor control arms
    `VJ_GDB_STUB_DISABLE_{HOOKS,IDLE_GATE,68K_HOOK,DSP_HOOK}` exist for
-   exactly that and are listed in `BUILD_AXES`, so the attribution can be
-   repeated there in four runs without re-deriving any of this.
+   exactly that and are all listed in `BUILD_AXES`, so the attribution can
+   be repeated there in four runs without re-deriving any of this.  **Check
+   the two per-arm binary hashes `opt_ab.sh` prints before believing any
+   null result** -- that is what the inert-gate correction above turned on,
+   and it is the second time on this feature that identical arms produced a
+   confident-looking p-value.
 
    Shipped-by-default stands for now at a measured ~2% cost, deliberately,
    pending those numbers.


### PR DESCRIPTION
Refs #652
<!-- link-issue: #652 -->

## Summary

The idle-gate control arm added in #711 **never did anything**, so the attribution row `Idle-skip gating | ~0% | p=0.4897` was one binary measured against itself — the #709 trap reproduced inside the PR written to correct #709.

The `ifeq` carried its backslash-continuation **inside** the `$(...)`:

```make
ifeq ($(VJ_GDB_STUB_DISABLE_IDLE_GATE \
              VJ_GDB_STUB_DISABLE_68K_HOOK VJ_GDB_STUB_DISABLE_DSP_HOOK),1)
```

make reads that as one variable reference named `VJ_GDB_STUB_DISABLE_IDLE_GATE VJ_GDB_STUB_DISABLE_68K_HOOK VJ_GDB_STUB_DISABLE_DSP_HOOK`. No such variable exists, so it expands empty, `ifeq (,1)` never fires, and `-DVJ_GDB_STUB_DISABLE_IDLE_GATE` is never defined for **any** value of **any** of those three variables. The code it gates is real (`src/tom/gpu.c:2193`, `src/jerry/dsp.c:1912`).

The two extra names had leaked in from the `BUILD_AXES` edit they belong to — which is also why `BUILD_AXES` was missing them.

## Evidence

Binary hashes before the fix, all `make clean` builds:

| arm | sha256[:16] |
|---|---|
| baseline / `IDLE_GATE=0` | `de95224107feb3c2` |
| `IDLE_GATE=1` | `de95224107feb3c2` ← **identical** |
| `HOOKS=1` | `81e65904a50a39e3` |
| `DSP_HOOK=1` | `6a6a365e09e8dfbb` |
| `68K_HOOK=1` | `9f3f63421f1a0275` |

The three per-processor arms are real and **their rows stand** — including the DSP attribution. Only idle-gating was unmeasured.

## Changes

- **`Makefile`** — fix the conditional; add `VJ_GDB_STUB_DISABLE_68K_HOOK` and `VJ_GDB_STUB_DISABLE_DSP_HOOK` to `BUILD_AXES`. Those two were only ever safe because `opt_ab.sh` runs `make clean` between arms; a hand-run incremental build would have produced exactly the chimera the `BUILD_AXES` comment warns about. Added a comment explaining why the continuation cannot sit inside the `$(...)`.
- **`docs/gdb-stub-design.md`** — record the correction, the re-measurement, and the standing instruction to check the two per-arm hashes before believing any null.

## Re-measurement

With the gate live (arms now differ: `8e2a80ecedc0` vs `f28825134333`), `test/tools/opt_ab.sh ... 12`, 24 samples/arm:

```
IDLE_GATE=0  n=24  min=147.8  median=242.1  max=271.1
IDLE_GATE=1  n=24  min=108.1  median=238.8  max=252.4
median delta B vs A: -1.4%   Mann-Whitney z=+1.22  p=0.2238  -> NOT significant
```

**The original conclusion was right; its evidence was not.** Idle-skip gating is genuinely free, and is therefore *not* a candidate for the ~2% DSP residual — which remains unexplained, as documented.

Host load 6–8 throughout, recorded as such rather than described as idle (#709 claimed "idle" while reporting load 9–10; both could not be true).

## Verification

- `make TEST_EXPORTS=1 test` → **exit 0, zero FAILs**.
- Scanned `Makefile` / `Makefile.common` for the same malformed-`ifeq` pattern: **no other instances**.

## Noticed, not fixed

`CROSS_COMPILE` is used in an `ifeq` but is not in `BUILD_AXES`. Switching toolchains with a warm tree could mix objects. Out of scope here — `platform=` (which *is* an axis) covers the normal cross-build routes, so this is a latent hand-build hazard rather than a live bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
