### PR TITLE
fix(cd): HLE align scan must not return on an odd-misaligned decoy run (Baldies #738)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2078,6 +2078,7 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# ~600, so 1200 frames is decisive and cheap.  Private corpus only.
 	@bal=$$(find -L test/roms/private -iname 'Baldies*Rev 1*.cue' 2>/dev/null | head -1); \
 	if [ -n "$$bal" ]; then \
+		$(MAKE) --no-print-directory test/tools/cd_wedge_probe >/dev/null || exit 1; \
 		if ./test/tools/cd_wedge_probe ./$(TARGET) "$$bal" --frames 1200 --arm 300 --freeze-frames 400 \
 				--option virtualjaguar_cd_boot_mode=hle >/dev/null 2>&1; then \
 			echo "  PASS: [baldies_hle_cutscene_progresses] no freeze in 1200 frames (#738)"; \

--- a/Makefile
+++ b/Makefile
@@ -1353,7 +1353,7 @@ clean:
 		tools/jagcd/jagcd-chd-check \
 		test/tools/test_memory_map test/tools/test_option_visibility test/test_memtrack test/test_nvmbios test/tools/test_dsp_audio_diag \
 		test/tools/test_frame_timing test/tools/test_runahead_determinism test/tools/test_pertitle_db \
-		test/tools/test_disk_control \
+		test/tools/test_disk_control test/tools/cd_wedge_probe \
 		test/test_biosdb test/test_cart_bios_loader \
 		test/test_titledb test/test_titlehook test/tools/test_hook_gate \
 		test/tools/test_wedge_spin test/tools/test_texdump test/tools/test_texreplace test/test_voicechat test/test_voice_netpacket test/tools/test_voicechat_inertness test/tools/voicechat_pair test/tools/i2s_lag_probe \
@@ -2070,6 +2070,24 @@ test: test/test_dram_timing test/test_cheat test/test_event_queue test/test_jlin
 	@# a corpus machine.
 	./test/tools/test_disk_control ./$(TARGET) --case 5 --quiet
 
+	@# Baldies HLE cutscene (#738): the boot classifier PASSED this title
+	@# while it was frozen from frame ~600 (it reaches game code and is
+	@# not thrashing -- it is just waiting on a dead clock), so the cover
+	@# has to be a freeze detector.  cd_wedge_probe exits 42 on 400
+	@# identical frames after frame 300; the unpatched core froze at
+	@# ~600, so 1200 frames is decisive and cheap.  Private corpus only.
+	@bal=$$(find -L test/roms/private -iname 'Baldies*Rev 1*.cue' 2>/dev/null | head -1); \
+	if [ -n "$$bal" ]; then \
+		if ./test/tools/cd_wedge_probe ./$(TARGET) "$$bal" --frames 1200 --arm 300 --freeze-frames 400 \
+				--option virtualjaguar_cd_boot_mode=hle >/dev/null 2>&1; then \
+			echo "  PASS: [baldies_hle_cutscene_progresses] no freeze in 1200 frames (#738)"; \
+		else \
+			echo "  FAIL: [baldies_hle_cutscene_progresses] Baldies froze under HLE (#738: stream marker misaligned?)"; exit 1; \
+		fi; \
+	else \
+		bash scripts/test-skip.sh record "Baldies HLE cutscene progression (#738)" "Baldies (USA) (Rev 1).cue not in the private corpus"; \
+	fi
+
 	@bash scripts/test-skip.sh record "Disk control audio-disc insert (#651)" \
 		"no one-session (Red Book) disc in the private corpus"
 	@disc=$$(find -L test/roms/private -iname '*.cdi' -o -iname '*.cue' 2>/dev/null | head -1); \
@@ -2407,6 +2425,14 @@ test/tools/test_disk_control: test/tools/test_disk_control.c \
 		test/harness/harness.c test/harness/harness.h
 	$(CC) -O2 -Wall -std=c99 $(INCFLAGS) \
 		-o $@ test/tools/test_disk_control.c \
+		test/harness/harness.c \
+		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
+
+# Freeze detector used by the Baldies HLE cutscene check below (#738).
+test/tools/cd_wedge_probe: test/tools/cd_wedge_probe.c \
+		test/harness/harness.c test/harness/harness.h
+	$(CC) -O2 -Wall -std=c99 -I. $(INCFLAGS) \
+		-o $@ test/tools/cd_wedge_probe.c \
 		test/harness/harness.c \
 		$(if $(filter Linux,$(shell uname -s)),-ldl) -lm
 

--- a/src/cd/jagcd_hle.c
+++ b/src/cd/jagcd_hle.c
@@ -486,6 +486,25 @@ static uint32_t HLERawStreamAlignOffset(uint32_t startLBA, uint32_t destAddr,
             {
                uint32_t relOff = s2 * 2352 + i;
                uint32_t mis    = (destAddr + relOff) & 3;
+               /* The I2S capture phase is a WORD phase: a genuine marker
+                * lands at destination misalignment 0 or 2, never 1 or 3.
+                * An odd-misaligned byte-fill run is therefore payload that
+                * happens to repeat a printable byte, not a mastering
+                * marker -- and returning on it hides the real one.
+                * Baldies (#738): sector 8 opens with 65 x '{' at misalign
+                * 1; the true 64 x ''' chunk marker sits in sector 7 at
+                * misalign 2.  Returning "shift 0" on the decoy left the
+                * marker 2-aligned, the game's 16-aligned-long locator
+                * counted 15, and it aborted its cutscene into a
+                * stack-unsafe exit that hangs the console.  Skip the
+                * decoy and keep scanning. */
+               if (mis & 1u)
+               {
+                  HLE_LOG("align scan: ignoring %s run (%u) at LBA %u off "
+                          "%u -- odd dest misalign %u is not a word phase\n",
+                          what, run, startLBA + s2, i, mis);
+                  continue;
+               }
                HLE_LOG("align scan: %s run (%u) at LBA %u off %u "
                        "(stream off %u, dest misalign %u) -- shift %u\n",
                        what, run, startLBA + s2, i, relOff, mis,


### PR DESCRIPTION
Refs #738

Baldies (CD) froze ~600 frames into its intro under the default HLE boot mode — on the stale boot matrix and on v3.6.1. It now plays.

## Root cause

The game streams its cutscene from CD and locates each chunk by scanning the stream buffer at 4-byte stride for **16 consecutive aligned longs** equal to a mastering marker (`$27272727`), followed by `'STAB'`. HLE delivered the stream with the marker at destination misalignment **2**, so only 15 aligned longs fit. Not found → sentinel `$11111111` → `JMP` into the exit routine **without restoring A7** → the exit stops both processors and its `RTS` pops the record loop's return address → a deadline wait on a clock nobody advances any more.

`HLERawStreamAlignOffset()` exists for precisely this (hardware's I2S capture phase varies per attempt; ours is deterministic), but its pass-2 marker hunt searches sectors 8, 7, 9, 6, 10 and **returned on the first candidate**:

```
align scan: generic byte-fill marker run (16) at LBA 23395 off 601 (stream off 19417, dest misalign 1) -- shift 0
```

Sector 8 opens with **65 × `{`** — printable payload fill — at misalign **1**. The real 64 × `'` marker in sector 7 at misalign 2 was never examined.

## Fix

An odd misalignment cannot be an I2S word-phase error (the code already maps it to "no shift"), so a candidate at misalign 1 or 3 is a decoy by construction: skip it and keep scanning. One `if (mis & 1u) continue;` with the reasoning in a comment.

## Verification

| check | result |
|---|---|
| Baldies HLE marker runs | now at `$F6E08` / `$115134` — mod 4 = 0, 16 aligned longs |
| Baldies HLE cutscene | renders f600 → f1700+ (was frozen from f600); GPU and DSP both running at f1800; `cd_wedge_probe` clean over 2400 frames |
| Myst (USA) / (Demo) / (Demo)(Alt) — the scanner's original titles | still `PASS` |
| Full HLE CD corpus vs unpatched `f9a3c89` (built in a worktree, same classifier) | every commercial title `PASS`; FAIL set **identical** (7 homebrew boot-band + 2 LOAD_FAIL) |
| `make TEST_EXPORTS=1 test` | exit 0, zero failures; audio pair PASS (presence IS1; clipping Atari Karts / Skyhammer / IS2) |
| C89 lint | clean |

## Regression cover (second commit)

The boot classifier **passed Baldies while it was frozen** — it reaches game code and isn't thrashing, it's just waiting on a dead clock. So the cover is a freeze detector: `cd_wedge_probe` is now built by `make test` and run on Baldies HLE for 1200 frames (400-identical threshold after frame 300). Proven to discriminate: unpatched core exits 42 at the ~600 freeze, fixed core exits 0. Private-corpus only, ledgered as a skip elsewhere.

## Notes for #738

The long investigation on the issue (dead clock, DSP self-halt, video IRQs, RISC speed, PIT rate, CD pacing) was all analysis of the game's **abort path**, and stands as such — every emulator-side mechanism it exonerated is still exonerated. The normal path never stops the processors. Iron Soldier 2 was already verified fixed on v3.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)