### PR TITLE
fix(boot): no-content boot comes up in the CD BIOS, not an empty cart slot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ tools/jagcd/jagcd-chd-check
 tools/jagcd/chdman
 tools/jagcd/*.exe
 test/tools/blit_memo_verify
+test/tools/dsp_halt_backtrace
 test/tools/dsp_idle_ab
 test/tools/dsp_idle_probe_falsify
 test/tools/gpu_idle_ab

--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -14,7 +14,7 @@ systemname = "Jaguar"
 systemid = "atari_jaguar"
 
 # Libretro Features
-supports_no_game = "false"
+supports_no_game = "true"
 database = "Atari - Jaguar"
 savestate = "true"
 savestate_features = "3"

--- a/docs/settings-and-performance-guide.md
+++ b/docs/settings-and-performance-guide.md
@@ -449,6 +449,11 @@ disk-control interface, so a frontend can start it with no content at all and
 hand it a disc afterwards — which is what makes "launch the core, put in a
 music CD, get the Virtual Light Machine" reachable.
 
+Started with no content, the core comes up **in the CD BIOS**, on its
+insert-disc screen, which is the screen you insert *from*. No files are
+required: an external CD BIOS ROM in the system directory is preferred if you
+have one, and otherwise an embedded image is used.
+
 Two things to know about how that behaves:
 
 - **Inserting a disc restarts the console.** The boot strategy is derived from

--- a/libretro.c
+++ b/libretro.c
@@ -6267,6 +6267,21 @@ bool retro_load_game(const struct retro_game_info *info)
        * zero files present. */
       stage_cd_bios();
 
+      /* The CD unit is attached -- that is WHY the BIOS is running -- so
+       * this is CD mode with nothing in the tray, not cartridge mode.
+       * Both flags mirror open_disc_and_resolve_boot(); only the disc is
+       * missing.  Without them a machine sitting in the CD BIOS gets the
+       * options menu inverted against it (update_option_visibility() keys
+       * both gates off jaguar_cd_mode, so CD Boot Mode / CD BIOS Type
+       * would be HIDDEN and the cartridge-BIOS option shown), and the
+       * Memory Track cart -- which plugs into the CD unit and is present
+       * whether or not a disc is -- would stay absent until the first
+       * insert.  Safe with no disc: the three disc-identity accessors
+       * return zero when nothing is mounted (see the savestate chunk),
+       * and the MT save-buffer paths only touch mtMem. */
+      jaguar_cd_mode             = true;
+      jaguarMemTrackInserted     = opt_memory_track;
+
       vjs.useJaguarBIOS          = true;
       bootConfig.isCDGame        = false;
       bootConfig.showBootROM     = true;

--- a/libretro.c
+++ b/libretro.c
@@ -6242,15 +6242,36 @@ bool retro_load_game(const struct retro_game_info *info)
    }
    else if (!info)
    {
-      /* No-content boot (issue #646): ResolveBootConfig() only knows about
-       * cart/CD content, and there is no 68K program anywhere for HLE to
-       * jump into, so the real boot ROM is the only sane strategy --
-       * exactly what real hardware shows with an empty cart slot. */
+      /* No-content boot (issue #646, corrected for #726): come up in the
+       * CD BIOS, not on an empty cart slot.
+       *
+       * cd_boot_strategy_none models a bare console -- the boot ROM running
+       * against a zeroed cart window.  That is authentic for a Jaguar with
+       * no CD unit attached, but it is a dead end for the feature this path
+       * exists to serve: the CD BIOS is what offers "insert a disc", and it
+       * is mapped as a cartridge at $800000, so nothing reachable from the
+       * empty-slot screen can ever get to it.  Booting bare in order to
+       * insert a disc afterwards -- the whole point of #646 plus disk
+       * control (#651) -- was therefore unreachable, which is what #726
+       * reported as "red logo, and you cannot boot into CD".
+       *
+       * ResolveBootConfig() is still not usable here (it only knows about
+       * cart/CD content), so this mirrors its CDBOOT_BIOS arm by hand:
+       * showBootROM is forced on because the real CD BIOS path requires it.
+       *
+       * Neither call below can fail for want of a file.  stage_cd_bios()
+       * prefers an external ROM from the system directory and otherwise
+       * copies an embedded image, and bios_boot() needs no disc -- it
+       * memcpys the staged BIOS, takes the run address from $800404 and
+       * resets -- so the BIOS comes up on its own insert-disc screen with
+       * zero files present. */
+      stage_cd_bios();
+
       vjs.useJaguarBIOS          = true;
       bootConfig.isCDGame        = false;
       bootConfig.showBootROM     = true;
-      bootConfig.cdBiosAvailable = false;
-      bootConfig.strategy        = &cd_boot_strategy_none;
+      bootConfig.cdBiosAvailable = true;
+      bootConfig.strategy        = &cd_boot_strategy_bios;
    }
    else
    {

--- a/test/test_boot_config.c
+++ b/test/test_boot_config.c
@@ -584,7 +584,14 @@ TEST(no_game_env_declared)
     p_retro_deinit();
 }
 
-TEST(no_game_boot_selects_none_strategy)
+/* Renamed from no_game_boot_selects_none_strategy (#726).  It asserted
+ * IS_NONE, which pinned the bare-console boot that made the feature
+ * useless: cd_boot_strategy_none runs the boot ROM against a zeroed cart
+ * window -- the empty-slot logo -- and the CD BIOS is mapped as a
+ * cartridge, so nothing reachable from that screen could ever get to it.
+ * No-content boot exists to be a place you insert a disc FROM, so the
+ * BIOS is the correct resolution and this now pins that instead. */
+TEST(no_game_boot_selects_cd_bios_strategy)
 {
     bool loaded;
 
@@ -596,9 +603,14 @@ TEST(no_game_boot_selects_none_strategy)
             p_bootConfig->isCDGame, p_bootConfig->showBootROM,
             p_bootConfig->strategy ? p_bootConfig->strategy->name : "null");
 
+    /* isCDGame stays false: the BIOS is up, but no disc is mounted.  That
+     * pairing (bios + !isCDGame) is what the disk-control insert test uses
+     * to tell "bare BIOS" from "disc mounted". */
     ASSERT_EQ(p_bootConfig->isCDGame, false);
     ASSERT_EQ(p_bootConfig->showBootROM, true);
-    ASSERT(IS_NONE(*p_bootConfig));
+    ASSERT_EQ(p_bootConfig->cdBiosAvailable, true);
+    ASSERT(IS_BIOS(*p_bootConfig));
+    ASSERT(!IS_NONE(*p_bootConfig));
     core_teardown();
 }
 
@@ -711,7 +723,7 @@ int main(int argc, char *argv[])
     /* ---- Part 3: No-content boot (never gated -- needs no ROM) ---- */
     SUITE("No-Content Boot (RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME)");
     RUN(no_game_env_declared);
-    RUN(no_game_boot_selects_none_strategy);
+    RUN(no_game_boot_selects_cd_bios_strategy);
     RUN(no_game_save_ram_is_empty);
     RUN(no_game_runs_and_resets_without_crashing);
     total_fail += REPORT();

--- a/test/tools/test_disk_control.c
+++ b/test/tools/test_disk_control.c
@@ -221,13 +221,21 @@ int main(int argc, char **argv)
 
     switch (case_num) {
     case 1: {
-        int registered, was_none, added, inserted, now_cd;
+        int registered, was_bare_bios, added, inserted, now_cd;
 
         registered = cfg.disk_cb_registered
                   && cfg.disk_add_image_index
                   && cfg.disk_replace_image_index
                   && cfg.disk_set_eject_state;
-        was_none   = strcmp(strategy_name(), "none") == 0;
+        /* No-content boot resolves to the CD BIOS (#726), so the strategy
+         * NAME alone no longer separates before-insert from after: a
+         * real-BIOS disc resolves to "bios" as well, and asserting
+         * strategy_is_cd() on both sides would be vacuous.  isCDGame is
+         * what actually moves -- false for the bare BIOS sitting on its
+         * insert-disc screen, true once a disc is mounted -- so both
+         * halves below pair the name with it. */
+        was_bare_bios = strcmp(strategy_name(), "bios") == 0
+                     && !bootcfg->isCDGame;
 
         gi.path = disc_path;
         added    = registered
@@ -235,23 +243,27 @@ int main(int argc, char **argv)
                 && cfg.disk_replace_image_index(0, &gi)
                 && cfg.disk_set_eject_state(true);
         inserted = added && cfg.disk_set_eject_state(false);
-        now_cd   = strategy_is_cd();
+        now_cd   = strategy_is_cd() && bootcfg->isCDGame;
 
         results[nres++] = mkres(registered, "case1_interface_registered",
             registered ? "core registered the disk control ext interface"
                        : "no disk control interface registered -- every "
                          "assertion below would be vacuous");
-        results[nres++] = mkres(was_none, "case1_no_content_resolved",
-            was_none ? "strategy was \"none\" before the insert"
-                     : "strategy was not \"none\" at no-content boot");
+        results[nres++] = mkres(was_bare_bios, "case1_no_content_resolved",
+            was_bare_bios ? "no-content boot came up in the CD BIOS with no "
+                            "disc mounted"
+                          : "no-content boot did not resolve to the CD BIOS "
+                            "(#726: it must, or the insert-disc screen is "
+                            "unreachable)");
         results[nres++] = mkres(inserted, "case1_insert_succeeded",
             inserted ? "set_eject_state(false) returned true"
                      : "insert was refused");
         results[nres++] = mkres(now_cd, "case1_boot_resolution_reran",
-            now_cd ? "strategy is now a CD strategy -- resolution re-ran"
-                   : "strategy did NOT move off \"none\" -- the insert "
-                     "reset the machine without re-resolving");
-        pass = registered && was_none && inserted && now_cd;
+            now_cd ? "a disc is mounted and a CD strategy resolved -- "
+                     "resolution re-ran"
+                   : "isCDGame never went true -- the insert reset the "
+                     "machine without re-resolving");
+        pass = registered && was_bare_bios && inserted && now_cd;
         break;
     }
     case 4: {


### PR DESCRIPTION
Closes #726

## The report, and what it actually was

#726 said v3.6.0's no-content boot shows the red logo and dies, with no way to reach the CD BIOS.

**First: that report was made against a stale install.** The core in the reporter's RetroArch is `v3.5.1 e6709d2`, and its info file is v3.1.0-era. No-content boot landed in bc5b849, which `git tag --contains` puts in **v3.6.0 only** — so the installed core never had the feature. Confirmed by string-scanning the installed dylib: it has three boot paths (cart, HLE, real BIOS) and no bare-console path at all.

**But the feature was still broken**, for a different reason, and that is what this fixes.

## The real defect

No-content boot resolved to `cd_boot_strategy_none`: the boot ROM running against a zeroed cart window. That is authentic for a Jaguar with no CD unit attached — and a dead end. The CD BIOS is what offers "insert a disc", and it is mapped as a cartridge at `$800000`, so **nothing reachable from the empty-slot screen can ever get to it.** "Launch bare, insert a disc, reach the VLM" — the point of #646 + #651 and the headline of v3.6.0 — was unreachable by construction.

This resolves to the real CD BIOS instead, mirroring `ResolveBootConfig()`'s `CDBOOT_BIOS` arm by hand (it still isn't usable here — it only knows cart/CD content). Neither call can fail for want of a file: `stage_cd_bios()` prefers an external ROM and otherwise copies an embedded image, and `bios_boot()` needs no disc.

Second commit fixes the same path leaving `jaguar_cd_mode` and `jaguarMemTrackInserted` at their cartridge defaults — see the Copilot thread below.

## Measured, not assumed

Two separate runs, both against this branch's core. Stating the provenance of each, since the frame numbers differ:

**1. `test_disk_control` case 5** — 600 headless frames of no-content boot, reading the real framebuffer:

| | frames | non-black | distinct |
|---|---|---|---|
| before | 600 | 564 | **35** (static logo) |
| after | 600 | 549 | **528** (BIOS animating) |

**2. A throwaway capture probe** (not case 5, and not in the diff) using the same `harness_load_no_content` entry point, purely to see what those 528 frames actually *are* — a change-counter alone cannot tell an animating BIOS from churn:

- frame 400 of a 600-frame run → the CD BIOS cube intro
- frame 2200 of a **2400**-frame run → its insert-disc attract screen, which is the screen a disc is inserted from

The 2400-frame run is the only source of the frame-2200 capture; case 5 itself remains 600 frames. Thanks to @kimi for catching that the original wording implied otherwise.

## Also: `supports_no_game` was never flipped

`dist/info` still said `supports_no_game = "false"` after `SET_SUPPORT_NO_GAME` shipped. RetroArch reads the **info database**, not the runtime env call, to decide whether to offer a contentless launch — so the feature wasn't advertised to the frontend at all. One line.

## Two tests asserted the old strategy

Both encoded the bug, which is how it shipped green:

- `no_game_boot_selects_none_strategy` asserted `IS_NONE`. Renamed to `no_game_boot_selects_cd_bios_strategy`; now pins the BIOS plus `cdBiosAvailable`.
- `test_disk_control` case 1 compared strategy names either side of an insert. No-content is now `"bios"` and a real-BIOS disc also resolves to `"bios"`, so that comparison **would have gone vacuous**. It now pairs the name with `isCDGame`, which is what actually moves: false for the bare BIOS on its insert screen, true once a disc is mounted.

## Verification

- Full suite: exit 0, zero failures
- C89 lint clean; build-identity guard OK
- Audio pair by hand: presence RMS 1174.2 (expected ~1175), clipping 0 saturated samples
- Acid gate: `Regressions: 0` (147/150, the 3 FAILs are baselined)
- `test_disk_control` cases 1/3/5 green with a real disc; case 1's changed assertion is load-bearing (it failed before the `libretro.c` change)

The `.gitignore` hunk is unrelated to the boot fix and kept deliberately: the `dsp_halt_backtrace` binary is produced by a tool whose source is already tracked, and without the ignore it gets staged by `git add -A`. One line, and it stops a 100 KB binary landing in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)