### PR TITLE
test(acid): record the four GPU/render timing tests in the baseline

### DIFF
--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -130,6 +130,9 @@
 [PASS tests/stress/many_blits.jag
 [PASS tests/stress/rapid_irq_pump.jag
 [PASS tests/timing/doom_update_gate_rate.jag
+[PASS tests/timing/gpu_alu_loop_rate.jag
+[PASS tests/timing/gpu_load_use_loop_rate.jag
+[PASS tests/timing/gpu_store_ext_loop_rate.jag
 [PASS tests/timing/halfline_count_per_frame.jag
 [PASS tests/timing/halfline_period_us.jag
 [PASS tests/timing/hc_advance.jag
@@ -137,6 +140,7 @@
 [PASS tests/timing/input_edge_per_field.jag
 [PASS tests/timing/jerry_pit_setup.jag
 [PASS tests/timing/pit_countdown_rate.jag
+[PASS tests/timing/render_bound_loop_rate.jag
 [PASS tests/timing/vblank_60hz_exact.jag
 [PASS tests/timing/vc_advance.jag
 [PASS tests/timing/vc_field_bit.jag


### PR DESCRIPTION
`Refs #408`
<!-- link-issue: #408 -->

## What

`check-baseline.py` has been reporting these as *"New tests (not yet in baseline)"* since they started passing:

```
tests/timing/gpu_alu_loop_rate.jag
tests/timing/gpu_load_use_loop_rate.jag
tests/timing/gpu_store_ext_loop_rate.jag
tests/timing/render_bound_loop_rate.jag
```

**Unrecorded means unprotected.** A test that isn't in `BASELINE.txt` can go PASS → FAIL and the gate still reports "no regressions", because there's nothing to compare against. Recording them is what makes the gate ratchet.

This was deliberately skipped during the v3.6.0 release cut — moving a baseline inside a release branch changes what the gate accepts at exactly the moment you least want that — and noted there for pickup on `develop`.

## Verified the ratchet, rather than trusting the green

- Baseline 146 → 150 lines, inserted in sorted position within the `tests/timing` block (the checker sorts internally, so that's for human readability, not correctness).
- Re-run against the same acid log: `Regressions: 0`, `New tests: 0`.
- **Injected a real PASS → FAIL** into a copy of that log:

```
Regressions:        1
### REGRESSIONS (was PASS, now FAIL/NOT-RUN) -- BLOCKING
  PASS -> FAIL        tests/timing/render_bound_loop_rate.jag
FAIL: regressions or missing tests detected.        (exit 1)
```

That last step earned its place: my **first** attempt at it used a `sed` pattern that didn't match the real log format (`[PASS       ]` pads *inside* the brackets), so the checker saw an unmodified log and reported "no regressions" — a verification that verified nothing. The result above is from a copy where the injected FAIL was confirmed present first.

## Acid run

147/150 passed. The three failures are the bus tests already recorded as known `[FAIL` in the baseline, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
