### PR TITLE
release: v3.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ tools/jagcd/jagcd-chd-check
 tools/jagcd/chdman
 tools/jagcd/*.exe
 test/tools/blit_memo_verify
+test/tools/dsp_halt_backtrace
 test/tools/dsp_idle_ab
 test/tools/dsp_idle_probe_falsify
 test/tools/gpu_idle_ab

--- a/Makefile
+++ b/Makefile
@@ -2061,6 +2061,15 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# REM SESSION markers and CDI headers declare numSessions=2 -- so it
 	@# would pass against a data disc for the wrong reason.  Ledgered as a
 	@# skip rather than written to look like coverage.
+	@# Case 5 (no-content boot renders AND progresses, #726) takes NO disc
+	@# and must NOT sit inside the corpus guard below.  It is the
+	@# regression cover for the bug that shipped in v3.6.0, so it has to
+	@# run on public CI and on contributor machines, which are exactly the
+	@# checkouts with no test/roms/private.  An earlier revision nested it
+	@# in the `if [ -n "$$disc" ]` block, where it silently ran nowhere but
+	@# a corpus machine.
+	./test/tools/test_disk_control ./$(TARGET) --case 5 --quiet
+
 	@bash scripts/test-skip.sh record "Disk control audio-disc insert (#651)" \
 		"no one-session (Red Book) disc in the private corpus"
 	@disc=$$(find -L test/roms/private -iname '*.cdi' -o -iname '*.cue' 2>/dev/null | head -1); \
@@ -2068,7 +2077,6 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		rc=0; \
 		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 1 --quiet || rc=1; \
 		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 3 --quiet || rc=1; \
-		./test/tools/test_disk_control ./$(TARGET) --case 5 --quiet || rc=1; \
 		discb=$$(find -L test/roms/private -iname '*.cdi' -o -iname '*.cue' 2>/dev/null | sed -n 2p); \
 		if [ -n "$$discb" ]; then \
 			if ./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --disc-b "$$discb" --case 4 --quiet; then :; \

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ TARGET_NAME := virtualjaguar
 # Single source-of-truth for the human-readable version string.
 # Bumped by .github/workflows/version-bump.yml (greps this line).
 # Composed into CORE_VERSION in src/core/version.h, generated below.
-CORE_BASE_VERSION := v3.6.0
+CORE_BASE_VERSION := v3.6.1
 
 ifeq ($(DEBUG),1)
    CFLAGS += -DBUILD_TIMESTAMP="\"debug $(shell date -u +%Y-%m-%dT%H:%M:%SZ)\""

--- a/Makefile
+++ b/Makefile
@@ -2068,6 +2068,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 		rc=0; \
 		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 1 --quiet || rc=1; \
 		./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --case 3 --quiet || rc=1; \
+		./test/tools/test_disk_control ./$(TARGET) --case 5 --quiet || rc=1; \
 		discb=$$(find -L test/roms/private -iname '*.cdi' -o -iname '*.cue' 2>/dev/null | sed -n 2p); \
 		if [ -n "$$discb" ]; then \
 			if ./test/tools/test_disk_control ./$(TARGET) --disc "$$disc" --disc-b "$$discb" --case 4 --quiet; then :; \

--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -14,7 +14,7 @@ systemname = "Jaguar"
 systemid = "atari_jaguar"
 
 # Libretro Features
-supports_no_game = "false"
+supports_no_game = "true"
 database = "Atari - Jaguar"
 savestate = "true"
 savestate_features = "3"

--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -5,7 +5,7 @@ supported_extensions = "j64|jag|rom|abs|cof|bin|prg|cue|cdi|chd"
 corename = "Virtual Jaguar"
 license = "GPLv3"
 permissions = ""
-display_version = "v3.6.0"
+display_version = "v3.6.1"
 categories = "Emulator"
 
 # Hardware Information

--- a/docs/RELEASE_NOTES_v3.6.1.md
+++ b/docs/RELEASE_NOTES_v3.6.1.md
@@ -1,0 +1,78 @@
+# Virtual Jaguar libretro v3.6.1
+
+**A patch release for one thing: booting the core with no content now lands you
+in the CD BIOS, which is the screen you insert a disc from.**
+
+v3.6.0 shipped no-content boot (#646) and the disk-control interface (#651) so
+you could launch the core bare, put in a disc, and reach the Virtual Light
+Machine with an audio CD. That combination did not work. This fixes it.
+
+---
+
+## The fix
+
+No-content boot resolved to a **bare console**: the boot ROM running against a
+zeroed cartridge window. That is authentic for a Jaguar with no CD unit
+attached — and it is a dead end. The CD BIOS is what offers "insert a disc",
+and it is mapped as a cartridge at `$800000`, so nothing reachable from the
+empty-slot screen could ever get to it. The headline feature of v3.6.0 was
+unreachable by construction.
+
+Starting with no content now boots the **real CD BIOS**, which comes up on its
+own insert-disc screen. No files are required: an external CD BIOS ROM in your
+system directory is preferred if you have one, and otherwise an embedded image
+is used.
+
+Two smaller consequences of the same path, fixed alongside:
+
+- It reported cartridge mode rather than **CD mode with an empty tray**, which
+  inverted the options menu against a machine sitting in the CD BIOS — CD Boot
+  Mode and CD BIOS Type were hidden, and the cartridge-BIOS option was shown.
+- The **Memory Track** cart plugs into the CD unit and is present whether or not
+  a disc is, but it stayed absent until the first insert.
+
+## `supports_no_game` was never advertised
+
+`dist/info` still said `supports_no_game = "false"` after
+`RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME` shipped in v3.6.0. RetroArch reads the
+**info database**, not the runtime environment call, to decide whether to offer
+a contentless launch — so frontends were never told the core supports it. Now
+`"true"`.
+
+If your frontend does not offer "Start Core" without content, its info file is
+out of date; update it from the libretro info repository.
+
+## Why the tests did not catch this
+
+Two tests asserted which boot *strategy* resolved and never checked what the
+machine did with it, so a correctly-resolved dead end passed cleanly. Both now
+pin the corrected behaviour.
+
+One of them is worth noting for anyone reading the diff: `test_disk_control`
+case 1 compared strategy names either side of a disc insert. With no-content now
+resolving to `"bios"` — and a real-BIOS disc also resolving to `"bios"` — that
+comparison **would have gone vacuous**, passing while asserting nothing. It now
+pairs the strategy name with `isCDGame`, which is what actually moves: false for
+the bare BIOS on its insert screen, true once a disc is mounted.
+
+---
+
+## Upgrading
+
+Nothing to do beyond installing the core. Savestates, per-title defaults, hooks
+and cheats are unchanged from v3.6.0.
+
+**If you reported the v3.6.0 no-content boot as broken, check which core you
+have installed.** The original report for #726 was made against a v3.5.1 core —
+a version that predates the feature entirely — which is worth ruling out before
+anything else.
+
+## Known limitations
+
+Unchanged from v3.6.0:
+
+- Inserting a disc restarts the console. A continuous swap depends on CD BIOS
+  disc-presence polling that has not been verified.
+- The enhancement profile governs `internal_resolution` and `true_color` only.
+- `docs/WHATSNEW` has no sections for v3.1.0 through v3.5.1; the per-release
+  notes in `docs/RELEASE_NOTES_v*.md` are authoritative for those.

--- a/docs/WHATSNEW
+++ b/docs/WHATSNEW
@@ -1,3 +1,33 @@
+Virtual Jaguar v3.6.1 libretro
+------------------------------
+
+No-content boot fix. Full notes: docs/RELEASE_NOTES_v3.6.1.md
+
+== Fixes ==
+* No-content boot now comes up in the CD BIOS, on its insert-disc screen,
+  instead of a bare console with an empty cart slot (#726). The CD BIOS is
+  mapped as a cartridge at $800000, so nothing reachable from the
+  empty-slot screen could get to it -- which made "launch bare, insert a
+  disc, reach the VLM" (#646 + #651) unreachable by construction. No files
+  are required: an external CD BIOS ROM in the system directory wins if
+  present, otherwise an embedded image is used.
+* The same path now reports CD mode with an empty tray rather than
+  cartridge mode, so the options menu is no longer inverted against a
+  machine sitting in the CD BIOS (CD Boot Mode / CD BIOS Type were hidden,
+  the cartridge-BIOS option shown), and the Memory Track cart is present
+  from boot rather than only after the first insert.
+* dist/info: supports_no_game is "true". It was left "false" when
+  SET_SUPPORT_NO_GAME shipped in v3.6.0, and RetroArch reads the info
+  database -- not the runtime environment call -- to decide whether to
+  offer a contentless launch, so the feature was never advertised.
+
+== Tests ==
+* Two tests asserted the old boot strategy and so encoded the bug. Both now
+  pin the corrected behaviour; test_disk_control case 1 pairs the strategy
+  name with isCDGame, because bare BIOS and a real-BIOS disc both resolve
+  to "bios" and comparing names alone would have gone vacuous.
+
+
 Virtual Jaguar v3.6.0 libretro
 ------------------------------
 

--- a/docs/settings-and-performance-guide.md
+++ b/docs/settings-and-performance-guide.md
@@ -449,6 +449,11 @@ disk-control interface, so a frontend can start it with no content at all and
 hand it a disc afterwards — which is what makes "launch the core, put in a
 music CD, get the Virtual Light Machine" reachable.
 
+Started with no content, the core comes up **in the CD BIOS**, on its
+insert-disc screen, which is the screen you insert *from*. No files are
+required: an external CD BIOS ROM in the system directory is preferred if you
+have one, and otherwise an embedded image is used.
+
 Two things to know about how that behaves:
 
 - **Inserting a disc restarts the console.** The boot strategy is derived from

--- a/libretro.c
+++ b/libretro.c
@@ -6242,15 +6242,51 @@ bool retro_load_game(const struct retro_game_info *info)
    }
    else if (!info)
    {
-      /* No-content boot (issue #646): ResolveBootConfig() only knows about
-       * cart/CD content, and there is no 68K program anywhere for HLE to
-       * jump into, so the real boot ROM is the only sane strategy --
-       * exactly what real hardware shows with an empty cart slot. */
+      /* No-content boot (issue #646, corrected for #726): come up in the
+       * CD BIOS, not on an empty cart slot.
+       *
+       * cd_boot_strategy_none models a bare console -- the boot ROM running
+       * against a zeroed cart window.  That is authentic for a Jaguar with
+       * no CD unit attached, but it is a dead end for the feature this path
+       * exists to serve: the CD BIOS is what offers "insert a disc", and it
+       * is mapped as a cartridge at $800000, so nothing reachable from the
+       * empty-slot screen can ever get to it.  Booting bare in order to
+       * insert a disc afterwards -- the whole point of #646 plus disk
+       * control (#651) -- was therefore unreachable, which is what #726
+       * reported as "red logo, and you cannot boot into CD".
+       *
+       * ResolveBootConfig() is still not usable here (it only knows about
+       * cart/CD content), so this mirrors its CDBOOT_BIOS arm by hand:
+       * showBootROM is forced on because the real CD BIOS path requires it.
+       *
+       * Neither call below can fail for want of a file.  stage_cd_bios()
+       * prefers an external ROM from the system directory and otherwise
+       * copies an embedded image, and bios_boot() needs no disc -- it
+       * memcpys the staged BIOS, takes the run address from $800404 and
+       * resets -- so the BIOS comes up on its own insert-disc screen with
+       * zero files present. */
+      stage_cd_bios();
+
+      /* The CD unit is attached -- that is WHY the BIOS is running -- so
+       * this is CD mode with nothing in the tray, not cartridge mode.
+       * Both flags mirror open_disc_and_resolve_boot(); only the disc is
+       * missing.  Without them a machine sitting in the CD BIOS gets the
+       * options menu inverted against it (update_option_visibility() keys
+       * both gates off jaguar_cd_mode, so CD Boot Mode / CD BIOS Type
+       * would be HIDDEN and the cartridge-BIOS option shown), and the
+       * Memory Track cart -- which plugs into the CD unit and is present
+       * whether or not a disc is -- would stay absent until the first
+       * insert.  Safe with no disc: the three disc-identity accessors
+       * return zero when nothing is mounted (see the savestate chunk),
+       * and the MT save-buffer paths only touch mtMem. */
+      jaguar_cd_mode             = true;
+      jaguarMemTrackInserted     = opt_memory_track;
+
       vjs.useJaguarBIOS          = true;
       bootConfig.isCDGame        = false;
       bootConfig.showBootROM     = true;
-      bootConfig.cdBiosAvailable = false;
-      bootConfig.strategy        = &cd_boot_strategy_none;
+      bootConfig.cdBiosAvailable = true;
+      bootConfig.strategy        = &cd_boot_strategy_bios;
    }
    else
    {

--- a/src/core/version_fallback.h
+++ b/src/core/version_fallback.h
@@ -32,7 +32,7 @@
 #define VJAG_VERSION_H
 
 /* Keep in sync with CORE_BASE_VERSION in the Makefile. */
-#define CORE_BASE_VERSION "v3.6.0"
+#define CORE_BASE_VERSION "v3.6.1"
 
 /* Spelled so it cannot be mistaken for a real rev in a bug report: a build
  * that reports this had no git metadata available at compile time. */

--- a/test/acid/BASELINE.txt
+++ b/test/acid/BASELINE.txt
@@ -130,6 +130,9 @@
 [PASS tests/stress/many_blits.jag
 [PASS tests/stress/rapid_irq_pump.jag
 [PASS tests/timing/doom_update_gate_rate.jag
+[PASS tests/timing/gpu_alu_loop_rate.jag
+[PASS tests/timing/gpu_load_use_loop_rate.jag
+[PASS tests/timing/gpu_store_ext_loop_rate.jag
 [PASS tests/timing/halfline_count_per_frame.jag
 [PASS tests/timing/halfline_period_us.jag
 [PASS tests/timing/hc_advance.jag
@@ -137,6 +140,7 @@
 [PASS tests/timing/input_edge_per_field.jag
 [PASS tests/timing/jerry_pit_setup.jag
 [PASS tests/timing/pit_countdown_rate.jag
+[PASS tests/timing/render_bound_loop_rate.jag
 [PASS tests/timing/vblank_60hz_exact.jag
 [PASS tests/timing/vc_advance.jag
 [PASS tests/timing/vc_field_bit.jag

--- a/test/test_boot_config.c
+++ b/test/test_boot_config.c
@@ -584,7 +584,14 @@ TEST(no_game_env_declared)
     p_retro_deinit();
 }
 
-TEST(no_game_boot_selects_none_strategy)
+/* Renamed from no_game_boot_selects_none_strategy (#726).  It asserted
+ * IS_NONE, which pinned the bare-console boot that made the feature
+ * useless: cd_boot_strategy_none runs the boot ROM against a zeroed cart
+ * window -- the empty-slot logo -- and the CD BIOS is mapped as a
+ * cartridge, so nothing reachable from that screen could ever get to it.
+ * No-content boot exists to be a place you insert a disc FROM, so the
+ * BIOS is the correct resolution and this now pins that instead. */
+TEST(no_game_boot_selects_cd_bios_strategy)
 {
     bool loaded;
 
@@ -596,9 +603,14 @@ TEST(no_game_boot_selects_none_strategy)
             p_bootConfig->isCDGame, p_bootConfig->showBootROM,
             p_bootConfig->strategy ? p_bootConfig->strategy->name : "null");
 
+    /* isCDGame stays false: the BIOS is up, but no disc is mounted.  That
+     * pairing (bios + !isCDGame) is what the disk-control insert test uses
+     * to tell "bare BIOS" from "disc mounted". */
     ASSERT_EQ(p_bootConfig->isCDGame, false);
     ASSERT_EQ(p_bootConfig->showBootROM, true);
-    ASSERT(IS_NONE(*p_bootConfig));
+    ASSERT_EQ(p_bootConfig->cdBiosAvailable, true);
+    ASSERT(IS_BIOS(*p_bootConfig));
+    ASSERT(!IS_NONE(*p_bootConfig));
     core_teardown();
 }
 
@@ -711,7 +723,7 @@ int main(int argc, char *argv[])
     /* ---- Part 3: No-content boot (never gated -- needs no ROM) ---- */
     SUITE("No-Content Boot (RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME)");
     RUN(no_game_env_declared);
-    RUN(no_game_boot_selects_none_strategy);
+    RUN(no_game_boot_selects_cd_bios_strategy);
     RUN(no_game_save_ram_is_empty);
     RUN(no_game_runs_and_resets_without_crashing);
     total_fail += REPORT();

--- a/test/tools/test_disk_control.c
+++ b/test/tools/test_disk_control.c
@@ -221,13 +221,21 @@ int main(int argc, char **argv)
 
     switch (case_num) {
     case 1: {
-        int registered, was_none, added, inserted, now_cd;
+        int registered, was_bare_bios, added, inserted, now_cd;
 
         registered = cfg.disk_cb_registered
                   && cfg.disk_add_image_index
                   && cfg.disk_replace_image_index
                   && cfg.disk_set_eject_state;
-        was_none   = strcmp(strategy_name(), "none") == 0;
+        /* No-content boot resolves to the CD BIOS (#726), so the strategy
+         * NAME alone no longer separates before-insert from after: a
+         * real-BIOS disc resolves to "bios" as well, and asserting
+         * strategy_is_cd() on both sides would be vacuous.  isCDGame is
+         * what actually moves -- false for the bare BIOS sitting on its
+         * insert-disc screen, true once a disc is mounted -- so both
+         * halves below pair the name with it. */
+        was_bare_bios = strcmp(strategy_name(), "bios") == 0
+                     && !bootcfg->isCDGame;
 
         gi.path = disc_path;
         added    = registered
@@ -235,23 +243,27 @@ int main(int argc, char **argv)
                 && cfg.disk_replace_image_index(0, &gi)
                 && cfg.disk_set_eject_state(true);
         inserted = added && cfg.disk_set_eject_state(false);
-        now_cd   = strategy_is_cd();
+        now_cd   = strategy_is_cd() && bootcfg->isCDGame;
 
         results[nres++] = mkres(registered, "case1_interface_registered",
             registered ? "core registered the disk control ext interface"
                        : "no disk control interface registered -- every "
                          "assertion below would be vacuous");
-        results[nres++] = mkres(was_none, "case1_no_content_resolved",
-            was_none ? "strategy was \"none\" before the insert"
-                     : "strategy was not \"none\" at no-content boot");
+        results[nres++] = mkres(was_bare_bios, "case1_no_content_resolved",
+            was_bare_bios ? "no-content boot came up in the CD BIOS with no "
+                            "disc mounted"
+                          : "no-content boot did not resolve to the CD BIOS "
+                            "(#726: it must, or the insert-disc screen is "
+                            "unreachable)");
         results[nres++] = mkres(inserted, "case1_insert_succeeded",
             inserted ? "set_eject_state(false) returned true"
                      : "insert was refused");
         results[nres++] = mkres(now_cd, "case1_boot_resolution_reran",
-            now_cd ? "strategy is now a CD strategy -- resolution re-ran"
-                   : "strategy did NOT move off \"none\" -- the insert "
-                     "reset the machine without re-resolving");
-        pass = registered && was_none && inserted && now_cd;
+            now_cd ? "a disc is mounted and a CD strategy resolved -- "
+                     "resolution re-ran"
+                   : "isCDGame never went true -- the insert reset the "
+                     "machine without re-resolving");
+        pass = registered && was_bare_bios && inserted && now_cd;
         break;
     }
     case 4: {

--- a/test/tools/test_disk_control.c
+++ b/test/tools/test_disk_control.c
@@ -91,6 +91,50 @@ static int strategy_is_cd(void)
     return strcmp(n, "hle") == 0 || strcmp(n, "bios") == 0;
 }
 
+/* Frame-progression tracking for case 5 (issue #726).
+ *
+ * Cases 1/3/4 assert which boot STRATEGY resolved.  That is necessary and
+ * not sufficient: a machine that resolves the right strategy and then
+ * freezes on the boot ROM's red logo passes every one of them, which is
+ * exactly how the v3.6.0 no-content regression shipped.  So this tracks
+ * whether the picture actually CHANGES, which is the thing a user sees. */
+static uint32_t vid_hash;         /* FNV-1a over the frame just delivered */
+static uint32_t vid_prev_hash;
+static unsigned vid_frames;       /* frames the core actually delivered   */
+static unsigned vid_changes;      /* frames whose pixels differed         */
+static unsigned vid_nonblack;     /* frames with any non-black pixel      */
+
+static void vid_cb(void *ud, const void *data, unsigned w, unsigned h,
+                   size_t pitch)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    uint32_t hsh = 2166136261u;
+    unsigned y, x;
+    int nonblack = 0;
+
+    (void)ud;
+    if (!p)                       /* duped frame: no new pixels */
+        return;
+    vid_frames++;
+    for (y = 0; y < h; y++)
+    {
+        const uint32_t *row = (const uint32_t *)(p + (size_t)y * pitch);
+        for (x = 0; x < w; x++)
+        {
+            uint32_t px = row[x];
+            hsh = (hsh ^ (px & 0x00FFFFFFu)) * 16777619u;
+            if (px & 0x00FFFFFFu)
+                nonblack = 1;
+        }
+    }
+    if (nonblack)
+        vid_nonblack++;
+    if (vid_frames > 1 && hsh != vid_prev_hash)
+        vid_changes++;
+    vid_prev_hash = hsh;
+    vid_hash      = hsh;
+}
+
 static harness_result mkres(int ok, const char *name, const char *detail)
 {
     harness_result r;
@@ -121,20 +165,28 @@ int main(int argc, char **argv)
         else if (strcmp(argv[i], "--disc-b") == 0 && i + 1 < argc)
             disc_path_b = argv[i + 1];
     }
-    if (case_num != 1 && case_num != 3 && case_num != 4) {
+    if (case_num != 1 && case_num != 3 && case_num != 4
+        && case_num != 5) {
         fprintf(stderr, "usage: test_disk_control <core> --disc <image> "
-                        "--case N[1|3|4] [--quiet]\n"
+                        "--case N[1|3|4|5] [--quiet]\n"
                         "  (case 2 needs a one-session audio disc; none "
                         "exists in the corpus)\n");
         return 1;
     }
-    if (!disc_path) {
+    if (!disc_path && case_num != 5) {
         fprintf(stderr, "test_disk_control: no --disc given\n");
         return 1;
     }
 
     cfg.frames = 10;
     cfg.quiet  = 1;
+    if (case_num == 5)
+    {
+        /* Long enough for the boot ROM to get past its first screen if it
+         * is going to; short enough to stay a unit test. */
+        cfg.frames         = 600;
+        cfg.video_callback = vid_cb;
+    }
 
     /* Must be set before the load: the core registers disk control during
      * retro_load_game, and the harness refuses the env call unless this
@@ -244,6 +296,43 @@ int main(int argc, char **argv)
                    : "state refused on its OWN disc -- the check is too "
                      "strict, not just strict");
         pass = saved && cross_refused && own_ok;
+        break;
+    }
+    case 5: {
+        /* No-content boot must RENDER, not just resolve (issue #726).
+         *
+         * Two assertions, and the second is the one that matters:
+         *   - the boot ROM puts something on screen at all, and
+         *   - the picture keeps CHANGING.
+         *
+         * A frozen red Jaguar logo satisfies "non-black" forever, so
+         * non-black alone would be another vacuous check. Motion is what
+         * separates "booting" from "wedged on the logo".
+         *
+         * Deliberately no assertion about WHICH screen: this test should
+         * survive a future change to what a bare console shows. */
+        int rendered, moving;
+
+        harness_run(&cfg);
+
+        rendered = (vid_frames > 0 && vid_nonblack > 0);
+        /* >=2 distinct images over the window. Generous on purpose: the
+         * bar is "not frozen", not "animates smoothly". */
+        moving   = (vid_changes >= 2);
+
+        results[nres++] = mkres(rendered, "case5_no_content_renders",
+            rendered ? "bare-console boot put a non-black image on screen"
+                     : "bare-console boot rendered nothing (or all black)");
+        results[nres++] = mkres(moving, "case5_no_content_progresses",
+            moving ? "the picture changes -- the machine is running"
+                   : "the picture NEVER CHANGES -- wedged on the boot screen "
+                     "(this is issue #726: strategy resolves, machine does "
+                     "not run)");
+
+        fprintf(stderr, "  [case5] frames=%u nonblack=%u changes=%u\n",
+                vid_frames, vid_nonblack, vid_changes);
+
+        pass = rendered && moving;
         break;
     }
     case 3: {

--- a/test/tools/test_disk_control.c
+++ b/test/tools/test_disk_control.c
@@ -98,11 +98,11 @@ static int strategy_is_cd(void)
  * freezes on the boot ROM's red logo passes every one of them, which is
  * exactly how the v3.6.0 no-content regression shipped.  So this tracks
  * whether the picture actually CHANGES, which is the thing a user sees. */
-static uint32_t vid_hash;         /* FNV-1a over the frame just delivered */
-static uint32_t vid_prev_hash;
+static uint32_t vid_prev_hash;    /* FNV-1a over the previous frame       */
 static unsigned vid_frames;       /* frames the core actually delivered   */
 static unsigned vid_changes;      /* frames whose pixels differed         */
 static unsigned vid_nonblack;     /* frames with any non-black pixel      */
+static int      vid_bad_pitch;    /* set if the frame was not 4 bytes/px  */
 
 static void vid_cb(void *ud, const void *data, unsigned w, unsigned h,
                    size_t pitch)
@@ -115,6 +115,16 @@ static void vid_cb(void *ud, const void *data, unsigned w, unsigned h,
     (void)ud;
     if (!p)                       /* duped frame: no new pixels */
         return;
+
+    /* The harness video callback carries no pixel-format field, and this
+     * indexes rows as uint32_t -- correct for the core's XRGB8888 output,
+     * but a silent out-of-bounds read past each row if that ever became
+     * RGB565.  Validate rather than assume: a format change should fail
+     * loudly here, not read garbage and look like a flaky test. */
+    if (pitch < (size_t)w * 4) {
+        vid_bad_pitch = 1;
+        return;
+    }
     vid_frames++;
     for (y = 0; y < h; y++)
     {
@@ -132,7 +142,6 @@ static void vid_cb(void *ud, const void *data, unsigned w, unsigned h,
     if (vid_frames > 1 && hsh != vid_prev_hash)
         vid_changes++;
     vid_prev_hash = hsh;
-    vid_hash      = hsh;
 }
 
 static harness_result mkres(int ok, const char *name, const char *detail)
@@ -315,14 +324,17 @@ int main(int argc, char **argv)
 
         harness_run(&cfg);
 
-        rendered = (vid_frames > 0 && vid_nonblack > 0);
+        rendered = (vid_frames > 0 && vid_nonblack > 0 && !vid_bad_pitch);
         /* >=2 distinct images over the window. Generous on purpose: the
          * bar is "not frozen", not "animates smoothly". */
         moving   = (vid_changes >= 2);
 
         results[nres++] = mkres(rendered, "case5_no_content_renders",
             rendered ? "bare-console boot put a non-black image on screen"
-                     : "bare-console boot rendered nothing (or all black)");
+                     : (vid_bad_pitch
+                        ? "frame was not XRGB8888 (pitch < w*4) -- this test "
+                          "reads rows as uint32_t and cannot score it"
+                        : "bare-console boot rendered nothing (or all black)"));
         results[nres++] = mkres(moving, "case5_no_content_progresses",
             moving ? "the picture changes -- the machine is running"
                    : "the picture NEVER CHANGES -- wedged on the boot screen "


### PR DESCRIPTION
Refs #726

Patch release for one thing: **booting the core with no content now lands you in the CD BIOS**, which is the screen you insert a disc from.

v3.6.0 shipped no-content boot (#646) and disk control (#651) so you could launch bare, insert a disc, and reach the VLM with an audio CD. That combination did not work — no-content boot resolved to a bare console (boot ROM against a zeroed cart window), and the CD BIOS is mapped *as a cartridge* at `$800000`, so nothing reachable from the empty-slot screen could get to it. The headline feature was unreachable by construction.

## Contents

- **#731** — no-content boot comes up in the CD BIOS; same path now reports CD mode with an empty tray rather than cartridge mode (the options menu was inverted against it, and Memory Track was absent until the first insert); `supports_no_game` flipped in `dist/info`.
- **#727 / #728** — already on `develop`: the frame-progression test that redirected #726, and the acid baseline ratchet.
- **#729** — the `pr-issue-link` error-message fix, back-merged from `master`.

## Version bump

| | |
|---|---|
| `CORE_BASE_VERSION` | `v3.6.1` |
| `display_version` | `v3.6.1` |
| `check-info-version.sh` | OK |

## Pre-tag gates

Per `docs/release-process.md`, all run against this branch:

- `make test` — exit 0, zero failures
- C89 lint clean
- **Audio pair by hand** (the gate `make test` silently skips without the private ROMs): presence RMS **1174.2** against an expected ~1175; clipping **0** saturated samples
- **Acid baseline** — `Regressions: 0` (147/150; the 3 FAILs are the baselined ones)

## Note for anyone tracking #726

The original report was made against a **v3.5.1** core — a version predating the feature entirely. The stale install is worth ruling out separately from this fix; the release notes say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)