### PR TITLE
fix(dsp): don't deliver a CPU interrupt to a stopped DSP (#635)

### DIFF
--- a/src/jerry/dsp.c
+++ b/src/jerry/dsp.c
@@ -810,9 +810,45 @@ void DSPWriteLong(uint32_t offset, uint32_t data, uint32_t who/*=UNKNOWN*/)
                // Check for CPU -> DSP interrupt
                if (data & DSPINT0)
                {
-                  m68k_end_timeslice();
-                  DSPReleaseTimeslice();
-                  DSPSetIRQLine(DSPIRQ_CPU, ASSERT_LINE);
+                  /* Only deliver a CPU->DSP interrupt when the DSP is
+                   * actually RUNNING (issue #635, White Men Can't Jump).
+                   *
+                   * The game stops its DSP by raising DSPINT0 -- its INT0
+                   * handler is a shutdown routine ($F1B76A: disable
+                   * INT_ENA0/1, clear the latches, write $20 to D_CTRL so
+                   * DSPGO clears).  Its reload sequence is: stop, copy a
+                   * fresh 2.5KB program over DSP RAM, set D_PC, set DSPGO.
+                   *
+                   * At the stop, DSPGO is ALREADY clear (the traced write
+                   * is OR.L #4 over a prior value of $820, bit 0 = 0), so
+                   * there is no running program to consume the interrupt.
+                   * Delivered unconditionally, the latch survives into the
+                   * NEWLY started program, which enables INT_ENA0/1 during
+                   * its own init and immediately services it -- running the
+                   * shutdown handler and stopping itself after ~1,319
+                   * opcodes.  The 68K then posts command $0D to the mailbox
+                   * at $F1B2C0, nothing ever consumes it, and the next
+                   * caller spins forever at $01C306 waiting for it to clear.
+                   * The GPU stops being fed and the picture freezes.
+                   *
+                   * The game cannot rely on the latch being cleared later:
+                   * its start routine writes D_FLAGS <- 0, and JTRM Rev 8 is
+                   * explicit that "writing a zero leaves them unchanged".
+                   *
+                   * JTRM Rev 8 does NOT state whether a CPU interrupt raised
+                   * while the DSP is stopped latches -- the interrupt
+                   * section describes the latches without reference to
+                   * DSPGO.  This gate is therefore argued from behaviour,
+                   * not from a manual line: the title demonstrably works on
+                   * hardware, and it cannot if a stop-interrupt is still
+                   * pending when its replacement program starts.  Worth
+                   * confirming against hardware if anyone can. */
+                  if (DSP_RUNNING)
+                  {
+                     m68k_end_timeslice();
+                     DSPReleaseTimeslice();
+                     DSPSetIRQLine(DSPIRQ_CPU, ASSERT_LINE);
+                  }
                   data &= ~DSPINT0;
                }
                // Protect writes to VERSION and the interrupt latches...


### PR DESCRIPTION
Closes #635
<!-- link-issue: #635 -->

## Summary

White Men Can't Jump freezes at its menus and produces **no audio at all**, in **both** HLE and real-BIOS modes. One condition fixes all of it: only deliver a CPU→DSP interrupt when the DSP is actually running.

## The mechanism

The game stops its DSP by raising **DSPINT0** — its INT0 handler (`$F1B340`) is a shutdown routine that disables `INT_ENA0/1`, clears the latches, and writes `$20` to `D_CTRL` so DSPGO clears. Its reload sequence is: **stop → copy a fresh 2.5 KB program over DSP RAM (`$01C370`) → set `D_PC`, set DSPGO (`$01C396`)**.

At the stop, **DSPGO is already clear** — the traced write is `OR.L #4` over a prior value of `$820`, bit 0 = 0 — so there is no running program to consume the interrupt.

Delivered unconditionally, the latch survives into the **newly started** program, which enables `INT_ENA0/1` during its own init and immediately services it — running the shutdown handler and stopping itself after ~1,319 opcodes. The 68K then posts command `$0D` to the mailbox at `$F1B2C0`; nothing consumes it; the next caller spins forever at `$01C306` waiting for it to read zero. The GPU stops being fed and the picture freezes two frames later.

The game cannot recover on its own: its start routine writes `D_FLAGS <- 0`, and JTRM Rev 8 is explicit that *"writing a zero leaves them unchanged."*

## Measured

| | before | after |
|---|---|---|
| HLE freeze (static run to end of 2500) | 1708 frames | **none** |
| real-BIOS freeze | 1890 frames | **none** |
| audio `nonsilent` samples | **0** | **1,811,463** |
| `first_audio_frame` | −1 (never) | **19** |
| DSP opcodes in 600 frames | 1,319 | **269,848,134** |

## Honest limit on the justification

**JTRM Rev 8 does not state whether a CPU interrupt raised while the DSP is stopped latches.** Its interrupt section describes the latches without reference to DSPGO. I read the manual PDF directly rather than `docs/jtrm-gpu-dsp.md`, whose CTRL section is tagged *"Derived from src/jerry/dsp.c — NOT verified against the JTRM"* (the circular provenance #522 warns about).

So this gate is **argued from behaviour, not from a manual line**: the title demonstrably works on real hardware, and it cannot if a stop-interrupt is still pending when its replacement program starts. Worth confirming against hardware if anyone can — I've said the same in the code comment rather than implying manual backing this doesn't have.

## Verification

- `make TEST_EXPORTS=1 test` → **exit 0, zero FAILs**.
- **Both** audio tests — the required pair for any DSP change, since clipping alone misses the silencing class — **PASS** on Doom, AvP, Iron Soldier and Tempest 2000.
- Sanity sweep over 5 titles: no new static framebuffers. Cybermorph shows a static attract screen; **A/B'd against an unmodified build** to confirm that is pre-existing, not a regression.

`regression_test.sh` could not be run on this host (`clang++` resolves to a ccache shim pointing at a stale Swift toolchain, which breaks the C++ miniretro at its first build step — pre-existing and unrelated). CI runs it.

## Provenance

The full investigation is in #635, including five eliminated hypotheses (`risc_idle_skip`, the DSPGO tight-poll auto-clear, an internal emulator halt path, a DSPINT0 latching-model error, and a stop/restart race) and every correction I made along the way. The two probes that made it measurable are in PR #722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
