### PR TITLE
ci(pr-issue-link): stop reporting an API refusal as a missing link tag

### DIFF
--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -87,6 +87,57 @@ jobs:
           fi
           echo "$out"
 
+          # pr-link-issue.sh exits non-zero for TWO different reasons, and
+          # they need different advice:
+          #
+          #   a) there is no tag in the body -- the author must add one, and
+          #   b) a tag WAS found but GitHub refused the mutation.
+          #
+          # Reporting (b) as (a) sends the author hunting for a tag that is
+          # already there.  That happened on PR #725: the body carried both
+          # `Refs #652` and the HTML comment, but #652 had accumulated so
+          # many manually-linked PRs that addCloseIssueReferences returned
+          # "Issue exceeds manual reference limit" -- and this job said "no
+          # link tag in its body", which is the one thing that was untrue.
+          case "$out" in
+            *"exceeds manual reference limit"*)
+              {
+                echo "### ⚠️ Could not link -- the ISSUE is at GitHub's link limit"
+                echo
+                echo "A link tag **was** found in this PR's body. GitHub refused the"
+                echo "link because the target issue already has the maximum number of"
+                echo "manually-linked pull requests:"
+                echo
+                echo '```'
+                echo "$out"
+                echo '```'
+                echo
+                echo "Nothing is wrong with this PR. Either link a different (or newer)"
+                echo "issue, or add the \`no-issue\` label -- the work is still traceable"
+                echo "through the \`Refs #N\` text in the description."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::PR #$PR has a link tag, but the target issue is at GitHub's manual-reference limit -- see the job summary. This is NOT a missing tag."
+              exit 1
+              ;;
+            *"GraphQL"*|*"HTTP 4"*|*"HTTP 5"*|*"gh: "*)
+              {
+                echo "### ⚠️ Could not link -- the GitHub API refused the request"
+                echo
+                echo "A link tag may well be present; the API call itself failed:"
+                echo
+                echo '```'
+                echo "$out"
+                echo '```'
+                echo
+                echo "Re-run this job first -- several of these are transient. If it"
+                echo "persists, read the message above rather than assuming the tag is"
+                echo "missing."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::PR #$PR: the GitHub API refused the link (see the job summary). This is an API failure, NOT necessarily a missing link tag."
+              exit 1
+              ;;
+          esac
+
           {
             echo "### ❌ This PR is not linked to an issue"
             echo


### PR DESCRIPTION
<!-- link-issue: #679 -->
Refs #679

## The bug

`scripts/pr-link-issue.sh` exits non-zero for **two** different reasons, and this job collapsed them into one message:

- there is no link tag in the PR body, **or**
- a tag *was* found, but GitHub refused the mutation.

Reporting the second as the first sends the author hunting for a tag that is already there.

**This is not hypothetical — it happened on #725 during the v3.6.0 release.** That PR's body carried *both* `Refs #652` and the HTML-comment form. #652 had accumulated so many manually-linked PRs that `addCloseIssueReferences` returned:

```
gh: Issue exceeds manual reference limit
```

…and this job announced *"PR #725 has no linked issue and no link tag in its body"* — the one thing that was demonstrably untrue. It cost a wrong diagnosis until the job log was read closely enough to spot the real line buried above the error.

## The fix

Two branches ahead of the existing one, so the **common no-tag case is untouched**:

- **`exceeds manual reference limit`** → says the tag was found, the *issue* is at its limit, nothing is wrong with the PR, and gives the two real options (link a different issue, or the `no-issue` label).
- **any other API failure** (GraphQL / HTTP 4xx / 5xx / `gh:` error) → quotes the message, suggests a re-run since several are transient, and states explicitly that this is **not necessarily** a missing tag.

Both echo the API's own text into the job summary rather than paraphrasing, so the next person reads the actual reason rather than my guess at it.

## Verification

- Workflow YAML parses; the `run` block passes `bash -n`.
- **Each branch exercised against sample stderr, including the verbatim string from #725:**

| input | branch |
|---|---|
| `gh: Issue exceeds manual reference limit` | LIMIT |
| `gh: GraphQL: something else broke` | API-ERROR |
| `no link tag found in body` | no-tag (unchanged) |

- No line exceeds the 200-char yamllint limit (the first draft had one at 215; caught and shortened).

## Why master

`pull_request_target` reads its workflow from the **default branch**, not the PR base — the same reason #655 put the linking job here rather than on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
