### PR TITLE
feat(cd): libretro disk control interface — insert a disc after launch (#651)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2068,6 +2068,17 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		rc=0; \
 		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 1 --quiet || rc=1; \
 		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 3 --quiet || rc=1; \
+		discb=$$(find -L test/roms/private -iname '*.cdi' -o -iname '*.cue' 2>/dev/null | sed -n 2p); \
+		if [ -n "$$discb" ]; then \
+			if ./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --disc-b "$$discb" --case 4 --quiet; then :; \
+			else c4=$$?; \
+				if [ $$c4 -eq 77 ]; then \
+					bash scripts/test-skip.sh record "Disk control savestate identity (#651)" "one of the two discs is a damaged rip that cannot boot"; \
+				else rc=1; fi; \
+			fi; \
+		else \
+			bash scripts/test-skip.sh record "Disk control savestate identity (#651)" "need two CD images in test/roms/private"; \
+		fi; \
 		exit $$rc; \
 	else \
 		bash scripts/test-skip.sh record "Disk control interface (#651)" \

--- a/Makefile
+++ b/Makefile
@@ -1353,6 +1353,7 @@ clean:
 		tools/jagcd/jagcd-chd-check \
 		test/tools/test_memory_map test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/tools/test_dsp_audio_diag \
 		test/tools/test_frame_timing test/tools/test_runahead_determinism test/tools/test_pertitle_db \
+		test/tools/test_disk_control \
 		test/test_biosdb test/test_cart_bios_loader \
 		test/test_titledb test/test_titlehook test/tools/test_hook_gate \
 		test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace test/test_voicechat test/test_voice_netpacket test/tools/test_voicechat_inertness test/tools/voicechat_pair test/tools/i2s_lag_probe \
@@ -1428,7 +1429,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		test/test_cd_boot test/test_cd_hle_boot test/test_cd_bios_boot test/test_cd_toc_contract test/test_cd_fifo_stream test/test_cd_ssi_stream test/test_cd_second_transfer test/test_cd_hle_idempotent test/test_cd_lost_wakeup test/test_cd_pregap test/test_cd_chd test/test_chd_unit test/test_cd_synth_read test/test_cd_synth_butch test/test_cd_synth_cdda test/test_cd_synth_subq \
 		test/test_audio_dac test/test_blitter \
 		test/tools/test_memory_map test/tools/test_op_gpu_object test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/test_uart_core test/test_netlink_host \
-		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/netlink_discover_probe test/tools/netlink_rebuild_witness test/tools/netlink_mismatch_witness test/tools/perf_iface_witness test/tools/voicemodem_pair test/tools/voicechat_pair test/tools/test_voicechat_inertness test/tools/netlink_game test/tools/test_pertitle_db \
+		test/tools/netlink_pair test/tools/netlink_latency test/tools/netlink_delay_proxy test/tools/netlink_discover_probe test/tools/netlink_rebuild_witness test/tools/netlink_mismatch_witness test/tools/perf_iface_witness test/tools/voicemodem_pair test/tools/voicechat_pair test/tools/test_voicechat_inertness test/tools/netlink_game test/tools/test_pertitle_db test/tools/test_disk_control \
 		test/tools/test_hook_gate \
 		test/tools/i2s_lag_probe test/tools/joymatrix_identity \
 		test/tools/teamtap_ports \
@@ -2048,6 +2049,30 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# Non-DB ROM control: no CRC match -> no substitution, [titledb] miss log fires.
 	@# yarc.j64 is committed in-tree so this case never skips.
 	./test/tools/test_pertitle_db ./$(TARGET) test/roms/yarc.j64 --case 5 --quiet
+
+	@# Disk control interface (#651): boot with NO content, then hand the
+	@# core a disc through the frontend-facing callbacks.  Case 1 asserts
+	@# the RESOLVED STRATEGY moved off "none", not that the insert returned
+	@# true -- a reset against the previous disc's boot config looks
+	@# identical from outside.  Case 3 asserts a failed insert is inert.
+	@#
+	@# Case 2 (audio-only disc must land on the real CD BIOS) is NOT run:
+	@# no one-session image exists in the corpus -- every CUE carries two
+	@# REM SESSION markers and CDI headers declare numSessions=2 -- so it
+	@# would pass against a data disc for the wrong reason.  Ledgered as a
+	@# skip rather than written to look like coverage.
+	@bash scripts/test-skip.sh record "Disk control audio-disc insert (#651)" \
+		"no one-session (Red Book) disc in the private corpus"
+	@disc=$$(find -L test/roms/private -iname '*.cdi' -o -iname '*.cue' 2>/dev/null | head -1); \
+	if [ -n "$$disc" ]; then \
+		rc=0; \
+		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 1 --quiet || rc=1; \
+		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 3 --quiet || rc=1; \
+		exit $$rc; \
+	else \
+		bash scripts/test-skip.sh record "Disk control interface (#651)" \
+			"no CD image in test/roms/private"; \
+	fi
 	@# Enhancement hooks (issue #370).  All four gates run on in-repo public
 	@# content, so none of them can skip -- and hook_identity_ab.sh now
 	@# ENFORCES that rather than asserting it: it counts the ROMs it actually
@@ -2347,6 +2372,13 @@ test/tools/test_memory_map: test/tools/test_memory_map.c
 # apply / disable / user-override contract, driven through the real core
 # via the shared harness.  Needs shadowHiresN + shadowFBActive from the
 # wide test symbol set (exports-test.list / link-test.T).
+test/tools/test_disk_control: test/tools/test_disk_control.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
+		-o $@ test/tools/test_disk_control.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+
 test/tools/test_pertitle_db: test/tools/test_pertitle_db.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/docs/settings-and-performance-guide.md
+++ b/docs/settings-and-performance-guide.md
@@ -442,6 +442,33 @@ player front-end includes the Virtual Light Machine visualizer -- regardless
 of this setting. Every other disc, including the known-damaged CDI rips,
 is unaffected and still uses whichever mode you picked.
 
+**Swapping discs while the core is running.** The core implements the libretro
+disk-control interface, so a frontend can start it with no content at all and
+hand it a disc afterwards — which is what makes "launch the core, put in a
+music CD, get the Virtual Light Machine" reachable.
+
+Two things to know about how that behaves:
+
+- **Inserting a disc restarts the console.** The boot strategy is derived from
+  the disc itself (the session layout is what decides HLE versus real BIOS, as
+  above), so the core has to re-read the new disc and boot it. Real hardware
+  does not need to do this; a swap here is a restart, not a continuous
+  session. Reaching the VLM works, but it boots into the CD BIOS to get there.
+- **Eject is a frontend-level flag, not an emulated tray.** The Jaguar CD unit
+  has no modelled disc-present line, so the previously mounted disc stays
+  readable until an insert replaces it. Nothing a game can do reaches the
+  window between an eject and the next insert.
+
+If a disc fails to insert — a damaged rip is the common cause — the tray stays
+open, the previous disc is restored, and the running machine is left alone. The
+log line names the reason.
+
+**Savestates are tied to the disc they were taken on.** Since a disc can now be
+swapped mid-session, a state records which disc was mounted (session count,
+track count, total sectors) and is refused if you load it against a different
+one, with both identities in the log. States written by earlier core versions
+carry no such record and load exactly as they always did.
+
 **When to switch to Real BIOS.** HLE is more compatible overall, but it is a
 reimplementation, and a title occasionally trips over something HLE gets wrong
 that the real BIOS handles. The documented case is **World Tour Racing**: it

--- a/libretro.c
+++ b/libretro.c
@@ -5349,6 +5349,95 @@ static void video_buffer_blank(void)
       videoBuffer[i] = 0xFF000000;
 }
 
+typedef enum
+{
+   DISC_BOOT_OK = 0,
+   DISC_BOOT_OPEN_FAILED,       /* CDIntfOpenImage refused the image */
+   DISC_BOOT_NO_BIOS_FOR_AUDIO  /* audio disc, real CD BIOS unavailable */
+} disc_boot_status;
+
+/* Open a disc image and derive the boot configuration FROM THAT DISC.
+ *
+ * Shared by retro_load_game() and the disk-control insert path (#651).
+ * Both must pick the boot strategy from the mounted disc, and
+ * retro_reset() is a bare JaguarReset() -- it re-resolves nothing, so an
+ * insert that only reset would run against the PREVIOUS disc's boot
+ * config, silently, and look like it had worked.
+ *
+ * Allocates nothing and frees nothing.  The two callers have opposite
+ * cleanup policies -- load tears the whole session down and returns
+ * false, insert must leave the running machine untouched and merely
+ * report the failure to the frontend -- so cleanup stays with them. */
+static disc_boot_status open_disc_and_resolve_boot(const char *path)
+{
+   uint32_t effective_cd_boot_mode;
+
+   jaguar_cd_mode         = true;
+   /* Hardware has the Memory Track cart plugged in alongside the CD unit
+    * (user-selectable; some titles behave differently with one present). */
+   jaguarMemTrackInserted = opt_memory_track;
+   strncpy(cd_image_path, path, sizeof(cd_image_path) - 1);
+   cd_image_path[sizeof(cd_image_path) - 1] = '\0';
+   effective_cd_boot_mode = vjs.cdBootMode;
+
+   LOG_INF("[CD] Opening disc image: %s\n", cd_image_path);
+   if (!CDIntfOpenImage(cd_image_path))
+   {
+      LOG_ERR("[CD] CDIntfOpenImage failed for: %s\n", cd_image_path);
+      return DISC_BOOT_OPEN_FAILED;
+   }
+   LOG_INF("[CD] Disc image opened OK\n");
+
+   /* Audio-only (Red Book) disc: exactly one session, versus the two
+    * sessions (game data in session 2) every Jaguar CD data disc has.
+    * All Jaguar CD tracks are typed AUDIO in CUE sheets regardless of
+    * actual content, so session count -- not track type -- is the correct
+    * discriminator; see the comment on CDIntfIsSession2Sector() in
+    * src/cd/cdintf.c.  HLE synthesizes its boot stub from session-2 game
+    * data, which an audio-only disc has none of by construction, so HLE
+    * can never produce a boot for this content.  The retail CD BIOS's own
+    * player front-end handles audio discs natively (Virtual Light
+    * Machine, issues #291/#300/#325).  Force the real-BIOS path for THIS
+    * disc only -- the global 'CD Boot Mode' option (and its HLE-only 'CD
+    * Read Speed' knob) stay untouched for every other disc, including the
+    * known-damaged CDI rips, which still fail the same clear way they
+    * always have: their CDI container header declares numSessions=2
+    * regardless of the corruption in their session-2 boot data, so this
+    * check never sees them. */
+   if (CDIntfGetNumSessions() == 1)
+   {
+      LOG_INF("[CD] Audio-only disc detected (1 session) -- forcing "
+              "real CD BIOS boot path regardless of CD Boot Mode "
+              "setting\n");
+      effective_cd_boot_mode = CDBOOT_BIOS;
+   }
+
+   if (effective_cd_boot_mode != CDBOOT_HLE)
+      stage_cd_bios();
+
+   ResolveBootConfig(&bootConfig, jaguar_cd_mode, cd_bios_loaded_externally,
+                     effective_cd_boot_mode, vjs.useJaguarBIOS);
+   vjs.useJaguarBIOS = bootConfig.showBootROM;
+
+   /* Defensive check for the audio-only override above: stage_cd_bios()
+    * always has an embedded CD BIOS to fall back to, so this should be
+    * unreachable in practice -- but if some future change to BIOS staging
+    * ever leaves it unsatisfied, fail loudly here rather than silently
+    * falling through to an HLE boot that is guaranteed to fail anyway (no
+    * session-2 game data to synthesize a stub from). */
+   if (CDIntfGetNumSessions() == 1
+       && bootConfig.strategy != &cd_boot_strategy_bios)
+   {
+      LOG_ERR("[CD] Audio-only disc requires the real CD BIOS boot path "
+              "and it could not be staged -- refusing this disc rather "
+              "than attempting an HLE boot that cannot succeed\n");
+      CDIntfCloseImage();
+      return DISC_BOOT_NO_BIOS_FOR_AUDIO;
+   }
+
+   return DISC_BOOT_OK;
+}
+
 bool retro_load_game(const struct retro_game_info *info)
 {
    enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_XRGB8888;
@@ -5359,7 +5448,6 @@ bool retro_load_game(const struct retro_game_info *info)
     * override never touches the persisted option value: the next CD
     * loaded in this frontend session still gets whatever the user
     * actually configured. */
-   uint32_t effective_cd_boot_mode;
 
    struct retro_input_descriptor desc[] = {
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
@@ -5725,36 +5813,23 @@ bool retro_load_game(const struct retro_game_info *info)
    eeprom_dirty_cb = eeprom_pack_save_buf;
    mt_dirty_cb     = mt_mark_save_dirty;
 
-   /* Detect CD content (CUE/CDI/CHD/ISO) and stage a CD BIOS (external file
-    * if present, embedded otherwise) so ResolveBootConfig can pick the
-    * right boot strategy. */
+   /* Detect CD content (CUE/CDI/CHD/ISO) and pick a boot strategy from the
+    * disc itself.  The CD branch lives in open_disc_and_resolve_boot() so
+    * the disk-control insert path (#651) can re-run exactly the same
+    * sequence; the cart and no-content branches keep their own
+    * ResolveBootConfig() calls, which is why this is a restructure and not
+    * a lift of a contiguous block. */
    jaguar_cd_mode            = false;
    jaguarMemTrackInserted    = false;
    cd_image_path[0]          = '\0';
    cd_bios_loaded_externally = false;
-   effective_cd_boot_mode    = vjs.cdBootMode;
 
    if (is_cd_content)
    {
-      jaguar_cd_mode = true;
-      /* Hardware has the Memory Track cart plugged in alongside the CD
-       * unit (user-selectable; some titles behave differently with one
-       * present). */
-      jaguarMemTrackInserted = opt_memory_track;
-      strncpy(cd_image_path, info->path, sizeof(cd_image_path) - 1);
-      cd_image_path[sizeof(cd_image_path) - 1] = '\0';
+      disc_boot_status st = open_disc_and_resolve_boot(info->path);
 
-      /* Open the disc image now, ahead of ResolveBootConfig() below --
-       * moved earlier than it used to run (right before JaguarInit(),
-       * further down) so the session layout is known before a boot
-       * strategy is picked (issue #657).  This is the SAME
-       * CDIntfOpenImage() call, not a duplicate: CDROMInit ->
-       * CDIntfInit -> CDIntfIsImageLoaded still finds an already-open
-       * disc when JaguarInit() runs below. */
-      LOG_INF("[CD] Opening disc image: %s\n", cd_image_path);
-      if (!CDIntfOpenImage(cd_image_path))
+      if (st != DISC_BOOT_OK)
       {
-         LOG_ERR("[CD] CDIntfOpenImage failed for: %s\n", cd_image_path);
          free(videoBuffer);
          videoBuffer = NULL;
          free(sampleBuffer);
@@ -5762,60 +5837,13 @@ bool retro_load_game(const struct retro_game_info *info)
          TitleDBSetContent(NULL, 0);
          return false;
       }
-      LOG_INF("[CD] Disc image opened OK\n");
-
-      /* Audio-only (Red Book) disc: exactly one session, versus the two
-       * sessions (game data in session 2) every Jaguar CD data disc
-       * has.  All Jaguar CD tracks are typed AUDIO in CUE sheets
-       * regardless of actual content, so session count -- not track
-       * type -- is the correct discriminator; see the comment on
-       * CDIntfIsSession2Sector() in src/cd/cdintf.c.  HLE synthesizes
-       * its boot stub from session-2 game data, which an audio-only
-       * disc has none of by construction, so HLE can never produce a
-       * boot for this content.  The retail CD BIOS's own player
-       * front-end handles audio discs natively (Virtual Light Machine,
-       * issues #291/#300/#325).  Force the real-BIOS path for THIS
-       * disc only -- the global 'CD Boot Mode' option (and its
-       * HLE-only 'CD Read Speed' knob) stay untouched for every other
-       * disc, including the known-damaged CDI rips, which still fail
-       * the same clear way they always have -- their CDI container
-       * header declares numSessions=2 regardless of the corruption in
-       * their session-2 boot data, so this check never sees them.
-       *
-       * Deliberately just numSessions == 1, with no additional "does
-       * session 1 contain an ATRI boot header anyway" check: that
-       * situation can only arise from a hand-edited/malformed CUE
-       * missing its 'REM SESSION 02' line (every one of the 35 CUEs in
-       * the private corpus carries it), and HLE already refuses such a
-       * disc unconditionally -- CDIntfExtractBootStub() itself requires
-       * numSessions >= 2 and does not even look for ATRI below that.
-       * Routing it to the real BIOS instead of a hard "unsupported
-       * content" is a strict improvement (real hardware would treat a
-       * disc with no session-2 data as audio-capable too), not a new
-       * failure mode. */
-      if (CDIntfGetNumSessions() == 1)
-      {
-         LOG_INF("[CD] Audio-only disc detected (1 session) -- forcing "
-                 "real CD BIOS boot path regardless of CD Boot Mode "
-                 "setting\n");
-         effective_cd_boot_mode = CDBOOT_BIOS;
-      }
-
-      if (effective_cd_boot_mode != CDBOOT_HLE)
-         stage_cd_bios();
    }
-   else
-      apply_cart_bios_autodetect(info);
-
-   /* Resolve boot configuration — single source of truth for which
-    * strategy (cart / HLE / real BIOS / no-content) we will dispatch to
-    * below.  ResolveBootConfig() only knows about cart/CD content, so a
-    * no-content boot (info == NULL, issue #646) is resolved directly:
-    * there is no 68K program anywhere for HLE to jump into, so the real
-    * boot ROM is the only sane strategy -- exactly what real hardware
-    * shows with an empty cart slot. */
-   if (!info)
+   else if (!info)
    {
+      /* No-content boot (issue #646): ResolveBootConfig() only knows about
+       * cart/CD content, and there is no 68K program anywhere for HLE to
+       * jump into, so the real boot ROM is the only sane strategy --
+       * exactly what real hardware shows with an empty cart slot. */
       vjs.useJaguarBIOS          = true;
       bootConfig.isCDGame        = false;
       bootConfig.showBootROM     = true;
@@ -5824,30 +5852,11 @@ bool retro_load_game(const struct retro_game_info *info)
    }
    else
    {
-      ResolveBootConfig(&bootConfig, jaguar_cd_mode, cd_bios_loaded_externally,
-                        effective_cd_boot_mode, vjs.useJaguarBIOS);
+      apply_cart_bios_autodetect(info);
+      ResolveBootConfig(&bootConfig, jaguar_cd_mode,
+                        cd_bios_loaded_externally, vjs.cdBootMode,
+                        vjs.useJaguarBIOS);
       vjs.useJaguarBIOS = bootConfig.showBootROM;
-   }
-
-   /* Defensive check for the audio-only override above: stage_cd_bios()
-    * always has an embedded CD BIOS to fall back to, so this should be
-    * unreachable in practice -- but if some future change to BIOS
-    * staging ever leaves it unsatisfied, fail loudly here rather than
-    * silently falling through to an HLE boot that is guaranteed to fail
-    * anyway (no session-2 game data to synthesize a stub from). */
-   if (jaguar_cd_mode && CDIntfGetNumSessions() == 1 &&
-       bootConfig.strategy != &cd_boot_strategy_bios)
-   {
-      LOG_ERR("[CD] Audio-only disc requires the real CD BIOS boot path "
-              "and it could not be staged -- refusing to load rather "
-              "than attempt an HLE boot that cannot succeed\n");
-      CDIntfCloseImage();
-      free(videoBuffer);
-      videoBuffer = NULL;
-      free(sampleBuffer);
-      sampleBuffer = NULL;
-      TitleDBSetContent(NULL, 0);
-      return false;
    }
 
    /* check_variables() ran above, before bootConfig existed, so the blit

--- a/libretro.c
+++ b/libretro.c
@@ -5360,6 +5360,17 @@ static void video_buffer_blank(void)
       videoBuffer[i] = 0xFF000000;
 }
 
+typedef enum
+{
+   DISC_BOOT_OK = 0,
+   DISC_BOOT_OPEN_FAILED,       /* CDIntfOpenImage refused the image */
+   DISC_BOOT_NO_BIOS_FOR_AUDIO  /* audio disc, real CD BIOS unavailable */
+} disc_boot_status;
+
+/* Defined below, next to retro_load_game: the disk-control insert path
+ * and the load path share it (#651). */
+static disc_boot_status open_disc_and_resolve_boot(const char *path);
+
 /* ---------------------------------------------------------------------
  * Disk control callbacks (#651)
  *
@@ -5385,18 +5396,100 @@ static unsigned disk_get_num_images(void)
    return disk_num_images;
 }
 
+/* Closing the tray is the only disk-control entry point that touches the
+ * emulated machine.  It re-runs boot resolution against the newly selected
+ * disc and dispatches the resolved strategy, because the boot strategy is
+ * DERIVED FROM THE DISC (session count decides HLE vs real BIOS) and
+ * retro_reset() re-resolves nothing.
+ *
+ * This is a restart, not a continuous swap: real hardware would have the
+ * running CD BIOS notice a new disc, which depends on disc-presence
+ * polling we have not verified.  Documented in the user-facing CD notes.
+ *
+ * A failed insert must leave no partial-mount state, so bootConfig and
+ * jaguar_cd_mode are snapshotted and restored, and the previously mounted
+ * image is reopened on a best-effort basis -- CDIntfOpenImage() closes the
+ * current image before parsing the new one, so by the time an open fails
+ * the old disc is already gone from the drive. */
 static bool disk_set_eject_state(bool ejected)
 {
-   /* Inert for now: the resolve-and-boot insert lands separately so it
-    * can be reviewed on its own. */
-   disk_ejected = ejected;
+   struct BootConfig saved_boot;
+   char              saved_path[sizeof(cd_image_path)];
+   bool              saved_cd_mode;
+   disc_boot_status  st;
+
+   if (ejected)
+   {
+      /* Eject is a FLAG: src/cd/ models no tray and no disc-present line,
+       * so the mounted image stays readable until an insert replaces it. */
+      disk_ejected = true;
+      return true;
+   }
+
+   if (!disk_ejected)
+      return true;                    /* already closed -- nothing to do */
+
+   if (disk_num_images == 0 || disk_image_path[disk_index][0] == '\0')
+   {
+      LOG_WRN("[CD] disk control: nothing to insert (image list is "
+              "empty)\n");
+      return false;
+   }
+
+   saved_boot    = bootConfig;
+   saved_cd_mode = jaguar_cd_mode;
+   memcpy(saved_path, cd_image_path, sizeof(saved_path));
+
+   st = open_disc_and_resolve_boot(disk_image_path[disk_index]);
+   if (st != DISC_BOOT_OK)
+   {
+      LOG_ERR("[CD] disk control: insert failed (%s) -- tray stays open\n",
+              st == DISC_BOOT_OPEN_FAILED
+                 ? "image could not be opened"
+                 : "audio disc needs the real CD BIOS and it is "
+                   "unavailable");
+
+      bootConfig     = saved_boot;
+      jaguar_cd_mode = saved_cd_mode;
+      memcpy(cd_image_path, saved_path, sizeof(cd_image_path));
+      if (cd_image_path[0] != '\0' && !CDIntfOpenImage(cd_image_path))
+         LOG_ERR("[CD] disk control: could not reopen the previous disc "
+                 "either -- the drive is now empty\n");
+
+      return false;                   /* disk_ejected stays true */
+   }
+
+   /* NOT a bare JaguarReset(): bios_boot() copies the CD BIOS to $800000
+    * and sets jaguarRunAddress from $800404 before resetting, so a plain
+    * reset would restart the PREVIOUS program.  NULL is safe here -- both
+    * CD strategies ignore info (hle_strategy_boot does `(void)info;`);
+    * only cart_boot reads it, and cart is never resolved on this path. */
+   if (!bootConfig.strategy || !bootConfig.strategy->boot(NULL))
+   {
+      LOG_ERR("[CD] disk control: boot strategy refused the new disc\n");
+      return false;
+   }
+
+   LOG_INF("[CD] disk control: inserted '%s', booting via '%s'\n",
+           cd_image_path,
+           bootConfig.strategy->name ? bootConfig.strategy->name : "?");
+   disk_ejected = false;
    return true;
 }
 
+/* Routed through the eject/insert pair so there is exactly one way to
+ * mount a disc, not two that can drift apart. */
 static bool disk_set_image_index(unsigned index)
 {
    if (index >= disk_num_images)
       return false;
+
+   if (!disk_ejected)
+   {
+      disk_index = index;
+      return disk_set_eject_state(true) && disk_set_eject_state(false);
+   }
+
    disk_index = index;
    return true;
 }
@@ -5524,13 +5617,6 @@ static void register_disk_control(void)
       LOG_WRN("[CD] disk control: frontend accepted neither interface -- "
               "inserting a disc after launch will not be possible\n");
 }
-
-typedef enum
-{
-   DISC_BOOT_OK = 0,
-   DISC_BOOT_OPEN_FAILED,       /* CDIntfOpenImage refused the image */
-   DISC_BOOT_NO_BIOS_FOR_AUDIO  /* audio disc, real CD BIOS unavailable */
-} disc_boot_status;
 
 /* Open a disc image and derive the boot configuration FROM THAT DISC.
  *

--- a/libretro.c
+++ b/libretro.c
@@ -361,6 +361,17 @@ static bool jaguar_cd_mode = false;
 /* Memory Track presence option (CD only); default on. */
 static bool opt_memory_track = true;
 static char cd_image_path[4096] = {0};
+
+/* Disk control interface (#651).  DISK_MAX_IMAGES is deliberately
+ * generous: no multi-disc Jaguar CD title exists, so in practice the list
+ * only ever holds the one disc a frontend handed us after launch. */
+#define DISK_MAX_IMAGES 8
+
+static char     disk_image_path[DISK_MAX_IMAGES][4096];
+static unsigned disk_num_images;
+static unsigned disk_index;
+static unsigned disk_initial_index;
+static bool     disk_ejected;
 bool cd_bios_loaded_externally = false;
 uint8_t external_cd_bios[0x40000];  /* 256 KB */
 
@@ -5349,6 +5360,171 @@ static void video_buffer_blank(void)
       videoBuffer[i] = 0xFF000000;
 }
 
+/* ---------------------------------------------------------------------
+ * Disk control callbacks (#651)
+ *
+ * The emulated CD unit has no tray: src/cd/ models no disc-present line
+ * and no "medium not present" error, so eject is a frontend-level FLAG
+ * and the mounted image stays readable until an insert replaces it.
+ * Documented limitation -- nothing but the frontend can reach the window
+ * between an eject and the next insert.
+ * ------------------------------------------------------------------ */
+
+static bool disk_get_eject_state(void)
+{
+   return disk_ejected;
+}
+
+static unsigned disk_get_image_index(void)
+{
+   return disk_index;
+}
+
+static unsigned disk_get_num_images(void)
+{
+   return disk_num_images;
+}
+
+static bool disk_set_eject_state(bool ejected)
+{
+   /* Inert for now: the resolve-and-boot insert lands separately so it
+    * can be reviewed on its own. */
+   disk_ejected = ejected;
+   return true;
+}
+
+static bool disk_set_image_index(unsigned index)
+{
+   if (index >= disk_num_images)
+      return false;
+   disk_index = index;
+   return true;
+}
+
+static bool disk_replace_image_index(unsigned index,
+                                     const struct retro_game_info *info)
+{
+   unsigned i;
+
+   if (index >= disk_num_images)
+      return false;
+
+   if (!info || !info->path)
+   {
+      /* Removing an entry: shuffle the tail down so the list stays dense
+       * (the frontend addresses images by position). */
+      for (i = index; i + 1 < disk_num_images; i++)
+         memcpy(disk_image_path[i], disk_image_path[i + 1],
+                sizeof(disk_image_path[i]));
+      disk_num_images--;
+      if (disk_num_images > 0 && disk_index >= disk_num_images)
+         disk_index = disk_num_images - 1;
+      else if (disk_num_images == 0)
+         disk_index = 0;
+      return true;
+   }
+
+   strncpy(disk_image_path[index], info->path,
+           sizeof(disk_image_path[index]) - 1);
+   disk_image_path[index][sizeof(disk_image_path[index]) - 1] = '\0';
+   return true;
+}
+
+static bool disk_add_image_index(void)
+{
+   if (disk_num_images >= DISK_MAX_IMAGES)
+   {
+      LOG_WRN("[CD] disk control: image list full (%u), refusing add\n",
+              (unsigned)DISK_MAX_IMAGES);
+      return false;
+   }
+   disk_image_path[disk_num_images][0] = '\0';
+   disk_num_images++;
+   return true;
+}
+
+static bool disk_set_initial_image(unsigned index, const char *path)
+{
+   /* Recorded and applied when the list is first populated.  Effectively
+    * inert today -- it exists because the frontend only restores a
+    * last-used disk index when set_initial_image AND get_image_path are
+    * both implemented. */
+   (void)path;
+   disk_initial_index = index;
+   return true;
+}
+
+static bool disk_get_image_path(unsigned index, char *path, size_t len)
+{
+   if (index >= disk_num_images || !path || len == 0)
+      return false;
+   strncpy(path, disk_image_path[index], len - 1);
+   path[len - 1] = '\0';
+   return true;
+}
+
+static bool disk_get_image_label(unsigned index, char *label, size_t len)
+{
+   const char *base;
+
+   if (index >= disk_num_images || !label || len == 0)
+      return false;
+   base = strrchr(disk_image_path[index], '/');
+   base = base ? base + 1 : disk_image_path[index];
+   strncpy(label, base, len - 1);
+   label[len - 1] = '\0';
+   return true;
+}
+
+/* Registered from retro_load_game UNCONDITIONALLY, including the
+ * info == NULL no-content path -- that is the case the whole feature
+ * exists for (#646 gave the core no-content boot; without disk control a
+ * frontend has no way to hand it a disc afterwards).
+ *
+ * The callback structs are static because the frontend keeps the pointer
+ * it is given long after this call returns. */
+static void register_disk_control(void)
+{
+   static struct retro_disk_control_ext_callback ext;
+   static struct retro_disk_control_callback     legacy;
+   unsigned version = 0;
+
+   ext.set_eject_state     = disk_set_eject_state;
+   ext.get_eject_state     = disk_get_eject_state;
+   ext.get_image_index     = disk_get_image_index;
+   ext.set_image_index     = disk_set_image_index;
+   ext.get_num_images      = disk_get_num_images;
+   ext.replace_image_index = disk_replace_image_index;
+   ext.add_image_index     = disk_add_image_index;
+   ext.set_initial_image   = disk_set_initial_image;
+   ext.get_image_path      = disk_get_image_path;
+   ext.get_image_label     = disk_get_image_label;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION,
+                  &version)
+       && version >= 1
+       && environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE, &ext))
+   {
+      LOG_INF("[CD] disk control: ext interface v%u registered\n", version);
+      return;
+   }
+
+   legacy.set_eject_state     = disk_set_eject_state;
+   legacy.get_eject_state     = disk_get_eject_state;
+   legacy.get_image_index     = disk_get_image_index;
+   legacy.set_image_index     = disk_set_image_index;
+   legacy.get_num_images      = disk_get_num_images;
+   legacy.replace_image_index = disk_replace_image_index;
+   legacy.add_image_index     = disk_add_image_index;
+
+   if (environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, &legacy))
+      LOG_INF("[CD] disk control: legacy interface registered "
+              "(no ext support)\n");
+   else
+      LOG_WRN("[CD] disk control: frontend accepted neither interface -- "
+              "inserting a disc after launch will not be possible\n");
+}
+
 typedef enum
 {
    DISC_BOOT_OK = 0,
@@ -5813,6 +5989,11 @@ bool retro_load_game(const struct retro_game_info *info)
    eeprom_dirty_cb = eeprom_pack_save_buf;
    mt_dirty_cb     = mt_mark_save_dirty;
 
+   /* Disk control (#651): register before the content branch, so it is
+    * registered on the no-content path too -- that is the case the
+    * feature exists for. */
+   register_disk_control();
+
    /* Detect CD content (CUE/CDI/CHD/ISO) and pick a boot strategy from the
     * disc itself.  The CD branch lives in open_disc_and_resolve_boot() so
     * the disk-control insert path (#651) can re-run exactly the same
@@ -6007,6 +6188,11 @@ void retro_unload_game(void)
    jaguar_cd_mode    = false;
    jaguarMemTrackInserted = false;
    cd_image_path[0]  = '\0';
+   memset(disk_image_path, 0, sizeof(disk_image_path));
+   disk_num_images    = 0;
+   disk_index         = 0;
+   disk_initial_index = 0;
+   disk_ejected       = false;
    /* Content type is unknown again — restore the full option list. */
    content_loaded    = false;
    no_game_active    = false;
@@ -6368,6 +6554,15 @@ void retro_deinit(void)
    ShadowFBShutdown();
    ShadowHiresShutdown();
    BlitMemoShutdown();
+
+   /* Disk control statics (#651): same reasoning as the shutdowns above --
+    * iOS cannot dlclose the core, so a stale image list would survive into
+    * the next load and offer the frontend a disc that is no longer there. */
+   memset(disk_image_path, 0, sizeof(disk_image_path));
+   disk_num_images    = 0;
+   disk_index         = 0;
+   disk_initial_index = 0;
+   disk_ejected       = false;
    /* Texture dump (#369): close the manifest, log the session summary,
     * free the dedupe set and reset every static. */
    TexDumpShutdown();

--- a/libretro.c
+++ b/libretro.c
@@ -4625,6 +4625,27 @@ bool retro_serialize(void *data, size_t size)
     * loadable. */
    buf += UARTWireSpeedupStateSave(buf);
 
+   /* v14: mounted-disc identity + image index (#651).  Disk control lets a
+    * frontend swap the disc mid-session, so a state and the mounted disc
+    * can now disagree -- which they never could before, when the disc was
+    * fixed at load.  All three identity words come from accessors that
+    * already exist (cdintf.h); zero when no disc is mounted.
+    *
+    * STRICTLY LAST, after the wire-speedup chunk: same reasoning as Team
+    * Tap's comment above -- appending keeps every v12/v13 blob loadable,
+    * interleaving would silently desync all of them. */
+   {
+      uint32_t disc_sessions = jaguar_cd_mode ? CDIntfGetNumSessions() : 0;
+      uint32_t disc_tracks   = jaguar_cd_mode ? CDIntfGetNumTracks() : 0;
+      uint32_t disc_sectors  = jaguar_cd_mode ? CDIntfGetDiscTotalSectors() : 0;
+      uint32_t disc_index    = disk_index;
+
+      STATE_SAVE_VAR(buf, disc_sessions);
+      STATE_SAVE_VAR(buf, disc_tracks);
+      STATE_SAVE_VAR(buf, disc_sectors);
+      STATE_SAVE_VAR(buf, disc_index);
+   }
+
    written = (size_t)(buf - start);
    if (written > STATE_SIZE)
       return false;
@@ -4822,6 +4843,40 @@ bool retro_unserialize(const void *data, size_t size)
       buf += UARTWireSpeedupStateLoad(buf);
    else
       UARTSetWireSpeedupEffective(1);
+
+   /* v14: mounted-disc identity (#651) -- see the matching save comment.
+    * Refuse a state taken on a different disc rather than resuming a
+    * machine whose CD state points at content that is not mounted. States
+    * written before v14 carry no identity and load unchanged, exactly as
+    * they did when the disc could not change mid-session. */
+   if (version >= STATE_VERSION_DISK_CONTROL)
+   {
+      uint32_t disc_sessions, disc_tracks, disc_sectors, disc_index;
+
+      STATE_LOAD_VAR(buf, disc_sessions);
+      STATE_LOAD_VAR(buf, disc_tracks);
+      STATE_LOAD_VAR(buf, disc_sectors);
+      STATE_LOAD_VAR(buf, disc_index);
+
+      if (jaguar_cd_mode
+          && (disc_sessions != CDIntfGetNumSessions()
+              || disc_tracks != CDIntfGetNumTracks()
+              || disc_sectors != CDIntfGetDiscTotalSectors()))
+      {
+         LOG_ERR("[CD] refusing savestate: taken on a different disc "
+                 "(state: %u sessions / %u tracks / %u sectors; mounted: "
+                 "%u / %u / %u)\n",
+                 (unsigned)disc_sessions, (unsigned)disc_tracks,
+                 (unsigned)disc_sectors,
+                 (unsigned)CDIntfGetNumSessions(),
+                 (unsigned)CDIntfGetNumTracks(),
+                 (unsigned)CDIntfGetDiscTotalSectors());
+         return false;
+      }
+
+      if (disc_index < disk_num_images)
+         disk_index = disc_index;
+   }
 
    /* tomRam8 was restored raw above; recompute the DRAM/refresh timing
     * that bus_arbiter derives from MEMCON1/MEMCON2 so it matches the
@@ -5441,13 +5496,32 @@ static bool disk_set_eject_state(bool ejected)
    memcpy(saved_path, cd_image_path, sizeof(saved_path));
 
    st = open_disc_and_resolve_boot(disk_image_path[disk_index]);
-   if (st != DISC_BOOT_OK)
+
+   /* NOT a bare JaguarReset(): bios_boot() copies the CD BIOS to $800000
+    * and sets jaguarRunAddress from $800404 before resetting, so a plain
+    * reset would restart the PREVIOUS program.  NULL is safe here -- both
+    * CD strategies ignore info (hle_strategy_boot does `(void)info;`);
+    * only cart_boot reads it, and cart is never resolved on this path.
+    *
+    * A damaged rip reaches HERE, not the branch above: the image parses
+    * and resolves fine, and it is the boot itself that fails (several CDI
+    * V2 rips in circulation are missing their boot header entirely).  So
+    * both failures share one restore -- an early version restored only on
+    * the resolve failure and left a half-configured machine behind on the
+    * far more likely one. */
+   if (st != DISC_BOOT_OK
+       || !bootConfig.strategy
+       || !bootConfig.strategy->boot(NULL))
    {
-      LOG_ERR("[CD] disk control: insert failed (%s) -- tray stays open\n",
-              st == DISC_BOOT_OPEN_FAILED
-                 ? "image could not be opened"
-                 : "audio disc needs the real CD BIOS and it is "
-                   "unavailable");
+      if (st == DISC_BOOT_OPEN_FAILED)
+         LOG_ERR("[CD] disk control: insert failed -- image could not be "
+                 "opened\n");
+      else if (st == DISC_BOOT_NO_BIOS_FOR_AUDIO)
+         LOG_ERR("[CD] disk control: insert failed -- audio disc needs the "
+                 "real CD BIOS and it is unavailable\n");
+      else
+         LOG_ERR("[CD] disk control: insert failed -- the boot strategy "
+                 "refused this disc (a damaged rip will do this)\n");
 
       bootConfig     = saved_boot;
       jaguar_cd_mode = saved_cd_mode;
@@ -5456,18 +5530,9 @@ static bool disk_set_eject_state(bool ejected)
          LOG_ERR("[CD] disk control: could not reopen the previous disc "
                  "either -- the drive is now empty\n");
 
+      LOG_WRN("[CD] disk control: tray stays open, previous disc "
+              "restored\n");
       return false;                   /* disk_ejected stays true */
-   }
-
-   /* NOT a bare JaguarReset(): bios_boot() copies the CD BIOS to $800000
-    * and sets jaguarRunAddress from $800404 before resetting, so a plain
-    * reset would restart the PREVIOUS program.  NULL is safe here -- both
-    * CD strategies ignore info (hle_strategy_boot does `(void)info;`);
-    * only cart_boot reads it, and cart is never resolved on this path. */
-   if (!bootConfig.strategy || !bootConfig.strategy->boot(NULL))
-   {
-      LOG_ERR("[CD] disk control: boot strategy refused the new disc\n");
-      return false;
    }
 
    LOG_INF("[CD] disk control: inserted '%s', booting via '%s'\n",

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -80,7 +80,7 @@ extern "C" {
  *     nothing here and the loader falls back to stock (1), which is
  *     exactly what a pre-#552 core was — see UARTWireSpeedupStateLoad(). */
 #define STATE_MAGIC     0x564A5353  /* "VJSS" */
-#define STATE_VERSION   13
+#define STATE_VERSION   14
 /* Oldest layout retro_unserialize still accepts.  States between
  * STATE_MIN_VERSION and STATE_VERSION load by reading each chunk in the
  * layout the header version names (see DACStateLoad, CDROMStateLoad);
@@ -171,6 +171,18 @@ extern "C" {
  * what a pre-v13 core was.  The adapter's own presence is NOT serialized
  * (it is user configuration; see joystick.h). */
 #define STATE_VERSION_TEAMTAP 13
+
+/* v14: disk control (#651).  The mounted disc's identity -- session count,
+ * track count, total sectors, all three already exported by cdintf.h --
+ * plus the current image index.  Loading a state taken on disc A while
+ * disc B is mounted would resume a machine whose CD state points at
+ * content that is not there; refusing it loudly beats the silent
+ * wrong-disc class.  Hashing the image is not an option: a Jaguar CD disc
+ * runs to hundreds of megabytes and states are written constantly.
+ *
+ * 13 shipped in v3.5.1, so this needs its own bump; 14 is now the single
+ * shared bump for this release, per the one-bump-per-release policy. */
+#define STATE_VERSION_DISK_CONTROL 14
 
 /* Header flags */
 #define STATE_FLAG_MEMTRACK  0x01

--- a/test/harness/harness.c
+++ b/test/harness/harness.c
@@ -462,6 +462,34 @@ static bool cb_environment(unsigned cmd, void *data)
             ? ((const struct retro_audio_buffer_status_callback *)data)->callback
             : NULL;
         return true;
+    case RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION:
+        /* Opt-in like the buffer-status hook above (#651).  Answering 0 --
+         * or refusing -- would push the core onto the legacy interface,
+         * which has no get_image_path/get_image_label, so a test could not
+         * read back what it inserted. */
+        if (!active_cfg || !active_cfg->accept_disk_control_cb)
+            return false;
+        if (data)
+            *(unsigned *)data = 1;
+        return true;
+    case RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE:
+        if (!active_cfg || !active_cfg->accept_disk_control_cb)
+            return false;
+        if (data) {
+            const struct retro_disk_control_ext_callback *dc =
+                (const struct retro_disk_control_ext_callback *)data;
+            active_cfg->disk_set_eject_state     = dc->set_eject_state;
+            active_cfg->disk_get_eject_state     = dc->get_eject_state;
+            active_cfg->disk_get_image_index     = dc->get_image_index;
+            active_cfg->disk_set_image_index     = dc->set_image_index;
+            active_cfg->disk_get_num_images      = dc->get_num_images;
+            active_cfg->disk_replace_image_index = dc->replace_image_index;
+            active_cfg->disk_add_image_index     = dc->add_image_index;
+            active_cfg->disk_get_image_path      = dc->get_image_path;
+            active_cfg->disk_get_image_label     = dc->get_image_label;
+            active_cfg->disk_cb_registered       = 1;
+        }
+        return true;
     case RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE:
         /* Only answer when a tool explicitly opted in (--av-skip-video);
          * otherwise fall through to `default: return false`, which is
@@ -726,6 +754,37 @@ bool harness_load_rom(harness_config *cfg)
 
     /* rom_data ownership: libretro spec says core copies what it needs,
      * but VJ keeps a pointer. We leak intentionally for test lifetime. */
+
+    if (cfg->load_state_path && !harness_load_state(cfg, cfg->load_state_path))
+        return false;
+
+    harness_reset_audio(cfg);
+    return true;
+}
+
+/* No-content boot (#646): retro_load_game(NULL).  Mirrors harness_load_rom's
+ * init ordering exactly -- set_environment before retro_init, then the a/v
+ * and input callbacks, then the load -- because the core registers its
+ * environment-driven interfaces (including disk control, #651) during that
+ * sequence, and a load with them unregistered would look like the feature
+ * was missing. */
+bool harness_load_no_content(harness_config *cfg)
+{
+    active_cfg = cfg;
+
+    lr_set_environment(cb_environment);
+    lr_init();
+    lr_set_video_refresh(cb_video);
+    lr_set_audio_sample(cb_audio_sample);
+    lr_set_audio_sample_batch(cb_audio_batch);
+    lr_set_input_poll(cb_input_poll);
+    lr_set_input_state(cb_input_state);
+
+    if (!lr_load_game(NULL)) {
+        fprintf(stderr, "harness: retro_load_game(NULL) failed "
+                        "(core may not support no-content boot)\n");
+        return false;
+    }
 
     if (cfg->load_state_path && !harness_load_state(cfg, cfg->load_state_path))
         return false;

--- a/test/harness/harness.h
+++ b/test/harness/harness.h
@@ -184,6 +184,10 @@ typedef bool (*harness_frame_cb)(void *userdata, unsigned frame);
 typedef void (*harness_video_cb)(void *userdata, const void *data,
                                  unsigned width, unsigned height, size_t pitch);
 
+/* Forward declaration only: this header deliberately does not include
+ * libretro.h (see accept_disk_control_cb below). */
+struct retro_game_info;
+
 typedef struct {
     /* Configuration (set before init) */
     const char   *core_path;
@@ -280,6 +284,33 @@ typedef struct {
     void        (*audio_buf_cb)(bool active, unsigned occupancy,
                                 bool underrun_likely);
 
+    /* RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE capture (#651),
+     * opt-in exactly like accept_audio_buf_cb: when accept_disk_control_cb
+     * is non-zero the environment callback answers
+     * GET_DISK_CONTROL_INTERFACE_VERSION with 1 and copies the core's
+     * entry points out of the ext struct, so a test can drive
+     * eject/insert the way a frontend would.  Default 0 refuses both
+     * calls, matching every harness tool that predates this option.
+     *
+     * The entry points are spelled out one by one, and retro_game_info is
+     * only forward-declared above, for the same reason audio_buf_cb is
+     * spelled out: this header deliberately does not include libretro.h.
+     * A test that needs to BUILD a retro_game_info includes libretro.h
+     * itself. */
+    int           accept_disk_control_cb;
+    int           disk_cb_registered;
+    bool        (*disk_set_eject_state)(bool ejected);
+    bool        (*disk_get_eject_state)(void);
+    unsigned    (*disk_get_image_index)(void);
+    bool        (*disk_set_image_index)(unsigned index);
+    unsigned    (*disk_get_num_images)(void);
+    bool        (*disk_replace_image_index)(unsigned index,
+                                            const struct retro_game_info *info);
+    bool        (*disk_add_image_index)(void);
+    bool        (*disk_get_image_path)(unsigned index, char *path, size_t len);
+    bool        (*disk_get_image_label)(unsigned index, char *label,
+                                        size_t len);
+
     /* Runtime state (set by harness) */
     void  *core_handle;
     unsigned current_frame;
@@ -351,6 +382,12 @@ bool harness_load_core(harness_config *cfg);
 /* Load a ROM into the core.  Requires core loaded + rom_path set.
  * If cfg->load_state_path is set, the state is restored afterwards. */
 bool harness_load_rom(harness_config *cfg);
+
+/* No-content boot (#646): retro_load_game(NULL).  Separate entry point
+ * because harness_load_rom() requires cfg->rom_path and refuses NULL,
+ * and the disk-control insert path (#651) is only reachable from a
+ * core that launched with no content. */
+bool harness_load_no_content(harness_config *cfg);
 
 /* Write the core's current state to `path` (raw core blob). */
 bool harness_save_state(harness_config *cfg, const char *path);

--- a/test/tools/test_disk_control.c
+++ b/test/tools/test_disk_control.c
@@ -107,6 +107,7 @@ int main(int argc, char **argv)
     harness_result results[6];
     unsigned nres = 0;
     const char *disc_path = NULL;
+    const char *disc_path_b = NULL;
     int case_num = 0;
     int i;
     int pass = 0;
@@ -117,10 +118,12 @@ int main(int argc, char **argv)
             case_num = atoi(argv[i + 1]);
         else if (strcmp(argv[i], "--disc") == 0 && i + 1 < argc)
             disc_path = argv[i + 1];
+        else if (strcmp(argv[i], "--disc-b") == 0 && i + 1 < argc)
+            disc_path_b = argv[i + 1];
     }
-    if (case_num != 1 && case_num != 3) {
+    if (case_num != 1 && case_num != 3 && case_num != 4) {
         fprintf(stderr, "usage: test_disk_control <core> --disc <image> "
-                        "--case N[1|3] [--quiet]\n"
+                        "--case N[1|3|4] [--quiet]\n"
                         "  (case 2 needs a one-session audio disc; none "
                         "exists in the corpus)\n");
         return 1;
@@ -188,6 +191,59 @@ int main(int argc, char **argv)
                    : "strategy did NOT move off \"none\" -- the insert "
                      "reset the machine without re-resolving");
         pass = registered && was_none && inserted && now_cd;
+        break;
+    }
+    case 4: {
+        /* Serialize on disc A, mount disc B, assert the load is REFUSED --
+         * and then assert the state still loads on its OWN disc.  That
+         * second half is the control: a serializer that refused EVERY
+         * state would satisfy the mismatch assertion on its own. */
+        int saved, cross_refused, own_ok;
+        const char *state_path = "/tmp/vj_disk_control_case4.state";
+
+        if (!disc_path_b) {
+            fprintf(stderr, "test_disk_control: case 4 needs --disc-b\n");
+            return 77;   /* ledgered skip, not a pass */
+        }
+
+        gi.path = disc_path;
+        if (!(cfg.disk_add_image_index()
+              && cfg.disk_replace_image_index(0, &gi)
+              && cfg.disk_set_eject_state(true)
+              && cfg.disk_set_eject_state(false))) {
+            fprintf(stderr, "test_disk_control: could not mount disc A "
+                            "(damaged rip?) -- skipping\n");
+            return 77;   /* corpus property, not a code failure */
+        }
+        saved = harness_save_state(&cfg, state_path);
+
+        gi.path = disc_path_b;
+        cfg.disk_set_eject_state(true);
+        cfg.disk_replace_image_index(0, &gi);
+        if (!cfg.disk_set_eject_state(false)) {
+            fprintf(stderr, "test_disk_control: could not mount disc B "
+                            "(damaged rip?) -- skipping\n");
+            return 77;   /* several CDI V2 rips cannot boot at all */
+        }
+        cross_refused = !harness_load_state(&cfg, state_path);
+
+        gi.path = disc_path;
+        cfg.disk_set_eject_state(true);
+        cfg.disk_replace_image_index(0, &gi);
+        cfg.disk_set_eject_state(false);
+        own_ok = harness_load_state(&cfg, state_path);
+
+        results[nres++] = mkres(saved, "case4_state_saved",
+            saved ? "state written while disc A was mounted"
+                  : "could not write a state");
+        results[nres++] = mkres(cross_refused, "case4_mismatch_refused",
+            cross_refused ? "state from disc A refused against disc B"
+                          : "A WRONG-DISC STATE WAS ACCEPTED");
+        results[nres++] = mkres(own_ok, "case4_own_disc_roundtrips",
+            own_ok ? "state still loads on the disc it was taken from"
+                   : "state refused on its OWN disc -- the check is too "
+                     "strict, not just strict");
+        pass = saved && cross_refused && own_ok;
         break;
     }
     case 3: {

--- a/test/tools/test_disk_control.c
+++ b/test/tools/test_disk_control.c
@@ -1,0 +1,235 @@
+/*
+ * test/tools/test_disk_control.c
+ *
+ * E2E test for the libretro disk control interface (issue #651): boot the
+ * core with NO content, hand it a disc through the frontend-facing
+ * callbacks, and assert that boot resolution actually RE-RAN against the
+ * newly inserted disc.
+ *
+ * Why the assertion is on the resolved STRATEGY, not on the return value:
+ * a reset against the PREVIOUS disc's boot config looks identical from
+ * outside -- the machine restarts, the call returns true, frames keep
+ * coming -- so "insert returned true" proves nothing at all.  What proves
+ * the resolution re-ran is that bootConfig.strategy moved off the
+ * no-content strategy and onto a CD one.  bootConfig and the four
+ * strategy structs are exported under TEST_EXPORTS=1, and CDBootStrategy
+ * carries a `name` ("none"/"hle"/"bios"/"cart"), so the check reads that
+ * string rather than comparing pointers.
+ *
+ * Cases:
+ *
+ *   1  No-content boot, then insert a real disc.  The strategy must be
+ *      "none" before the insert (proving the no-content path resolved)
+ *      and a CD strategy after it (proving open_disc_and_resolve_boot()
+ *      ran again).  Also asserts the core registered the ext interface at
+ *      all -- without that, every later assertion is vacuous.
+ *
+ *   2  Audio-only (Red Book, one-session) disc inserted after launch must
+ *      land on the real CD BIOS, since HLE synthesizes its boot stub from
+ *      session-2 data an audio disc has none of.  NOT RUN: no one-session
+ *      image exists in the corpus -- every CUE carries two REM SESSION
+ *      markers and CDI headers declare numSessions=2.  Writing it against
+ *      a data disc would pass for the wrong reason, so `make test` skips
+ *      it via scripts/test-skip.sh rather than pretending to cover it.
+ *
+ *   3  A failed insert must be inert.  Insert a path that cannot be
+ *      opened: the call returns false, the tray stays open, and -- the
+ *      part that matters -- the resolved strategy is UNCHANGED.  Checking
+ *      only the return value would pass against the inert stub this
+ *      interface shipped with one commit earlier.
+ *
+ * Run: test_disk_control <core> --disc <image> --case N [--quiet]
+ */
+
+#define _DEFAULT_SOURCE 1
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "../harness/harness.h"
+#include "../../libretro-common/include/libretro.h"
+
+/* Mirrors src/cd/jagcd_boot.h and src/core/settings.h.  Declared here
+ * rather than including those headers: settings.h drags in the whole vjs
+ * configuration surface (and MAX_PATH with it) for two fields this test
+ * reads through a dlsym'd pointer.  Only the leading layout matters --
+ * `strategy` is the last field of struct BootConfig, and `name` the first
+ * of CDBootStrategy, so a trailing-field addition to either cannot
+ * silently shift what is read here. */
+struct dc_strategy
+{
+    const char *name;
+    /* remaining function pointers unused by this test */
+};
+
+struct dc_bootconfig
+{
+    bool isCDGame;
+    bool showBootROM;
+    bool cdBiosAvailable;
+    const struct dc_strategy *strategy;
+};
+
+static struct dc_bootconfig *bootcfg;
+
+static const char *strategy_name(void)
+{
+    if (!bootcfg || !bootcfg->strategy || !bootcfg->strategy->name)
+        return "(none resolved)";
+    return bootcfg->strategy->name;
+}
+
+/* A CD strategy is anything the CD path can resolve to: HLE synthesizes a
+ * boot stub from session-2 data, the real BIOS runs the retail CD BIOS.
+ * Which one a given disc takes depends on CD Boot Mode and the session
+ * count, and this test deliberately does not pin that -- case 1 asks only
+ * whether resolution re-ran, not which way it went. */
+static int strategy_is_cd(void)
+{
+    const char *n = strategy_name();
+    return strcmp(n, "hle") == 0 || strcmp(n, "bios") == 0;
+}
+
+static harness_result mkres(int ok, const char *name, const char *detail)
+{
+    harness_result r;
+    r.status = ok ? "PASS" : "FAIL";
+    r.name   = name;
+    r.detail = detail;
+    return r;
+}
+
+int main(int argc, char **argv)
+{
+    harness_config cfg = HARNESS_CONFIG_DEFAULT;
+    struct retro_game_info gi;
+    harness_result results[6];
+    unsigned nres = 0;
+    const char *disc_path = NULL;
+    int case_num = 0;
+    int i;
+    int pass = 0;
+    char before[64];
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--case") == 0 && i + 1 < argc)
+            case_num = atoi(argv[i + 1]);
+        else if (strcmp(argv[i], "--disc") == 0 && i + 1 < argc)
+            disc_path = argv[i + 1];
+    }
+    if (case_num != 1 && case_num != 3) {
+        fprintf(stderr, "usage: test_disk_control <core> --disc <image> "
+                        "--case N[1|3] [--quiet]\n"
+                        "  (case 2 needs a one-session audio disc; none "
+                        "exists in the corpus)\n");
+        return 1;
+    }
+    if (!disc_path) {
+        fprintf(stderr, "test_disk_control: no --disc given\n");
+        return 1;
+    }
+
+    cfg.frames = 10;
+    cfg.quiet  = 1;
+
+    /* Must be set before the load: the core registers disk control during
+     * retro_load_game, and the harness refuses the env call unless this
+     * is on (matching the accept_audio_buf_cb convention). */
+    cfg.accept_disk_control_cb = 1;
+
+    if (!harness_init_from_args(&cfg, argc, argv))
+        return 1;
+
+    bootcfg = (struct dc_bootconfig *)harness_dlsym(&cfg, "bootConfig");
+    if (!bootcfg) {
+        fprintf(stderr, "test_disk_control: bootConfig not exported -- "
+                        "rebuild with `make TEST_EXPORTS=1`\n");
+        return 1;
+    }
+
+    if (!harness_load_no_content(&cfg)) {
+        fprintf(stderr, "test_disk_control: no-content load failed\n");
+        return 1;
+    }
+
+    memset(&gi, 0, sizeof(gi));
+
+    switch (case_num) {
+    case 1: {
+        int registered, was_none, added, inserted, now_cd;
+
+        registered = cfg.disk_cb_registered
+                  && cfg.disk_add_image_index
+                  && cfg.disk_replace_image_index
+                  && cfg.disk_set_eject_state;
+        was_none   = strcmp(strategy_name(), "none") == 0;
+
+        gi.path = disc_path;
+        added    = registered
+                && cfg.disk_add_image_index()
+                && cfg.disk_replace_image_index(0, &gi)
+                && cfg.disk_set_eject_state(true);
+        inserted = added && cfg.disk_set_eject_state(false);
+        now_cd   = strategy_is_cd();
+
+        results[nres++] = mkres(registered, "case1_interface_registered",
+            registered ? "core registered the disk control ext interface"
+                       : "no disk control interface registered -- every "
+                         "assertion below would be vacuous");
+        results[nres++] = mkres(was_none, "case1_no_content_resolved",
+            was_none ? "strategy was \"none\" before the insert"
+                     : "strategy was not \"none\" at no-content boot");
+        results[nres++] = mkres(inserted, "case1_insert_succeeded",
+            inserted ? "set_eject_state(false) returned true"
+                     : "insert was refused");
+        results[nres++] = mkres(now_cd, "case1_boot_resolution_reran",
+            now_cd ? "strategy is now a CD strategy -- resolution re-ran"
+                   : "strategy did NOT move off \"none\" -- the insert "
+                     "reset the machine without re-resolving");
+        pass = registered && was_none && inserted && now_cd;
+        break;
+    }
+    case 3: {
+        int added, refused, still_ejected, unchanged, still_runs;
+
+        strncpy(before, strategy_name(), sizeof(before) - 1);
+        before[sizeof(before) - 1] = '\0';
+
+        gi.path = "/nonexistent/definitely-not-a-disc.cue";
+        added   = cfg.disk_cb_registered
+               && cfg.disk_add_image_index()
+               && cfg.disk_replace_image_index(0, &gi)
+               && cfg.disk_set_eject_state(true);
+
+        refused       = added && !cfg.disk_set_eject_state(false);
+        still_ejected = cfg.disk_get_eject_state
+                     && cfg.disk_get_eject_state();
+        unchanged     = strcmp(before, strategy_name()) == 0;
+
+        harness_step(&cfg);
+        still_runs = 1;   /* reaching here without a crash is the check */
+
+        results[nres++] = mkres(refused, "case3_bad_insert_refused",
+            refused ? "set_eject_state(false) returned false"
+                    : "a broken image was accepted");
+        results[nres++] = mkres(still_ejected, "case3_tray_stays_open",
+            still_ejected ? "get_eject_state() still true after failure"
+                          : "tray reported closed after a failed insert");
+        results[nres++] = mkres(unchanged, "case3_strategy_unchanged",
+            unchanged ? "resolved strategy untouched by the failed insert"
+                      : "failed insert changed the resolved strategy -- "
+                        "the machine is now half-configured");
+        results[nres++] = mkres(still_runs, "case3_machine_still_runs",
+            "core still stepped a frame after the failed insert");
+        pass = refused && still_ejected && unchanged && still_runs;
+        break;
+    }
+    default:
+        return 1;
+    }
+
+    harness_report(&cfg, results, nres);
+    harness_shutdown(&cfg);
+    return pass ? 0 : 1;
+}


### PR DESCRIPTION
Closes #651
<!-- link-issue: #651 -->

## Summary

The core implemented neither `SET_DISK_CONTROL_INTERFACE` nor its `_EXT` form. That single gap blocked two features: #646 gave the core no-content boot, but nothing could then hand it a disc; and the audio-CD/VLM path needs exactly that.

Six commits, each independently reviewable and green on its own.

## The load-bearing piece

`retro_reset()` is a bare `JaguarReset()` and re-resolves nothing, while the boot strategy is **derived from the disc** (session count decides HLE vs real BIOS). An insert that merely reset would run against the *previous* disc's boot config — silently, and looking like it worked. Hence `open_disc_and_resolve_boot()`, extracted and verified on its own so any load-path regression stays attributable.

Two design errors caught before implementation:

- `ResolveBootConfig()` is shared with the **cart** path, so this restructures `retro_load_game`'s branch rather than lifting a contiguous block.
- Insert dispatches `strategy->boot(NULL)`, **not** `JaguarReset()`. `bios_boot()` copies the CD BIOS to `$800000` and sets `jaguarRunAddress` from `$800404` before resetting; a bare reset would restart the previous program. NULL is safe — both CD strategies ignore `info` (`hle_strategy_boot` does `(void)info;`); only `cart_boot` reads it, and cart is never resolved here.

## Deliberate limitations, stated up front

- **Insert restarts the console.** #651's framing ("launch, put in a music CD, get the VLM") implies a *continuous* swap. This does not provide that — reaching the VLM works, but by restarting into the CD BIOS. The continuous version depends on whether the CD BIOS polls for disc presence, which is unverified and recorded rather than guessed at.
- **Eject is a flag, not a tray.** `src/cd/` models no disc-present line, so the mounted image stays readable until an insert replaces it.
- **No m3u parsing.** No multi-disc Jaguar CD title exists; the frontend populates the list.

## Savestates

`STATE_VERSION` 13 → 14. 13 shipped in v3.5.1 (checked with `git merge-base --is-ancestor`), so this needs its own bump; **14 is now the single shared bump for this release**.

Identity is sessions / tracks / total sectors — all three from accessors that already existed in `cdintf.h`, so no `CDIntf` work. Hashing the image is not viable at hundreds of MB per disc. The chunk is strictly last, so every v12/v13 blob stays loadable; pre-v14 states carry no identity and load unchanged.

## Testing

New `test/tools/test_disk_control`, wired into `make test`.

**Case 1 asserts the resolved *strategy*, not the return value** — a reset against the previous disc's boot config restarts the machine and returns true, so it looks identical from outside. Confirmed **red first**: against the inert stub, case 1 failed on exactly `case1_boot_resolution_reran` while the other three passed.

Case 3 (failed insert is inert) and case 4 (state from disc A refused against disc B, **plus** the control that it still loads on its own disc — without which a serializer refusing everything would pass).

**Case 2 is not written.** An audio-disc insert needs a one-session Red Book image and none exists in the corpus — every CUE carries two `REM SESSION` markers, CDI headers declare `numSessions=2`. Against a data disc it would pass for the wrong reason, so it is ledgered via `test-skip.sh` rather than faked into looking like coverage.

## A bug the tests found

Mounting `vidgrid.cdi` — one of the known-broken CDI V2 rips — showed that a **damaged rip fails at `strategy->boot()`, not at resolve**, and that path returned false *without* restoring the snapshot, leaving exactly the half-configured machine the design says cannot happen. Both failure paths now share one restore, and the previous disc is reopened best-effort (`CDIntfOpenImage()` closes the current image before parsing the new one, so by the time an open fails the old disc is already out of the drive).

## Verification

- `make TEST_EXPORTS=1 test` → **exit 0, zero FAILs**, at every one of the six commits.
- Pure-refactor proof: 600-frame Myst CD boot digest **byte-identical** before/after, both files non-empty at 601 rows.
- `scripts/c89-lint.sh` clean on every touched `.c`.
- **`regression_test.sh` could not be run on this host** and is not claimed as passing: `clang++` resolves to a ccache shim pointing at a stale Swift 5.3.3 toolchain whose libc++ headers break the C++ miniretro at its first build step, before the core is touched. Pre-existing and unrelated (`miniretro.cc` is not in this diff). CI runs it.

## Recorded, not guessed

- Does the CD BIOS poll for disc presence? Not needed here, but it is the fact that decides whether a continuous-swap version is possible at all. Worth answering from `docs/atari-jaguar-1999/06 - Jaguar CD-ROM.pdf`.
- `CDIntfCloseImage()` and CHD VFS state: an insert cycle is the first path that closes and reopens an image within one session. No failure observed, but the CHD path was not specifically exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
