### PR TITLE
test(cd): assert no-content boot renders and progresses, not just resolves (#726)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2061,6 +2061,15 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# REM SESSION markers and CDI headers declare numSessions=2 -- so it
 	@# would pass against a data disc for the wrong reason.  Ledgered as a
 	@# skip rather than written to look like coverage.
+	@# Case 5 (no-content boot renders AND progresses, #726) takes NO disc
+	@# and must NOT sit inside the corpus guard below.  It is the
+	@# regression cover for the bug that shipped in v3.6.0, so it has to
+	@# run on public CI and on contributor machines, which are exactly the
+	@# checkouts with no test/roms/private.  An earlier revision nested it
+	@# in the `if [ -n "$$disc" ]` block, where it silently ran nowhere but
+	@# a corpus machine.
+	./test/tools/test_disk_control ./$(TARGET) --case 5 --quiet
+
 	@bash scripts/test-skip.sh record "Disk control audio-disc insert (#651)" \
 		"no one-session (Red Book) disc in the private corpus"
 	@disc=$$(find -L test/roms/private -iname '*.cdi' -o -iname '*.cue' 2>/dev/null | head -1); \
@@ -2068,7 +2077,6 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		rc=0; \
 		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 1 --quiet || rc=1; \
 		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 3 --quiet || rc=1; \
-		./test/tools/test_disk_control ./$(TARGET) --case 5 --quiet || rc=1; \
 		discb=$$(find -L test/roms/private -iname '*.cdi' -o -iname '*.cue' 2>/dev/null | sed -n 2p); \
 		if [ -n "$$discb" ]; then \
 			if ./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --disc-b "$$discb" --case 4 --quiet; then :; \

--- a/Makefile
+++ b/Makefile
@@ -2068,6 +2068,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		rc=0; \
 		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 1 --quiet || rc=1; \
 		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 3 --quiet || rc=1; \
+		./test/tools/test_disk_control ./$(TARGET) --case 5 --quiet || rc=1; \
 		discb=$$(find -L test/roms/private -iname '*.cdi' -o -iname '*.cue' 2>/dev/null | sed -n 2p); \
 		if [ -n "$$discb" ]; then \
 			if ./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --disc-b "$$discb" --case 4 --quiet; then :; \

--- a/test/tools/test_disk_control.c
+++ b/test/tools/test_disk_control.c
@@ -91,6 +91,50 @@ static int strategy_is_cd(void)
     return strcmp(n, "hle") == 0 || strcmp(n, "bios") == 0;
 }
 
+/* Frame-progression tracking for case 5 (issue #726).
+ *
+ * Cases 1/3/4 assert which boot STRATEGY resolved.  That is necessary and
+ * not sufficient: a machine that resolves the right strategy and then
+ * freezes on the boot ROM's red logo passes every one of them, which is
+ * exactly how the v3.6.0 no-content regression shipped.  So this tracks
+ * whether the picture actually CHANGES, which is the thing a user sees. */
+static uint32_t vid_hash;         /* FNV-1a over the frame just delivered */
+static uint32_t vid_prev_hash;
+static unsigned vid_frames;       /* frames the core actually delivered   */
+static unsigned vid_changes;      /* frames whose pixels differed         */
+static unsigned vid_nonblack;     /* frames with any non-black pixel      */
+
+static void vid_cb(void *ud, const void *data, unsigned w, unsigned h,
+                   size_t pitch)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    uint32_t hsh = 2166136261u;
+    unsigned y, x;
+    int nonblack = 0;
+
+    (void)ud;
+    if (!p)                       /* duped frame: no new pixels */
+        return;
+    vid_frames++;
+    for (y = 0; y < h; y++)
+    {
+        const uint32_t *row = (const uint32_t *)(p + (size_t)y * pitch);
+        for (x = 0; x < w; x++)
+        {
+            uint32_t px = row[x];
+            hsh = (hsh ^ (px & 0x00FFFFFFu)) * 16777619u;
+            if (px & 0x00FFFFFFu)
+                nonblack = 1;
+        }
+    }
+    if (nonblack)
+        vid_nonblack++;
+    if (vid_frames > 1 && hsh != vid_prev_hash)
+        vid_changes++;
+    vid_prev_hash = hsh;
+    vid_hash      = hsh;
+}
+
 static harness_result mkres(int ok, const char *name, const char *detail)
 {
     harness_result r;
@@ -121,20 +165,28 @@ int main(int argc, char **argv)
         else if (strcmp(argv[i], "--disc-b") == 0 && i + 1 < argc)
             disc_path_b = argv[i + 1];
     }
-    if (case_num != 1 && case_num != 3 && case_num != 4) {
+    if (case_num != 1 && case_num != 3 && case_num != 4
+        && case_num != 5) {
         fprintf(stderr, "usage: test_disk_control <core> --disc <image> "
-                        "--case N[1|3|4] [--quiet]\n"
+                        "--case N[1|3|4|5] [--quiet]\n"
                         "  (case 2 needs a one-session audio disc; none "
                         "exists in the corpus)\n");
         return 1;
     }
-    if (!disc_path) {
+    if (!disc_path && case_num != 5) {
         fprintf(stderr, "test_disk_control: no --disc given\n");
         return 1;
     }
 
     cfg.frames = 10;
     cfg.quiet  = 1;
+    if (case_num == 5)
+    {
+        /* Long enough for the boot ROM to get past its first screen if it
+         * is going to; short enough to stay a unit test. */
+        cfg.frames         = 600;
+        cfg.video_callback = vid_cb;
+    }
 
     /* Must be set before the load: the core registers disk control during
      * retro_load_game, and the harness refuses the env call unless this
@@ -244,6 +296,43 @@ int main(int argc, char **argv)
                    : "state refused on its OWN disc -- the check is too "
                      "strict, not just strict");
         pass = saved && cross_refused && own_ok;
+        break;
+    }
+    case 5: {
+        /* No-content boot must RENDER, not just resolve (issue #726).
+         *
+         * Two assertions, and the second is the one that matters:
+         *   - the boot ROM puts something on screen at all, and
+         *   - the picture keeps CHANGING.
+         *
+         * A frozen red Jaguar logo satisfies "non-black" forever, so
+         * non-black alone would be another vacuous check. Motion is what
+         * separates "booting" from "wedged on the logo".
+         *
+         * Deliberately no assertion about WHICH screen: this test should
+         * survive a future change to what a bare console shows. */
+        int rendered, moving;
+
+        harness_run(&cfg);
+
+        rendered = (vid_frames > 0 && vid_nonblack > 0);
+        /* >=2 distinct images over the window. Generous on purpose: the
+         * bar is "not frozen", not "animates smoothly". */
+        moving   = (vid_changes >= 2);
+
+        results[nres++] = mkres(rendered, "case5_no_content_renders",
+            rendered ? "bare-console boot put a non-black image on screen"
+                     : "bare-console boot rendered nothing (or all black)");
+        results[nres++] = mkres(moving, "case5_no_content_progresses",
+            moving ? "the picture changes -- the machine is running"
+                   : "the picture NEVER CHANGES -- wedged on the boot screen "
+                     "(this is issue #726: strategy resolves, machine does "
+                     "not run)");
+
+        fprintf(stderr, "  [case5] frames=%u nonblack=%u changes=%u\n",
+                vid_frames, vid_nonblack, vid_changes);
+
+        pass = rendered && moving;
         break;
     }
     case 3: {

--- a/test/tools/test_disk_control.c
+++ b/test/tools/test_disk_control.c
@@ -98,11 +98,11 @@ static int strategy_is_cd(void)
  * freezes on the boot ROM's red logo passes every one of them, which is
  * exactly how the v3.6.0 no-content regression shipped.  So this tracks
  * whether the picture actually CHANGES, which is the thing a user sees. */
-static uint32_t vid_hash;         /* FNV-1a over the frame just delivered */
-static uint32_t vid_prev_hash;
+static uint32_t vid_prev_hash;    /* FNV-1a over the previous frame       */
 static unsigned vid_frames;       /* frames the core actually delivered   */
 static unsigned vid_changes;      /* frames whose pixels differed         */
 static unsigned vid_nonblack;     /* frames with any non-black pixel      */
+static int      vid_bad_pitch;    /* set if the frame was not 4 bytes/px  */
 
 static void vid_cb(void *ud, const void *data, unsigned w, unsigned h,
                    size_t pitch)
@@ -115,6 +115,16 @@ static void vid_cb(void *ud, const void *data, unsigned w, unsigned h,
     (void)ud;
     if (!p)                       /* duped frame: no new pixels */
         return;
+
+    /* The harness video callback carries no pixel-format field, and this
+     * indexes rows as uint32_t -- correct for the core's XRGB8888 output,
+     * but a silent out-of-bounds read past each row if that ever became
+     * RGB565.  Validate rather than assume: a format change should fail
+     * loudly here, not read garbage and look like a flaky test. */
+    if (pitch < (size_t)w * 4) {
+        vid_bad_pitch = 1;
+        return;
+    }
     vid_frames++;
     for (y = 0; y < h; y++)
     {
@@ -132,7 +142,6 @@ static void vid_cb(void *ud, const void *data, unsigned w, unsigned h,
     if (vid_frames > 1 && hsh != vid_prev_hash)
         vid_changes++;
     vid_prev_hash = hsh;
-    vid_hash      = hsh;
 }
 
 static harness_result mkres(int ok, const char *name, const char *detail)
@@ -315,14 +324,17 @@ int main(int argc, char **argv)
 
         harness_run(&cfg);
 
-        rendered = (vid_frames > 0 && vid_nonblack > 0);
+        rendered = (vid_frames > 0 && vid_nonblack > 0 && !vid_bad_pitch);
         /* >=2 distinct images over the window. Generous on purpose: the
          * bar is "not frozen", not "animates smoothly". */
         moving   = (vid_changes >= 2);
 
         results[nres++] = mkres(rendered, "case5_no_content_renders",
             rendered ? "bare-console boot put a non-black image on screen"
-                     : "bare-console boot rendered nothing (or all black)");
+                     : (vid_bad_pitch
+                        ? "frame was not XRGB8888 (pitch < w*4) -- this test "
+                          "reads rows as uint32_t and cannot score it"
+                        : "bare-console boot rendered nothing (or all black)"));
         results[nres++] = mkres(moving, "case5_no_content_progresses",
             moving ? "the picture changes -- the machine is running"
                    : "the picture NEVER CHANGES -- wedged on the boot screen "


### PR DESCRIPTION
Refs #726
<!-- link-issue: #726 -->

## The gap this closes

Cases 1/3/4 of `test_disk_control` assert which boot **strategy** resolved. Necessary, not sufficient: a machine that resolves the right strategy and then freezes on the boot ROM's logo passes every one of them — which is exactly how the v3.6.0 no-content regression shipped **with a green suite**.

Case 5 boots with no content and watches the real framebuffer for 600 frames via `harness_video_cb`:

- something non-black reaches the screen at all, **and**
- the picture **keeps changing**.

The second is the one that matters. A frozen red Jaguar logo satisfies "non-black" forever, so non-black alone would be another vacuous check — motion is what separates *booting* from *wedged on the logo*. The bar is ≥2 distinct images, deliberately generous: the claim is "not frozen", not "animates smoothly". Nothing asserts *which* screen, so it survives a future change to what a bare console shows.

## The result redirects #726

**This test passes on develop:**

```
[case5] frames=600  nonblack=564  changes=35
PASS: bare-console boot put a non-black image on screen
PASS: the picture changes -- the machine is running
```

**The emulated machine is not wedged.** No-content boot renders and keeps rendering for 600 frames. So the reported failure — red logo, dies, can't reach the CD BIOS — is **not the core hanging**; it is something in the RetroArch path that the dlopen harness does not exercise (AV info / geometry / video presentation with no content are the obvious suspects).

That eliminates the emulator-wedge branch of the investigation, which is where I would otherwise have started.

## Why keep it, given it passes

It is the missing coverage for the assertion class that let this ship in the first place, it costs 600 headless frames, and it now guards the property a user actually cares about. Wired into `make test`.

## Verification

`make TEST_EXPORTS=1 test` → exit 0, zero FAILs. `scripts/c89-lint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
