### PR TITLE
test(tools): --option support + config banner for risc_pc_histogram (#635)

### DIFF
--- a/test/tools/dsp_halt_backtrace.c
+++ b/test/tools/dsp_halt_backtrace.c
@@ -1,0 +1,173 @@
+/* test/tools/dsp_halt_backtrace.c -- who jumped to the DSP's shutdown
+ * routine?
+ *
+ * Issue #635 (White Men Can't Jump).  In HLE mode the game's DSP program
+ * executes ~1,319 opcodes at startup, jumps to an orderly shutdown block
+ * at $F1B76A (disable INT_ENA0/1, clear the latches, write $20 to D_CTRL
+ * so DSPGO clears), and parks forever in a 3-instruction `jr` loop at
+ * $F1B78C.  ~1,275 frames later the 68K posts command $0D to $F1B2C0 and
+ * spins for an ack that a stopped DSP can never write.
+ *
+ * The three transfers that could reach $F1B76A are all REGISTER-INDIRECT
+ * (`jump T, (r10)`, `jump T, (r24)`, `jump NZ, (r1)`), so static
+ * disassembly cannot name the caller -- the target is computed at
+ * runtime.  This tool reads the runtime PC history instead.
+ *
+ * Why a plain end-of-run dump is sufficient, rather than trapping the
+ * 1->0 transition of DSPGO: once the DSP halts it executes nothing more,
+ * so its PC ring STOPS being written and preserves the last up-to-1024
+ * PCs leading into the shutdown.  Sampling later cannot lose them.  The
+ * tool still reports the frame at which DSPGO cleared, and refuses to
+ * print a backtrace if the DSP never stopped (in which case the ring is
+ * live and the newest entries would be unrelated).
+ *
+ * Build:
+ *   cc -O2 -Wall -std=c99 -I. -I./libretro-common/include \
+ *      -o test/tools/dsp_halt_backtrace test/tools/dsp_halt_backtrace.c \
+ *      test/harness/harness.c -ldl -lm
+ * Run (HLE mode is the default and is where the bug lives):
+ *   ./test/tools/dsp_halt_backtrace ./virtualjaguar_libretro.dylib rom.jag \
+ *      --frames 60 [--depth 64]
+ * Needs a TEST_EXPORTS=1 core (dsp_control and vjtrace_backtrace are
+ * hidden otherwise).
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../harness/harness.h"
+
+/* src/core/vjag_memory.h: enum { UNKNOWN, JAGUAR, DSP, GPU, ... } */
+#define WHO_DSP 2
+
+#define MAX_DEPTH 1024
+
+static void (*p_backtrace)(int, uint32_t *, int, int *);
+static void (*p_arm)(void);
+static uint32_t *p_dsp_control;
+
+static int  prev_running = -1;
+static int  halt_frame   = -1;
+static uint32_t frames_seen;
+
+/* harness_frame_cb: bool (*)(void *userdata, unsigned frame).  Returning
+ * true keeps the run going. */
+static bool on_frame(void *userdata, unsigned frame)
+{
+   int running;
+
+   (void)userdata;
+   frames_seen = frame;
+   if (!p_dsp_control)
+      return true;
+
+   running = (*p_dsp_control & 0x01) ? 1 : 0;
+   if (prev_running == 1 && running == 0 && halt_frame < 0)
+      halt_frame = (int)frame;
+   prev_running = running;
+   return true;
+}
+
+int main(int argc, char **argv)
+{
+   harness_config cfg = HARNESS_CONFIG_DEFAULT;
+   uint32_t pcs[MAX_DEPTH];
+   int count = 0, depth = 64, i;
+
+   for (i = 1; i < argc; i++)
+   {
+      if (strcmp(argv[i], "--depth") == 0 && i + 1 < argc)
+         depth = atoi(argv[i + 1]);
+   }
+   if (depth < 1 || depth > MAX_DEPTH)
+   {
+      fprintf(stderr, "--depth must be 1..%d\n", MAX_DEPTH);
+      return 1;
+   }
+
+   cfg.frames = 60;
+   cfg.quiet  = 1;
+   if (!harness_init_from_args(&cfg, argc, argv))
+      return 1;
+   if (!cfg.rom_path)
+   {
+      fprintf(stderr, "dsp_halt_backtrace: no ROM given\n");
+      return 1;
+   }
+
+   p_backtrace = (void (*)(int, uint32_t *, int, int *))
+      harness_dlsym(&cfg, "vjtrace_backtrace");
+   p_dsp_control = (uint32_t *)harness_dlsym(&cfg, "dsp_control");
+   /* The PC history ring is gated on vjtrace_armed, which defaults OFF --
+    * an unarmed core records nothing and the backtrace comes back EMPTY,
+    * which reads exactly like "the DSP executed nothing".  Arm it before
+    * the ROM loads so the very first DSP instructions are captured; the
+    * halt happens within the first frame or two. */
+   p_arm = (void (*)(void))harness_dlsym(&cfg, "vjtrace_arm");
+   if (p_arm)
+      p_arm();
+   else
+      fprintf(stderr, "dsp_halt_backtrace: WARNING -- vjtrace_arm not "
+                      "exported; the backtrace will be empty\n");
+
+   if (!p_backtrace || !p_dsp_control)
+   {
+      fprintf(stderr, "dsp_halt_backtrace: vjtrace_backtrace/dsp_control not "
+                      "exported -- rebuild with `make TEST_EXPORTS=1`\n");
+      return 1;
+   }
+
+   cfg.frame_callback = on_frame;
+   if (!harness_load_rom(&cfg))
+      return 1;
+   harness_run(&cfg);
+
+   printf("dsp_control=$%08X (DSPGO=%u)\n",
+          (unsigned)*p_dsp_control, (unsigned)(*p_dsp_control & 1));
+
+   if (*p_dsp_control & 1)
+   {
+      /* Refuse rather than mislead: a running DSP keeps overwriting the
+       * ring, so the newest entries are wherever it happens to be now --
+       * not the path into any shutdown. */
+      printf("DSP is STILL RUNNING after %u frames -- no halt to explain.\n",
+             (unsigned)frames_seen);
+      printf("(backtrace withheld: the ring is live and would show current "
+             "execution, not a halt path)\n");
+      return 2;
+   }
+
+   if (halt_frame >= 0)
+      printf("DSPGO cleared during frame %d\n", halt_frame);
+   else
+      printf("DSPGO was already clear at the first sampled frame "
+             "(halt happened before frame 1, or mid-frame before sampling)\n");
+
+   p_backtrace(WHO_DSP, pcs, depth, &count);
+   /* vjt_backtrace_ring returns OLDEST first: the last entry is the last
+    * instruction executed.  Verified empirically -- the final D_CTRL store
+    * at $F1B78A lands in the LAST slot, not the first. */
+   printf("\nDSP backtrace, OLDEST first (last entry = last instruction "
+          "executed, %d entries):\n", count);
+   for (i = 0; i < count; i++)
+   {
+      const char *tag = "";
+      if (pcs[i] == 0x00F1B78C || pcs[i] == 0x00F1B78E
+          || pcs[i] == 0x00F1B790)
+         tag = "   <- park loop";
+      else if (pcs[i] == 0x00F1B782 || pcs[i] == 0x00F1B784
+               || pcs[i] == 0x00F1B78A)
+         tag = "   <- D_CTRL store (DSPGO=0)";
+      else if (pcs[i] == 0x00F1B76A)
+         tag = "   <- SHUTDOWN ENTRY (caller is the line ABOVE)";
+      printf("  [%3d] $%08X%s\n", i, (unsigned)pcs[i], tag);
+   }
+
+   if (count == 0)
+      printf("  (empty -- the DSP PC ring recorded nothing; VJ_TRACE may be "
+             "disarmed in this build)\n");
+
+   harness_shutdown(&cfg);
+   return 0;
+}

--- a/test/tools/risc_pc_histogram.c
+++ b/test/tools/risc_pc_histogram.c
@@ -141,6 +141,34 @@ static unsigned long long *(*pperf_counters_find)(const char *);
 static int bios_option_set = 0;
 static const char *blitter_value = "enabled"; /* default: fast blitter */
 
+/* --option KEY=VALUE overrides (issue #635).
+ *
+ * This tool answers GET_VARIABLE from its own table rather than the
+ * harness's, and that table hardcodes virtualjaguar_bios="enabled".  That
+ * is deliberate for benchmark comparability -- every historical number
+ * from this tool was taken in real-BIOS mode -- but it was SILENT, and
+ * silently measuring a different configuration than you think is how a
+ * wrong conclusion gets published.  It did exactly that during the #635
+ * investigation: DSP opcode counts taken here (real BIOS) were correlated
+ * against a freeze measured elsewhere in HLE mode, and read as one
+ * timeline.
+ *
+ * So: the defaults are unchanged, --option can override any of them
+ * including the BIOS, and the effective set is PRINTED before the run so
+ * the configuration is never implicit again. */
+#define MAX_OVERRIDES 16
+static struct { const char *key, *val; } overrides[MAX_OVERRIDES];
+static int n_overrides = 0;
+
+static const char *override_lookup(const char *key)
+{
+   int i;
+   for (i = 0; i < n_overrides; i++)
+      if (strcmp(overrides[i].key, key) == 0)
+         return overrides[i].val;
+   return NULL;
+}
+
 /* High-resolution timer helpers */
 #ifdef __APPLE__
 static mach_timebase_info_data_t timebase_info;
@@ -204,6 +232,17 @@ static bool environment_cb(unsigned cmd, void *data)
       case RETRO_ENVIRONMENT_GET_VARIABLE:
       {
          struct retro_variable *var = (struct retro_variable *)data;
+         const char *ov = override_lookup(var->key);
+         if (ov)
+         {
+            /* An override answers ANY key, including ones this table does
+             * not otherwise know -- that is the point: the core would
+             * otherwise silently fall back to its registered default. */
+            var->value = ov;
+            if (strcmp(var->key, "virtualjaguar_bios") == 0)
+               bios_option_set = 1;
+            return true;
+         }
          if (strcmp(var->key, "virtualjaguar_bios") == 0)
          {
             var->value = "enabled";
@@ -287,6 +326,9 @@ static void print_usage(const char *progname)
       "\n"
       "Options:\n"
       "  num_frames           Number of frames to benchmark (default: 300)\n"
+      "  --option KEY=VALUE   Override a core option (repeatable).\n"
+      "                       NOTE: without this, virtualjaguar_bios is\n"
+      "                       forced to 'enabled' (real BIOS).\n"
       "  --blitter fast       Use fast blitter (default)\n"
       "  --blitter accurate   Use accurate (Midsummer2) blitter\n"
       "  --warmup N           Run N warmup frames before timing\n"
@@ -338,6 +380,26 @@ int main(int argc, char **argv)
             return 1;
          }
       }
+      else if (strcmp(argv[i], "--option") == 0 && i + 1 < argc)
+      {
+         char *kv = argv[++i];
+         char *eq = strchr(kv, '=');
+         if (!eq)
+         {
+            fprintf(stderr, "--option needs KEY=VALUE (got '%s')\n", kv);
+            return 1;
+         }
+         if (n_overrides >= MAX_OVERRIDES)
+         {
+            fprintf(stderr, "too many --option overrides (max %d)\n",
+                    MAX_OVERRIDES);
+            return 1;
+         }
+         *eq = '\0';                 /* split in place; argv outlives us */
+         overrides[n_overrides].key = kv;
+         overrides[n_overrides].val = eq + 1;
+         n_overrides++;
+      }
       else if (strcmp(argv[i], "--warmup") == 0 && i + 1 < argc)
          warmup_frames = atoi(argv[++i]);
       else if (strcmp(argv[i], "--load-srm") == 0 && i + 1 < argc)
@@ -362,6 +424,27 @@ int main(int argc, char **argv)
    {
       fprintf(stderr, "ERROR: --warmup must be >= 0 (got %d)\n", warmup_frames);
       return 1;
+   }
+
+   /* Print the effective configuration BEFORE the run.  This tool answers
+    * GET_VARIABLE from its own table and forces real-BIOS mode unless
+    * overridden; leaving that implicit produced a wrong conclusion during
+    * #635 (numbers taken here in BIOS mode, compared against a freeze
+    * measured in HLE mode).  Never implicit again. */
+   {
+      int oi;
+      const char *bios_eff = override_lookup("virtualjaguar_bios");
+      printf("config: virtualjaguar_bios=%s%s  blitter=%s\n",
+             bios_eff ? bios_eff : "enabled",
+             bios_eff ? " (overridden)" : " (TOOL DEFAULT -- real BIOS)",
+             strcmp(blitter_value, "enabled") == 0 ? "fast" : "accurate");
+      for (oi = 0; oi < n_overrides; oi++)
+         if (strcmp(overrides[oi].key, "virtualjaguar_bios") != 0)
+            printf("config: %s=%s (overridden)\n",
+                   overrides[oi].key, overrides[oi].val);
+      if (n_overrides == 0)
+         printf("config: no --option overrides; every other core option "
+                "uses its REGISTERED default\n");
    }
 
 #ifdef __APPLE__


### PR DESCRIPTION
Refs #635
<!-- link-issue: #635 -->

## The trap

`risc_pc_histogram` answers `GET_VARIABLE` from its **own** table, not the harness's, and that table hardcoded:

```c
if (strcmp(var->key, "virtualjaguar_bios") == 0)
{
   var->value = "enabled";      /* always real BIOS */
```

Every key it did not know returned false, so the core silently fell back to registered defaults. **Neither fact was printed anywhere.**

This is not hypothetical — it produced a wrong published conclusion in #635. DSP opcode counts taken with this tool (real BIOS, idle-skip on) were correlated against a freeze measured with `frame_hash_ab` in default HLE mode, and reported as one timeline. The retraction is in the issue.

## Changes

- **`--option KEY=VALUE`**, repeatable. Overrides **any** key, including ones the table doesn't otherwise know — that's the point, since those were exactly the keys silently taking registered defaults.
- **The effective configuration is printed before the run**, and says explicitly when the BIOS setting is the *tool default* rather than a choice:

```
config: virtualjaguar_bios=disabled (overridden)  blitter=fast
config: virtualjaguar_risc_idle_skip=disabled (overridden)
```

versus, with no overrides:

```
config: virtualjaguar_bios=enabled (TOOL DEFAULT -- real BIOS)  blitter=fast
config: no --option overrides; every other core option uses its REGISTERED default
```

## Defaults deliberately unchanged

Every historical number from this tool was taken in real-BIOS mode with the fast blitter. Changing the default would silently invalidate comparisons against those numbers rather than fixing anything — the problem was that the choice was invisible, not that it was wrong.

## Immediately useful

The measurement this unblocks, run on White Men Can't Jump:

| config | dsp_opcodes (total) |
|---|---|
| real BIOS (the old forced default) | 335,030,047 |
| **HLE + idle-skip off** | **1,319** |

The DSP runs ~1.3k opcodes at startup and never executes again for the rest of the session. That was impossible to measure with this tool before.

## Verification

Builds clean, `scripts/c89-lint.sh` clean, and the override is confirmed to actually take effect via the new banner (not just accepted and ignored).
