### PR TITLE
feat(debug): opt-in LAN binding for the GDB stub, with a peer check (#652)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2155,9 +2155,14 @@ test/test_titlehook: test/tools/test_titlehook.c src/core/titlehook.c \
 # GDB Remote Serial Protocol engine (issue #652, Phase 1).  Pure protocol
 # unit tests: no emulator, no sockets. src/debug/gdbstub.c never calls
 # socket() and never dereferences a Jaguar global, so it links alone here.
-test/tools/test_gdbstub_proto: test/tools/test_gdbstub_proto.c src/debug/gdbstub.c
-	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
-		-o $@ test/tools/test_gdbstub_proto.c src/debug/gdbstub.c
+test/tools/test_gdbstub_proto: test/tools/test_gdbstub_proto.c src/debug/gdbstub.c \
+		src/debug/gdbsock.c
+	@# -DINLINE: gdbsock.c pulls in src/core/log.h for the refused-peer
+	@# warning, and log.h uses INLINE, which the core build supplies via
+	@# -DINLINE="inline". Test rules get no such default.
+	$(CC) -O2 -Wall -std=c99 -DINLINE=inline $(INCFLAGS) \
+		-o $@ test/tools/test_gdbstub_proto.c src/debug/gdbstub.c \
+		src/debug/gdbsock.c
 
 test/test_event_queue: test/test_event_queue.c src/core/event.c src/core/event.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -2152,9 +2152,15 @@ test/test_titlehook: test/tools/test_titlehook.c src/core/titlehook.c \
 		-o $@ test/tools/test_titlehook.c src/core/titlehook.c \
 		src/core/titledb.c src/core/crc32.c src/core/hookfile.c
 
-# GDB Remote Serial Protocol engine (issue #652, Phase 1).  Pure protocol
-# unit tests: no emulator, no sockets. src/debug/gdbstub.c never calls
-# socket() and never dereferences a Jaguar global, so it links alone here.
+# GDB Remote Serial Protocol engine (issue #652).  No emulator:
+# src/debug/gdbstub.c never dereferences a Jaguar global.
+#
+# gdbsock.c is linked too, for the bind-mode fail-closed tests (#652 LAN
+# option).  It DOES contain socket code, but none of it runs here -- the
+# tests only exercise GDBSockSetBindMode()/GDBSockGetBindMode(), which
+# touch a single static and never open a socket.  Linking the real file
+# rather than a stub is the point: it is the shipped default that must
+# be proven safe, not a copy of it.
 test/tools/test_gdbstub_proto: test/tools/test_gdbstub_proto.c src/debug/gdbstub.c \
 		src/debug/gdbsock.c
 	@# -DINLINE: gdbsock.c pulls in src/core/log.h for the refused-peer

--- a/docs/gdb-stub-guide.md
+++ b/docs/gdb-stub-guide.md
@@ -197,8 +197,23 @@ implementation was actually verified against; please file an issue with what you
 
 ## Security notes (short version — see the design doc for the full reasoning)
 
-- The listener binds `127.0.0.1` only, always. There is no option to change this. If you need to
-  reach it from another machine, forward the port yourself (e.g. `ssh -L`).
+- **The listener binds `127.0.0.1` by default.** On desktop, if you only need it from another
+  machine occasionally, forwarding the port yourself is still the safest route
+  (`ssh -L 2345:127.0.0.1:2345 <host>`) — it needs no core option and no open port.
+- **`GDB Stub: Network Binding` (`virtualjaguar_gdb_bind`) can widen that to `lan`.** This exists
+  for the case SSH cannot cover: debugging a game running on a phone, tablet or TV, where there is
+  no shell on the device to forward from. Understand what you are turning on:
+  - **The GDB remote protocol has no authentication of any kind.** While the stub is open on the
+    LAN, anyone who can reach the port can read and write the emulated machine's memory and control
+    its execution. There is no password, no token, and no handshake to add one to.
+  - Connections from **public (non-private) addresses are refused and logged** even in `lan` mode —
+    only RFC1918, CGNAT (100.64/10), link-local and loopback peers are accepted. That stops the
+    silent accidental case (carrier NAT, a misconfigured hotspot). It does **not** make a hostile
+    LAN safe, and it will also refuse a legitimate VPN peer on a public range.
+  - It is **latched once at content load**, so changing it mid-session does nothing until you reload.
+  - It **fails closed**: absent, unset or unrecognised values resolve to loopback.
+  - When `lan` is active the core logs a warning naming the address and port, and shows an on-screen
+    banner saying the stub is open to your network. Turn it back to `loopback` when you are done.
 - Only one client at a time; a second connection attempt is closed immediately.
 - Every memory read and write is bounds-checked against the emulated map — a malformed or
   hostile packet cannot read or write outside emulated space.

--- a/libretro.c
+++ b/libretro.c
@@ -6059,7 +6059,7 @@ bool retro_load_game(const struct retro_game_info *info)
       {
          if (GDBSockOpen(gdb_stub_port) == 0)
          {
-            char gdb_msg_text[96];
+            char gdb_msg_text[160];  /* both warnings fit in LAN mode */
 
             gdb_stub_socket_open = true;
             GDBTargetOpen();
@@ -6074,10 +6074,15 @@ bool retro_load_game(const struct retro_game_info *info)
                int lan = (GDBSockGetBindMode() == GDB_BIND_LAN);
                const char *host = lan ? "0.0.0.0" : "127.0.0.1";
 
+               /* The freeze warning applies in BOTH modes -- binding
+                * scope changes who can reach the stub, not what a halt
+                * does to the frontend. An earlier revision dropped it
+                * from the LAN banner, which made the banner say less
+                * exactly when more is at stake. */
                snprintf(gdb_msg_text, sizeof(gdb_msg_text),
-                        "GDB stub listening on %s:%d%s", host, gdb_stub_port,
-                        lan ? " -- OPEN TO YOUR NETWORK" : " -- halts freeze "
-                              "this frontend");
+                        "GDB stub listening on %s:%d%s -- halts freeze this "
+                        "frontend", host, gdb_stub_port,
+                        lan ? " OPEN TO YOUR NETWORK;" : "");
                gdb_stub_show_banner(gdb_msg_text);
 
                if (lan)

--- a/libretro.c
+++ b/libretro.c
@@ -5995,6 +5995,23 @@ bool retro_load_game(const struct retro_game_info *info)
       struct retro_variable timeout_var;
       int halt_timeout_seconds = 0;
 
+      /* Bind scope (issue #652).  Latched ONCE here, alongside the gate
+       * and for the same raw-read reason: a per-title DB row must never
+       * be able to widen the debug socket beyond loopback.  Anything but
+       * an explicit "lan" resolves to loopback inside
+       * GDBSockSetBindMode(), so an absent or garbled value fails
+       * closed. */
+      {
+         struct retro_variable bind_var;
+         bind_var.key   = "virtualjaguar_gdb_bind";
+         bind_var.value = NULL;
+         if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &bind_var)
+             && bind_var.value && !strcmp(bind_var.value, "lan"))
+            GDBSockSetBindMode(GDB_BIND_LAN);
+         else
+            GDBSockSetBindMode(GDB_BIND_LOOPBACK);
+      }
+
       gdb_var.key   = "virtualjaguar_gdb_stub";
       gdb_var.value = NULL;
       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &gdb_var) && gdb_var.value)
@@ -6050,13 +6067,42 @@ bool retro_load_game(const struct retro_game_info *info)
             if (gdb_stub_wait_at_boot)
                GDBTargetArmWaitAtBoot();
 
-            snprintf(gdb_msg_text, sizeof(gdb_msg_text),
-                     "GDB stub listening on 127.0.0.1:%d -- halts will "
-                     "freeze this frontend", gdb_stub_port);
-            gdb_stub_show_banner(gdb_msg_text);
-            LOG_INF("[GDB] stub listening on 127.0.0.1:%d%s%s\n", gdb_stub_port,
-                    gdb_stub_wait_at_boot ? " (halting at boot)" : "",
-                    halt_timeout_seconds > 0 ? " (halt-timeout armed)" : "");
+            {
+               /* Say WHICH address, never a hardcoded 127.0.0.1 -- the
+                * bind scope is now a user choice, and a banner that lies
+                * about it is worse than no banner. */
+               int lan = (GDBSockGetBindMode() == GDB_BIND_LAN);
+               const char *host = lan ? "0.0.0.0" : "127.0.0.1";
+
+               snprintf(gdb_msg_text, sizeof(gdb_msg_text),
+                        "GDB stub listening on %s:%d%s", host, gdb_stub_port,
+                        lan ? " -- OPEN TO YOUR NETWORK" : " -- halts freeze "
+                              "this frontend");
+               gdb_stub_show_banner(gdb_msg_text);
+
+               if (lan)
+                  /* WRN, not INF: this is the one configuration where an
+                   * unattended core is remotely controllable, and the RSP
+                   * protocol has no authentication.  It must be visible in
+                   * a log someone skims. */
+                  LOG_WRN("[GDB] stub listening on %s:%d -- REACHABLE FROM "
+                          "YOUR LOCAL NETWORK. The GDB protocol has no "
+                          "authentication: anyone who can reach this port "
+                          "can read/write emulated memory and control "
+                          "execution. Public (non-private) peers are refused. "
+                          "Set GDB Stub: Network Binding back to 'loopback' "
+                          "when you are done.%s%s\n",
+                          host, gdb_stub_port,
+                          gdb_stub_wait_at_boot ? " (halting at boot)" : "",
+                          halt_timeout_seconds > 0
+                             ? " (halt-timeout armed)" : "");
+               else
+                  LOG_INF("[GDB] stub listening on %s:%d%s%s\n", host,
+                          gdb_stub_port,
+                          gdb_stub_wait_at_boot ? " (halting at boot)" : "",
+                          halt_timeout_seconds > 0
+                             ? " (halt-timeout armed)" : "");
+            }
          }
          else
          {

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -631,7 +631,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "virtualjaguar_gdb_stub",
       "GDB Debug Stub (Restart)",
       NULL,
-      "Open a GDB remote debugging server on localhost so a debugger can inspect the emulated machine. Developer-facing; leave disabled for normal play. The server only ever listens on 127.0.0.1 -- it is not reachable from another machine. Requires a restart.",
+      "Open a GDB remote debugging server on localhost so a debugger can inspect the emulated machine. Developer-facing; leave disabled for normal play. By default the server listens only on 127.0.0.1 and is not reachable from another machine; 'GDB Stub: Network Binding' can widen that to your local network, with the security consequences described there. Requires a restart.",
       NULL,
       "diagnostics",
       {
@@ -640,6 +640,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "disabled"
+   },
+   {
+      "virtualjaguar_gdb_bind",
+      "GDB Stub: Network Binding (Debug)",
+      NULL,
+      "Which addresses the GDB stub will accept debugger connections from. 'Loopback' (default) accepts only connections from this same machine -- on a phone, tablet or TV that means nothing outside the device can ever reach it. 'LAN' additionally accepts connections from your local network, so you can debug a game running on another device from your computer. SECURITY: the GDB protocol has NO authentication of any kind. While the stub is open, anyone who can reach the port can read and write the emulated machine's memory and control its execution. Only use 'LAN' on a network you trust, only while you are actually debugging, and turn it back off afterwards. Connections from public (non-private) addresses are refused and logged even in 'LAN' mode. Has no effect unless GDB Stub is enabled. Takes effect on content load.",
+      NULL,
+      "diagnostics",
+      {
+         { "loopback", "Loopback (this machine only)" },
+         { "lan",      "LAN (local network -- see warning)" },
+         { NULL, NULL },
+      },
+      "loopback"
    },
    {
       "virtualjaguar_gdb_port",

--- a/src/debug/gdbsock.c
+++ b/src/debug/gdbsock.c
@@ -10,6 +10,7 @@
 #endif
 #include <string.h>
 #include "gdbstub.h"
+#include "log.h"   /* refused-peer warning; same logger gdbtarget.c uses */
 
 #if defined(_WIN32) || defined(__unix__) || defined(__APPLE__) || \
     defined(__linux__) || defined(__ANDROID__)
@@ -62,6 +63,40 @@ static void GDBSetNonBlocking(gdb_sock_t s)
 #endif
 }
 
+/* Default is the safe one, so a caller that never sets it -- a test, or a
+ * frontend that does not know the option exists -- gets loopback. */
+static int gdbBindMode = GDB_BIND_LOOPBACK;
+
+void GDBSockSetBindMode(int mode)
+{
+   /* Anything that is not explicitly LAN resolves to loopback: fail
+    * closed, so a garbled or future option value cannot widen the bind. */
+   gdbBindMode = (mode == GDB_BIND_LAN) ? GDB_BIND_LAN : GDB_BIND_LOOPBACK;
+}
+
+int GDBSockGetBindMode(void)
+{
+   return gdbBindMode;
+}
+
+/* Is this peer on a network we are willing to accept from?
+ *
+ * RFC1918 (10/8, 172.16/12, 192.168/16), CGNAT 100.64/10, link-local
+ * 169.254/16, and loopback.  Anything else -- i.e. a routable public
+ * address -- is refused.  Deliberately conservative: a VPN peer on a
+ * non-private range is refused too, which is visible in the log rather
+ * than silent. */
+static int gdb_peer_allowed(uint32_t hostorder)
+{
+   if ((hostorder & 0xFF000000u) == 0x7F000000u) return 1; /* 127/8      */
+   if ((hostorder & 0xFF000000u) == 0x0A000000u) return 1; /* 10/8       */
+   if ((hostorder & 0xFFF00000u) == 0xAC100000u) return 1; /* 172.16/12  */
+   if ((hostorder & 0xFFFF0000u) == 0xC0A80000u) return 1; /* 192.168/16 */
+   if ((hostorder & 0xFFC00000u) == 0x64400000u) return 1; /* 100.64/10  */
+   if ((hostorder & 0xFFFF0000u) == 0xA9FE0000u) return 1; /* 169.254/16 */
+   return 0;
+}
+
 int GDBSockOpen(int port)
 {
    struct sockaddr_in addr;
@@ -80,8 +115,11 @@ int GDBSockOpen(int port)
    memset(&addr, 0, sizeof(addr));
    addr.sin_family      = AF_INET;
    addr.sin_port        = htons((unsigned short)port);
-   /* Loopback ONLY. Never INADDR_ANY -- this is a security invariant. */
-   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   /* Loopback unless the user deliberately opted into LAN for this
+    * session (issue #652).  Loopback remains the DEFAULT and the
+    * fallback for any unrecognised option value -- see gdbstub.h. */
+   addr.sin_addr.s_addr = htonl(gdbBindMode == GDB_BIND_LAN
+                                ? INADDR_ANY : INADDR_LOOPBACK);
 
    if (bind(gdbListen, (struct sockaddr *)&addr, sizeof(addr)) != 0 ||
        listen(gdbListen, 1) != 0)
@@ -116,9 +154,32 @@ int GDBSockPoll(void)
    if (gdb_sock_valid(gdbClient))
       return 1;
 
-   incoming = accept(gdbListen, NULL, NULL);
-   if (!gdb_sock_valid(incoming))
-      return 0;
+   {
+      struct sockaddr_in peer;
+      socklen_t          plen = (socklen_t)sizeof(peer);
+
+      memset(&peer, 0, sizeof(peer));
+      incoming = accept(gdbListen, (struct sockaddr *)&peer, &plen);
+      if (!gdb_sock_valid(incoming))
+         return 0;
+
+      /* Only meaningful when bound beyond loopback; harmless otherwise,
+       * since a loopback bind can only ever yield a 127/8 peer. */
+      if (gdbBindMode == GDB_BIND_LAN
+          && !gdb_peer_allowed(ntohl(peer.sin_addr.s_addr)))
+      {
+         {
+            uint32_t a = ntohl(peer.sin_addr.s_addr);
+            LOG_WRN("[gdb] REFUSED connection from %u.%u.%u.%u -- not a "
+                    "private/link-local address. gdb_bind=lan accepts only "
+                    "RFC1918, CGNAT, link-local and loopback peers.\n",
+                    (unsigned)((a >> 24) & 0xFF), (unsigned)((a >> 16) & 0xFF),
+                    (unsigned)((a >> 8) & 0xFF), (unsigned)(a & 0xFF));
+         }
+         gdb_closesock(incoming);
+         return 0;
+      }
+   }
 
    GDBSetNonBlocking(incoming);
    gdbClient = incoming;
@@ -167,6 +228,8 @@ int GDBSockHasClient(void)
 #else /* no BSD sockets on this target */
 
 int  GDBSockOpen(int port) { (void)port; return -1; }
+void GDBSockSetBindMode(int mode) { (void)mode; }
+int  GDBSockGetBindMode(void) { return GDB_BIND_LOOPBACK; }
 void GDBSockClose(void)    { }
 int  GDBSockPoll(void)     { return 0; }
 int  GDBSockRecv(char *buf, int max) { (void)buf; (void)max; return 0; }

--- a/src/debug/gdbsock.c
+++ b/src/debug/gdbsock.c
@@ -170,8 +170,9 @@ int GDBSockPoll(void)
       {
          {
             uint32_t a = ntohl(peer.sin_addr.s_addr);
-            LOG_WRN("[gdb] REFUSED connection from %u.%u.%u.%u -- not a "
-                    "private/link-local address. gdb_bind=lan accepts only "
+            LOG_WRN("[GDB] REFUSED connection from %u.%u.%u.%u -- not a "
+                    "private/link-local address. virtualjaguar_gdb_bind=lan "
+                    "accepts only "
                     "RFC1918, CGNAT, link-local and loopback peers.\n",
                     (unsigned)((a >> 24) & 0xFF), (unsigned)((a >> 16) & 0xFF),
                     (unsigned)((a >> 8) & 0xFF), (unsigned)(a & 0xFF));

--- a/src/debug/gdbstub.h
+++ b/src/debug/gdbstub.h
@@ -237,8 +237,10 @@ int GDBSockHasClientAttachEvent(void);
  * opt-in, per session, and never the value an unset/garbled option
  * resolves to.
  *
- * GDB_BIND_LAN additionally rejects any peer outside RFC1918 /
- * link-local / loopback at accept() time.  That does not make a hostile
+ * GDB_BIND_LAN additionally rejects, at accept() time, any peer outside
+ * RFC1918 (10/8, 172.16/12, 192.168/16), CGNAT (100.64/10), link-local
+ * (169.254/16) and loopback -- gdb_peer_allowed() in gdbsock.c is the
+ * authority on that list.  That does not make a hostile
  * LAN safe; it exists to stop the SILENT accidental case -- a public
  * address via carrier NAT or a misconfigured hotspot -- which is the
  * failure a user cannot notice. A refused peer is logged. */

--- a/src/debug/gdbstub.h
+++ b/src/debug/gdbstub.h
@@ -228,6 +228,29 @@ int GDBSockHasClientAttachEvent(void);
  * rest are inert, so the caller degrades to "stub unavailable" rather
  * than failing content load.
  */
+/* Bind scope for the listening socket (issue #652).
+ *
+ * DEFAULT AND FALLBACK IS LOOPBACK.  An open GDB stub is arbitrary read
+ * and write of emulated memory plus control of execution, and the RSP
+ * protocol carries NO authentication whatsoever -- anyone who can reach
+ * the port owns the emulated machine.  So binding beyond loopback is
+ * opt-in, per session, and never the value an unset/garbled option
+ * resolves to.
+ *
+ * GDB_BIND_LAN additionally rejects any peer outside RFC1918 /
+ * link-local / loopback at accept() time.  That does not make a hostile
+ * LAN safe; it exists to stop the SILENT accidental case -- a public
+ * address via carrier NAT or a misconfigured hotspot -- which is the
+ * failure a user cannot notice. A refused peer is logged. */
+#define GDB_BIND_LOOPBACK 0
+#define GDB_BIND_LAN      1
+
+/* Latched once at content load from the raw core option; never re-read
+ * mid-session, so a settings change cannot widen a socket that is
+ * already open. */
+void GDBSockSetBindMode(int mode);
+int  GDBSockGetBindMode(void);
+
 int GDBSockOpen(int port);
 void GDBSockClose(void);
 int GDBSockPoll(void);

--- a/test/tools/test_gdbstub_proto.c
+++ b/test/tools/test_gdbstub_proto.c
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include <libretro.h>
 #include "../../src/debug/gdbstub.h"
 
 /* ------------------------------------------------------------------ */
@@ -17,6 +18,12 @@
 /* ------------------------------------------------------------------ */
 
 static int tf_pass = 0, tf_fail = 0, tf_skip = 0;
+/* gdbsock.c logs a refused non-private peer (#652) through src/core/log.h.
+ * NULL makes VJ_LOG fall back to its vj_log_stderr path, so the warning
+ * still works standalone instead of the include becoming a link error --
+ * same stub test_blitter_mmio.c and test_titlehook.c already use. */
+retro_log_printf_t vj_log_cb = NULL;
+
 static const char *tf_suite = "";
 static const char *tf_name = "";
 static bool tf_failed = false;
@@ -566,6 +573,37 @@ TEST(hg_selects_thread_and_qc_reports_it) {
     ASSERT_STR(reply, "QC2");
 }
 
+
+/* Bind scope (issue #652).  The DEFAULT is the whole point: an open GDB
+ * stub is unauthenticated read/write of the emulated machine, so the safe
+ * value must be what you get from doing nothing, from an absent option,
+ * and from any value we do not recognise.  These four assertions are what
+ * stop that default drifting in a later refactor. */
+TEST(bind_mode_defaults_to_loopback) {
+    /* No setter call -- a frontend that never heard of this option, or a
+     * test, must still get loopback. */
+    ASSERT_EQ(GDBSockGetBindMode(), GDB_BIND_LOOPBACK);
+}
+
+TEST(bind_mode_lan_is_settable) {
+    GDBSockSetBindMode(GDB_BIND_LAN);
+    ASSERT_EQ(GDBSockGetBindMode(), GDB_BIND_LAN);
+    GDBSockSetBindMode(GDB_BIND_LOOPBACK);
+}
+
+TEST(bind_mode_unknown_value_fails_closed) {
+    GDBSockSetBindMode(GDB_BIND_LAN);
+    GDBSockSetBindMode(99);          /* garbage / future value */
+    ASSERT_EQ(GDBSockGetBindMode(), GDB_BIND_LOOPBACK);
+}
+
+TEST(bind_mode_returns_to_loopback) {
+    GDBSockSetBindMode(GDB_BIND_LAN);
+    GDBSockSetBindMode(GDB_BIND_LOOPBACK);
+    ASSERT_EQ(GDBSockGetBindMode(), GDB_BIND_LOOPBACK);
+}
+
+
 int main(void) {
     int total_fail = 0;
 
@@ -618,6 +656,10 @@ int main(void) {
     RUN(qrcmd_without_monitor_op_is_unsupported);
     RUN(thread_roster_is_fixed_at_three);
     RUN(hg_selects_thread_and_qc_reports_it);
+    RUN(bind_mode_defaults_to_loopback);
+    RUN(bind_mode_lan_is_settable);
+    RUN(bind_mode_unknown_value_fails_closed);
+    RUN(bind_mode_returns_to_loopback);
     total_fail += REPORT();
 
     return total_fail;


### PR DESCRIPTION
Refs #652
<!-- link-issue: #652 -->

## Why

The stub bound `INADDR_LOOPBACK` unconditionally. Right as a default, but it makes one real case impossible: **debugging a game running on a phone, tablet or TV.** SSH port-forwarding covers desktop-to-desktop; a stock iOS/tvOS device has no shell to forward *from*, so there was no path at all.

## What

New core option **`virtualjaguar_gdb_bind`** — `loopback` (default) / `lan`. The plumbing is four lines; the security posture is the actual design:

- **Fails closed.** Absent, unset or unrecognised values resolve to loopback inside `GDBSockSetBindMode()`, *and* the module's initial value is loopback — so a caller that never sets it (a test, or a frontend that has never heard of the option) still gets the safe bind.
- **Read raw via `environ_cb`**, never `get_variable_pertitle()` — same rule as the enhancement-hooks gate. A per-title DB row must not be able to open a debug socket on the user's behalf.
- **Latched once at content load**, so changing the setting mid-session can't widen an already-open socket.
- **Peer check at `accept()`.** In `lan` mode only RFC1918, CGNAT (100.64/10), link-local and loopback peers are accepted; anything routable is closed and logged with its address.
- **Loud.** `LOG_WRN` (not INF) naming the bound address and port, plus the on-screen banner, whenever `lan` is live.

## What the peer check does and doesn't do

It stops the **silent accidental** case — a public address via carrier NAT, a misconfigured hotspot — which is the failure a user cannot notice. It does **not** make a hostile LAN safe, and it will refuse a legitimate VPN peer on a public range (visibly, in the log). That trade is stated rather than implied.

**The GDB remote protocol has no authentication of any kind**, and nothing here adds any. While the stub is open on the LAN, anyone who can reach the port can read/write emulated memory and control execution. That's in the option text, the user guide, and the header comment.

## Two things corrected in passing

- The banner previously printed a hardcoded `127.0.0.1`. It now reports the **actual** bound address — otherwise it would have become a lie in `lan` mode.
- The `gdb_stub` option's own description asserted the server *"only ever listens on 127.0.0.1 — it is not reachable from another machine."* No longer unconditionally true; reworded.

## Tests

Four fail-closed assertions in `test_gdbstub_proto` (**22 total, was 18**): default is loopback with no setter call, explicit LAN is honoured, an unrecognised value falls back to loopback rather than LAN, and LAN can be turned back off. Those are what stop the default drifting in a later refactor.

Linking `gdbsock.c` into that test needed `-DINLINE=inline` (for `log.h`) and the `vj_log_cb` stub that `test_blitter_mmio.c` and `test_titlehook.c` already use.

## Not verified

Whether **iOS/tvOS** permits RetroArch to accept inbound LAN connections without a local-network entitlement prompt. Listening is generally allowed, but I have not tested it on a device and this PR does not claim it works there — that's the next thing to try, and the reason the option exists.

## Verification

`make TEST_EXPORTS=1 test` → exit 0, zero FAILs. `scripts/c89-lint.sh` clean on every touched `.c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
